### PR TITLE
Delete server files removed with asset manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 -   Asset manager contextmenu not rendering correctly when scrolling down
 -   Grid layers of al lower floors being visible
 -   DM being able to invite themselves to the room as a player
+-   Removing a file in the asset manager now deletes the file on the server
 
 ## [0.19.3] - 2020-04-01
 

--- a/server/api/socket/asset_manager.py
+++ b/server/api/socket/asset_manager.py
@@ -117,6 +117,11 @@ async def assetmgmt_rm(sid, data):
         return
     asset.delete_instance(recursive=True, delete_nullable=True)
 
+    if asset.file_hash is not None and (ASSETS_DIR / asset.file_hash).exists():
+        if Asset.select().where(Asset.file_hash == asset.file_hash).count() == 0:
+            logger.info(f"No asset maps to file {asset.file_hash}, removing from server")
+            (ASSETS_DIR / asset.file_hash).unlink()
+
 
 @sio.on("Asset.Upload", namespace="/pa_assetmgmt")
 @auth.login_required(app, sio)


### PR DESCRIPTION
Relatively simple two line change to enable the server to actually delete files. Folders and Files that are removed by the Asset Manager call the same `Asset.Remove` endpoint, so it is necessary to check if the asset being removed is a file or folder. Folders aren't created on the server, so checking for the file_hash's existence is sufficient to protect against errors which arise from trying to delete non-existent assets on the server.

I've briefly tested this and confirmed that I can add and remove assets and their asset files indeed are removed from the server disk.