### PR TITLE
Feature/gh 187 anchor points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,260 +9,261 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   Account Settings
-    -   Set email address.
-    -   Change password.
-    -   Delete account.
+- Account Settings
+  - Set email address
+  - Change password
+  - Delete account
+- Snap to nearby existing points while drawing and while resizing points
 
 ## [0.18.2] - 2019-12-29
 
 ### Fixed
 
--   JS build files being out of date.
+- JS build files being out of date.
 
 ## [0.18.1] - 2019-12-05
 
 ### Fixed
 
--   Shapes not syncing on mouse move.
+- Shapes not syncing on mouse move.
 
 ## [0.18.0] - 2019-11-09
 
 ### Added
 
--   Option to set custom units of length (defaults to ft)
--   Ping tool
--   Option to change the location of tokens/shapes
--   Option to edit shapes in groups (move to other layer, move to other location, move to top/bottom, add initiative)
--   Option to Ctrl-select tokens/shapes
--   Default right click menu to all tools that didnt have it
--   Colour in the location bar to show current location
--   Polygon tool options
-    -   brush size (defaults to 1 grid cell in width)
-    -   closed/open polygon toggle, when enable automatically connects first and last point.
--   Escape cancels draw tool actions
+- Option to set custom units of length (defaults to ft)
+- Ping tool
+- Option to change the location of tokens/shapes
+- Option to edit shapes in groups (move to other layer, move to other location, move to top/bottom, add initiative)
+- Option to Ctrl-select tokens/shapes
+- Default right click menu to all tools that didnt have it
+- Colour in the location bar to show current location
+- Polygon tool options
+  - brush size (defaults to 1 grid cell in width)
+  - closed/open polygon toggle, when enable automatically connects first and last point.
+- Escape cancels draw tool actions
 
 ### Changed
 
--   Pasted shapes are now pasted relative to the screen position
--   Login page now autofocusses on the username input field.
--   All shapes on the FOW layer are now invisible while not on the FOW layer.
--   Circle borders (including basic tokens) are now inset, so that they fit within their squares.
--   Basic token text scaling has been changed slightly to have more uniformly sized characters.
+- Pasted shapes are now pasted relative to the screen position
+- Login page now autofocusses on the username input field.
+- All shapes on the FOW layer are now invisible while not on the FOW layer.
+- Circle borders (including basic tokens) are now inset, so that they fit within their squares.
+- Basic token text scaling has been changed slightly to have more uniformly sized characters.
 
--   [tech] Mousemove events are now throttled, so that they don't fire a gazillion events.
--   [tech] tslint swapped out for eslint
--   [tech] Refactor Layer.draw to use Shape.drawSelection
--   [tech] Refactor most uses of forEach to for..of
+- [tech] Mousemove events are now throttled, so that they don't fire a gazillion events.
+- [tech] tslint swapped out for eslint
+- [tech] Refactor Layer.draw to use Shape.drawSelection
+- [tech] Refactor most uses of forEach to for..of
 
 ### Fixed
 
--   [DM] Session lock state not being shown correctly upon joining.
--   Sessions with a slash in their name do not work
--   Ruler width not being the same at all zoom levels.
--   Brushhelper sticking around on layer change.
--   Temporary shapes not being properly cleared on player disconnect.
--   Private shape auras, trackers, labels and name being revealed during movement.
--   Fix light auras clipping over walls.
--   Fix bug with circle draws using negative radii.
--   Polygon preview segment always showing up as black.
+- [DM] Session lock state not being shown correctly upon joining.
+- Sessions with a slash in their name do not work
+- Ruler width not being the same at all zoom levels.
+- Brushhelper sticking around on layer change.
+- Temporary shapes not being properly cleared on player disconnect.
+- Private shape auras, trackers, labels and name being revealed during movement.
+- Fix light auras clipping over walls.
+- Fix bug with circle draws using negative radii.
+- Polygon preview segment always showing up as black.
 
--   [tech] Improved docker image creation script
-    -   Faster compilation and smaller final size
-    -   Now the frontend is also compiled inside a container
+- [tech] Improved docker image creation script
+  - Faster compilation and smaller final size
+  - Now the frontend is also compiled inside a container
 
 ## [0.17.1] - 2019-06-17
 
 ### Fixed
 
--   Issue with MIME-types of .js files being wrongly reported as text/plain.
+- Issue with MIME-types of .js files being wrongly reported as text/plain.
 
 ## [0.17.0] - 2019-06-16
 
 ### Changed
 
--   The DM options menu is now a proper dialog.
-    -   Options are sorted by catecory.
-    -   A list of players with access to the session is shown with an option to kick them.
-    -   A url is shown for the invite url so you no longer have to figure this out yourself.
-    -   A button to refresh the invite url is now present.
-    -   A button to remove the session is added.
-    -   A button to (un)lock the session is added.
+- The DM options menu is now a proper dialog.
+  - Options are sorted by catecory.
+  - A list of players with access to the session is shown with an option to kick them.
+  - A url is shown for the invite url so you no longer have to figure this out yourself.
+  - A button to refresh the invite url is now present.
+  - A button to remove the session is added.
+  - A button to (un)lock the session is added.
 
 ### Fixed
 
--   Shape updates often causing unnecessary lighting recalculations.
+- Shape updates often causing unnecessary lighting recalculations.
 
 ## [0.16.0] - 2019-05-19
 
 ### Added
 
--   Option to listen on a socket instead of HOST:PORT.
--   Vision tool to change active tokens.
--   Vision lock button to initiative to only show vision of current actor.
-    -   This only applies to tokens the player owns for other tokens the normal vision is restored.
-    -   This is purely client side and can thus be chosen by player/DM separately.
--   Camera lock button to initiative to automatically center on current actor.
-    -   It will center when an actor begins its turn and the client is owner of that actor.
-    -   It does not prevent camera movement after the initial center action.
--   Automatic build of windows executables on azure pipelines for all tags
-    -   These will also create a github release automatically
--   Fake player button to DM Settings to disable all DM functions except DM settings.
-    -   You can control which player(s) you want to emulate with the vision tool.
+- Option to listen on a socket instead of HOST:PORT.
+- Vision tool to change active tokens.
+- Vision lock button to initiative to only show vision of current actor.
+  - This only applies to tokens the player owns for other tokens the normal vision is restored.
+  - This is purely client side and can thus be chosen by player/DM separately.
+- Camera lock button to initiative to automatically center on current actor.
+  - It will center when an actor begins its turn and the client is owner of that actor.
+  - It does not prevent camera movement after the initial center action.
+- Automatic build of windows executables on azure pipelines for all tags
+  - These will also create a github release automatically
+- Fake player button to DM Settings to disable all DM functions except DM settings.
+  - You can control which player(s) you want to emulate with the vision tool.
 
 ### Changed
 
