### PR TITLE
Fix uses of getLayer without floor name

### DIFF
--- a/client/src/game/manager.ts
+++ b/client/src/game/manager.ts
@@ -60,7 +60,7 @@ export class GameManager {
                 visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape });
                 visibilityStore.recalculateVision(shape.floor);
             }
-            layerManager.getLayer(data.shape.layer)!.invalidate(false);
+            layerManager.getLayer(data.shape.floor, data.shape.layer)!.invalidate(false);
             layerManager.invalidateLightAllFloors();
             if (shape.movementObstruction && !alteredMovement) {
                 visibilityStore.deleteFromTriag({

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -163,7 +163,7 @@ export function pasteShapes(targetLayer?: string): Shape[] {
 }
 
 export function deleteShapes(): void {
-    if (layerManager.getLayer === undefined) {
+    if (layerManager.getLayer(layerManager.floor!.name) === undefined) {
         console.log("No active layer selected for delete operation");
         return;
     }

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -168,15 +168,13 @@ class GameStore extends VuexModule implements GameState {
     deleteLabel(data: { uuid: string; user: string }): void {
         if (!(data.uuid in this.labels)) return;
         const label = this.labels[data.uuid];
-        const updatedLayers: Set<string> = new Set();
         for (const shape of layerManager.UUIDMap.values()) {
             const i = shape.labels.indexOf(label);
             if (i >= 0) {
                 shape.labels.splice(i, 1);
-                updatedLayers.add(shape.layer);
+                layerManager.getLayer(shape.floor, shape.layer)!.invalidate(false);
             }
         }
-        for (const layer of updatedLayers) layerManager.getLayer(layer)!.invalidate(false);
         Vue.delete(this.labels, data.uuid);
     }
 

--- a/client/src/game/visibility/te/draw.ts
+++ b/client/src/game/visibility/te/draw.ts
@@ -74,7 +74,7 @@ function drl(from: number[], to: number[], constrained: boolean, local: boolean)
     // } else {
     //     console.log(" ", from, to);
     // }
-    const dl = layerManager.getLayer("draw");
+    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.beginPath();
@@ -88,7 +88,7 @@ function drl(from: number[], to: number[], constrained: boolean, local: boolean)
 export function drawEdge(edge: Edge, colour: string, local = false): void {
     const from = edge.first!.vertices[edge.second === 0 ? 1 : 0]!.point!;
     const to = edge.first!.vertices[edge.second === 2 ? 1 : 2]!.point!;
-    const dl = layerManager.getLayer("draw");
+    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.beginPath();
@@ -180,7 +180,7 @@ export function drawPolygonT(tds: TDS, local = true, clear = true, logs: 0 | 1 |
 //     const POINTS = 	[[[2204.40109629713,1502.9370921248671],[2194.4969483467376,1501.8032381745284],[2182.960505429924,849.4588854915166],[2195.2603028653853,848.4339023718949],[2195.2603028653853,1094.4298510811182],[2221.909863975551,1099.554766679227],[2220.8848808559296,1105.7046653969574],[2190.135387267276,1107.7546316362009],[2197.310269104629,1306.6013568428232],[2254.7093238034477,1302.5014243643361],[2255.734306923069,1306.6013568428232],[2193.2103366261417,1314.8012217997973]],
 //         [[200,-1350],[200,4350],[750,4350],[750,-1350]],
 //         [[3556.1308949025706,368.2067431718624],[3556.1308949025706,4099.326575833981],[4125.828761825174,4099.326575833981],[4125.828761825174,368.2067431718624]]];
-//     for (const [i, shape] of (<Polygon[]>layerManager.getLayer()!.shapes).entries()) {
+//     for (const [i, shape] of (<Polygon[]>layerManager.getLayer(layerManager.floor!.name, )!.shapes).entries()) {
 //         shape.refPoint = GlobalPoint.fromArray(POINTS[i][0]);
 //         shape._vertices = POINTS[i].slice(1).map(p => GlobalPoint.fromArray(p));
 //         socket.emit("Shape.Position.Update", { shape: shape.asDict(), redraw: true, temporary: false });
@@ -193,5 +193,5 @@ export function drawPolygonT(tds: TDS, local = true, clear = true, logs: 0 | 1 |
 //         s += `${triag.uid}\t${triag.vertices.map(v => v === null ? '0,0' : v.point!.join(",")).join("\t")}\t${triag.neighbours.map(n=>n!.uid).join("\t")}\n`;
 //     }
 //     console.log(s);
-//     deleteShapeFromTriag(TriangulationTarget.VISION, layerManager.getLayer()!.shapes[2]);
+//     deleteShapeFromTriag(TriangulationTarget.VISION, layerManager.getLayer(layerManager.floor!.name, )!.shapes[2]);
 // }

--- a/client/src/game/visibility/te/iterative.ts
+++ b/client/src/game/visibility/te/iterative.ts
@@ -159,7 +159,7 @@ export class IterativeDelete {
         for (const edge of vertex.getIncidentEdges(true)) {
             const ccwv = edge.first!.vertices[ccw(edge.second)]!;
             const ccwp = ccwv.point!;
-            // layerManager.getLayer("draw")!.clear();
+            // layerManager.getLayer(layerManager.floor!.name, "draw")!.clear();
             // drawPoint(vertex.point!, 10, "blue");
             // drawPoint(ccwp, 10, "green");
             const edgeCovered = equalPoints(ccwp, from.point!) || collinearInOrder(vertex.point!, ccwp, from.point!);

--- a/client/src/game/visibility/te/te.ts
+++ b/client/src/game/visibility/te/te.ts
@@ -62,7 +62,7 @@ function expandEdge(
     const ro = orientation(q, right, nvh.point!);
     const lo = orientation(q, left, nvh.point!);
 
-    // const ctx = layerManager.getLayer("draw")!.ctx;
+    // const ctx = layerManager.getLayer(layerManager.floor!.name, "draw")!.ctx;
     // ctx.beginPath();
     // ctx.strokeStyle = "red";
     // ctx.lineJoin = "round";


### PR DESCRIPTION
Since the addition of floors, `getlayer` has been readjusted to require a floor name as the first parameter.  This apparently has not been properly fixed everywhere.

This PR fixes some found issues, most prominently is the shapeUpdate when a redraw is required.