### PR TITLE
Hide ALL shapes on FOW layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 - Pasted shapes are now pasted relative to the screen position
 - Login page now autofocusses on the username input field.
+- All shapes on the FOW layer are now invisible while not on the FOW layer.
 - [tech] Mousemove events are now throttled, so that they don't fire a gazillion events.
 - [tech] tslint swapped out for eslint
 - [tech] Refactor Layer.draw to use Shape.drawSelection
@@ -37,7 +38,6 @@ All notable changes to this project will be documented in this file.
 - Ruler width not being the same at all zoom levels.
 - Brushhelper sticking around on layer change.
 - Temporary shapes not being properly cleared on player disconnect.
-    - These are things like rulers, ping indicators etc.
 - [tech] Improved docker image creation script
   - Faster compilation and smaller final size
   - Now the frontend is also compiled inside a container

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -134,8 +134,7 @@ export class Layer {
                 if (shape.options.has("skipDraw") && shape.options.get("skipDraw")) continue;
                 if (layerManager.getLayer() === undefined) continue;
                 if (!shape.visibleInCanvas(state.canvas)) continue;
-                if (state.name === "fow" && shape.visionObstruction && layerManager.getLayer()!.name !== state.name)
-                    continue;
+                if (state.name === "fow" && layerManager.getLayer()!.name !== state.name) continue;
                 shape.drawAuras(ctx);
             }
             for (const shape of this.shapes) {
@@ -149,8 +148,7 @@ export class Layer {
                     continue;
                 if (layerManager.getLayer() === undefined) continue;
                 if (!shape.visibleInCanvas(state.canvas)) continue;
-                if (state.name === "fow" && shape.visionObstruction && layerManager.getLayer()!.name !== state.name)
-                    continue;
+                if (state.name === "fow" && layerManager.getLayer()!.name !== state.name) continue;
                 shape.draw(ctx);
             }
 


### PR DESCRIPTION
This PR closes issue #175 and hides all shapes on the fow layer regardless of their vision blocking setting (while not on the FOW layer).