### PR TITLE
bugfix(Lighting): Window resizes could mess with lighting boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 -   Set any shape as marker and jump to that position from the sidebar [LDeeJay1969]
 -   Floor/Layer bar now moves along with the side menu when opened
 -   Side menu and locations menu no longer overlap
+-   Window resizing messing with the lighting borders
 
 ## [0.19.3] - 2020-04-01
 

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -25,6 +25,16 @@ export class FOWLayer extends Layer {
         this.vCtx = this.virtualCanvas.getContext("2d")!;
     }
 
+    setWidth(width: number): void {
+        super.setWidth(width);
+        this.virtualCanvas.width = width;
+    }
+
+    setHeight(height: number): void {
+        super.setHeight(height);
+        this.virtualCanvas.height = height;
+    }
+
     addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, snappable = true): void {
         super.addShape(shape, sync, invalidate, snappable);
         if (shape.options.has("preFogShape") && shape.options.get("preFogShape")) {

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -25,13 +25,13 @@ export class FOWLayer extends Layer {
         this.vCtx = this.virtualCanvas.getContext("2d")!;
     }
 
-    setWidth(width: number): void {
-        super.setWidth(width);
+    set width(width: number) {
+        super.width = width;
         this.virtualCanvas.width = width;
     }
 
-    setHeight(height: number): void {
-        super.setHeight(height);
+    set height(height: number) {
+        super.height = height;
         this.virtualCanvas.height = height;
     }
 

--- a/client/src/game/layers/fowplayers.ts
+++ b/client/src/game/layers/fowplayers.ts
@@ -20,6 +20,16 @@ export class FOWPlayersLayer extends Layer {
         this.vCtx = this.virtualCanvas.getContext("2d")!;
     }
 
+    setWidth(width: number): void {
+        super.setWidth(width);
+        this.virtualCanvas.width = width;
+    }
+
+    setHeight(height: number): void {
+        super.setHeight(height);
+        this.virtualCanvas.height = height;
+    }
+
     draw(): void {
         if (!this.valid) {
             // console.time("VI");

--- a/client/src/game/layers/fowplayers.ts
+++ b/client/src/game/layers/fowplayers.ts
@@ -20,13 +20,13 @@ export class FOWPlayersLayer extends Layer {
         this.vCtx = this.virtualCanvas.getContext("2d")!;
     }
 
-    setWidth(width: number): void {
-        super.setWidth(width);
+    set width(width: number) {
+        super.width = width;
         this.virtualCanvas.width = width;
     }
 
-    setHeight(height: number): void {
-        super.setHeight(height);
+    set height(height: number) {
+        super.height = height;
         this.virtualCanvas.height = height;
     }
 

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -55,6 +55,16 @@ export class Layer {
         }
     }
 
+    setWidth(width: number): void {
+        this.canvas.width = width;
+        this.width = width;
+    }
+
+    setHeight(height: number): void {
+        this.canvas.height = height;
+        this.height = height;
+    }
+
     addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, snappable = true): void {
         shape.layer = this.name;
         shape.floor = this.floor;

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -13,8 +13,6 @@ import { drawAuras } from "../shapes/aura";
 
 export class Layer {
     name: string;
-    width: number;
-    height: number;
     canvas: HTMLCanvasElement;
     ctx: CanvasRenderingContext2D;
     floor: string;
@@ -42,8 +40,6 @@ export class Layer {
     constructor(canvas: HTMLCanvasElement, name: string, floor: string) {
         this.canvas = canvas;
         this.name = name;
-        this.width = canvas.width;
-        this.height = canvas.height;
         this.ctx = canvas.getContext("2d")!;
         this.floor = floor;
     }
@@ -55,14 +51,20 @@ export class Layer {
         }
     }
 
-    setWidth(width: number): void {
-        this.canvas.width = width;
-        this.width = width;
+    get width(): number {
+        return this.canvas.width;
     }
 
-    setHeight(height: number): void {
+    set width(width: number) {
+        this.canvas.width = width;
+    }
+
+    get height(): number {
+        return this.canvas.height;
+    }
+
+    set height(height: number) {
         this.canvas.height = height;
-        this.height = height;
     }
 
     addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, snappable = true): void {

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -10,8 +10,6 @@ export interface Floor {
 
 class LayerManager {
     floors: Floor[] = [];
-    width = window.innerWidth;
-    height = window.innerHeight;
 
     UUIDMap: Map<string, Shape> = new Map();
 
@@ -65,14 +63,12 @@ class LayerManager {
     }
 
     setWidth(width: number): void {
-        this.width = width;
         for (const layer of this.floors.flatMap(f => f.layers)) {
             layer.width = width;
         }
     }
 
     setHeight(height: number): void {
-        this.height = height;
         for (const layer of this.floors.flatMap(f => f.layers)) {
             layer.height = height;
         }

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -67,16 +67,14 @@ class LayerManager {
     setWidth(width: number): void {
         this.width = width;
         for (const layer of this.floors.flatMap(f => f.layers)) {
-            layer.canvas.width = width;
-            layer.width = width;
+            layer.setWidth(width);
         }
     }
 
     setHeight(height: number): void {
         this.height = height;
         for (const layer of this.floors.flatMap(f => f.layers)) {
-            layer.canvas.height = height;
-            layer.height = height;
+            layer.setHeight(height);
         }
     }
 

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -67,14 +67,14 @@ class LayerManager {
     setWidth(width: number): void {
         this.width = width;
         for (const layer of this.floors.flatMap(f => f.layers)) {
-            layer.setWidth(width);
+            layer.width = width;
         }
     }
 
     setHeight(height: number): void {
         this.height = height;
         for (const layer of this.floors.flatMap(f => f.layers)) {
-            layer.setHeight(height);
+            layer.height = height;
         }
     }
 


### PR DESCRIPTION
On window resize all canvas elements are automatically readjusted.  The lighting and vision systems however use a virtual canvas for some off screen drawing which was not being adjusted and could cause strange walls appearing.