### PR TITLE
Fix empty note and asset accordion being too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Unable to drag modal dialogs in Firefox
 - Unable to drag assets in Asset Manager in Firefox
+- Empty asset and note list was to small for icons
 
 ## [0.9] - 2018-09-26
 

--- a/PlanarAlly/static/css/planarally.css
+++ b/PlanarAlly/static/css/planarally.css
@@ -119,6 +119,7 @@ svg {
     background-color: white;
     display: none;
     overflow: hidden;
+    min-height: 2em;
 }
 
 .accordion-subpanel {


### PR DESCRIPTION
If the asset or note accordion were empty they were to small for the icons. This PR fixes that issue:
![planarallyfixsmall](https://user-images.githubusercontent.com/8882369/46582222-c914c000-ca43-11e8-92f8-94d9e1323744.png)


Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>