### PR TITLE
fix(Location): Moving all players not doing anything

### DIFF
--- a/client/src/game/ui/menu/locations.vue
+++ b/client/src/game/ui/menu/locations.vue
@@ -102,7 +102,7 @@ export default class LocationBar extends Vue {
         }
         // e.item.remove();
         // e.clone.remove();
-        // socket.emit("Location.Change", { location: toLocation, users: players });
+        socket.emit("Location.Change", { location: toLocation, users: players });
     }
 
     endPlayerDrag(e: { item: HTMLDivElement; from: HTMLDivElement; to: HTMLDivElement }): void {


### PR DESCRIPTION
During the development somehow accidentally a line got commented and as a result moving all players didn't actually do much anymore