### PR TITLE
bugfix(Polygon): Take line width into account for selection detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 
 -   configuration option to specify allowed CORS origins
 
+### Fixed
+
+-   Polygon width now properly taken into account when trying to select it
+
 ## [0.19.3] - 2020-04-01
 
 ### Fixed

--- a/client/src/game/geom.ts
+++ b/client/src/game/geom.ts
@@ -4,10 +4,21 @@ A strong focus is made to ensure that at no time a global and a local point are 
 At first glance this adds weird looking hacks as ts does not support nominal typing.
 */
 
-export function getPointDistance(p1: Point, p2: Point): number {
+export function getPointDistance(p1: Point | Vector, p2: Point | Vector): number {
     const a = p1.x - p2.x;
     const b = p1.y - p2.y;
     return Math.sqrt(a * a + b * b);
+}
+
+export function getDistanceToSegment(p: Point, line: [Point, Point]): number {
+    const lineVector = Vector.fromPoints(...line);
+    const pointVector = Vector.fromPoints(line[0], p);
+    const pointVectorScaled = pointVector.multiply(1 / lineVector.length());
+    let t = lineVector.normalize().dot(pointVectorScaled);
+    if (t < 0) t = 0;
+    else if (t > 1) t = 1;
+    const nearest = lineVector.multiply(t);
+    return getPointDistance(nearest, pointVector);
 }
 
 export class Point {
@@ -64,6 +75,9 @@ export class Vector {
         this.x = x;
         this.y = y;
     }
+    static fromPoints(p1: Point, p2: Point): Vector {
+        return new Vector(p2.x - p1.x, p2.y - p1.y);
+    }
     dot(other: Vector): number {
         return this.x * other.x + this.y * other.y;
     }
@@ -82,6 +96,9 @@ export class Vector {
     }
     reverse(): Vector {
         return new Vector(-this.x, -this.y);
+    }
+    add(other: Vector): Vector {
+        return new Vector(this.x + other.x, this.y + other.y);
     }
     multiply(scale: number): Vector {
         return new Vector(this.x * scale, this.y * scale);

--- a/client/src/game/shapes/polygon.ts
+++ b/client/src/game/shapes/polygon.ts
@@ -90,6 +90,7 @@ export class Polygon extends Shape {
         if (nearbyThreshold === undefined) nearbyThreshold = this.lineWidth / 2;
         const bbox = this.getBoundingBox(nearbyThreshold);
         if (!bbox.contains(point)) return false;
+        if (this.isClosed) return true;
         const vertices = this.vertices;
         for (const [i, v] of vertices.entries()) {
             const nv = vertices[(i + 1) % vertices.length];

--- a/client/src/game/shapes/polygon.ts
+++ b/client/src/game/shapes/polygon.ts
@@ -1,5 +1,5 @@
 import { ServerPolygon } from "../comm/types/shapes";
-import { GlobalPoint } from "../geom";
+import { GlobalPoint, getDistanceToSegment } from "../geom";
 import { g2lx, g2ly, g2lz } from "../units";
 import { getFogColour } from "../utils";
 import { BoundingRect } from "./boundingrect";
@@ -86,8 +86,18 @@ export class Polygon extends Shape {
         super.drawPost(ctx);
     }
 
-    contains(point: GlobalPoint): boolean {
-        return this.getBoundingBox().contains(point);
+    contains(point: GlobalPoint, nearbyThreshold?: number): boolean {
+        if (nearbyThreshold === undefined) nearbyThreshold = this.lineWidth / 2;
+        const bbox = this.getBoundingBox(nearbyThreshold);
+        if (!bbox.contains(point)) return false;
+        const vertices = this.vertices;
+        for (const [i, v] of vertices.entries()) {
+            const nv = vertices[(i + 1) % vertices.length];
+            const distance = getDistanceToSegment(point, [v, nv]);
+            console.log(distance);
+            if (distance <= nearbyThreshold) return true;
+        }
+        return false;
     }
 
     center(): GlobalPoint;
@@ -107,7 +117,7 @@ export class Polygon extends Shape {
         else this._vertices[resizePoint - 1] = point;
         return resizePoint;
     }
-    getBoundingBox(): BoundingRect {
+    getBoundingBox(delta = 0): BoundingRect {
         let minx: number = this.refPoint.x;
         let maxx: number = this.refPoint.x;
         let miny: number = this.refPoint.y;
@@ -118,6 +128,10 @@ export class Polygon extends Shape {
             if (p.y < miny) miny = p.y;
             if (p.y > maxy) maxy = p.y;
         }
-        return new BoundingRect(new GlobalPoint(minx, miny), maxx - minx, maxy - miny);
+        return new BoundingRect(
+            new GlobalPoint(minx - delta, miny - delta),
+            maxx - minx + 2 * delta,
+            maxy - miny + 2 * delta,
+        );
     }
 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -80,8 +80,7 @@ export abstract class Shape {
 
     abstract getBoundingBox(): BoundingRect;
 
-    // If inWorldCoord is
-    abstract contains(point: GlobalPoint): boolean;
+    abstract contains(point: GlobalPoint, nearbyThreshold?: number): boolean;
 
     abstract center(): GlobalPoint;
     abstract center(centerPoint: GlobalPoint): void;


### PR DESCRIPTION
The detection to see if a polygon line was selected did not take the line width into account which makes it pretty difficult to select if the two points are grid aligned.

This solves part of issue #262 