### PR TITLE
bugfix(AssetList): case insensitive search

### DIFF
--- a/client/src/game/ui/menu/asset_node.vue
+++ b/client/src/game/ui/menu/asset_node.vue
@@ -44,7 +44,7 @@ export default class AssetNode extends Vue {
         if (this.asset.__files)
             return (<AssetFile[]>this.asset.__files)
                 .concat()
-                .filter(f => f.name.includes(this.search))
+                .filter(f => f.name.toLowerCase().includes(this.search.toLowerCase()))
                 .sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1));
         return [];
     }


### PR DESCRIPTION
Fix the asset list search in-game to be case insensitive.  Closes #296 