### PR TITLE
Improve look of context menu

### DIFF
--- a/PlanarAlly/static/css/planarally.css
+++ b/PlanarAlly/static/css/planarally.css
@@ -242,7 +242,8 @@ a, a:visited, a:hover, a:active {
 #contextMenu ul {
     /*width: 100%;*/
     /*height: 100%;*/
-    border: 1px solid black;
+    border: 1px solid #82c8a0;
+    border-radius: 5px;
     background: white;
     padding: 0;
     list-style: none;
@@ -250,7 +251,7 @@ a, a:visited, a:hover, a:active {
 }
 
 #contextMenu ul li {
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid #82c8a0;
     padding: 5px;
 }
 


### PR DESCRIPTION
<img width="187" alt="New context menu" src="https://user-images.githubusercontent.com/8882369/42622233-35de785c-85c0-11e8-9cda-57c1aa3c239e.PNG">

This is the same style as the toolbar and other menus in the room.

Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>