### PR TITLE
Bugfix/gh 288 kick dm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 -   Asset manager not showing uploaded files until refreshed
 -   Asset manager contextmenu not rendering correctly when scrolling down
 -   Grid layers of al lower floors being visible
+-   DM being able to invite themselves to the room as a player
 
 ## [0.19.3] - 2020-04-01
 

--- a/client/src/game/api/events/access.ts
+++ b/client/src/game/api/events/access.ts
@@ -1,7 +1,6 @@
 import { ownerToClient, ServerShapeOwner } from "../../comm/types/shapes";
 import { layerManager } from "../../layers/manager";
 import { socket } from "../socket";
-import { gameStore } from "../../store";
 
 socket.on("Shape.Owner.Add", (data: ServerShapeOwner) => {
     const shape = layerManager.UUIDMap.get(data.shape);

--- a/client/src/game/ui/selection/edit_dialog/access.vue
+++ b/client/src/game/ui/selection/edit_dialog/access.vue
@@ -5,11 +5,9 @@ import Component from "vue-class-component";
 import { Prop } from "vue-property-decorator";
 
 import { socket } from "@/game/api/socket";
-import { layerManager } from "@/game/layers/manager";
 import { Shape } from "@/game/shapes/shape";
 import { gameStore } from "@/game/store";
 import { ShapeOwner } from "../../../shapes/owners";
-import { ownerToServer } from "../../../comm/types/shapes";
 
 @Component
 export default class EditDialogAccess extends Vue {

--- a/server/api/http/__init__.py
+++ b/server/api/http/__init__.py
@@ -19,9 +19,7 @@ async def claim_invite(request):
     if room is None:
         return web.HTTPNotFound()
     else:
-        if user.name != room.creator and not PlayerRoom.get_or_none(
-            player=user, room=room
-        ):
+        if user != room.creator and not PlayerRoom.get_or_none(player=user, room=room):
             PlayerRoom.create(player=user, room=room)
 
             for csid in state.get_sids(user=room.creator, room=room):


### PR DESCRIPTION
This PR fixes #288, the problem where it's possible to as a DM invite yourself to the session and thus have both a DM and player session in your overview.

The PR prevents this from happening but also removes any player DMs that happen to exist already.