### PR TITLE
Add configuration option for CORS origins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+-   configuration option to specify allowed CORS origins
+
 ### Fixed
 
 -   Clientside access violations

--- a/Dockerfiles/server_config_docker.cfg
+++ b/Dockerfiles/server_config_docker.cfg
@@ -11,5 +11,11 @@ ssl = false
 ssl_fullchain = cert/fullchain.pem
 ssl_privkey = cert/privkey.pem
 
+# Allowed CORS origins
+# If not specified, only the host runnig the server is allowed
+# Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
+# More information on the meaning of these values can be found at https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+cors_allowed_origins = ['*']
+
 [General]
 save_file = data/planar.sqlite

--- a/Dockerfiles/server_config_docker.cfg
+++ b/Dockerfiles/server_config_docker.cfg
@@ -12,10 +12,11 @@ ssl_fullchain = cert/fullchain.pem
 ssl_privkey = cert/privkey.pem
 
 # Allowed CORS origins
-# If not specified, only the host runnig the server is allowed
-# Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
-# More information on the meaning of these values can be found at https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
-cors_allowed_origins = ['*']
+#     If not specified, only the host runnig the server is allowed
+#     Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
+#     More information on the meaning of these values can be found at
+#     https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+# cors_allowed_origins = ['*']
 
 [General]
 save_file = data/planar.sqlite

--- a/server/app.py
+++ b/server/app.py
@@ -12,11 +12,16 @@ from aiohttp_security import SessionIdentityPolicy
 from aiohttp_session.cookie_storage import EncryptedCookieStorage
 
 import auth
+from config import config
 from utils import FILE_DIR
 
 # SETUP SERVER
 
-sio = socketio.AsyncServer(async_mode="aiohttp", engineio_logger=False)
+sio = socketio.AsyncServer(
+    async_mode="aiohttp",
+    engineio_logger=False,
+    cors_allowed_origins=config.get("general", "cors_allowed_origins", fallback=None),
+)
 app = web.Application()
 app["AuthzPolicy"] = auth.AuthPolicy()
 aiohttp_security.setup(app, SessionIdentityPolicy(), app["AuthzPolicy"])

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -12,10 +12,11 @@ ssl_fullchain = cert/fullchain.pem
 ssl_privkey = cert/privkey.pem
 
 # Allowed CORS origins
-# If not specified, only the host runnig the server is allowed
-# Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
-# More information on the meaning of these values can be found at https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
-cors_allowed_origins = ['*']
+#     If not specified, only the host runnig the server is allowed
+#     Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
+#     More information on the meaning of these values can be found at
+#     https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+# cors_allowed_origins = ['*']
 
 [General]
 save_file = planar.sqlite

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -11,5 +11,11 @@ ssl = false
 ssl_fullchain = cert/fullchain.pem
 ssl_privkey = cert/privkey.pem
 
+# Allowed CORS origins
+# If not specified, only the host runnig the server is allowed
+# Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
+# More information on the meaning of these values can be found at https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+cors_allowed_origins = ['*']
+
 [General]
 save_file = planar.sqlite


### PR DESCRIPTION
As requested in #257 this PR adds a configuration option to the server config to set the origins allowed for CORS.