### PR TITLE
Improve visual style of toolbar and layer manager

### DIFF
--- a/PlanarAlly/static/css/planarally.css
+++ b/PlanarAlly/static/css/planarally.css
@@ -132,7 +132,6 @@ a, a:visited, a:hover, a:active {
     bottom: 25px;
     left: 25px;
     z-index: 10;
-    background-color: white;
 }
 
 #layerselect ul {
@@ -140,16 +139,23 @@ a, a:visited, a:hover, a:active {
     list-style: none;
     padding: 0;
     margin: 0;
-    border: solid 1px black;
+    border: solid 1px #82c8a0;
+    border-radius: 5px;
 }
 
 #layerselect li {
     display: flex;
-    border-right: solid 1px black;
+    background-color: #eee;
+    border-right: solid 1px #82c8a0;
+}
+
+#layerselect li:first-child {
+    border-radius: 5px 0px 0px 5px;
 }
 
 #layerselect li:last-child {
     border-right: none;
+    border-radius: 0px 5px 5px 0px;
 }
 
 #layerselect li:hover {

--- a/PlanarAlly/static/css/planarally.css
+++ b/PlanarAlly/static/css/planarally.css
@@ -175,7 +175,6 @@ a, a:visited, a:hover, a:active {
     bottom: 25px;
     right: 25px;
     z-index: 10;
-    background-color: white;
 }
 
 #toolselect ul {
@@ -183,16 +182,23 @@ a, a:visited, a:hover, a:active {
     list-style: none;
     padding: 0;
     margin: 0;
-    border: solid 1px black;
+    border: solid 1px #82c8a0;
+    border-radius: 5px;
 }
 
 #toolselect li {
     display: flex;
-    border-right: solid 1px black;
+    background-color: #eee;
+    border-right: solid 1px #82c8a0;
 }
 
 #toolselect li:last-child {
     border-right: none;
+    border-radius: 0px 5px 5px 0px;
+}
+
+#toolselect li:first-child {
+    border-radius: 5px 0px 0px 5px;
 }
 
 #toolselect li:hover {

--- a/PlanarAlly/static/js/planarally.js
+++ b/PlanarAlly/static/js/planarally.js
@@ -17842,7 +17842,9 @@ __webpack_require__.r(__webpack_exports__);
 
 
 
-
+String.prototype.capitalize = function() {
+    return this.charAt(0).toUpperCase() + this.slice(1);
+}
 
 class GameManager {
     constructor() {
@@ -20844,7 +20846,7 @@ function setupTools() {
         const toolInstance = new tool.clz();
         _planarally__WEBPACK_IMPORTED_MODULE_0__["default"].tools.set(tool.name, toolInstance);
         const extra = tool.defaultSelect ? " class='tool-selected'" : "";
-        const toolLi = $("<li id='tool-" + tool.name + "'" + extra + "><a href='#'>" + tool.name + "</a></li>");
+        const toolLi = $("<li id='tool-" + tool.name + "'" + extra + "><a href='#'>" + tool.name.capitalize() + "</a></li>");
         toolselectDiv.append(toolLi);
         if (tool.hasDetail) {
             const div = toolInstance.detailDiv;

--- a/PlanarAlly/static/js/planarally.js
+++ b/PlanarAlly/static/js/planarally.js
@@ -17932,7 +17932,7 @@ class GameManager {
                 let extra = '';
                 if (selectable_layers === 0)
                     extra = " class='layer-selected'";
-                layerselectdiv.find('ul').append("<li id='select-" + new_layer.name + "'" + extra + "><a href='#'>" + new_layer.name + "</a></li>");
+                layerselectdiv.find('ul').append("<li id='select-" + new_layer.name + "'" + extra + "><a href='#'>" + new_layer.name.capitalize() + "</a></li>");
                 selectable_layers += 1;
             }
             const canvas = $('#' + new_layer.name + '-layer')[0];


### PR DESCRIPTION
Improves the style of the toolbars by rounding the corners, changing the border color to green and capitalizing the first letter of the names.

![screenshotlayers](https://user-images.githubusercontent.com/8882369/40244043-1739aaa8-5ac2-11e8-83d8-26cae18697e7.png)
![screenshottoolbar](https://user-images.githubusercontent.com/8882369/40244044-175bd196-5ac2-11e8-8aca-bb303a5626d8.png)
