### PR TITLE
feat(asset): Add search bar to in-game asset menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 -   alt modifier can be used to disable draw/resize snapping
 -   Client option to invert the ALT behaviour (i.e. invert snapping behaviour)
 -   Logo, version info and some urls to the topleft section which is only visible if both locations bar and menu are opened
+-   Search bar to asset menu
 
 ### Fixed
 

--- a/client/src/game/ui/menu/asset_node.vue
+++ b/client/src/game/ui/menu/asset_node.vue
@@ -1,8 +1,20 @@
 <template>
     <ul>
-        <li v-for="folder in folders" :key="folder" class="folder" @click.stop="toggle">
+        <li
+            v-for="folder in folders"
+            :key="folder"
+            class="folder"
+            @click.stop="toggle"
+            v-show="!emptyFolders.includes(folder)"
+        >
             {{ folder }}
-            <asset-node :asset="asset[folder]"></asset-node>
+            <asset-node
+                :asset="asset[folder]"
+                :name="folder"
+                :search="search"
+                @folderShow="folderShow"
+                @folderEmpty="folderEmpty"
+            ></asset-node>
         </li>
         <li
             v-for="file in files"
@@ -24,7 +36,7 @@
 <script lang="ts">
 import Vue from "vue";
 import Component from "vue-class-component";
-import { Prop } from "vue-property-decorator";
+import { Prop, Watch } from "vue-property-decorator";
 
 import { AssetFile, AssetList } from "@/core/comm/types";
 import { alphSort } from "@/core/utils";
@@ -34,11 +46,32 @@ import { alphSort } from "@/core/utils";
 })
 export default class AssetNode extends Vue {
     @Prop() asset!: AssetList;
+    @Prop() search!: string;
+    @Prop() name!: string;
+
+    empty = false;
+    emptyFolders: string[] = [];
+
+    @Watch("search")
+    test(_val: string): void {
+        this.checkVisibility();
+    }
+
+    checkVisibility(): void {
+        const newEmpty = this.files.length === 0 && this.folders.length <= this.emptyFolders.length;
+        if (!this.empty && newEmpty) {
+            this.empty = true;
+            this.$emit("folderEmpty", this.name);
+        } else if (this.empty && !newEmpty) {
+            this.empty = false;
+            this.$emit("folderShow", this.name);
+        }
+    }
 
     showImage = null;
     get folders(): string[] {
         return Object.keys(this.asset)
-            .filter(el => !["__files"].includes(el))
+            .filter(el => "__files" !== el)
             .sort(alphSort);
     }
 
@@ -46,12 +79,25 @@ export default class AssetNode extends Vue {
         if (this.asset.__files)
             return (<AssetFile[]>this.asset.__files)
                 .concat()
+                .filter(f => f.name.includes(this.search))
                 .sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1));
         return [];
     }
 
+    folderEmpty(name: string): void {
+        this.emptyFolders.push(name);
+        this.checkVisibility();
+    }
+
+    folderShow(name: string): void {
+        this.emptyFolders.splice(
+            this.emptyFolders.findIndex(x => x === name),
+            1,
+        );
+        this.checkVisibility();
+    }
+
     toggle(event: { target: HTMLElement }): void {
-        // tslint:disable-next-line:prefer-for-of
         for (let i = 0; i < event.target.children.length; i++) {
             const el = <HTMLElement>event.target.children[i];
             el.style.display = el.style.display === "" ? "block" : "";

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -6,11 +6,12 @@
             <template v-if="IS_DM">
                 <button class="menu-accordion">Assets</button>
                 <div id="menu-assets" class="menu-accordion-panel">
+                    <input id="asset-search" v-if="assets" v-model="assetSearch" placeholder="Search" />
                     <a class="actionButton" href="/assets" target="blank" title="Open asset manager">
                         <i class="fas fa-external-link-alt"></i>
                     </a>
                     <div class="directory" id="menu-tokens">
-                        <asset-node :asset="assets"></asset-node>
+                        <asset-node :asset="assets" :search="assetSearch"></asset-node>
                         <div v-if="!assets">No assets</div>
                     </div>
                 </div>
@@ -80,10 +81,9 @@ import ColorPicker from "@/core/components/colorpicker.vue";
 import Game from "@/game/game.vue";
 import AssetNode from "@/game/ui/menu/asset_node.vue";
 
-import { layerManager } from "@/game/layers/manager";
-
 import { uuidv4 } from "@/core/utils";
 import { Note } from "@/game/comm/types/general";
+import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
 import { EventBus } from "../../event-bus";
 
@@ -97,6 +97,8 @@ import { EventBus } from "../../event-bus";
     },
 })
 export default class MenuBar extends Vue {
+    assetSearch = "";
+
     get IS_DM(): boolean {
         return gameStore.IS_DM || gameStore.FAKE_PLAYER;
     }
@@ -167,6 +169,14 @@ export default class MenuBar extends Vue {
 #menu-assets {
     display: flex;
     flex-direction: column;
+}
+
+#asset-search {
+    text-align: center;
+}
+
+#asset-search::placeholder {
+    text-align: center;
 }
 
 /*

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -129,8 +129,11 @@ export default class MenuBar extends Vue {
     settingsClick(event: { target: HTMLElement }): void {
         if (event.target.classList.contains("menu-accordion")) {
             event.target.classList.toggle("menu-accordion-active");
-            const next = <HTMLElement>event.target.nextElementSibling;
-            if (next !== null) next.style.display = next.style.display === "" ? "block" : "";
+            // const next = <HTMLElement>event.target.nextElementSibling;
+            // if (next !== null) {
+            //     if (next.style.display === "") next.style.removeProperty("display");
+            //     else next.style.display = "";
+            // }
         }
     }
     createNote(): void {
@@ -166,7 +169,7 @@ export default class MenuBar extends Vue {
 </script>
 
 <style scoped>
-#menu-assets {
+.menu-accordion-active + #menu-assets {
     display: flex;
     flex-direction: column;
 }
@@ -259,6 +262,10 @@ DIRECTORY.CSS changes
     display: none;
     overflow: hidden;
     min-height: 2em;
+}
+
+.menu-accordion-active + .menu-accordion-panel {
+    display: block;
 }
 
 .menu-accordion-subpanel {

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -5,7 +5,7 @@
             <!-- ASSETS -->
             <template v-if="IS_DM">
                 <button class="menu-accordion">Assets</button>
-                <div class="menu-accordion-panel">
+                <div id="menu-assets" class="menu-accordion-panel">
                     <a class="actionButton" href="/assets" target="blank" title="Open asset manager">
                         <i class="fas fa-external-link-alt"></i>
                     </a>
@@ -164,6 +164,11 @@ export default class MenuBar extends Vue {
 </script>
 
 <style scoped>
+#menu-assets {
+    display: flex;
+    flex-direction: column;
+}
+
 /*
 DIRECTORY.CSS changes
 
@@ -212,11 +217,10 @@ DIRECTORY.CSS changes
 }
 
 .actionButton {
-    position: absolute;
-    right: 0;
     margin: 5px;
-    margin-right: 10px;
-    padding: 0;
+    align-self: flex-end;
+    margin-bottom: -30px;
+    z-index: 11;
 }
 
 .menu-accordion {


### PR DESCRIPTION
This PR adds a simple search bar to the sidemenu in the asset panel.

It does a simple .includes check to determine whether it matches, so no fancy regex or such for now.
All folders with subitems that do not match the search are hidden.