### PR TITLE
Add tiered config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 -   Logo, version info and some urls to the topleft section which is only visible if both locations bar and menu are opened
 -   Search bar to asset menu
 -   Some basic tooltips to icons
+-   Tiered configuration. Configuration file in the data directory takes precedence over one in the folder with server files. Useful for docker deployments to keep the configuration in a volume.
 
 ### Fixed
 

--- a/server/config.py
+++ b/server/config.py
@@ -3,7 +3,7 @@ import configparser
 from utils import FILE_DIR
 
 config = configparser.ConfigParser()
-config.read(FILE_DIR / "server_config.cfg")
+config.read([FILE_DIR / "server_config.cfg", FILE_DIR / "data" / "server_config.cfg"])
 
 SAVE_FILE = config['General']['save_file']
 


### PR DESCRIPTION
This adds a secondary but more important config file in data dir. Any option set in that file override settings from previous files. This file can contain only a handful of options. All other will be taken from base config file.