--   Filter tool is only visible if there are labels defined.
+- Filter tool is only visible if there are labels defined.
 
 ### Fixed
 
--   Fix a bug causing labels without category to throw errors.
--   CSS bug with menu.
--   Bug making it impossible to remove trackers/auras.
--   Windows build being completely broken.
+- Fix a bug causing labels without category to throw errors.
+- CSS bug with menu.
+- Bug making it impossible to remove trackers/auras.
+- Windows build being completely broken.
 
 ## [0.15.1] - 2019-05-15
 
 ### Fixed
 
--   Upgrade from save format 12 to 13 failing in some cases.
+- Upgrade from save format 12 to 13 failing in some cases.
 
 ## [0.15.0] - 2019-04-14
 
 ### Added
 
--   Keybinding to toggle UI (ctrl+u).
--   Keybinding to copy selection to clipboard (ctrl+c).
--   Keybinding to paste clipboard to board (ctrl+v).
--   Labeling system.
-    -   You can add labels to shapes.
-    -   You can filter the gameboard on these labels.
+- Keybinding to toggle UI (ctrl+u).
+- Keybinding to copy selection to clipboard (ctrl+c).
+- Keybinding to paste clipboard to board (ctrl+v).
+- Labeling system.
+  - You can add labels to shapes.
+  - You can filter the gameboard on these labels.
 
 ### Changed
 
--   Asset preview now disappears when starting a drag asset action.
--   A mouse down in general will now trigger layer or tool selection.
-    -   In the past a 'click' was required, now any 'mousedown' will trigger.
--   Zoom scale has been modified.
--   Select tool can now also select shapes not owned by the player.
-    -   The selection info box is shown with all info visible for the user.
-    -   The tokens cannot be dragged or resized.
-    -   Groupselect will only select your own tokens.
--   Some minor style changes to the edit asset dialog
--   Shape names can now be hidden from other users.
--   Default vision mode changed to triangle mode. Legacy vision mode (bvh) can still be selected in the DM options.
+- Asset preview now disappears when starting a drag asset action.
+- A mouse down in general will now trigger layer or tool selection.
+  - In the past a 'click' was required, now any 'mousedown' will trigger.
+- Zoom scale has been modified.
+- Select tool can now also select shapes not owned by the player.
+  - The selection info box is shown with all info visible for the user.
+  - The tokens cannot be dragged or resized.
+  - Groupselect will only select your own tokens.
+- Some minor style changes to the edit asset dialog
+- Shape names can now be hidden from other users.
+- Default vision mode changed to triangle mode. Legacy vision mode (bvh) can still be selected in the DM options.
 
 ### Fixed
 
--   Bug causing rulers to stick on DM screen.
--   Bug causing rulers to not appear on other screens.
--   Drag and drop asset on firefox redirecting to random urls.
--   Some eventlisteners not being removed properly.
-    -   This caused zoom behaviour to mess up when leaving and joining a room multiple times.
--   Bug causing players not being able to add or update initiative effects.
--   Bug causing shown initiative effect to be one lower than it actually is on location load.
--   Move layer to/from DM layer having broken results for players untill a refresh of the page.
--   Bug causing some windows (e.g. initiatives) to no longer appear.
--   Vision bugs at different zoom levels caused by the world boundary being too large.
-    -   Reduced boundary location from 1e10 to 1e8.
--   Bug causing the vision recalculation not happening in a lot of cases.
+- Bug causing rulers to stick on DM screen.
+- Bug causing rulers to not appear on other screens.
+- Drag and drop asset on firefox redirecting to random urls.
+- Some eventlisteners not being removed properly.
+  - This caused zoom behaviour to mess up when leaving and joining a room multiple times.
+- Bug causing players not being able to add or update initiative effects.
+- Bug causing shown initiative effect to be one lower than it actually is on location load.
+- Move layer to/from DM layer having broken results for players untill a refresh of the page.
+- Bug causing some windows (e.g. initiatives) to no longer appear.
+- Vision bugs at different zoom levels caused by the world boundary being too large.
+  - Reduced boundary location from 1e10 to 1e8.
+- Bug causing the vision recalculation not happening in a lot of cases.
 
 ### Removed
 
--   Some old css files.
+- Some old css files.
 
 ### [0.14.2] - 2019-01-29
 
 ### Fixed
 
--   Registered users had to logout and login again before being able to perform actions.
--   [tech] Javascript files being wrongly served as plaintext in some obscure cases.
+- Registered users had to logout and login again before being able to perform actions.
+- [tech] Javascript files being wrongly served as plaintext in some obscure cases.
 
 ## [0.14.1] - 2019-01-28
 
 ### Fixed
 
--   A lot of things breaking due to a bug in shape ownership.
+- A lot of things breaking due to a bug in shape ownership.
 
 ## [0.14.0] - 2019-01-27
 
 ### Added
 
--   Polygon shape in the draw tool.
-    -   This is especially nice in combination with the new experimental vision mode!
--   [DM] Options to set the minimal and maximal vision ranges when using LOS.
-    -   A radial gradient is applied starting from the minimal range and stopping at the maximal range.
-    -   This effectively allows you to play with how far tokens can see.
--   Autocomplete hints to the login form.
--   Edit shape dialog now has options to change the border and fill colour.
--   Shape properties can now also be opened from the contextmenu (i.e. right click on a shape).
+- Polygon shape in the draw tool.
+  - This is especially nice in combination with the new experimental vision mode!
+- [DM] Options to set the minimal and maximal vision ranges when using LOS.
+  - A radial gradient is applied starting from the minimal range and stopping at the maximal range.
+  - This effectively allows you to play with how far tokens can see.
+- Autocomplete hints to the login form.
+- Edit shape dialog now has options to change the border and fill colour.
+- Shape properties can now also be opened from the contextmenu (i.e. right click on a shape).
 
 ### Changed
 
--   Wait with recalculating vision until all shapes are added on startup.
--   Vision mode toggle has been moved to the DM options and is now synced with the server.
+- Wait with recalculating vision until all shapes are added on startup.
+- Vision mode toggle has been moved to the DM options and is now synced with the server.
 
 ### Fixed
 
