### PR TITLE
bug(Ownership): Fix specific edit/access right changing not working

### DIFF
--- a/server/api/socket/shape/access.py
+++ b/server/api/socket/shape/access.py
@@ -4,6 +4,7 @@ import auth
 from api.socket.initiative import send_client_initiatives
 from app import app, logger, sio
 from models import Floor, Layer, Location, PlayerRoom, Room, Shape, ShapeOwner, User
+from models.role import Role
 from models.shape.access import has_ownership
 from state.game import game_state
 
@@ -76,7 +77,7 @@ async def update_shape_owner(sid: int, data: Dict[str, Any]):
         )
         raise exc
 
-    if not ShapeOwner.get_or_none(shape=shape, user=pr.player):
+    if not has_ownership(shape, pr):
         logger.warning(
             f"{pr.player.name} attempted to change asset ownership of a shape it does not own"
         )


### PR DESCRIPTION
The code responsible for changing just one of the two access rights, was not using a proper method to check permission, which resulted in the DM not being able to change these settings.