### PR TITLE
Use zoomFactor instead of zoomDisplay to sync Fixes #176

### DIFF
--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -95,7 +95,7 @@ class GameStore extends VuexModule implements GameState {
         return {
             panX: gameStore.panX,
             panY: gameStore.panY,
-            zoomFactor: gameStore.zoomDisplay,
+            zoomFactor: gameStore.zoomFactor,
         };
     }
 
@@ -240,7 +240,7 @@ class GameStore extends VuexModule implements GameState {
         this.panX += diff.x;
         this.panY += diff.y;
         layerManager.invalidate();
-        sendClientOptions(this.locationOptions);
+        sendClientOptions(gameStore.locationOptions);
     }
 
     @Mutation


### PR DESCRIPTION
This PR changes the zoom value that is used to sync with the server from the display value to the actual used value.

Additionally a bug is fixed whereby the locationOptions were passed as undefined due to shenanigans with vuex-module-decorator