### PR TITLE
feat(Floor): Move players with edit access if shape changes floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 -   Progressbar to the asset manager
 -   Location rename
 -   Location removal
+-   Upon floor change all players with edit access will auto move to the same floor
 
 ### Changed
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -148,6 +148,7 @@ socket.on("Shape.Floor.Change", (data: { uuid: string; floor: string }) => {
     const shape = layerManager.UUIDMap.get(data.uuid);
     if (shape === undefined) return;
     shape.moveFloor(data.floor, false);
+    if (shape.ownedBy({ editAccess: true })) gameStore.selectFloor(data.floor);
 });
 socket.on("Shape.Layer.Change", (data: { uuid: string; layer: string }) => {
     const shape = layerManager.UUIDMap.get(data.uuid);


### PR DESCRIPTION
In most circumstances the players that have edit access to a shape will want to follow the shape moving floors.  This closes #336 