### PR TITLE
Recover from "scrolling away" from the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
     -   Change password
     -   Delete account
 -   Snap to nearby existing points while drawing and while resizing points
+-   CTRL-0 (zero) now resets the viewport to origin (0,0) [LDeeJay1969]
 
 ### Removed
 

--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -68,6 +68,12 @@ export function onKeyDown(event: KeyboardEvent): void {
             event.preventDefault();
             event.stopPropagation();
             gameStore.toggleUI();
+        } else if (event.key === "r" && event.ctrlKey) {
+            // Ctrl-r - Re-center/reset the viewport
+            gameStore.setPanX(0);
+            gameStore.setPanY(0);
+            sendClientOptions(gameStore.locationOptions);
+            window.location.reload();
         } else if (event.key === "c" && event.ctrlKey) {
             // Ctrl-c - Copy
             copyShapes();

--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -68,12 +68,12 @@ export function onKeyDown(event: KeyboardEvent): void {
             event.preventDefault();
             event.stopPropagation();
             gameStore.toggleUI();
-        } else if (event.key === "r" && event.ctrlKey) {
-            // Ctrl-r - Re-center/reset the viewport
+        } else if (event.key === "0" && event.ctrlKey) {
+            // Ctrl-0 - Re-center/reset the viewport
             gameStore.setPanX(0);
             gameStore.setPanY(0);
             sendClientOptions(gameStore.locationOptions);
-            window.location.reload();
+            layerManager.invalidate();
         } else if (event.key === "c" && event.ctrlKey) {
             // Ctrl-c - Copy
             copyShapes();


### PR DESCRIPTION
Resets the viewport of the client back to 0,0