--   Fix visionmode menu toggle not remembering what is currently selected.
--   SelectionHelper mistakenly geting send to the server.
--   SelectionHelper sometimes getting moved to a different layer instead of the actual shape.
--   Some small QOL changes to multiline.
--   Logout routing.
--   Active location not being remembered by server.
--   Notes not getting cleared on location change.
--   AssetManager shift selection causing double selections.
--   AssetManager issues with (re)moving files.
--   Player location not saving properly.
--   Prevent duplicate owner entries for a shape.
+- Fix visionmode menu toggle not remembering what is currently selected.
+- SelectionHelper mistakenly geting send to the server.
+- SelectionHelper sometimes getting moved to a different layer instead of the actual shape.
+- Some small QOL changes to multiline.
+- Logout routing.
+- Active location not being remembered by server.
+- Notes not getting cleared on location change.
+- AssetManager shift selection causing double selections.
+- AssetManager issues with (re)moving files.
+- Player location not saving properly.
+- Prevent duplicate owner entries for a shape.
 
 ## [0.13.3] - 2019-01-19
 
 ### Fixed
 
--   Multiple bugs with triangle vision
+- Multiple bugs with triangle vision
 
 ## [0.13.2] - 2019-01-13
 
 ### Fixed
 
--   Static images were accidently no longer checked into the repository.
--   DM layer was not being sent by the server.
+- Static images were accidently no longer checked into the repository.
+- DM layer was not being sent by the server.
 
 ## [0.13.0] - 2019-01-13
 
 ### Added
 
--   A new vision system has been added based on triangulation.
-    -   You can select this new system as a client option
-    -   It is more precise (i.e. exact) than the previous vision system which was a good approximation.
-    -   It can handle any polygon under any angle, so expect some new draw tools in the future!
-    -   It is slightly more expensive to preprocess, but this should be relatively unnoticeable.
+- A new vision system has been added based on triangulation.
+  - You can select this new system as a client option
+  - It is more precise (i.e. exact) than the previous vision system which was a good approximation.
+  - It can handle any polygon under any angle, so expect some new draw tools in the future!
+  - It is slightly more expensive to preprocess, but this should be relatively unnoticeable.
 
 ### Fixed
 
--   Draw tool mouseUp behaviour had some strange quirks that are now ironed uit.
-    -   In particular this prevented some shapes of being synced correctly.
+- Draw tool mouseUp behaviour had some strange quirks that are now ironed uit.
+  - In particular this prevented some shapes of being synced correctly.
 
 ## 0.12.0
 
 ### Added
 
--   Added curl to docker container for proper health check
--   Remember which layer was selected last time [Issue 109]
+- Added curl to docker container for proper health check
+- Remember which layer was selected last time [Issue 109]
 
 ### Changed
 
--   [tech] Shape index unique constraint dropped to simplify some code
--   [tech] Massive overhaul of the code organization
--   [tech] Moved from manual webpack config to vue-cli
--   [tech] Moved to a single page application with vue-router
+- [tech] Shape index unique constraint dropped to simplify some code
+- [tech] Massive overhaul of the code organization
+- [tech] Moved from manual webpack config to vue-cli
+- [tech] Moved to a single page application with vue-router
 
 ## Fixed
 
--   Backspace key added as delete action (Fixes Mac OS X delete behaviour) [Issue 69]
--   Added host config option to docker config file
--   Moving shapes to another layer would not always succeed at the server [Issue 108]
+- Backspace key added as delete action (Fixes Mac OS X delete behaviour) [Issue 69]
+- Added host config option to docker config file
+- Moving shapes to another layer would not always succeed at the server [Issue 108]
 
 ## 0.11.6
 
@@ -270,17 +271,17 @@ A collection of small improvements and fixes.
 
 ### Added
 
--   host option in server_config.cfg [Issue 99]
+- host option in server_config.cfg [Issue 99]
 
 ### Changed
 
--   GridLayer.size from IntegerField to FloatField [Issue 105]
--   Location.unit_size from IntegerField to FloatField [Issue 105]
+- GridLayer.size from IntegerField to FloatField [Issue 105]
+- Location.unit_size from IntegerField to FloatField [Issue 105]
 
 ### Fixed
 
--   Tokens appear as black/red with all lighting settings disabled [Issues 90/91]
--   Trackers and Auras were not saved server side. [Issue 106]
+- Tokens appear as black/red with all lighting settings disabled [Issues 90/91]
+- Trackers and Auras were not saved server side. [Issue 106]
 
 ## 0.11.5
 
@@ -288,8 +289,8 @@ Hotfixes for 0.10.0
 
 ### Fixed
 
--   Drag and Drop file uploading fixed
--   New location creation fixed
+- Drag and Drop file uploading fixed
+- New location creation fixed
 
 ## 0.11.4
 
@@ -297,7 +298,7 @@ More hotfixes for 0.10.0
 
 ### Fixed
 
--   Asset uploading
+- Asset uploading
 
 ## 0.11.3
 
@@ -305,7 +306,7 @@ Another hotfix for 0.10.0.
 
 ### Fixed
 
--   Actually fix the user creation bug for once.
+- Actually fix the user creation bug for once.
 
 ## 0.11.2
 
@@ -313,7 +314,7 @@ Another hotfix for 0.10.0.
 
 ### Fixed
 
--   Made a woopsie while fixing the earlier user creation error.
+- Made a woopsie while fixing the earlier user creation error.
 
 ## 0.11.1
 
@@ -321,8 +322,8 @@ This version contains hotfixes for the 0.10.0 release
 
 ### Fixed
 
--   Save file was not generated at the right time causing errors when no save file exists during startup
--   User creation was broken
+- Save file was not generated at the right time causing errors when no save file exists during startup
+- User creation was broken
 
 ## 0.11.0
 
