### PR TITLE
feature(Draw): disable snapping with alt modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   configuration option to specify allowed CORS origins
+-   alt modifier can be used to disable draw/resize snapping
 
 ### Fixed
 

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -407,7 +407,8 @@ export default class DrawTool extends Tool {
     }
 
     onMouseMove(event: MouseEvent): void {
-        const endPoint = snapToPoint(this.getLayer()!, l2g(getLocalPointFromEvent(event)), this.ruler?.refPoint);
+        let endPoint = l2g(getLocalPointFromEvent(event));
+        if (!event.altKey) endPoint = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
         this.onMove(endPoint);
     }
 
@@ -416,12 +417,14 @@ export default class DrawTool extends Tool {
     }
 
     onTouchStart(event: TouchEvent): void {
-        const startPoint = snapToPoint(this.getLayer()!, l2g(getLocalPointFromEvent(event)), this.ruler?.refPoint);
+        let startPoint = l2g(getLocalPointFromEvent(event));
+        if (!event.altKey) startPoint = snapToPoint(this.getLayer()!, startPoint, this.ruler?.refPoint);
         this.onDown(startPoint);
     }
 
     onTouchMove(event: TouchEvent): void {
-        const endPoint = snapToPoint(this.getLayer()!, l2g(getLocalPointFromEvent(event)), this.ruler?.refPoint);
+        let endPoint = l2g(getLocalPointFromEvent(event));
+        if (!event.altKey) endPoint = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
         this.onMove(endPoint);
     }
 

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -187,10 +187,10 @@ export default class SelectTool extends Tool {
                     let ignorePoint: GlobalPoint | undefined;
                     if (this.resizePoint >= 0)
                         ignorePoint = GlobalPoint.fromArray(this.originalResizePoints[this.resizePoint]);
-                    this.resizePoint = sel.resize(
-                        this.resizePoint,
-                        snapToPoint(layerManager.getLayer(layerManager.floor!.name)!, gp, ignorePoint),
-                    );
+                    let targetPoint = gp;
+                    if (!event.altKey)
+                        targetPoint = snapToPoint(layerManager.getLayer(layerManager.floor!.name)!, gp, ignorePoint);
+                    this.resizePoint = sel.resize(this.resizePoint, targetPoint);
                     if (sel !== this.selectionHelper) {
                         // todo: think about calling deleteIntersectVertex directly on the corner point
                         if (sel.visionObstruction) {


### PR DESCRIPTION
WIth the introduction of draw and resize snapping in the latest release, some complaints came in of uses where the snapping would actually work against the DM.

This PR introduces the alt modifier that while pressed disables the snapping feature just like the grid snapping.