### PR TITLE
feature(Resize): shape resizing can now retain aspect ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 -   Some basic tooltips to icons
 -   Tiered configuration. Configuration file in the data directory takes precedence over one in the folder with server files. Useful for docker deployments to keep the configuration in a volume
 -   Use spacebar to cycle between your owned tokens
+-   Aspect ratio lock with ctrl modifier
 
 ### Changed
 
@@ -28,6 +29,10 @@ All notable changes to this project will be documented in this file.
     -   Now gives a bit more information on how to use it
     -   After making a selection you can adjust it to better fit your needs
     -   Choose the X/Y numbers after selecting the shape
+-   Shape resizing
+    -   Now only snaps the point you're resizing instead of an awkward complete shape resize
+-   Drawing
+    -   When snapping enabled will now snap startpoint on mouse down and last point on mouse up
 
 ### Fixed
 

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -8,7 +8,7 @@ import { Layer } from "@/game/layers/layer";
 import { layerManager } from "@/game/layers/manager";
 import { Asset } from "@/game/shapes/asset";
 import { gameStore } from "@/game/store";
-import { l2gx, l2gy, l2gz } from "@/game/units";
+import { l2gx, l2gy, l2gz, clampGridLine } from "@/game/units";
 import { visibilityStore } from "@/game/visibility/store";
 import { addCDT, removeCDT } from "@/game/visibility/te/pa";
 