@@ -337,14 +338,14 @@ If you are about to install/use this release you either have completed part 1 (r
 
 ### Changed
 
--   [tech] Save file format is changed to sqlite!
+- [tech] Save file format is changed to sqlite!
 
 ### Fixed
 
--   Shape grid snapping not getting synced on draw
--   Select tool no longer selected by default on load
--   Add new location action messed up websocket rooms
--   CircularTokens created by non-DM users now properly set owner
+- Shape grid snapping not getting synced on draw
+- Select tool no longer selected by default on load
+- Add new location action messed up websocket rooms
+- CircularTokens created by non-DM users now properly set owner
 
 ## 0.10.0
 
@@ -377,20 +378,20 @@ Aside of the major save file changes, some other things are present in this rele
 
 ### Added
 
--   Option to choose save file location [contributed by Schemen]
-    -   The server config now has an option to specify a different save file name and/or location.
--   Dockerfile [contributed by Schemen]
-    -   A dockerfile is now present to support deployment in docker containers
--   VERSION file in the python folder
-    -   This will be used in the future to detect software updates
+- Option to choose save file location [contributed by Schemen]
+  - The server config now has an option to specify a different save file name and/or location.
+- Dockerfile [contributed by Schemen]
+  - A dockerfile is now present to support deployment in docker containers
+- VERSION file in the python folder
+  - This will be used in the future to detect software updates
 
 ### Fixed
 
--   Unable to drag modal dialogs in Firefox
--   Unable to drag assets in Asset Manager in Firefox
--   Empty asset and note list was to small for icons
--   Tools started with lowercase
--   Radial menu buttons had border when clicking them
+- Unable to drag modal dialogs in Firefox
+- Unable to drag assets in Asset Manager in Firefox
+- Empty asset and note list was to small for icons
+- Tools started with lowercase
+- Radial menu buttons had border when clicking them
 
 ## [0.9] - 2018-09-26
 
@@ -411,53 +412,53 @@ Assets are now stored in `/static/assets/` instead of `/static/img/assets/`. In 
 
 ### Added
 
--   Added a note system
--   Initiative tracker update
-    -   Now shows the active actor and has a next turn button
-    -   Shows the current round number
-    -   Turn/Effect timers per actor that automatically count down
-    -   Show a border around shapes on hover in the initiative list
--   New Asset management panel
-    -   Out of game way to organize assets
-    -   Upload files via a dialog or by dropping them on the manager
-    -   Rename/remove files/directories
-    -   move files/folders to other folders
--   Freestyle brush has been added as a draw shape
-    -   FOW usage is limited
-        -   Currently only works when global fog is applied.
-        -   Works when used from the draw tool in reveal/hide mode
-        -   Does not properly work in normal mode on the fow layer!
-        -   In general: Use it to draw on non-fog layers or use it in reveal/hide mode
--   [tech] tools onSelect and onDeselect for more finegrained tweaking and UI helpers
--   Option for players to select the colour of their rulers.
+- Added a note system
+- Initiative tracker update
+  - Now shows the active actor and has a next turn button
+  - Shows the current round number
+  - Turn/Effect timers per actor that automatically count down
+  - Show a border around shapes on hover in the initiative list
+- New Asset management panel
+  - Out of game way to organize assets
+  - Upload files via a dialog or by dropping them on the manager
+  - Rename/remove files/directories
+  - move files/folders to other folders
+- Freestyle brush has been added as a draw shape
+  - FOW usage is limited
+    - Currently only works when global fog is applied.
+    - Works when used from the draw tool in reveal/hide mode
+    - Does not properly work in normal mode on the fow layer!
+    - In general: Use it to draw on non-fog layers or use it in reveal/hide mode
+- [tech] tools onSelect and onDeselect for more finegrained tweaking and UI helpers
+- Option for players to select the colour of their rulers.
 
 ### Changed
 
--   Renamed 'Tokens' to 'Assets' in the settings panel
--   Redesigned the way assets are shown in the settings panel
-    -   A tree view approach is used, showing preview images on hover
-    -   Removed the cog wheel
-    -   A button to open the asset manager is added to the in-game interface.
--   Draw and fow tools have been combined in one singular draw tool
-    -   Options between 'normal' mode and either 'hide' or 'reveal' mode if you want to draw fog
-    -   Fog is now always drawn in the client's active fog colour
-    -   Also shows a brush tip while moving the mouse
--   Dim aura range should no longer include the normal range value
-    -   e.g. an aura that used to be 20/60 should now be 20/40
--   [tech] Most UI is now rendered using the reactive Vue.js framework instead of JQuery
--   Draw order changed
-    -   First all auras are drawn and then all shapes are drawn
-    -   This prevents auras overlapping shapes
-    -   Shape order is still respected
+- Renamed 'Tokens' to 'Assets' in the settings panel
+- Redesigned the way assets are shown in the settings panel
+  - A tree view approach is used, showing preview images on hover
+  - Removed the cog wheel
+  - A button to open the asset manager is added to the in-game interface.
+- Draw and fow tools have been combined in one singular draw tool
+  - Options between 'normal' mode and either 'hide' or 'reveal' mode if you want to draw fog
+  - Fog is now always drawn in the client's active fog colour
+  - Also shows a brush tip while moving the mouse
+- Dim aura range should no longer include the normal range value
+  - e.g. an aura that used to be 20/60 should now be 20/40
+- [tech] Most UI is now rendered using the reactive Vue.js framework instead of JQuery
+- Draw order changed
+  - First all auras are drawn and then all shapes are drawn
+  - This prevents auras overlapping shapes
+  - Shape order is still respected
 
 ### Fixed
 
--   Select box not working properly on the fow layer
--   Ownership changes are now reflected in the initiative list
--   Dim value aura's had the wrong radius
--   Dim value aura's nog properly work with light sources.
-    -   Instead of halving the opacity, the radial gradient is applied across the entire aura + dim aura radius.
--   Deleting multiple shapes no longer sends the selectionhelper to the server
+- Select box not working properly on the fow layer
+- Ownership changes are now reflected in the initiative list
+- Dim value aura's had the wrong radius
+- Dim value aura's nog properly work with light sources.
+  - Instead of halving the opacity, the radial gradient is applied across the entire aura + dim aura radius.
+- Deleting multiple shapes no longer sends the selectionhelper to the server
 
 ## [0.8] - 2018-06-19
 
@@ -470,102 +471,102 @@ UPDATE YOUR SAVE BY EXECUTING `python ../scripts/convert/0_to_1.py` FROM WITHIN 
 
 ### Added
 
--   Show initiative action is added to the general context menu
--   [tech] A Bounding Volume Hierarchy ray tracing accelerator is used.
-    -   This greatly! improves the performance of all lighting including the experimental LoS based lighting.
--   [tech] multiple debugging flags under Settings.
--   [tech] extra layer added that is used for fow. Now two layers are responsible for this.
+- Show initiative action is added to the general context menu
+- [tech] A Bounding Volume Hierarchy ray tracing accelerator is used.
+  - This greatly! improves the performance of all lighting including the experimental LoS based lighting.
+- [tech] multiple debugging flags under Settings.
+- [tech] extra layer added that is used for fow. Now two layers are responsible for this.
 
 ### Changed
 
--   Right clicking will now only show a shape specific menu if it was done on a selection
-    -   All other right clicks will show the general purpose context menu
--   Light auras now properly follow the actual path formed by vision obstruction objects
--   FOW layer drawn shapes now retain their proper colour used during drawing.
--   Movement that is normally grid-snapping will go out off grid if it stops against a movement blocker
--   [tech] Cleaned up the Vector class, splitting it up in a Vector and a Ray class
-    -   Vector: purely direction indication
-    -   Ray: combination of an origin point and a vector
--   [tech] A much more performant ray box intersection algorithm is used
+- Right clicking will now only show a shape specific menu if it was done on a selection
+  - All other right clicks will show the general purpose context menu
+- Light auras now properly follow the actual path formed by vision obstruction objects
+- FOW layer drawn shapes now retain their proper colour used during drawing.
+- Movement that is normally grid-snapping will go out off grid if it stops against a movement blocker
+- [tech] Cleaned up the Vector class, splitting it up in a Vector and a Ray class
+  - Vector: purely direction indication
+  - Ray: combination of an origin point and a vector
+- [tech] A much more performant ray box intersection algorithm is used
 
 ### Fixed
 
--   Shapes no longer get stuck in movementblockers on occassions
--   Auras were ignored in the visibility check during layer shape draw
+- Shapes no longer get stuck in movementblockers on occassions
+- Auras were ignored in the visibility check during layer shape draw
 
 ### Reverted
 
--   assets dropped on canvas are no longer tagged as token
-    -   Tokens should only be used for actual player representatives
+- assets dropped on canvas are no longer tagged as token
+  - Tokens should only be used for actual player representatives
 
 ## [0.7] - 2018-06-12
 
 ### Added
 
--   Rough background to the annotation field to make it more readable
+- Rough background to the annotation field to make it more readable
 
 ### Fixed
 
--   Annotations correctly position centered on the screen
--   Annotations correctly wrap words to the next line
--   Delete key no longer removes shapes while in input fields.
--   Scrolling only zooms when a canvas is targetted.
--   Exit button now correctly positioned when token list is large
+- Annotations correctly position centered on the screen
+- Annotations correctly wrap words to the next line
+- Delete key no longer removes shapes while in input fields.
+- Scrolling only zooms when a canvas is targetted.
+- Exit button now correctly positioned when token list is large
 
 ## [0.6] - 2018-06-11
 
 ### HOTFIXED
 
--   shapes moved with arrow keys were not being synced to the server
--   assets dropped on canvas are immediately tagged as token
+- shapes moved with arrow keys were not being synced to the server
+- assets dropped on canvas are immediately tagged as token
 
 ### Added
 
--   [DM] Using the shift key, shapes can move freely through movement blocking terrain.
--   Pressing 'd' now deselects everything
+- [DM] Using the shift key, shapes can move freely through movement blocking terrain.
+- Pressing 'd' now deselects everything
 
 ### Changed
 
--   Arrow moves will move assets when they are selected instead of the canvas.
-    -   The canvas will still be moved if no shape is selected
-    -   [DM] Shift key can also be used to pass through terrain.
--   Shape drawing now uses same behaviour in regards to grid snapping
-    -   by default shapes will resize to fit the grid
-    -   when alt is pressed on mouseUp during drawing or if the grid is disabled, the shape will not resize to grid.
--   Only tokens will have a minimal vision aura
--   Add DM settings option to enable Line of Sight based lighting
--   Disable LoS based lighting by default
+- Arrow moves will move assets when they are selected instead of the canvas.
+  - The canvas will still be moved if no shape is selected
+  - [DM] Shift key can also be used to pass through terrain.
+- Shape drawing now uses same behaviour in regards to grid snapping
+  - by default shapes will resize to fit the grid
+  - when alt is pressed on mouseUp during drawing or if the grid is disabled, the shape will not resize to grid.
+- Only tokens will have a minimal vision aura
+- Add DM settings option to enable Line of Sight based lighting
+- Disable LoS based lighting by default
 
 ### Fixed
 
--   Deleting a selection of assets should now behave correctly. (Sometimes not all assets would be deleted)
+- Deleting a selection of assets should now behave correctly. (Sometimes not all assets would be deleted)
 
 ## [0.5] - 2018-06-03
 
 ### Added
 
--   Added an exit button in-game
-    -   This will now bring you back to your sessions
-    -   Also added a new logout button to the sessions menu
--   Add token toggle to shape settings
--   Line of sight based light for tokens
-    -   Only see lights that fall in your line of sight
+- Added an exit button in-game
+  - This will now bring you back to your sessions
+  - Also added a new logout button to the sessions menu
+- Add token toggle to shape settings
+- Line of sight based light for tokens
+  - Only see lights that fall in your line of sight
 
 ### Changed
 
--   Improved the visuals of the toolbar and layer manager
--   Multiple large light/shadow related performance improvements for firefox
-    -   Chromium based browsers had slight improvements but already were (ans still are) much more performant in regards to FOW calculation
--   Shapes that do not have an associated image, now show their name or token tag in the initiative dialog
+- Improved the visuals of the toolbar and layer manager
+- Multiple large light/shadow related performance improvements for firefox
+  - Chromium based browsers had slight improvements but already were (ans still are) much more performant in regards to FOW calculation
+- Shapes that do not have an associated image, now show their name or token tag in the initiative dialog
 
 ### Fixed
 
--   The dim value attribute of auras was wrongly used as the normal aura value
--   The grid is now redrawn at the same time as the other layers instead of immediately
--   The light source toggle on shapes now immediately redraws the screen
--   Map tool properly works in all directions again
--   Sessions with spaces not working
--   Assets with ' not appearing correctly in the token list
+- The dim value attribute of auras was wrongly used as the normal aura value
+- The grid is now redrawn at the same time as the other layers instead of immediately
+- The light source toggle on shapes now immediately redraws the screen
+- Map tool properly works in all directions again
+- Sessions with spaces not working
+- Assets with ' not appearing correctly in the token list
 
 ## [0.4] - 2018-05-04
 
@@ -573,42 +574,42 @@ The great bugfix release
 
 ### Added
 
--   Bring players here function in the rightclick menu when nothing is selected
-    -   This will bring over all players to the exact same pan and zoom settings as the DM
-    -   Only the DM can access this
+- Bring players here function in the rightclick menu when nothing is selected
+  - This will bring over all players to the exact same pan and zoom settings as the DM
+  - Only the DM can access this
 
 ### Fixed
 
--   Grid size DM UI works again. It broke in 0.3
--   Cutoff zoom at 0.01 instead of 0, as zoom factors of 1e-16 caused issues with pages crashing
--   Adding a new location did not correctly send some options to the client
--   The annotation field in the edit asset dialog now prevents key presses to propagate to the board (e.g. no longer deleting shapes because you pressed delete in the textfield)
--   The selection box now is smaller for very small assets
--   Slowdown on the opening of the edit asset dialog throughout gameplay has been fixed.
--   Location options not synced immediately
--   Quick tracker/aura edits now work again
+- Grid size DM UI works again. It broke in 0.3
+- Cutoff zoom at 0.01 instead of 0, as zoom factors of 1e-16 caused issues with pages crashing
+- Adding a new location did not correctly send some options to the client
+- The annotation field in the edit asset dialog now prevents key presses to propagate to the board (e.g. no longer deleting shapes because you pressed delete in the textfield)
+- The selection box now is smaller for very small assets
+- Slowdown on the opening of the edit asset dialog throughout gameplay has been fixed.
+- Location options not synced immediately
+- Quick tracker/aura edits now work again
 
 ## [0.3] - 2018-04-19
 
 ### Added
 
--   Shape selection option is added to the draw tool, currently giving the option between a rectangle and a circle.
--   More camera options
-    -   Use the arrow keys to move 1 grid unit in the pressed direction
-    -   Use the scroll wheel to zoom in and out
-    -   Press the middle mouse button to pan without using the dedicated pan tool
--   Quickly create simple circular text tokens
-    -   right click anywhere that is not an active selection and select the 'create basic token' option
-    -   You can insert any text and choose the fill and border colours
-    -   Although singular letters or numbers work great, any text will be scaled to fit inside the circle, so longer texts can also work.
+- Shape selection option is added to the draw tool, currently giving the option between a rectangle and a circle.
+- More camera options
+  - Use the arrow keys to move 1 grid unit in the pressed direction
+  - Use the scroll wheel to zoom in and out
+  - Press the middle mouse button to pan without using the dedicated pan tool
+- Quickly create simple circular text tokens
+  - right click anywhere that is not an active selection and select the 'create basic token' option
+  - You can insert any text and choose the fill and border colours
+  - Although singular letters or numbers work great, any text will be scaled to fit inside the circle, so longer texts can also work.
 
 ### Changed
 
--   Line width of shape borders increased to 5
+- Line width of shape borders increased to 5
 
 ### Fixed
 
--   Various initiative issues with locations
+- Various initiative issues with locations
 
 ## [0.2] - 2018-04-11
 
@@ -617,39 +618,39 @@ A couple of important bugfixes are included though.
 
 ### Added
 
--   A save file version is added to the save to possibly convert older saves in the future.
--   A barebones annotation system for shapes
-    -   You can add text to any asset using the edit asset dialog
-    -   Whenever you mouse-over a shape you own the text will appear at top of the screen
-    -   This is mostly a DM tool but players can use it as well.
+- A save file version is added to the save to possibly convert older saves in the future.
+- A barebones annotation system for shapes
+  - You can add text to any asset using the edit asset dialog
+  - Whenever you mouse-over a shape you own the text will appear at top of the screen
+  - This is mostly a DM tool but players can use it as well.
 
 ### Fixed
 
--   Websocket protocol now correctly chosen at the client side, this caused players to just see a blank scene in some situations
--   Players on a different IP as the dm now actually see images.
--   Pan and zoom options are now remembered per user AND location instead of only per user.
--   MovementObstruction and visionObstruction were not immediately synced on toggle.
--   Groupselect now behaves more predictable when one member collides with a movement blocker
+- Websocket protocol now correctly chosen at the client side, this caused players to just see a blank scene in some situations
+- Players on a different IP as the dm now actually see images.
+- Pan and zoom options are now remembered per user AND location instead of only per user.
+- MovementObstruction and visionObstruction were not immediately synced on toggle.
+- Groupselect now behaves more predictable when one member collides with a movement blocker
 
 ### Changed
 
--   Move from 1 large javascript file to a proper multi file typescript system
--   When dragging an asset against a movement blocker, it will smoothly slide across the blocker instead of completely locking up.
+- Move from 1 large javascript file to a proper multi file typescript system
+- When dragging an asset against a movement blocker, it will smoothly slide across the blocker instead of completely locking up.
 
 ## [0.1] - 2018-03-22
 
 ### Added
 
--   Initiative tracker
-    -   Right click on any asset and add it to the tracker.
-    -   Options to hide initiative of certain assets
-    -   The initiative of an asset will be removed on delete
-        -   this can be disabled with the 'group' flag. This is very handy for minions with the same initiative.
--   Every 5 minutes a save will be written to disk as an extra persistent layer.
-    -   saves already happend on other occasions.
+- Initiative tracker
+  - Right click on any asset and add it to the tracker.
+  - Options to hide initiative of certain assets
+  - The initiative of an asset will be removed on delete
+    - this can be disabled with the 'group' flag. This is very handy for minions with the same initiative.
+- Every 5 minutes a save will be written to disk as an extra persistent layer.
+  - saves already happend on other occasions.
 
 ### Fixed
 
--   The delete key no longer removes selected assets if used in an input field!
+- The delete key no longer removes selected assets if used in an input field!
 
 ## [0.0] - First public mention

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -31,7 +31,7 @@ export class Layer {
     selectionColor = "#CC0000";
     selectionWidth = 2;
 
-    points: Map<number[], Set<string>> = new Map();
+    points: Map<string, Set<string>> = new Map();
     postDrawCallbacks: (() => void)[] = [];
 
     constructor(canvas: HTMLCanvasElement, name: string) {
@@ -57,7 +57,8 @@ export class Layer {
         shape.checkVisionSources(invalidate);
         shape.setMovementBlock(shape.movementObstruction, invalidate);
         for (const point of shape.points) {
-            this.points.set(point, (this.points.get(point) || new Set()).add(shape.uuid));
+            const strp = JSON.stringify(point);
+            this.points.set(strp, (this.points.get(strp) || new Set()).add(shape.uuid));
         }
         if (shape.ownedBy(gameStore.username) && shape.isToken) gameStore.ownedtokens.push(shape.uuid);
         if (shape.annotation.length) gameStore.annotations.push(shape.uuid);
@@ -107,8 +108,9 @@ export class Layer {
         layerManager.UUIDMap.delete(shape.uuid);
 
         for (const point of shape.points) {
-            const val = this.points.get(point);
-            if (val === undefined || val.size === 1) this.points.delete(point);
+            const strp = JSON.stringify(point);
+            const val = this.points.get(strp);
+            if (val === undefined || val.size === 1) this.points.delete(strp);
             else val.delete(shape.uuid);
         }
 
@@ -204,7 +206,10 @@ export class Layer {
             }
         }
         for (const point of shape.points) {
-            if (this.points.has(point) && )
+            const strp = JSON.stringify(point);
+            if (this.points.has(strp) && !this.points.get(strp)!.has(shape.uuid))
+                this.points.get(strp)!.add(shape.uuid);
+            else if (!this.points.has(strp)) this.points.set(strp, new Set([shape.uuid]));
         }
     }
 }

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -49,16 +49,18 @@ export class Layer {
         }
     }
 
-    addShape(shape: Shape, sync: boolean, temporary?: boolean, invalidate = true): void {
+    addShape(shape: Shape, sync: boolean, temporary?: boolean, invalidate = true, snappable = true): void {
         if (temporary === undefined) temporary = false;
         shape.layer = this.name;
         this.shapes.push(shape);
         layerManager.UUIDMap.set(shape.uuid, shape);
         shape.checkVisionSources(invalidate);
         shape.setMovementBlock(shape.movementObstruction, invalidate);
-        for (const point of shape.points) {
-            const strp = JSON.stringify(point);
-            this.points.set(strp, (this.points.get(strp) || new Set()).add(shape.uuid));
+        if (snappable) {
+            for (const point of shape.points) {
+                const strp = JSON.stringify(point);
+                this.points.set(strp, (this.points.get(strp) || new Set()).add(shape.uuid));
+            }
         }
         if (shape.ownedBy(gameStore.username) && shape.isToken) gameStore.ownedtokens.push(shape.uuid);
         if (shape.annotation.length) gameStore.annotations.push(shape.uuid);

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -32,6 +32,7 @@ export class Layer {
     selectionWidth = 2;
 
     points: Map<number[], number> = new Map();
+    postDrawCallbacks: (() => void)[] = [];
 
     constructor(canvas: HTMLCanvasElement, name: string) {
         this.canvas = canvas;
@@ -171,7 +172,19 @@ export class Layer {
             }
             ctx.globalCompositeOperation = ogOP;
             this.valid = true;
+            this.resolveCallbacks();
         }
+    }
+
+    waitValid(): Promise<void> {
+        return new Promise((resolve, _reject) => {
+            this.postDrawCallbacks.push(resolve);
+        });
+    }
+
+    private resolveCallbacks(): void {
+        for (const cb of this.postDrawCallbacks) cb();
+        this.postDrawCallbacks = [];
     }
 
     moveShapeOrder(shape: Shape, destinationIndex: number, sync: boolean): void {

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -5,9 +5,9 @@ import { GridLayer } from "@/game/layers/grid";
 import { Layer } from "@/game/layers/layer";
 import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
-import { GlobalPoint } from "../geom";
+import { GlobalPoint, LocalPoint } from "../geom";
 import { Asset } from "../shapes/asset";
-import { l2gx, l2gy, l2gz } from "../units";
+import { l2gx, l2gy, l2gz, g2l } from "../units";
 
 export function createLayer(layerInfo: ServerLayer): void {
     // Create canvas element
@@ -63,4 +63,30 @@ export function dropAsset(event: DragEvent): void {
     }
 
     layer.addShape(asset, true);
+}
+
+export function snapToPoint(layer: Layer, endPoint: GlobalPoint): GlobalPoint {
+    const snapDistance = l2gz(20);
+    let smallestPoint: [number, GlobalPoint] | undefined;
+    for (const point of layer.points.keys()) {
+        const gp = GlobalPoint.fromArray(JSON.parse(point));
+        const l = endPoint.subtract(gp).length();
+        if (smallestPoint === undefined && l < snapDistance) smallestPoint = [l, gp];
+        else if (smallestPoint !== undefined && l < smallestPoint[0]) smallestPoint = [l, gp];
+    }
+    if (smallestPoint !== undefined) endPoint = smallestPoint[1];
+    return endPoint;
+}
+
+export function snapToPointLocal(layer: Layer, endPoint: LocalPoint): LocalPoint {
+    const snapDistance = 20;
+    let smallestPoint: [number, LocalPoint] | undefined;
+    for (const point of layer.points.keys()) {
+        const lp = g2l(GlobalPoint.fromArray(JSON.parse(point)));
+        const l = endPoint.subtract(lp).length();
+        if (smallestPoint === undefined && l < snapDistance) smallestPoint = [l, lp];
+        else if (smallestPoint !== undefined && l < smallestPoint[0]) smallestPoint = [l, lp];
+    }
+    if (smallestPoint !== undefined) endPoint = smallestPoint[1];
+    return endPoint;
 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -349,4 +349,8 @@ export abstract class Shape {
         const ownerIndex = this._owners.findIndex(o => o === owner);
         this._owners.splice(ownerIndex, 1);
     }
+
+    private updatePoints(): void {
+        this.layer.updateShapePoints(this);
+    }
 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -350,7 +350,7 @@ export abstract class Shape {
         this._owners.splice(ownerIndex, 1);
     }
 
-    private updatePoints(): void {
-        this.layer.updateShapePoints(this);
+    updatePoints(): void {
+        layerManager.getLayer(this.layer)?.updateShapePoints(this);
     }
 }

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -49,6 +49,7 @@ import { mapGetters } from "vuex";
 import ColorPicker from "@/core/components/colorpicker.vue";
 import DefaultContext from "@/game/ui/tools/defaultcontext.vue";
 import Tool from "@/game/ui/tools/tool.vue";
+import Tools from "./tools.vue";
 
 import { socket } from "@/game/api/socket";
 import { GlobalPoint } from "@/game/geom";
@@ -59,10 +60,9 @@ import { Polygon } from "@/game/shapes/polygon";
 import { Rect } from "@/game/shapes/rect";
 import { Shape } from "@/game/shapes/shape";
 import { gameStore } from "@/game/store";
-import { getUnitDistance, l2g } from "@/game/units";
+import { getUnitDistance, l2g, g2lx, g2ly } from "@/game/units";
 import { getMouse } from "@/game/utils";
 import { visibilityStore } from "../../visibility/store";
-import Tools from "./tools.vue";
 import { Layer } from "../../layers/layer";
 
 @Component({
@@ -380,6 +380,7 @@ export default class DrawTool extends Tool {
         this.brushHelper = new Circle(new GlobalPoint(-1000, -1000), this.brushSize / 2, this.fillColour);
         this.setupBrush();
         layer.addShape(this.brushHelper, false); // during mode change the shape is already added
+        this.showLayerPoints();
     }
     onDeselect(targetLayer?: string): void {
         const layer = this.getLayer(targetLayer);
@@ -397,6 +398,7 @@ export default class DrawTool extends Tool {
             this.active = false;
             layer.invalidate(false);
         }
+        this.hideLayerPoints();
     }
 
     private pushBrushBack(): void {
@@ -409,6 +411,22 @@ export default class DrawTool extends Tool {
         this.brushHelper = new Circle(new GlobalPoint(-1000, -1000), this.brushSize / 2, this.fillColour);
         this.setupBrush();
         layer.addShape(this.brushHelper, false); // during mode change the shape is already added
+    }
+
+    private async showLayerPoints(): Promise<void> {
+        const layer = this.getLayer()!;
+        await layer.waitValid();
+        const dL = layerManager.getLayer("draw")!;
+        for (const point of layer.points.keys()) {
+            dL.ctx.beginPath();
+            dL.ctx.arc(g2lx(point[0]), g2ly(point[1]), 5, 0, 2 * Math.PI);
+            dL.ctx.fill();
+        }
+    }
+
+    private hideLayerPoints(): void {
+        console.log("Clearing");
+        layerManager.getLayer("draw")?.invalidate(true);
     }
 }
 </script>

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -296,7 +296,7 @@ export default class DrawTool extends Tool {
         const snapDistance = l2gz(20);
         let smallestPoint: [number, GlobalPoint] | undefined;
         for (const point of layer.points.keys()) {
-            const gp = GlobalPoint.fromArray(point);
+            const gp = GlobalPoint.fromArray(JSON.parse(point));
             const l = endPoint.subtract(gp).length();
             if (smallestPoint === undefined && l < snapDistance) smallestPoint = [l, gp];
             else if (smallestPoint !== undefined && l < smallestPoint[0]) smallestPoint = [l, gp];
@@ -375,6 +375,7 @@ export default class DrawTool extends Tool {
 
     private finaliseShape(): void {
         if (this.shape === null) return;
+        this.shape.updatePoints();
         if (this.shape.points.length <= 1) {
             this.onDeselect();
             this.onSelect();
@@ -433,8 +434,9 @@ export default class DrawTool extends Tool {
         await layer.waitValid();
         const dL = layerManager.getLayer("draw")!;
         for (const point of layer.points.keys()) {
+            const parsedPoint = JSON.parse(point);
             dL.ctx.beginPath();
-            dL.ctx.arc(g2lx(point[0]), g2ly(point[1]), 5, 0, 2 * Math.PI);
+            dL.ctx.arc(g2lx(parsedPoint[0]), g2ly(parsedPoint[1]), 5, 0, 2 * Math.PI);
             dL.ctx.fill();
         }
     }

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -60,10 +60,11 @@ import { Polygon } from "@/game/shapes/polygon";
 import { Rect } from "@/game/shapes/rect";
 import { Shape } from "@/game/shapes/shape";
 import { gameStore } from "@/game/store";
-import { getUnitDistance, l2g, g2lx, g2ly, l2gz } from "@/game/units";
+import { getUnitDistance, l2g, g2lx, g2ly } from "@/game/units";
 import { getMouse } from "@/game/utils";
 import { visibilityStore } from "../../visibility/store";
 import { Layer } from "../../layers/layer";
+import { snapToPoint } from "../../layers/utils";
 
 @Component({
     components: {
@@ -292,7 +293,7 @@ export default class DrawTool extends Tool {
             return;
         }
 
-        const endPoint = this.snapToPoint(l2g(getMouse(event)));
+        const endPoint = snapToPoint(this.getLayer()!, l2g(getMouse(event)));
 
         if (this.brushHelper !== null) {
             this.brushHelper.r = this.helperSize;
@@ -406,7 +407,7 @@ export default class DrawTool extends Tool {
             this.active = false;
             layer.invalidate(false);
         }
-        layer.canvas.parentElement!.style.cursor = "default";
+        layer.canvas.parentElement!.style.removeProperty("cursor");
         this.hideLayerPoints();
     }
 
@@ -441,20 +442,6 @@ export default class DrawTool extends Tool {
     private hideLayerPoints(): void {
         console.log("Clearing");
         layerManager.getLayer("draw")?.invalidate(true);
-    }
-
-    private snapToPoint(endPoint: GlobalPoint): GlobalPoint {
-        const layer = this.getLayer()!;
-        const snapDistance = l2gz(20);
-        let smallestPoint: [number, GlobalPoint] | undefined;
-        for (const point of layer.points.keys()) {
-            const gp = GlobalPoint.fromArray(JSON.parse(point));
-            const l = endPoint.subtract(gp).length();
-            if (smallestPoint === undefined && l < snapDistance) smallestPoint = [l, gp];
-            else if (smallestPoint !== undefined && l < smallestPoint[0]) smallestPoint = [l, gp];
-        }
-        if (smallestPoint !== undefined) endPoint = smallestPoint[1];
-        return endPoint;
     }
 }
 </script>

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -246,6 +246,7 @@ export default class SelectTool extends Tool {
                     }
                     layer.invalidate(false);
                 }
+                sel.updatePoints();
             }
         }
         this.mode = SelectOperations.Noop;

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -16,6 +16,7 @@ import { g2l, g2lx, g2ly, l2g, l2gz } from "@/game/units";
 import { getMouse } from "@/game/utils";
 import { EventBus } from "../../event-bus";
 import { visibilityStore } from "../../visibility/store";
+import { snapToPointLocal } from "../../layers/utils";
 
 export enum SelectOperations {
     Noop,
@@ -66,7 +67,7 @@ export default class SelectTool extends Tool {
         for (let i = selectionStack.length - 1; i >= 0; i--) {
             const shape = selectionStack[i];
 
-            this.resizePoint = shape.getPointIndex(globalMouse, l2gz(3));
+            this.resizePoint = shape.getPointIndex(globalMouse, l2gz(5));
 
             // Resize case, a corner is selected
             if (this.resizePoint >= 0) {
@@ -167,7 +168,7 @@ export default class SelectTool extends Tool {
             } else if (this.mode === SelectOperations.Resize) {
                 for (const sel of layer.selection) {
                     if (!sel.ownedBy()) continue;
-                    sel.resize(this.resizePoint, mouse);
+                    sel.resize(this.resizePoint, snapToPointLocal(layerManager.getLayer()!, mouse));
                     if (sel !== this.selectionHelper) {
                         if (sel.visionObstruction) visibilityStore.recalculateVision();
                         socket.emit("Shape.Update", { shape: sel.asDict(), redraw: true, temporary: true });


### PR DESCRIPTION
This PR adds memory to each layer to remember which points are used by shapes in the layer.

With this information the draw tool and the resize feature of the select tool can automatically snap to these existing points.

This greatly reduces the overhead that can exist when using multilines to draw FOW as they are difficult to perfectly allign without snapping.

A future PR will add a modifier to cancel auto-snapping as well as a toggle to invert the modifier behaviour.

This closes PR #187 