### PR TITLE
Add more keybinding options for floor movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ All notable changes to this project will be documented in this file.
 -   Floors
     -   Create/Delete floors that are rendered on top of eachother to increase immersion
     -   Use Page Up/Down as a quick keybinding to move between floors
--  Touch Gestures [ZachMyers3]
--  Easier client traversing by removing _load route [ZachMyers3] 
--  Display current version on client [ZachMyers3]
+    -   Use Ctrl + Page Up/Down to move shapes across floors (combine with Shift to immediately move the camera as well)
+-   Touch Gestures [ZachMyers3]
+-   Easier client traversing by removing \_load route [ZachMyers3]
+-   Display current version on client [ZachMyers3]
 
 ### Removed
 

--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -13,10 +13,6 @@ export function onKeyUp(event: KeyboardEvent): void {
     } else {
         if (event.key === "Delete" || event.key === "Del" || event.key === "Backspace") {
             deleteShapes();
-        } else if (event.key === "PageUp" && gameStore.selectedFloorIndex < gameStore.floors.length - 1) {
-            gameStore.selectFloor(gameStore.selectedFloorIndex + 1);
-        } else if (event.key === "PageDown" && gameStore.selectedFloorIndex > 0) {
-            gameStore.selectFloor(gameStore.selectedFloorIndex - 1);
         }
     }
 }
@@ -66,11 +62,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             }
         } else if (event.key === "d") {
             // d - Deselect all
-            const layer = layerManager.getLayer(layerManager.floor!.name);
-            if (layer) {
-                layer.clearSelection();
-                layer.invalidate(true);
-            }
+            layerManager.clearSelection();
         } else if (event.key === "u" && event.ctrlKey) {
             // Ctrl-u - disable and reenable the Interface
             event.preventDefault();
@@ -88,6 +80,46 @@ export function onKeyDown(event: KeyboardEvent): void {
         } else if (event.key === "v" && event.ctrlKey) {
             // Ctrl-v - Paste
             pasteShapes();
+        } else if (event.key === "PageUp" && gameStore.selectedFloorIndex < gameStore.floors.length - 1) {
+            // Page Up - Move floor up
+            // Ctrl + Page Up - Move selected shapes floor up
+            // Ctrl + Shift + Page Up - Move selected shapes floor up AND move floor up
+            event.preventDefault();
+            if (gameStore.selectedFloorIndex + 1 >= gameStore.floors.length) return;
+            const selection = layerManager.getSelection() ?? [];
+            const newFloor = gameStore.floors[gameStore.selectedFloorIndex + 1];
+            const newLayer = layerManager.getLayer(newFloor)!;
+
+            if (event.ctrlKey) {
+                for (const shape of selection) {
+                    shape.moveFloor(newFloor, true);
+                }
+            }
+            if (!event.shiftKey) layerManager.clearSelection();
+            if (!event.ctrlKey || event.shiftKey) {
+                gameStore.selectFloor(gameStore.selectedFloorIndex + 1);
+            }
+            if (event.shiftKey) for (const shape of selection) newLayer.selection.push(shape);
+        } else if (event.key === "PageDown" && gameStore.selectedFloorIndex > 0) {
+            // Page Down - Move floor down
+            // Ctrl + Page Down - Move selected shape floor down
+            // Ctrl + Shift + Page Down - Move selected shapes floor down AND move floor down
+            event.preventDefault();
+            if (gameStore.selectedFloorIndex - 1 < 0) return;
+            const selection = layerManager.getSelection() ?? [];
+            const newFloor = gameStore.floors[gameStore.selectedFloorIndex - 1];
+            const newLayer = layerManager.getLayer(newFloor)!;
+
+            if (event.ctrlKey) {
+                for (const shape of selection) {
+                    shape.moveFloor(newFloor, true);
+                }
+            }
+            if (!event.shiftKey) layerManager.clearSelection();
+            if (!event.ctrlKey || event.shiftKey) {
+                gameStore.selectFloor(gameStore.selectedFloorIndex - 1);
+            }
+            if (event.shiftKey) for (const shape of selection) newLayer.selection.push(shape);
         }
     }
 }

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -141,6 +141,14 @@ class LayerManager {
         return layer.selection;
     }
 
+    clearSelection(): void {
+        const layer = this.getLayer(layerManager.floor!.name);
+        if (layer) {
+            layer.clearSelection();
+            layer.invalidate(true);
+        }
+    }
+
     invalidate(floorName: string): void {
         const floor = this.getFloor(floorName)!;
         for (let i = floor.layers.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Up until now there was one set of convenience keybindings related to floors: Page Up/Down, which would change the camera one floor up or down.

This PR adds the ability to move selected shapes by using ctrl + Page Up/Down without moving the camera and by using ctrl + shift + Page Up/Down which also moves the camera.

A small implementation change also means that Page Up/Down is now processed on key down and no longer on key up as it was previously