### PR TITLE
bug(Floor): Remember active floor upon rejoining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 -   DM being able to invite themselves to the room as a player
 -   Removing a file in the asset manager now deletes the file on the server
 -   Draw tool no longer delays rendering brush helper after layer/floor change
+-   Active floor is remembered upon rejoining the session
 
 ## [0.19.3] - 2020-04-01
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -75,7 +75,10 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     gameStore.setPanY(options.pan_y);
     gameStore.setZoomDisplay(zoomDisplay(options.zoom_factor));
     // gameStore.setZoomDisplay(0.5);
-    if (options.active_layer) layerManager.selectLayer(options.active_layer, false);
+    if (options.active_layer && options.active_floor) {
+        gameStore.selectFloor(options.active_floor);
+        layerManager.selectLayer(options.active_layer, false);
+    }
     for (const floor of layerManager.floors) {
         if (layerManager.getGridLayer(floor.name) !== undefined) layerManager.getGridLayer(floor.name)!.invalidate();
     }

--- a/client/src/game/comm/types/settings.ts
+++ b/client/src/game/comm/types/settings.ts
@@ -33,6 +33,7 @@ export interface ServerClient {
     pan_x: number;
     pan_y: number;
     zoom_factor: number;
+    active_floor?: string;
     active_layer?: string;
 }
 

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -261,6 +261,7 @@ class LocationUserOption(BaseModel):
         )
         if self.active_layer:
             d["active_layer"] = self.active_layer.name
+            d["active_floor"] = self.active_layer.floor.name
         return d
 
     class Meta:


### PR DESCRIPTION
When rejoining/reloading/reconnecting a session you no longer get put on the lowest floor, but on the floor you last visited.

This closes #334 