@@ -87,12 +87,9 @@ export function dropAsset(event: DragEvent): void {
 
     if (gameStore.useGrid) {
         const gs = gameStore.gridSize;
-        asset.refPoint = new GlobalPoint(
-            Math.round(asset.refPoint.x / gs) * gs,
-            Math.round(asset.refPoint.y / gs) * gs,
-        );
-        asset.w = Math.max(Math.round(asset.w / gs) * gs, gs);
-        asset.h = Math.max(Math.round(asset.h / gs) * gs, gs);
+        asset.refPoint = new GlobalPoint(clampGridLine(asset.refPoint.x), clampGridLine(asset.refPoint.y));
+        asset.w = Math.max(clampGridLine(asset.w), gs);
+        asset.h = Math.max(clampGridLine(asset.h), gs);
     }
 
     layer.addShape(asset, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);

--- a/client/src/game/shapes/baserect.ts
+++ b/client/src/game/shapes/baserect.ts
@@ -96,12 +96,16 @@ export abstract class BaseRect extends Shape {
         this.h = Math.max(Math.round(this.h / gs) * gs, gs);
         this.invalidate(false);
     }
-    resize(resizePoint: number, point: GlobalPoint): number {
+    resize(resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean): number {
+        const aspectRatio = this.w / this.h;
+        const oldW = this.w;
+        const oldH = this.h;
+
         switch (resizePoint) {
             case 0: {
                 this.w += this.refPoint.x - point.x;
                 this.h += this.refPoint.y - point.y;
-                this.refPoint = point;
+                this.refPoint = this.refPoint.add(new Vector(oldW - this.w, oldH - this.h));
                 break;
             }
             case 1: {
@@ -134,6 +138,21 @@ export abstract class BaseRect extends Shape {
         if (this.h < 0) {
             this.refPoint = this.refPoint.add(new Vector(0, this.h));
             this.h = Math.abs(this.h);
+        }
+
+        if (retainAspectRatio && !isNaN(aspectRatio)) {
+            const tempAspectRatio = this.w / this.h;
+            if (tempAspectRatio > aspectRatio) {
+                if (resizePoint === 0 || resizePoint === 3) {
+                    this.refPoint = new GlobalPoint(this.refPoint.x, this.refPoint.y + this.h - this.w / aspectRatio);
+                }
+                this.h = this.w / aspectRatio;
+            } else if (tempAspectRatio < aspectRatio) {
+                if (resizePoint === 0 || resizePoint === 1) {
+                    this.refPoint = new GlobalPoint(this.refPoint.x + this.w - this.h * aspectRatio, this.refPoint.y);
+                }
+                this.w = this.h * aspectRatio;
+            }
         }
 
         return (resizePoint + 4) % 4;

--- a/client/src/game/shapes/baserect.ts
+++ b/client/src/game/shapes/baserect.ts
@@ -3,7 +3,7 @@ import { BoundingRect } from "@/game/shapes/boundingrect";
 import { Shape } from "@/game/shapes/shape";
 import { gameStore } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
-import { g2lx, g2ly } from "@/game/units";
+import { g2lx, g2ly, clampGridLine } from "@/game/units";
 import { ServerShape } from "../comm/types/shapes";
 
 export abstract class BaseRect extends Shape {
@@ -74,12 +74,12 @@ export abstract class BaseRect extends Shape {
         let targetY;
 
         if ((this.w / gs) % 2 === 0) {
-            targetX = Math.round(mx / gs) * gs - this.w / 2;
+            targetX = clampGridLine(mx) - this.w / 2;
         } else {
             targetX = (Math.round((mx + gs / 2) / gs) - 1 / 2) * gs - this.w / 2;
         }
         if ((this.h / gs) % 2 === 0) {
-            targetY = Math.round(my / gs) * gs - this.h / 2;
+            targetY = clampGridLine(my) - this.h / 2;
         } else {
             targetY = (Math.round((my + gs / 2) / gs) - 1 / 2) * gs - this.h / 2;
         }
@@ -89,12 +89,15 @@ export abstract class BaseRect extends Shape {
 
         this.invalidate(false);
     }
-    resizeToGrid(): void {
-        const gs = gameStore.gridSize;
-        this.refPoint = new GlobalPoint(Math.round(this.refPoint.x / gs) * gs, Math.round(this.refPoint.y / gs) * gs);
-        this.w = Math.max(Math.round(this.w / gs) * gs, gs);
-        this.h = Math.max(Math.round(this.h / gs) * gs, gs);
-        this.invalidate(false);
+    resizeToGrid(resizePoint: number, retainAspectRatio: boolean): void {
+        this.resize(
+            resizePoint,
+            new GlobalPoint(
+                clampGridLine(this.refPoint.x + (resizePoint > 1 ? this.w : 0)),
+                clampGridLine(this.refPoint.y + ([1, 2].includes(resizePoint) ? this.h : 0)),
+            ),
+            retainAspectRatio,
+        );
     }
     resize(resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean): number {
         const aspectRatio = this.w / this.h;

--- a/client/src/game/shapes/circle.ts
+++ b/client/src/game/shapes/circle.ts
@@ -4,7 +4,7 @@ import { BoundingRect } from "@/game/shapes/boundingrect";
 import { Shape } from "@/game/shapes/shape";
 import { gameStore } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
-import { g2l, g2lz } from "@/game/units";
+import { g2l, g2lz, clampGridLine } from "@/game/units";
 import { getFogColour } from "@/game/utils";
 
 export class Circle extends Shape {
@@ -75,12 +75,12 @@ export class Circle extends Shape {
         let targetX;
         let targetY;
         if (((2 * this.r) / gs) % 2 === 0) {
-            targetX = Math.round(this.refPoint.x / gs) * gs;
+            targetX = clampGridLine(this.refPoint.x);
         } else {
             targetX = Math.round((this.refPoint.x - gs / 2) / gs) * gs + this.r;
         }
         if (((2 * this.r) / gs) % 2 === 0) {
-            targetY = Math.round(this.refPoint.y / gs) * gs;
+            targetY = clampGridLine(this.refPoint.y);
         } else {
             targetY = Math.round((this.refPoint.y - gs / 2) / gs) * gs + this.r;
         }
@@ -90,7 +90,7 @@ export class Circle extends Shape {
     }
     resizeToGrid(): void {
         const gs = gameStore.gridSize;
-        this.r = Math.max(Math.round(this.r / gs) * gs, gs / 2);
+        this.r = Math.max(clampGridLine(this.r), gs / 2);
         this.invalidate(false);
     }
     resize(resizePoint: number, point: GlobalPoint): number {

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -102,8 +102,8 @@ export abstract class Shape {
     // Code to snap a shape to the grid
     // This is shape dependent as the shape refPoints are shape specific in
     abstract snapToGrid(): void;
-    abstract resizeToGrid(): void;
-    abstract resize(resizePoint: number, point: GlobalPoint): number;
+    abstract resizeToGrid(resizePoint: number, retainAspectRatio: boolean): void;
+    abstract resize(resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean): number;
 
     abstract get points(): number[][];
 

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -207,7 +207,7 @@ export default class SelectTool extends Tool {
                     let targetPoint = gp;
                     if (useSnapping(event) && this.hasFeature(SelectFeatures.Snapping, features))
                         targetPoint = snapToPoint(layerManager.getLayer(layerManager.floor!.name)!, gp, ignorePoint);
-                    this.resizePoint = sel.resize(this.resizePoint, targetPoint);
+                    this.resizePoint = sel.resize(this.resizePoint, targetPoint, event.ctrlKey);
                     if (sel !== this.selectionHelper) {
                         // todo: think about calling deleteIntersectVertex directly on the corner point
                         if (sel.visionObstruction) {
@@ -227,7 +227,7 @@ export default class SelectTool extends Tool {
         }
     }
 
-    onUp(e: MouseEvent | TouchEvent, features: SelectFeatures[]): void {
+    onUp(event: MouseEvent | TouchEvent, features: SelectFeatures[]): void {
         if (!this.active) return;
         if (layerManager.getLayer(layerManager.floor!.name) === undefined) {
             console.log("No active layer!");
@@ -236,7 +236,7 @@ export default class SelectTool extends Tool {
         const layer = layerManager.getLayer(layerManager.floor!.name)!;
 
         if (this.mode === SelectOperations.GroupSelect) {
-            if (e.ctrlKey) {
+            if (event.ctrlKey) {
                 // If either control or shift are pressed, do not remove selection
             } else {
                 layer.clearSelection();
@@ -271,7 +271,7 @@ export default class SelectTool extends Tool {
 
                     if (
                         gameStore.useGrid &&
-                        useSnapping(e) &&
+                        useSnapping(event) &&
                         this.hasFeature(SelectFeatures.Snapping, features) &&
                         !this.deltaChanged
                     ) {
@@ -304,7 +304,7 @@ export default class SelectTool extends Tool {
                     layer.invalidate(false);
                 }
                 if (this.mode === SelectOperations.Resize) {
-                    if (gameStore.useGrid && useSnapping(e) && this.hasFeature(SelectFeatures.Snapping, features)) {
+                    if (gameStore.useGrid && useSnapping(event) && this.hasFeature(SelectFeatures.Snapping, features)) {
                         if (sel.visionObstruction)
                             visibilityStore.deleteFromTriag({
                                 target: TriangulationTarget.VISION,
@@ -315,7 +315,7 @@ export default class SelectTool extends Tool {
                                 target: TriangulationTarget.MOVEMENT,
                                 shape: sel,
                             });
-                        sel.resizeToGrid();
+                        sel.resizeToGrid(this.resizePoint, event.ctrlKey);
                         if (sel.visionObstruction) {
                             visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: sel });
                             visibilityStore.recalculateVision(sel.floor);

--- a/client/src/game/units.ts
+++ b/client/src/game/units.ts
@@ -57,5 +57,9 @@ export function l2gr(r: number): number {
     return l2gz(getUnitDistance(r));
 }
 
+export function clampGridLine(point: number): number {
+    return Math.round(point / gameStore.gridSize) * gameStore.gridSize;
+}
+
 (<any>window).g2lx = g2lx;
 (<any>window).g2ly = g2ly;

--- a/client/src/game/visibility/te/draw.ts
+++ b/client/src/game/visibility/te/draw.ts
@@ -182,7 +182,8 @@ export function drawPolygonT(tds: TDS, local = true, clear = true, logs: 0 | 1 |
     }
 }
 
-(<any>window).DC = drawPoint;
+(<any>window).drawPoint = drawPoint;
+(<any>window).drawPointLocal = drawPointL;
 (<any>window).DL = drl;
 (<any>window).DE = drawEdge;
 (<any>window).DP = drawPolygon;


### PR DESCRIPTION
You can now use the ctrl modifier to retain aspect ratio during resize operations.

Note that the ctrl modifier is also used to add more elements to your selection.  The former only triggers when resizing.

Also in this PR due to some changes to resizing in general:
* Improvements to general resizing: only snap resize the point being resized
* Improvements to drawing: snap start and endpoints to grid