### PR TITLE
Add asset rotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
     - The server config now has an option to specify a different save file name and/or location.
 - Dockerfile [contributed by Schemen]
     - A dockerfile is now present to support deployment in docker containers
+- Allow rotating assets 90 degrees at a time
 
 ### Fixed
 - Unable to drag modal dialogs in Firefox

--- a/ts_src/game/api_types.ts
+++ b/ts_src/game/api_types.ts
@@ -117,6 +117,7 @@ export interface ServerText extends ServerShape {
 }
 export interface ServerAsset extends ServerRect {
     src: string;
+    angle: number;
 }
 
 export interface Note {

--- a/ts_src/game/shapes/asset.ts
+++ b/ts_src/game/shapes/asset.ts
@@ -9,6 +9,7 @@ export default class Asset extends BaseRect {
     type = "asset";
     img: HTMLImageElement;
     src: string = "";
+    angle: number = 0;
     constructor(img: HTMLImageElement, topleft: GlobalPoint, w: number, h: number, uuid?: string) {
         super(topleft, w, h);
         if (uuid !== undefined) this.uuid = uuid;
@@ -17,16 +18,27 @@ export default class Asset extends BaseRect {
     asDict() {
         return Object.assign(this.getBaseDict(), {
             src: this.src,
+            angle: this.angle,
         });
     }
     fromDict(data: ServerAsset) {
         super.fromDict(data);
         this.src = data.src;
+        if (data.angle !== undefined)
+            this.angle = data.angle;
     }
     draw(ctx: CanvasRenderingContext2D) {
         super.draw(ctx);
         try {
-            ctx.drawImage(this.img, g2lx(this.refPoint.x), g2ly(this.refPoint.y), g2lz(this.w), g2lz(this.h));
+            ctx.save();
+            const x = g2lx(this.refPoint.x);
+            const y = g2ly(this.refPoint.y);
+            const w = g2lz(this.w);
+            const h = g2lz(this.h);
+            ctx.translate(x + (w / 2), y + (h / 2));
+            ctx.rotate(this.angle);
+            ctx.drawImage(this.img, - (w / 2), - (h / 2), w, h);
+            ctx.restore();
         } catch (error) {
             console.warn(`Shape ${this.uuid} could not load the image ${this.src}`);
         }

--- a/ts_src/game/ui/selection/shapecontext.vue
+++ b/ts_src/game/ui/selection/shapecontext.vue
@@ -95,11 +95,10 @@ export default Vue.component("shape-menu", {
             if (this.shape === null) return;
             if (this.shape.type === "asset") {
                 const layer = this.getActiveLayer()!;
-                layer.removeShape(this.shape, true);
                 this.shape.angle -= Math.PI / 2;
                 if (this.shape.angle < 0)
                     this.shape.angle += Math.PI * 2;
-                layer.addShape(this.shape, true);
+                layer.invalidate(true);
             }
             this.close();
         },
@@ -107,11 +106,10 @@ export default Vue.component("shape-menu", {
             if (this.shape === null) return;
             if (this.shape.type === "asset") {
                 const layer = this.getActiveLayer()!;
-                layer.removeShape(this.shape, true);
                 this.shape.angle += Math.PI / 2;
                 if (this.shape.angle >= Math.PI * 2)
                     this.shape.angle -= Math.PI * 2;
-                layer.addShape(this.shape, true);
+                layer.invalidate(true);
             }
             this.close();
         },

--- a/ts_src/game/ui/selection/shapecontext.vue
+++ b/ts_src/game/ui/selection/shapecontext.vue
@@ -93,22 +93,26 @@ export default Vue.component("shape-menu", {
         },
         rotateCCW() {
             if (this.shape === null) return;
-            if (this.shape.type === "asset") {
+            if (this.shape instanceof Asset) {
                 const layer = this.getActiveLayer()!;
+                const redraw = true;
                 this.shape.angle -= Math.PI / 2;
                 if (this.shape.angle < 0)
                     this.shape.angle += Math.PI * 2;
+                socket.emit("updateShape", { shape: this.shape.asDict(), redraw });
                 layer.invalidate(true);
             }
             this.close();
         },
         rotateCW() {
             if (this.shape === null) return;
-            if (this.shape.type === "asset") {
+            if (this.shape instanceof Asset) {
                 const layer = this.getActiveLayer()!;
+                const redraw = true;
                 this.shape.angle += Math.PI / 2;
                 if (this.shape.angle >= Math.PI * 2)
                     this.shape.angle -= Math.PI * 2;
+                socket.emit("updateShape", { shape: this.shape.asDict(), redraw });
                 layer.invalidate(true);
             }
             this.close();

--- a/ts_src/game/ui/selection/shapecontext.vue
+++ b/ts_src/game/ui/selection/shapecontext.vue
@@ -15,6 +15,8 @@
         </li>
         <li @click='moveToBack'>Move to back</li>
         <li @click='moveToFront'>Move to front</li>
+        <li @click='rotateCW'>Rotate clockwise</li>
+        <li @click='rotateCCW'>Rotate counterclockwise</li>
         <li @click='addInitiative'>{{ getInitiativeWord() }} initiative</li>
     </contextmenu>
 </template>
@@ -87,6 +89,30 @@ export default Vue.component("shape-menu", {
             if (this.shape === null) return;
             const layer = this.getActiveLayer()!;
             layer.moveShapeOrder(this.shape, layer.shapes.length - 1, true);
+            this.close();
+        },
+        rotateCCW() {
+            if (this.shape === null) return;
+            if (this.shape.type === "asset") {
+                const layer = this.getActiveLayer()!;
+                //layer.removeShape(this.shape, true);
+                this.shape.angle -= Math.PI / 2;
+                if (this.shape.angle < 0)
+                    this.shape.angle += Math.PI * 2;
+                //layer.addShape(this.shape, true);
+            }
+            this.close();
+        },
+        rotateCW() {
+            if (this.shape === null) return;
+            if (this.shape.type === "asset") {
+                const layer = this.getActiveLayer()!;
+                layer.removeShape(this.shape, true);
+                this.shape.angle += Math.PI / 2;
+                if (this.shape.angle >= Math.PI * 2)
+                    this.shape.angle -= Math.PI * 2;
+                layer.addShape(this.shape, true);
+            }
             this.close();
         },
         addInitiative() {

--- a/ts_src/game/ui/selection/shapecontext.vue
+++ b/ts_src/game/ui/selection/shapecontext.vue
@@ -15,8 +15,8 @@
         </li>
         <li @click='moveToBack'>Move to back</li>
         <li @click='moveToFront'>Move to front</li>
-        <li @click='rotateCW'>Rotate clockwise</li>
-        <li @click='rotateCCW'>Rotate counterclockwise</li>
+        <li v-if="this.shape !== null && this.shape.type === 'asset'" @click='rotateCW'>Rotate clockwise</li>
+        <li v-if="this.shape !== null && this.shape.type === 'asset'" @click='rotateCCW'>Rotate counterclockwise</li>
         <li @click='addInitiative'>{{ getInitiativeWord() }} initiative</li>
     </contextmenu>
 </template>

--- a/ts_src/game/ui/selection/shapecontext.vue
+++ b/ts_src/game/ui/selection/shapecontext.vue
@@ -95,11 +95,11 @@ export default Vue.component("shape-menu", {
             if (this.shape === null) return;
             if (this.shape.type === "asset") {
                 const layer = this.getActiveLayer()!;
-                //layer.removeShape(this.shape, true);
+                layer.removeShape(this.shape, true);
                 this.shape.angle -= Math.PI / 2;
                 if (this.shape.angle < 0)
                     this.shape.angle += Math.PI * 2;
-                //layer.addShape(this.shape, true);
+                layer.addShape(this.shape, true);
             }
             this.close();
         },


### PR DESCRIPTION
This allows for using tile sets for building maps.  Currently can only
rotate 90 degrees in either direction.

Make sure to do your PR on the `dev` branch and NOT on the `master` branch.  This repo uses gitflow which only uses the master branch as a release branch.

Make sure to update the `CHANGELOG`.