### PR TITLE
Exit and logout button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [0.5] - Not yet released
 
+### Added
+- Added an exit button in-game
+    - This will now bring you back to your sessions
+    - Also added a new logout button to the sessions menu
+
 ### Changed
 - Improved the visuals of the toolbar and layer manager
 

--- a/PlanarAlly/static/css/planarally.css
+++ b/PlanarAlly/static/css/planarally.css
@@ -339,6 +339,12 @@ a, a:visited, a:hover, a:active {
     margin-left: auto;
 }
 
+#exitButton {
+    position: absolute;
+    bottom: 0px;
+    width: 100%;
+}
+
 #zoomer {
     position: absolute;
     top: 25px;

--- a/PlanarAlly/static/css/rooms.css
+++ b/PlanarAlly/static/css/rooms.css
@@ -79,6 +79,20 @@ form {
     position: absolute;
 }
 
+#account-options {
+    display: flex;
+    background: #fff;
+    border-radius: 4px;
+    margin-top: 50px;
+    height: 45px;
+}
+
+#account-options form {
+    background: none;
+    border-radius: 0px;
+    width: 50%;
+}
+
 .input {
     position: relative;
     width: 90%;

--- a/PlanarAlly/templates/planarally.jinja2
+++ b/PlanarAlly/templates/planarally.jinja2
@@ -75,6 +75,7 @@
                     </div>
                 </div>
             {% endif %}
+            <a href="/rooms" id="exitButton"><button class="accordion">Exit</button></a>
         </div>
         {% if dm %}
             <div id="locations-menu">

--- a/PlanarAlly/templates/rooms.jinja2
+++ b/PlanarAlly/templates/rooms.jinja2
@@ -46,5 +46,13 @@
             <button type="submit" class="submit" title="Create"><i class="fas fa-arrow-right"></i></button>
         </fieldset>
     </form>
+    <div id="account-options">
+        <form action="/acountsettings" method="get">
+            <button type="submit" class="submit" title="Account Settings"><i class="fas fa-cog"></i></button>
+        </form>
+        <form action="/logout" method="get">
+            <button type="submit" class="submit" title="Logout"><i class="fas fa-sign-out-alt"></i></button>
+        </form>
+    </div>
 </div>
 </body>


### PR DESCRIPTION
This pull request adds a new exit button at the bottom of the menu and it takes the user back to their rooms. A new logout button was also added to the rooms page that uses the existing logout function on the server side. I was not quite sure about the placement of the logout button but I think it looks fine now and I also added a placeholder button that in the future can be used to alter account settings like changing passwords.

![screenshotexitbutton](https://user-images.githubusercontent.com/8882369/40279669-c54e97b8-5c46-11e8-8d43-b7b7fafe1aa0.png)
![logout-button](https://user-images.githubusercontent.com/8882369/40279671-cc846e7c-5c46-11e8-89a0-6d49be07a22a.png)
