### PR TITLE
bugfix(MapTool): sudden map jumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
     -   Now gives a bit more information on how to use it
     -   After making a selection you can adjust it to better fit your needs
     -   Choose the X/Y numbers after selecting the shape
+    -   The center of the drawn resize rectangle now will remain in the exact same place after resize. This prevents sudden map jump.
 -   Shape resizing
     -   Now only snaps the point you're resizing instead of an awkward complete shape resize
 -   Drawing

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -3,7 +3,7 @@ import Component from "vue-class-component";
 
 import Tool from "@/game/ui/tools/tool.vue";
 
-import { GlobalPoint } from "@/game/geom";
+import { GlobalPoint, Vector } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { BaseRect } from "@/game/shapes/baserect";
 import { Rect } from "@/game/shapes/rect";
@@ -60,14 +60,20 @@ export default class MapTool extends Tool {
     }
 
     apply(): void {
-        if (this.rect === null) return;
-
-        const w = this.rect.w;
-        const h = this.rect.h;
+        if (this.shape === null || this.rect === null) return;
+        const oldRefpoint = this.shape.refPoint;
+        const oldCenter = this.rect.center();
 
         if (this.shape instanceof BaseRect) {
-            this.shape.w *= (this.xCount * gameStore.gridSize) / w;
-            this.shape.h *= (this.yCount * gameStore.gridSize) / h;
+            const xFactor = (this.xCount * gameStore.gridSize) / this.rect.w;
+            const yFactor = (this.yCount * gameStore.gridSize) / this.rect.h;
+
+            this.shape.w *= xFactor;
+            this.shape.h *= yFactor;
+
+            const delta = oldCenter.subtract(oldRefpoint);
+            const newCenter = oldRefpoint.add(new Vector(xFactor * delta.x, yFactor * delta.y));
+            this.shape.refPoint = this.shape.refPoint.add(oldCenter.subtract(newCenter));
         }
         this.removeRect();
     }


### PR DESCRIPTION
As a result of the maptool resize, the map could sometimes jump to unexpected places.

This PR changes it so that the center of the chosen resize rectangle will remain in the exact same place after the resize.  This should result in less jarring resizes.