### PR TITLE
Fix assetrect colour sync

### DIFF
--- a/client/src/game/shapes/asset.ts
+++ b/client/src/game/shapes/asset.ts
@@ -9,6 +9,8 @@ export class Asset extends BaseRect {
     type = "assetrect";
     img: HTMLImageElement;
     src = "";
+    strokeColour = "white";
+
     constructor(img: HTMLImageElement, topleft: GlobalPoint, w: number, h: number, uuid?: string) {
         super(topleft, w, h, undefined, undefined, uuid);
         this.img = img;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -232,6 +232,8 @@ export abstract class Shape {
         this.trackers = data.trackers;
         this.labels = data.labels;
         this._owners = data.owners;
+        this.fillColour = data.fill_colour;
+        this.strokeColour = data.stroke_colour;
         this.isToken = data.is_token;
         this.nameVisible = data.name_visible;
         this.badge = data.badge;


### PR DESCRIPTION
AssetRects (i.e. shapes from your asset menu and not hand drawn with the draw tool) ignored stroke/fill colours as it is useless for their rendering.

It is however useful for badges.  This change makes it that the assetrect colours are also properly synced.

It also changes the default colour for assetrects strokeColour to white.