### PR TITLE
feat(Snapping): add client option to invert alt behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 -   configuration option to specify allowed CORS origins
 -   alt modifier can be used to disable draw/resize snapping
+-   Client option to invert the ALT behaviour (i.e. invert snapping behaviour)
 
 ### Fixed
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -63,6 +63,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     gameStore.setGridColour({ colour: options.grid_colour, sync: false });
     gameStore.setFOWColour({ colour: options.fow_colour, sync: false });
     gameStore.setRulerColour({ colour: options.ruler_colour, sync: false });
+    gameStore.setInvertAlt({ invertAlt: options.invert_alt, sync: false });
     gameStore.setPanX(options.pan_x);
     gameStore.setPanY(options.pan_y);
     gameStore.setZoomDisplay(zoomDisplay(options.zoom_factor));

--- a/client/src/game/comm/types/general.ts
+++ b/client/src/game/comm/types/general.ts
@@ -19,6 +19,7 @@ export interface ServerClient {
     grid_colour: string;
     fow_colour: string;
     ruler_colour: string;
+    invert_alt: boolean;
     pan_x: number;
     pan_y: number;
     zoom_factor: number;

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -87,6 +87,8 @@ class GameStore extends VuexModule implements GameState {
 
     selectionHelperID: string | null = null;
 
+    invertAlt = false;
+
     get selectedLayer(): string {
         return this.layers[this.selectedLayerIndex];
     }
@@ -488,6 +490,12 @@ class GameStore extends VuexModule implements GameState {
         if (data.sync) {
             socket.emit("Room.Info.Set.Locked", this.isLocked);
         }
+    }
+
+    @Mutation
+    setInvertAlt(data: { invertAlt: boolean; sync: boolean }): void {
+        this.invertAlt = data.invertAlt;
+        if (data.sync) socket.emit("Client.Options.Set", { invertAlt: data.invertAlt });
     }
 
     @Mutation

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -81,6 +81,8 @@
                             <color-picker id="fowColour" :color.sync="fowColour" />
                             <label for="rulerColour">Ruler Colour:</label>
                             <color-picker id="rulerColour" :color.sync="rulerColour" />
+                            <label for="invertAlt">Invert ALT behaviour</label>
+                            <div><input id="invertAlt" type="checkbox" v-model="invertAlt" /></div>
                         </div>
                     </div>
                 </div>
@@ -166,6 +168,12 @@ export default class MenuBar extends Vue {
     }
     set rulerColour(value: string) {
         gameStore.setRulerColour({ colour: value, sync: true });
+    }
+    get invertAlt(): boolean {
+        return gameStore.invertAlt;
+    }
+    set invertAlt(value: boolean) {
+        gameStore.setInvertAlt({ invertAlt: value, sync: true });
     }
     settingsClick(event: { target: HTMLElement }): void {
         if (event.target.classList.contains("menu-accordion")) {

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -64,7 +64,7 @@ import { Rect } from "@/game/shapes/rect";
 import { Shape } from "@/game/shapes/shape";
 import { gameStore } from "@/game/store";
 import { getUnitDistance, l2g, g2lx, g2ly } from "@/game/units";
-import { equalPoints, getLocalPointFromEvent } from "@/game/utils";
+import { equalPoints, getLocalPointFromEvent, useSnapping } from "@/game/utils";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget, insertConstraint, getCDT } from "@/game/visibility/te/pa";
 
@@ -381,7 +381,7 @@ export default class DrawTool extends Tool {
             return;
         }
         // TODO: handle touch event different than altKey, long press
-        if (!event.altKey && this.useGrid) {
+        if (useSnapping(event) && this.useGrid) {
             if (this.shape.visionObstruction)
                 visibilityStore.deleteFromTriag({
                     target: TriangulationTarget.VISION,
@@ -408,7 +408,7 @@ export default class DrawTool extends Tool {
 
     onMouseMove(event: MouseEvent): void {
         let endPoint = l2g(getLocalPointFromEvent(event));
-        if (!event.altKey) endPoint = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
+        if (useSnapping(event)) endPoint = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
         this.onMove(endPoint);
     }
 
@@ -418,13 +418,13 @@ export default class DrawTool extends Tool {
 
     onTouchStart(event: TouchEvent): void {
         let startPoint = l2g(getLocalPointFromEvent(event));
-        if (!event.altKey) startPoint = snapToPoint(this.getLayer()!, startPoint, this.ruler?.refPoint);
+        if (useSnapping(event)) startPoint = snapToPoint(this.getLayer()!, startPoint, this.ruler?.refPoint);
         this.onDown(startPoint);
     }
 
     onTouchMove(event: TouchEvent): void {
         let endPoint = l2g(getLocalPointFromEvent(event));
-        if (!event.altKey) endPoint = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
+        if (useSnapping(event)) endPoint = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
         this.onMove(endPoint);
     }
 

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -15,7 +15,7 @@ import { Rect } from "@/game/shapes/rect";
 import { gameStore } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { g2l, g2lx, g2ly, l2g, l2gz } from "@/game/units";
-import { getLocalPointFromEvent } from "@/game/utils";
+import { getLocalPointFromEvent, useSnapping } from "@/game/utils";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
 
@@ -188,7 +188,7 @@ export default class SelectTool extends Tool {
                     if (this.resizePoint >= 0)
                         ignorePoint = GlobalPoint.fromArray(this.originalResizePoints[this.resizePoint]);
                     let targetPoint = gp;
-                    if (!event.altKey)
+                    if (useSnapping(event))
                         targetPoint = snapToPoint(layerManager.getLayer(layerManager.floor!.name)!, gp, ignorePoint);
                     this.resizePoint = sel.resize(this.resizePoint, targetPoint);
                     if (sel !== this.selectionHelper) {
@@ -252,7 +252,7 @@ export default class SelectTool extends Tool {
                     )
                         continue;
 
-                    if (gameStore.useGrid && !e.altKey && !this.deltaChanged) {
+                    if (gameStore.useGrid && useSnapping(e) && !this.deltaChanged) {
                         if (sel.visionObstruction)
                             visibilityStore.deleteFromTriag({
                                 target: TriangulationTarget.VISION,
@@ -282,7 +282,7 @@ export default class SelectTool extends Tool {
                     layer.invalidate(false);
                 }
                 if (this.mode === SelectOperations.Resize) {
-                    if (gameStore.useGrid && !e.altKey) {
+                    if (gameStore.useGrid && useSnapping(e)) {
                         if (sel.visionObstruction)
                             visibilityStore.deleteFromTriag({
                                 target: TriangulationTarget.VISION,

--- a/client/src/game/utils.ts
+++ b/client/src/game/utils.ts
@@ -48,3 +48,7 @@ export function equalPoint(a: number, b: number, delta = 0.0001): boolean {
 export function equalPoints(a: number[], b: number[]): boolean {
     return equalPoint(a[0], b[0]) && equalPoint(a[1], b[1]);
 }
+
+export function useSnapping(event: MouseEvent | TouchEvent): boolean {
+    return gameStore.invertAlt === event.altKey;
+}

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -27,6 +27,7 @@ async def set_client(sid, data):
             ("gridColour", "grid_colour"),
             ("fowColour", "fow_colour"),
             ("rulerColour", "ruler_colour"),
+            ("invertAlt", "invert_alt"),
         ]:
             if option[0] in data:
                 setattr(user, option[1], data[option[0]])

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -15,6 +15,7 @@ class User(BaseModel):
     fow_colour = TextField(default="#000")
     grid_colour = TextField(default="#000")
     ruler_colour = TextField(default="#F00")
+    invert_alt = BooleanField(default=False)
 
     def __repr__(self):
         return f"<User {self.name}>"
@@ -35,4 +36,3 @@ class User(BaseModel):
     @classmethod
     def by_name(cls, name):
         return cls.get_or_none(fn.Lower(cls.name) == name.lower())
-

--- a/server/save.py
+++ b/server/save.py
@@ -12,7 +12,7 @@ from config import SAVE_FILE
 from models import ALL_MODELS, Constants
 from models.db import db
 
-SAVE_VERSION = 21
+SAVE_VERSION = 22
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
 
@@ -306,6 +306,17 @@ def upgrade(version):
             migrate(
                 migrator.add_column("shape", "badge", IntegerField(default=1)),
                 migrator.add_column("shape", "show_badge", BooleanField(default=False)),
+            )
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 21:
+        from peewee import BooleanField, BooleanField, IntegerField
+
+        migrator = SqliteMigrator(db)
+        db.foreign_keys = False
+        with db.atomic():
+            migrate(
+                migrator.add_column("user", "invert_alt", BooleanField(default=False))
             )
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()


### PR DESCRIPTION
This PR adds a new client option to set the behaviour of the alt modifier.

This modifier by default disables snapping while pressed.  The new user option inverts this and by default does not snap unless alt is pressed.