### PR TITLE
Fix broken annotations on location change. Fixes #156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
 -   Easier client traversing by removing \_load route [ZachMyers3]
 -   Display current version on client [ZachMyers3]
 
+### Fixed
+
+-   Annotations stop working when changing location
+
 ### Removed
 
 -   [tech] Client build artifacts are no longer available in the server folder

--- a/client/src/game/ui/annotation.ts
+++ b/client/src/game/ui/annotation.ts
@@ -20,15 +20,13 @@ export class AnnotationManager {
     }
 
     setActiveText(text: string): void {
-        if (this.layer === undefined) {
-            if (layerManager.hasLayer(layerManager.floor!.name, "draw")) {
-                this.layer = layerManager.getLayer(layerManager.floor!.name, "draw")!;
-                this.layer.addShape(this.annotationRect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
-                this.layer.addShape(this.annotationText, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
-            } else {
-                console.warn("There is no draw layer to draw annotations on!");
-                return;
-            }
+        if (layerManager.hasLayer(layerManager.floor!.name, "draw")) {
+            this.layer = layerManager.getLayer(layerManager.floor!.name, "draw")!;
+            this.layer.addShape(this.annotationRect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+            this.layer.addShape(this.annotationText, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+        } else {
+            console.warn("There is no draw layer to draw annotations on!");
+            return;
         }
         this.shown = text !== "";
         this.annotationText.refPoint = l2g(new LocalPoint(this.layer.canvas.width / 2, 50));


### PR DESCRIPTION
This PR fixes a stupid bug that has been in the codebase for a while; Changing location would stop the annotation manager from working.