### PR TITLE
feature(Shape): Improved user access permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ All notable changes to this project will be documented in this file.
 -   Some basic tooltips to icons
 -   Tiered configuration. Configuration file in the data directory takes precedence over one in the folder with server files. Useful for docker deployments to keep the configuration in a volume.
 
+### Changed
+
+-   Shape access
+    -   Now uses a dropdown prefilled with players so you no longer need to manually type it
+    -   Option to choose full edit access or only vision access
+    -   Default access to specify behaviour for non selected players
+
 ### Fixed
 
 -   Polygon width now properly taken into account when trying to select it

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5376,7 +5376,7 @@
                 },
                 "util": {
                     "version": "0.10.3",
-                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
                     "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
                     "dev": true,
                     "requires": {
@@ -6096,7 +6096,7 @@
         },
         "browserify-aes": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
@@ -6133,7 +6133,7 @@
         },
         "browserify-rsa": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
@@ -7295,7 +7295,7 @@
         },
         "create-hash": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
@@ -7308,7 +7308,7 @@
         },
         "create-hmac": {
             "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
@@ -7974,7 +7974,7 @@
         },
         "diffie-hellman": {
             "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
@@ -13364,7 +13364,7 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
@@ -15349,7 +15349,7 @@
         },
         "sha.js": {
             "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {

--- a/client/src/core/types.ts
+++ b/client/src/core/types.ts
@@ -1,0 +1,1 @@
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -1,4 +1,7 @@
+import "@/game/api/events/access";
+
 import { AssetList, SyncMode } from "@/core/comm/types";
+import { coreStore } from "@/core/store";
 import { socket } from "@/game/api/socket";
 import { BoardInfo, Note, ServerClient, ServerLocation } from "@/game/comm/types/general";
 import { ServerShape } from "@/game/comm/types/shapes";
@@ -11,7 +14,6 @@ import { gameStore } from "@/game/store";
 import { router } from "@/router";
 import { zoomDisplay } from "../utils";
 import { VisibilityMode, visibilityStore } from "../visibility/store";
-import { coreStore } from "@/core/store";
 
 socket.on("connect", () => {
     console.log("Connected");

--- a/client/src/game/api/events/access.ts
+++ b/client/src/game/api/events/access.ts
@@ -1,0 +1,36 @@
+import { ownerToClient, ServerShapeOwner } from "../../comm/types/shapes";
+import { layerManager } from "../../layers/manager";
+import { socket } from "../socket";
+import { gameStore } from "../../store";
+
+socket.on("Shape.Owner.Add", (data: ServerShapeOwner) => {
+    const shape = layerManager.UUIDMap.get(data.shape);
+    if (shape === undefined) return;
+    shape.addOwner(ownerToClient(data), false);
+});
+
+socket.on("Shape.Owner.Update", (data: ServerShapeOwner) => {
+    const shape = layerManager.UUIDMap.get(data.shape);
+    if (shape === undefined) return;
+    shape.updateOwner(ownerToClient(data), false);
+});
+
+socket.on("Shape.Owner.Delete", (data: ServerShapeOwner) => {
+    const shape = layerManager.UUIDMap.get(data.shape);
+    if (shape === undefined) return;
+    shape.removeOwner(data.user, false);
+});
+
+socket.on("Shape.Owner.Default.Update", (data: { shape: string; edit_access?: boolean; vision_access?: boolean }) => {
+    const shape = layerManager.UUIDMap.get(data.shape);
+    if (shape === undefined) return;
+    if (data.edit_access) shape.defaultEditAccess = data.edit_access;
+    if (data.vision_access) shape.defaultVisionAccess = data.vision_access;
+    const ownedIndex = gameStore.ownedtokens.indexOf(shape.uuid);
+    if (data.vision_access) {
+        if (ownedIndex === -1) gameStore.ownedtokens.push(shape.uuid);
+    } else {
+        if (ownedIndex >= 0) gameStore.ownedtokens.splice(ownedIndex, 1);
+    }
+    if (gameStore.fowLOS) layerManager.invalidateLightAllFloors();
+});

--- a/client/src/game/comm/types/shapes.ts
+++ b/client/src/game/comm/types/shapes.ts
@@ -1,3 +1,5 @@
+import { ShapeOwner } from "../../shapes/owners";
+
 export interface ServerShape {
     uuid: string;
     type_: string;
@@ -11,7 +13,7 @@ export interface ServerShape {
     trackers: Tracker[];
     auras: ServerAura[];
     labels: Label[];
-    owners: string[];
+    owners: ServerShapeOwner[];
     fill_colour: string;
     stroke_colour: string;
     name: string;
@@ -21,6 +23,13 @@ export interface ServerShape {
     options?: string;
     badge: number;
     show_badge: boolean;
+}
+
+export interface ServerShapeOwner {
+    shape: string;
+    user: string;
+    edit_access: boolean;
+    vision_access: boolean;
 }
 
 export interface ServerRect extends ServerShape {
@@ -65,3 +74,12 @@ export interface ServerAura {
     dim: number;
     colour: string;
 }
+
+export const ownerToServer = (owner: ShapeOwner): ServerShapeOwner => ({
+    user: owner.user,
+    shape: owner.shape,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    edit_access: owner.editAccess,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    vision_access: owner.visionAccess,
+});

--- a/client/src/game/comm/types/shapes.ts
+++ b/client/src/game/comm/types/shapes.ts
@@ -23,6 +23,8 @@ export interface ServerShape {
     options?: string;
     badge: number;
     show_badge: boolean;
+    default_edit_access: boolean;
+    default_vision_access: boolean;
 }
 
 export interface ServerShapeOwner {
@@ -82,4 +84,11 @@ export const ownerToServer = (owner: ShapeOwner): ServerShapeOwner => ({
     edit_access: owner.editAccess,
     // eslint-disable-next-line @typescript-eslint/camelcase
     vision_access: owner.visionAccess,
+});
+
+export const ownerToClient = (owner: ServerShapeOwner): ShapeOwner => ({
+    user: owner.user,
+    shape: owner.shape,
+    editAccess: owner.edit_access,
+    visionAccess: owner.vision_access,
 });

--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -45,7 +45,7 @@ export function onKeyDown(event: KeyboardEvent): void {
                 let recalculateVision = false;
                 let recalculateMovement = false;
                 for (const sel of selection) {
-                    if (!sel.ownedBy()) continue;
+                    if (!sel.ownedBy({ editAccess: true })) continue;
                     if (gameStore.selectionHelperID === sel.uuid) continue;
                     if (sel.movementObstruction) {
                         recalculateMovement = true;

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -93,7 +93,7 @@ export class FOWLayer extends Layer {
                 this.floor === gameStore.floors[gameStore.selectedFloorIndex]
             ) {
                 for (const sh of layerManager.getLayer(this.floor, "tokens")!.shapes) {
-                    if (!sh.ownedBy() || !sh.isToken) continue;
+                    if (!sh.ownedBy({ visionAccess: true }) || !sh.isToken) continue;
                     const bb = sh.getBoundingBox();
                     const lcenter = g2l(sh.center());
                     const alm = 0.8 * g2lz(bb.w);

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -68,7 +68,7 @@ export class Layer {
                 this.points.set(strp, (this.points.get(strp) || new Set()).add(shape.uuid));
             }
         }
-        if (shape.ownedBy(gameStore.username) && shape.isToken) gameStore.ownedtokens.push(shape.uuid);
+        if (shape.ownedBy({ visionAccess: true }) && shape.isToken) gameStore.ownedtokens.push(shape.uuid);
         if (shape.annotation.length) gameStore.annotations.push(shape.uuid);
         if (sync !== SyncMode.NO_SYNC)
             socket.emit("Shape.Add", { shape: shape.asDict(), temporary: sync === SyncMode.TEMP_SYNC });

--- a/client/src/game/shapes/owners.ts
+++ b/client/src/game/shapes/owners.ts
@@ -1,0 +1,6 @@
+export interface ShapeOwner {
+    shape: string;
+    user: string;
+    editAccess: boolean;
+    visionAccess: boolean;
+}

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -2,7 +2,7 @@ import { uuidv4 } from "@/core/utils";
 import { socket } from "@/game/api/socket";
 import { aurasFromServer, aurasToServer } from "@/game/comm/conversion/aura";
 import { InitiativeData } from "@/game/comm/types/general";
-import { ownerToServer, ServerShape } from "@/game/comm/types/shapes";
+import { ownerToClient, ownerToServer, ServerShape } from "@/game/comm/types/shapes";
 import { GlobalPoint, Vector } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
@@ -11,9 +11,9 @@ import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { addBlocker, getBlockers, getVisionSources, setVisionSources, sliceBlockers } from "@/game/visibility/utils";
 import tinycolor from "tinycolor2";
+import { PartialBy } from "../../core/types";
 import { BoundingRect } from "./boundingrect";
 import { ShapeOwner } from "./owners";
-import { PartialBy } from "../../core/types";
 
 export abstract class Shape {
     // Used to create class instance from server shape data
@@ -60,6 +60,9 @@ export abstract class Shape {
 
     badge = 1;
     showBadge = false;
+
+    defaultEditAccess = false;
+    defaultVisionAccess = false;
 
     constructor(refPoint: GlobalPoint, fillColour?: string, strokeColour?: string, uuid?: string) {
         this._refPoint = refPoint;
@@ -181,7 +184,7 @@ export abstract class Shape {
 
     setIsToken(isToken: boolean): void {
         this.isToken = isToken;
-        if (this.ownedBy()) {
+        if (this.ownedBy({ visionAccess: true })) {
             const i = gameStore.ownedtokens.indexOf(this.uuid);
             if (this.isToken && i === -1) gameStore.ownedtokens.push(this.uuid);
             else if (!this.isToken && i >= 0) gameStore.ownedtokens.splice(i, 1);
@@ -190,6 +193,7 @@ export abstract class Shape {
 
     abstract asDict(): ServerShape;
     getBaseDict(): ServerShape {
+        /* eslint-disable @typescript-eslint/camelcase */
         return {
             type_: this.type,
             uuid: this.uuid,
@@ -197,30 +201,24 @@ export abstract class Shape {
             y: this.refPoint.y,
             floor: this.floor,
             layer: this.layer,
-            // eslint-disable-next-line @typescript-eslint/camelcase
             draw_operator: this.globalCompositeOperation,
-            // eslint-disable-next-line @typescript-eslint/camelcase
             movement_obstruction: this.movementObstruction,
-            // eslint-disable-next-line @typescript-eslint/camelcase
             vision_obstruction: this.visionObstruction,
             auras: aurasToServer(this.auras),
             trackers: this.trackers,
             labels: this.labels,
             owners: this._owners.map(owner => ownerToServer(owner)),
-            // eslint-disable-next-line @typescript-eslint/camelcase
             fill_colour: this.fillColour,
-            // eslint-disable-next-line @typescript-eslint/camelcase
             stroke_colour: this.strokeColour,
             name: this.name,
-            // eslint-disable-next-line @typescript-eslint/camelcase
             name_visible: this.nameVisible,
             annotation: this.annotation,
-            // eslint-disable-next-line @typescript-eslint/camelcase
             is_token: this.isToken,
             options: JSON.stringify([...this.options]),
             badge: this.badge,
-            // eslint-disable-next-line @typescript-eslint/camelcase
             show_badge: this.showBadge,
+            default_edit_access: this.defaultEditAccess,
+            default_vision_access: this.defaultVisionAccess,
         };
     }
     fromDict(data: ServerShape): void {
@@ -232,18 +230,15 @@ export abstract class Shape {
         this.auras = aurasFromServer(data.auras);
         this.trackers = data.trackers;
         this.labels = data.labels;
-        this._owners = data.owners.map(owner => ({
-            user: owner.user,
-            shape: owner.shape,
-            editAccess: owner.edit_access,
-            visionAccess: owner.vision_access,
-        }));
+        this._owners = data.owners.map(owner => ownerToClient(owner));
         this.fillColour = data.fill_colour;
         this.strokeColour = data.stroke_colour;
         this.isToken = data.is_token;
         this.nameVisible = data.name_visible;
         this.badge = data.badge;
         this.showBadge = data.show_badge;
+        this.defaultEditAccess = data.default_edit_access;
+        this.defaultVisionAccess = data.default_vision_access;
         if (data.annotation) this.annotation = data.annotation;
         if (data.name) this.name = data.name;
         if (data.options) this.options = new Map(JSON.parse(data.options));
@@ -352,12 +347,18 @@ export abstract class Shape {
         return Object.freeze(this._owners.slice());
     }
 
-    ownedBy(username?: string): boolean {
-        if (username === undefined) username = gameStore.username;
+    ownedBy(options: Partial<{ editAccess: boolean; visionAccess: boolean }>): boolean {
         return (
             gameStore.IS_DM ||
-            this._owners.some(u => u.user === username) ||
-            (gameStore.FAKE_PLAYER && gameStore.activeTokens.includes(this.uuid))
+            (gameStore.FAKE_PLAYER && gameStore.activeTokens.includes(this.uuid)) ||
+            (options.editAccess && this.defaultEditAccess) ||
+            (options.visionAccess && this.defaultVisionAccess) ||
+            this._owners.some(
+                u =>
+                    u.user === gameStore.username &&
+                    (options.editAccess ? u.editAccess === true : true) &&
+                    (options.visionAccess ? u.visionAccess === true : true),
+            )
         );
     }
 
@@ -370,15 +371,39 @@ export abstract class Shape {
         if (fullOwner.shape !== this.uuid) return;
         if (!this.hasOwner(owner.user)) {
             this._owners.push(fullOwner);
+            if (owner.visionAccess && this.isToken) gameStore.ownedtokens.push(this.uuid);
             if (sync) socket.emit("Shape.Owner.Add", ownerToServer(fullOwner));
+            if (gameStore.fowLOS) layerManager.invalidateLightAllFloors();
         }
+    }
+
+    updateOwner(owner: PartialBy<ShapeOwner, "shape">, sync: boolean): void {
+        const fullOwner = { shape: this.uuid, ...owner };
+        if (fullOwner.shape !== this.uuid) return;
+        if (!this.hasOwner(owner.user)) return;
+        const targetOwner = this._owners.find(o => o.user === owner.user)!;
+        if (targetOwner.visionAccess !== fullOwner.visionAccess) {
+            const ownedIndex = gameStore.ownedtokens.indexOf(this.uuid);
+            if (fullOwner.visionAccess) {
+                if (ownedIndex === -1) gameStore.ownedtokens.push(this.uuid);
+            } else {
+                if (ownedIndex >= 0) gameStore.ownedtokens.splice(ownedIndex, 1);
+            }
+            targetOwner.visionAccess = fullOwner.visionAccess;
+        }
+        targetOwner.editAccess = fullOwner.editAccess;
+        if (sync) socket.emit("Shape.Owner.Update", ownerToServer(fullOwner));
+        if (gameStore.fowLOS) layerManager.invalidateLightAllFloors();
     }
 
     removeOwner(owner: string, sync: boolean): void {
         const ownerIndex = this._owners.findIndex(o => o.user === owner);
         if (ownerIndex < 0) return;
         const removed = this._owners.splice(ownerIndex, 1)[0];
+        const ownedIndex = gameStore.ownedtokens.indexOf(this.uuid);
+        if (ownedIndex >= 0) gameStore.ownedtokens.splice(ownedIndex, 1);
         if (sync) socket.emit("Shape.Owner.Delete", ownerToServer(removed));
+        if (gameStore.fowLOS) layerManager.invalidateLightAllFloors();
     }
 
     updatePoints(): void {

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -89,7 +89,7 @@ export function copyShapes(): void {
     if (!layer.selection) return;
     const clipboard: ServerShape[] = [];
     for (const shape of layer.selection) {
-        if (!shape.ownedBy()) continue;
+        if (!shape.ownedBy({ editAccess: true })) continue;
         if (gameStore.selectionHelperID === shape.uuid) continue;
         clipboard.push(shape.asDict());
     }
@@ -171,7 +171,7 @@ export function deleteShapes(): void {
     const l = layerManager.getLayer(layerManager.floor!.name)!;
     for (let i = l.selection.length - 1; i >= 0; i--) {
         const sel = l.selection[i];
-        if (!sel.ownedBy()) continue;
+        if (!sel.ownedBy({ editAccess: true })) continue;
         if (gameStore.selectionHelperID === sel.uuid) {
             l.selection.splice(i, 1);
             continue;

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -265,7 +265,7 @@ export default class Initiative extends Vue {
         if (this.cameraLock) {
             if (actorId !== null) {
                 const shape = layerManager.UUIDMap.get(actorId);
-                if (shape !== undefined && shape.ownedBy()) {
+                if (shape?.ownedBy({ visionAccess: true })) {
                     gameManager.setCenterPosition(shape.center());
                 }
             }

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -216,7 +216,7 @@ export default class Initiative extends Vue {
         const shape = layerManager.UUIDMap.get(actor.uuid);
         // Shapes that are unknown to this client are hidden from this client but owned by other clients
         if (shape === undefined) return false;
-        return shape.owners.includes(gameStore.username);
+        return shape.hasOwner(gameStore.username);
     }
     getDefaultEffect(): { uuid: string; name: string; turns: number } {
         return { uuid: uuidv4(), name: "New Effect", turns: 10 };

--- a/client/src/game/ui/selection/edit_dialog/access.vue
+++ b/client/src/game/ui/selection/edit_dialog/access.vue
@@ -1,0 +1,160 @@
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+
+import { Prop } from "vue-property-decorator";
+
+import { socket } from "@/game/api/socket";
+import { layerManager } from "@/game/layers/manager";
+import { Shape } from "@/game/shapes/shape";
+import { gameStore } from "@/game/store";
+import { ShapeOwner } from "../../../shapes/owners";
+import { ownerToServer } from "../../../comm/types/shapes";
+
+@Component
+export default class EditDialogAccess extends Vue {
+    @Prop() owned!: boolean;
+    @Prop() shape!: Shape;
+
+    $refs!: {
+        accessDropdown: HTMLSelectElement;
+    };
+
+    get players(): { id: number; name: string }[] {
+        return gameStore.players;
+    }
+
+    get playersWithoutAccess(): { id: number; name: string }[] {
+        return gameStore.players.filter(p => !this.shape.hasOwner(p.name));
+    }
+
+    addOwner(): void {
+        if (!this.owned) return;
+        const dropdown = this.$refs.accessDropdown;
+        const selectedUser = dropdown.options[dropdown.selectedIndex].value;
+        if (selectedUser === "") return;
+        this.shape.addOwner({ user: selectedUser, editAccess: true, visionAccess: true }, true);
+    }
+    removeOwner(value: string): void {
+        if (!this.owned) return;
+        this.shape.removeOwner(value, true);
+    }
+    toggleOwnerEditAccess(owner: ShapeOwner): void {
+        if (!this.owned) return;
+        owner.editAccess = !owner.editAccess;
+        socket.emit("Shape.Owner.Update", ownerToServer(owner));
+        if (gameStore.fowLOS) layerManager.invalidateLightAllFloors();
+    }
+    toggleOwnerVisionAccess(owner: ShapeOwner): void {
+        if (!this.owned) return;
+        owner.visionAccess = !owner.visionAccess;
+        socket.emit("Shape.Owner.Update", ownerToServer(owner));
+        if (gameStore.fowLOS) layerManager.invalidateLightAllFloors();
+    }
+    toggleDefaultEditAccess(): void {
+        if (!this.owned) return;
+        this.shape.defaultEditAccess = !this.shape.defaultEditAccess;
+        socket.emit("Shape.Owner.Default.Update", {
+            shape: this.shape.uuid,
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            edit_access: this.shape.defaultEditAccess,
+        });
+    }
+    toggleDefaultVisionAccess(): void {
+        if (!this.owned) return;
+        this.shape.defaultVisionAccess = !this.shape.defaultVisionAccess;
+        socket.emit("Shape.Owner.Default.Update", {
+            shape: this.shape.uuid,
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            vision_access: this.shape.defaultVisionAccess,
+        });
+    }
+}
+</script>
+
+<template>
+    <div style="display:contents">
+        <div class="spanrow header">Access</div>
+        <div class="owner"><i>Default</i></div>
+        <div
+            :style="{
+                opacity: shape.defaultEditAccess ? 1.0 : 0.3,
+                textAlign: 'center',
+                gridColumnStart: 'visible',
+            }"
+            :disabled="!owned"
+            @click="toggleDefaultEditAccess"
+            title="Toggle edit access"
+        >
+            <i class="fas fa-pencil-alt"></i>
+        </div>
+        <div
+            :style="{ opacity: shape.defaultVisionAccess ? 1.0 : 0.3, textAlign: 'center' }"
+            :disabled="!owned"
+            @click="toggleDefaultVisionAccess"
+            title="Toggle vision access"
+        >
+            <i class="fas fa-lightbulb"></i>
+        </div>
+        <template v-for="owner in shape.owners">
+            <div class="owner" :key="owner.user">
+                {{ owner.user }}
+            </div>
+            <div
+                :key="'ownerEdit-' + owner.user"
+                :style="{
+                    opacity: owner.editAccess ? 1.0 : 0.3,
+                    textAlign: 'center',
+                    gridColumnStart: 'visible',
+                }"
+                :disabled="!owned"
+                @click="toggleOwnerEditAccess(owner)"
+                title="Toggle edit access"
+            >
+                <i class="fas fa-pencil-alt"></i>
+            </div>
+            <div
+                :key="'ownerVision-' + owner.user"
+                :style="{ opacity: owner.visionAccess ? 1.0 : 0.3, textAlign: 'center' }"
+                :disabled="!owned"
+                @click="toggleOwnerVisionAccess(owner)"
+                title="Toggle vision access"
+            >
+                <i class="fas fa-lightbulb"></i>
+            </div>
+            <div
+                :key="'remove-' + owner.user"
+                @click="removeOwner(owner.user)"
+                :style="{ opacity: owned ? 1.0 : 0.3, textAlign: 'center', gridColumnStart: 'remove' }"
+                :disabled="!owned"
+                title="Remove owner access"
+            >
+                <i class="fas fa-trash-alt"></i>
+            </div>
+        </template>
+        <select
+            style="grid-column: name/colour;margin-top:5px;"
+            ref="accessDropdown"
+            v-show="playersWithoutAccess.length > 0 && owned"
+        >
+            <option v-for="player in playersWithoutAccess" :key="player.uuid" :disabled="!owned">
+                {{ player.name }}
+            </option>
+        </select>
+        <button
+            style="grid-column: visible/end;margin-top:5px;"
+            @click="addOwner"
+            v-show="playersWithoutAccess.length > 0 && owned"
+        >
+            Add access
+        </button>
+    </div>
+</template>
+
+<style scoped>
+.owner {
+    grid-column-start: name;
+    margin-bottom: 5px;
+    margin-left: 5px;
+}
+</style>

--- a/client/src/game/ui/selection/selection_info.vue
+++ b/client/src/game/ui/selection/selection_info.vue
@@ -49,7 +49,7 @@ import Vue from "vue";
 import Component from "vue-class-component";
 
 import Game from "@/game/game.vue";
-import EditDialog from "@/game/ui/selection/edit_dialog.vue";
+import EditDialog from "@/game/ui/selection/edit_dialog/dialog.vue";
 
 import { socket } from "@/game/api/socket";
 import { EventBus } from "@/game/event-bus";

--- a/client/src/game/ui/tools/createtoken_modal.vue
+++ b/client/src/game/ui/tools/createtoken_modal.vue
@@ -97,9 +97,8 @@ export default class CreateTokenModal extends Vue {
             this.fillColour,
             this.borderColour,
         );
-        token.addOwner(gameStore.username);
+        token.addOwner({ user: gameStore.username, editAccess: true, visionAccess: true }, false);
         layer.addShape(token, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);
-        layer.invalidate(false);
         this.visible = false;
     }
     updatePreview(): void {

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -273,7 +273,7 @@ export default class DrawTool extends Tool {
             if (this.modeSelect === "reveal") this.shape.globalCompositeOperation = "source-over";
             else if (this.modeSelect === "hide") this.shape.globalCompositeOperation = "destination-out";
 
-            this.shape.addOwner(gameStore.username);
+            this.shape.addOwner({ user: gameStore.username, editAccess: false, visionAccess: false }, false);
             if (layer.name === "fow" && this.modeSelect === "normal") {
                 this.shape.visionObstruction = true;
                 this.shape.movementObstruction = true;

--- a/client/src/game/ui/tools/ping.ts
+++ b/client/src/game/ui/tools/ping.ts
@@ -31,8 +31,8 @@ export class PingTool extends Tool {
         this.active = true;
         this.ping = new Circle(this.startPoint, 20, gameStore.rulerColour);
         this.border = new Circle(this.startPoint, 40, "#0000", gameStore.rulerColour);
-        this.ping.addOwner(gameStore.username);
-        this.border.addOwner(gameStore.username);
+        this.ping.addOwner({ user: gameStore.username, editAccess: false, visionAccess: false }, false);
+        this.border.addOwner({ user: gameStore.username, editAccess: false, visionAccess: false }, false);
         layer.addShape(this.ping, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
         layer.addShape(this.border, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
     }

--- a/client/src/game/ui/tools/ruler.ts
+++ b/client/src/game/ui/tools/ruler.ts
@@ -31,8 +31,8 @@ export class RulerTool extends Tool {
         this.active = true;
         this.ruler = new Line(this.startPoint, this.startPoint, l2gz(3), gameStore.rulerColour);
         this.text = new Text(this.startPoint.clone(), "", "bold 20px serif");
-        this.ruler.addOwner(gameStore.username);
-        this.text.addOwner(gameStore.username);
+        this.ruler.addOwner({ user: gameStore.username, editAccess: false, visionAccess: false }, false);
+        this.text.addOwner({ user: gameStore.username, editAccess: false, visionAccess: false }, false);
         layer.addShape(this.ruler, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
         layer.addShape(this.text, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
     }

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -150,7 +150,7 @@ export default class SelectTool extends Tool {
                 // If we are on the tokens layer do a movement block check.
                 if (layer.name === "tokens" && !(event.shiftKey && gameStore.IS_DM)) {
                     for (const sel of layer.selection) {
-                        if (!sel.ownedBy()) continue;
+                        if (!sel.ownedBy({ editAccess: true })) continue;
                         if (sel.uuid === this.selectionHelper.uuid) continue; // the selection helper should not be treated as a real shape.
                         delta = calculateDelta(delta, sel);
                         if (delta !== ogDelta) this.deltaChanged = true;
@@ -158,7 +158,7 @@ export default class SelectTool extends Tool {
                 }
                 // Actually apply the delta on all shapes
                 for (const sel of layer.selection) {
-                    if (!sel.ownedBy()) continue;
+                    if (!sel.ownedBy({ editAccess: true })) continue;
                     if (sel.visionObstruction)
                         visibilityStore.deleteFromTriag({
                             target: TriangulationTarget.VISION,
@@ -178,7 +178,7 @@ export default class SelectTool extends Tool {
                 layer.invalidate(false);
             } else if (this.mode === SelectOperations.Resize) {
                 for (const sel of layer.selection) {
-                    if (!sel.ownedBy()) continue;
+                    if (!sel.ownedBy({ editAccess: true })) continue;
                     if (sel.visionObstruction)
                         visibilityStore.deleteFromTriag({
                             target: TriangulationTarget.VISION,
@@ -225,10 +225,10 @@ export default class SelectTool extends Tool {
                 layer.clearSelection();
             }
             for (const shape of layer.shapes) {
-                if (!shape.ownedBy()) continue;
+                if (!shape.ownedBy({ editAccess: true })) continue;
                 if (shape === this.selectionHelper) continue;
                 const bbox = shape.getBoundingBox();
-                if (!shape.ownedBy()) continue;
+                if (!shape.ownedBy({ editAccess: true })) continue;
                 if (
                     this.selectionHelper!.refPoint.x <= bbox.topRight.x &&
                     this.selectionHelper!.refPoint.x + this.selectionHelper!.w >= bbox.topLeft.x &&
@@ -244,7 +244,7 @@ export default class SelectTool extends Tool {
             layer.invalidate(true);
         } else if (layer.selection.length) {
             for (const sel of layer.selection) {
-                if (!sel.ownedBy()) continue;
+                if (!sel.ownedBy({ editAccess: true })) continue;
                 if (this.mode === SelectOperations.Drag) {
                     if (
                         this.dragRay.origin!.x === g2lx(sel.refPoint.x) &&

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -56,8 +56,8 @@ export default class SelectTool extends Tool {
             return;
         }
 
-        if (!this.selectionHelper.owners.includes(gameStore.username)) {
-            this.selectionHelper.addOwner(gameStore.username);
+        if (!this.selectionHelper.hasOwner(gameStore.username)) {
+            this.selectionHelper.addOwner({ user: gameStore.username, editAccess: false, visionAccess: false }, false);
         }
 
         let hit = false;

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -4,7 +4,8 @@ from peewee import Case
 from playhouse.shortcuts import update_model_from_dict
 
 import auth
-from .initiative import send_client_initiatives
+from ..initiative import send_client_initiatives
+from . import access
 from app import app, logger, sio, state
 from models import (
     Aura,
@@ -114,122 +115,6 @@ async def update_shape_position(sid, data):
                 type_instance.save()
 
     await sync_shape_update(layer, room, data, sid, shape)
-
-
-@sio.on("Shape.Owner.Add", namespace="/planarally")
-@auth.login_required(app, sio)
-async def add_shape_owner(sid, data):
-    sid_data = state.sid_map[sid]
-    user = sid_data["user"]
-    room: Room = sid_data["room"]
-    location = sid_data["location"]
-
-    try:
-        shape = Shape.get(uuid=data["shape"])
-    except Shape.DoesNotExist as exc:
-        logger.warning(
-            f"Attempt to add owner to unknown shape by {user.name} [{data['shape']}]"
-        )
-        raise exc
-
-    target_user = User.by_name(data["user"])
-    if target_user is None:
-        logger.warning(
-            f"Attempt to add unknown user as owner to shape by {user.name} [{data['user']}]"
-        )
-        return
-
-    # Adding the DM as user is redundant and can only lead to confusion
-    if target_user == room.creator:
-        return
-
-    if not ShapeOwner.get_or_none(shape=shape, user=target_user):
-        ShapeOwner.create(
-            shape=shape,
-            user=target_user,
-            edit_access=data["edit_access"],
-            vision_access=data["vision_access"],
-        )
-    await send_client_initiatives(room, location, target_user)
-    await sio.emit(
-        "Shape.Owner.Add", data, room=room, skip_sid=sid, namespace="/planarally"
-    )
-
-
-@sio.on("Shape.Owner.Update", namespace="/planarally")
-@auth.login_required(app, sio)
-async def update_shape_owner(sid, data):
-    sid_data = state.sid_map[sid]
-    user = sid_data["user"]
-    room: Room = sid_data["room"]
-    location = sid_data["location"]
-
-    try:
-        shape = Shape.get(uuid=data["shape"])
-    except Shape.DoesNotExist as exc:
-        logger.warning(
-            f"Attempt to update owner of unknown shape by {user.name} [{data['shape']}]"
-        )
-        raise exc
-
-    target_user = User.by_name(data["user"])
-    if target_user is None:
-        logger.warning(
-            f"Attempt to update unknown user as owner to shape by {user.name} [{data['user']}]"
-        )
-        return
-
-    try:
-        so = ShapeOwner.get(shape=shape, user=target_user)
-    except ShapeOwner.DoesNotExist as exc:
-        logger.warning(f"Attempt to update unknown shape-owner relation by {user.name}")
-
-    so.shape = shape
-    so.user = target_user
-    so.edit_access = data["edit_access"]
-    so.vision_access = data["vision_access"]
-    so.save()
-
-    await sio.emit(
-        "Shape.Owner.Update", data, room=room, skip_sid=sid, namespace="/planarally"
-    )
-
-
-@sio.on("Shape.Owner.Delete", namespace="/planarally")
-@auth.login_required(app, sio)
-async def delete_shape_owner(sid, data):
-    sid_data = state.sid_map[sid]
-    user = sid_data["user"]
-    room: Room = sid_data["room"]
-    location = sid_data["location"]
-
-    try:
-        shape = Shape.get(uuid=data["shape"])
-    except Shape.DoesNotExist as exc:
-        logger.warning(
-            f"Attempt to delete owner of unknown shape by {user.name} [{data['shape']}]"
-        )
-        raise exc
-
-    target_user = User.by_name(data["user"])
-    if target_user is None:
-        logger.warning(
-            f"Attempt to delete unknown user as owner to shape by {user.name} [{data['user']}]"
-        )
-        return
-
-    try:
-        so = (
-            ShapeOwner.delete()
-            .where((ShapeOwner.shape == shape) & (ShapeOwner.user == target_user))
-            .execute()
-        )
-    except Exception as e:
-        logger.warning(f"Could not delete shape-owner relation by {user.name}")
-
-    await sio.emit(
-        "Shape.Owner.Delete", data, room=room, skip_sid=sid, namespace="/planarally"
-    )
 
 
 @sio.on("Shape.Update", namespace="/planarally")

--- a/server/api/socket/shape/access.py
+++ b/server/api/socket/shape/access.py
@@ -1,0 +1,192 @@
+import auth
+
+from api.socket.initiative import send_client_initiatives
+from app import app, logger, sio, state
+from models import Shape, ShapeOwner, User
+
+
+@sio.on("Shape.Owner.Add", namespace="/planarally")
+@auth.login_required(app, sio)
+async def add_shape_owner(sid, data):
+    sid_data = state.sid_map[sid]
+    user = sid_data["user"]
+    room: Room = sid_data["room"]
+    location = sid_data["location"]
+
+    try:
+        shape = Shape.get(uuid=data["shape"])
+    except Shape.DoesNotExist as exc:
+        logger.warning(
+            f"Attempt to add owner to unknown shape by {user.name} [{data['shape']}]"
+        )
+        raise exc
+
+    if not ShapeOwner.get_or_none(shape=shape, user=user):
+        logger.warning(
+            f"{user.name} attempted to change asset ownership of a shape it does not own"
+        )
+        return
+
+    target_user = User.by_name(data["user"])
+    if target_user is None:
+        logger.warning(
+            f"Attempt to add unknown user as owner to shape by {user.name} [{data['user']}]"
+        )
+        return
+
+    # Adding the DM as user is redundant and can only lead to confusion
+    if target_user == room.creator:
+        return
+
+    if not ShapeOwner.get_or_none(shape=shape, user=target_user):
+        ShapeOwner.create(
+            shape=shape,
+            user=target_user,
+            edit_access=data["edit_access"],
+            vision_access=data["vision_access"],
+        )
+    await send_client_initiatives(room, location, target_user)
+    await sio.emit(
+        "Shape.Owner.Add",
+        data,
+        room=location.get_path(),
+        skip_sid=sid,
+        namespace="/planarally",
+    )
+
+
+@sio.on("Shape.Owner.Update", namespace="/planarally")
+@auth.login_required(app, sio)
+async def update_shape_owner(sid, data):
+    sid_data = state.sid_map[sid]
+    user = sid_data["user"]
+    room: Room = sid_data["room"]
+    location = sid_data["location"]
+
+    try:
+        shape = Shape.get(uuid=data["shape"])
+    except Shape.DoesNotExist as exc:
+        logger.warning(
+            f"Attempt to update owner of unknown shape by {user.name} [{data['shape']}]"
+        )
+        raise exc
+
+    if not ShapeOwner.get_or_none(shape=shape, user=user):
+        logger.warning(
+            f"{user.name} attempted to change asset ownership of a shape it does not own"
+        )
+        return
+
+    target_user = User.by_name(data["user"])
+    if target_user is None:
+        logger.warning(
+            f"Attempt to update unknown user as owner to shape by {user.name} [{data['user']}]"
+        )
+        return
+
+    try:
+        so = ShapeOwner.get(shape=shape, user=target_user)
+    except ShapeOwner.DoesNotExist as exc:
+        logger.warning(f"Attempt to update unknown shape-owner relation by {user.name}")
+
+    so.shape = shape
+    so.user = target_user
+    so.edit_access = data["edit_access"]
+    so.vision_access = data["vision_access"]
+    so.save()
+
+    await sio.emit(
+        "Shape.Owner.Update",
+        data,
+        room=location.get_path(),
+        skip_sid=sid,
+        namespace="/planarally",
+    )
+
+
+@sio.on("Shape.Owner.Delete", namespace="/planarally")
+@auth.login_required(app, sio)
+async def delete_shape_owner(sid, data):
+    sid_data = state.sid_map[sid]
+    user = sid_data["user"]
+    room: Room = sid_data["room"]
+    location = sid_data["location"]
+
+    try:
+        shape = Shape.get(uuid=data["shape"])
+    except Shape.DoesNotExist as exc:
+        logger.warning(
+            f"Attempt to delete owner of unknown shape by {user.name} [{data['shape']}]"
+        )
+        raise exc
+
+    if not ShapeOwner.get_or_none(shape=shape, user=user):
+        logger.warning(
+            f"{user.name} attempted to change asset ownership of a shape it does not own"
+        )
+        return
+
+    target_user = User.by_name(data["user"])
+    if target_user is None:
+        logger.warning(
+            f"Attempt to delete unknown user as owner to shape by {user.name} [{data['user']}]"
+        )
+        return
+
+    try:
+        so = (
+            ShapeOwner.delete()
+            .where((ShapeOwner.shape == shape) & (ShapeOwner.user == target_user))
+            .execute()
+        )
+    except Exception as e:
+        logger.warning(f"Could not delete shape-owner relation by {user.name}")
+
+    await sio.emit(
+        "Shape.Owner.Delete",
+        data,
+        room=location.get_path(),
+        skip_sid=sid,
+        namespace="/planarally",
+    )
+
+
+@sio.on("Shape.Owner.Default.Update", namespace="/planarally")
+@auth.login_required(app, sio)
+async def update_default_shape_owner(sid, data):
+    sid_data = state.sid_map[sid]
+    user = sid_data["user"]
+    room: Room = sid_data["room"]
+    location = sid_data["location"]
+
+    try:
+        shape: Shape = Shape.get(uuid=data["shape"])
+    except Shape.DoesNotExist as exc:
+        logger.warning(
+            f"Attempt to update owner of unknown shape by {user.name} [{data['shape']}]"
+        )
+        raise exc
+
+    if not shape.default_edit_access and not ShapeOwner.get_or_none(
+        shape=shape, user=user
+    ):
+        logger.warning(
+            f"{user.name} attempted to change asset ownership of a shape it does not own"
+        )
+        return
+
+    if "edit_access" in data:
+        shape.default_edit_access = data["edit_access"]
+
+    if "vision_access" in data:
+        shape.default_vision_access = data["vision_access"]
+
+    shape.save()
+
+    await sio.emit(
+        "Shape.Owner.Default.Update",
+        data,
+        room=location.get_path(),
+        skip_sid=sid,
+        namespace="/planarally",
+    )

--- a/server/models/shape.py
+++ b/server/models/shape.py
@@ -44,6 +44,8 @@ class Shape(BaseModel):
     options = TextField(null=True)
     badge = IntegerField(default=1)
     show_badge = BooleanField(default=False)
+    default_edit_access = BooleanField(default=False)
+    default_vision_access = BooleanField(default=False)
 
     def __repr__(self):
         return f"<Shape {self.get_path()}>"

--- a/server/models/shape.py
+++ b/server/models/shape.py
@@ -57,9 +57,7 @@ class Shape(BaseModel):
     def as_dict(self, user: User, dm: bool):
         data = model_to_dict(self, recurse=False, exclude=[Shape.layer, Shape.index])
         # Owner query > list of usernames
-        data["owners"] = [
-            so.user.name for so in self.owners.select(User.name).join(User)
-        ]
+        data["owners"] = [owner.as_dict() for owner in self.owners]
         # Layer query > layer name
         data["layer"] = self.layer.name
         data["floor"] = self.layer.floor.name
@@ -130,9 +128,19 @@ class Aura(BaseModel):
 class ShapeOwner(BaseModel):
     shape = ForeignKeyField(Shape, backref="owners", on_delete="CASCADE")
     user = ForeignKeyField(User, backref="shapes", on_delete="CASCADE")
+    edit_access = BooleanField()
+    vision_access = BooleanField()
 
     def __repr__(self):
         return f"<ShapeOwner {self.user.name} {self.shape.get_path()}>"
+
+    def as_dict(self):
+        return {
+            "shape": self.shape.uuid,
+            "user": self.user.name,
+            "edit_access": self.edit_access,
+            "vision_access": self.vision_access,
+        }
 
 
 class ShapeType(BaseModel):

--- a/server/save.py
+++ b/server/save.py
@@ -12,7 +12,7 @@ from config import SAVE_FILE
 from models import ALL_MODELS, Constants
 from models.db import db
 
-SAVE_VERSION = 23
+SAVE_VERSION = 24
 
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
@@ -299,7 +299,7 @@ def upgrade(version):
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 20:
-        from peewee import BooleanField, BooleanField, IntegerField
+        from peewee import BooleanField, IntegerField
 
         migrator = SqliteMigrator(db)
         db.foreign_keys = False
@@ -311,7 +311,7 @@ def upgrade(version):
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 21:
-        from peewee import BooleanField, BooleanField, IntegerField
+        from peewee import BooleanField, IntegerField
 
         migrator = SqliteMigrator(db)
         db.foreign_keys = False
@@ -327,6 +327,22 @@ def upgrade(version):
         with db.atomic():
             db.execute_sql(
                 'CREATE TABLE IF NOT EXISTS "marker" ("id" INTEGER NOT NULL PRIMARY KEY, "shape_id" TEXT NOT NULL, "user_id" INTEGER NOT NULL, "location_id" INTEGER NOT NULL, FOREIGN KEY ("shape_id") REFERENCES "shape"("uuid") ON DELETE CASCADE, FOREIGN KEY ("location_id") REFERENCES "location" ("id") ON DELETE CASCADE, FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE)'
+            )
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 23:
+        from peewee import BooleanField, IntegerField
+
+        migrator = SqliteMigrator(db)
+        db.foreign_keys = False
+        with db.atomic():
+            migrate(
+                migrator.add_column(
+                    "shape_owner", "edit_access", BooleanField(default=True)
+                ),
+                migrator.add_column(
+                    "shape_owner", "vision_access", BooleanField(default=True)
+                ),
             )
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()

--- a/server/save.py
+++ b/server/save.py
@@ -343,6 +343,12 @@ def upgrade(version):
                 migrator.add_column(
                     "shape_owner", "vision_access", BooleanField(default=True)
                 ),
+                migrator.add_column(
+                    "shape", "default_edit_access", BooleanField(default=False)
+                ),
+                migrator.add_column(
+                    "shape", "default_vision_access", BooleanField(default=False)
+                ),
             )
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()


### PR DESCRIPTION
This PR improves various aspects of the shape access system.

It now shows a dropdown instead of a text field to select users in the session. This prevents accidental typos and just overall annoyance with adding access.

Additionally there is also the possibility to give someone vision access but not edit access.  Edit access here entails every kind of interaction with the shape.  And vision access is limited to just giving vision of the token's lightsources.

There now also is a default setting to choose behaviour for those players not specified.