### PR TITLE
Fix gridsize not settable

### DIFF
--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -71,9 +71,14 @@ async def set_gridsize(sid, grid_size):
     if room.creator != user:
         logger.warning(f"{user.name} attempted to set gridsize without DM rights")
         return
-    gl = GridLayer[Layer.get(location=location, name="grid")]
-    gl.size = grid_size
-    gl.save()
+    for layer in (
+        Layer.select()
+        .join(Floor)
+        .where((Floor.location == location) & (Layer.name == "grid"))
+    ):
+        gl = GridLayer[layer]
+        gl.size = grid_size
+        gl.save()
     await sio.emit(
         "Gridsize.Set",
         grid_size,


### PR DESCRIPTION
This PR fixes issue #224 .

Since the introduction of floors there has been a bug in the server which prevented the gridsize from being adjusted.

This might also address issue #221 which is also related to a bug with grid sizes.