### PR TITLE
bug(Floor): Always clear selection upon floor change

### DIFF
--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -129,7 +129,7 @@ export function onKeyDown(event: KeyboardEvent): void {
                     shape.moveFloor(newFloor, true);
                 }
             }
-            if (!event.shiftKey) layerManager.clearSelection();
+            layerManager.clearSelection();
             if (!event.ctrlKey || event.shiftKey) {
                 gameStore.selectFloor(gameStore.selectedFloorIndex + 1);
             }


### PR DESCRIPTION
Make sure to clear previous selection boxes when changing floors in all cases.

This closes #332 