### PR TITLE
Refactor Layer.draw to use Shape.drawSelection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Pasted shapes are now pasted relative to the screen position
 - [tech] Mousemove events are now throttled, so that they don't fire a gazillion events.
 - [tech] tslint swapped out for eslint
+- [tech] Refactor Layer.draw to use Shape.drawSelection
 
 ### Fixed
 

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -5,7 +5,6 @@ import { layerManager } from "@/game/layers/manager";
 import { Shape } from "@/game/shapes/shape";
 import { createShapeFromDict } from "@/game/shapes/utils";
 import { gameStore } from "@/game/store";
-import { g2lx, g2ly } from "@/game/units";
 import { visibilityStore } from "../visibility/store";
 
 export class Layer {
@@ -154,26 +153,9 @@ export class Layer {
                 ctx.fillStyle = this.selectionColor;
                 ctx.strokeStyle = this.selectionColor;
                 ctx.lineWidth = this.selectionWidth;
-                const z = gameStore.zoomFactor;
-                this.selection.forEach(sel => {
-                    ctx.globalCompositeOperation = sel.globalCompositeOperation;
-                    const bb = sel.getBoundingBox();
-                    // TODO: REFACTOR THIS TO Shape.drawSelection(ctx);
-                    ctx.strokeRect(g2lx(bb.topLeft.x), g2ly(bb.topLeft.y), bb.w * z, bb.h * z);
-
-                    for (const p of sel.points) {
-                        ctx.beginPath();
-                        ctx.arc(g2lx(p[0]), g2ly(p[1]), 3, 0, 2 * Math.PI);
-                        ctx.fill();
-                    }
-                    ctx.beginPath();
-                    ctx.moveTo(g2lx(sel.points[0][0]), g2ly(sel.points[0][1]));
-                    for (let i = 1; i <= sel.points.length; i++) {
-                        const vertex = sel.points[i % sel.points.length];
-                        ctx.lineTo(g2lx(vertex[0]), g2ly(vertex[1]));
-                    }
-                    ctx.stroke();
-                });
+                for (const shape of this.selection) {
+                    shape.drawSelection(ctx);
+                }
             }
             ctx.globalCompositeOperation = ogOP;
             this.valid = true;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -264,6 +264,29 @@ export abstract class Shape {
         }
     }
 
+    drawSelection(ctx: CanvasRenderingContext2D): void {
+        ctx.globalCompositeOperation = this.globalCompositeOperation;
+        const z = gameStore.zoomFactor;
+        const bb = this.getBoundingBox();
+        ctx.strokeRect(g2lx(bb.topLeft.x), g2ly(bb.topLeft.y), bb.w * z, bb.h * z);
+
+        // Draw vertices
+        for (const p of this.points) {
+            ctx.beginPath();
+            ctx.arc(g2lx(p[0]), g2ly(p[1]), 3, 0, 2 * Math.PI);
+            ctx.fill();
+        }
+
+        // Draw edges
+        ctx.beginPath();
+        ctx.moveTo(g2lx(this.points[0][0]), g2ly(this.points[0][1]));
+        for (let i = 1; i <= this.points.length; i++) {
+            const vertex = this.points[i % this.points.length];
+            ctx.lineTo(g2lx(vertex[0]), g2ly(vertex[1]));
+        }
+        ctx.stroke();
+    }
+
     getInitiativeRepr(): InitiativeData {
         return {
             uuid: this.uuid,


### PR DESCRIPTION
This PR adds Shape.drawSelection and refactors Layer.draw to use that method instead.

This opens up possibilities for shape specific selection implementations.