### PR TITLE
Fix error dragging assets in Asset Manager in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to this project will be documented in this file.
     - A dockerfile is now present to support deployment in docker containers
 
 ### Fixed
-- Unable to move modal dialogs in Firefox
+- Unable to drag modal dialogs in Firefox
+- Unable to drag assets in Asset Manager in Firefox
 
 ## [0.9] - 2018-09-26
 

--- a/ts_src/assetManager/assets.ts
+++ b/ts_src/assetManager/assets.ts
@@ -220,6 +220,7 @@ const vm = new Vue({
             }
         },
         startDrag(event: DragEvent, file: string | AssetFile) {
+            event.dataTransfer.setData('Hack', 'ittyHack');
             event.dataTransfer.dropEffect = "move";
             if (!this.selected.includes(file)) this.select(event, -1, file);
             this.draggingSelection = true;


### PR DESCRIPTION
Similar to https://github.com/Kruptein/PlanarAlly/pull/76 but for the Asset Manager.

This one just needs setData() to be called, but I can't set it to null it seems.