### PR TITLE
feat(Movement): Fit shapes through doors/paths slightly smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+-   During shape drag/move use a smaller version to do hitbox tests
+    - This improves behaviour when going through a very tight hallway or a door
+
 ## [0.20.1] - 2020-05-11
 
 ### Fixed

--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -47,7 +47,7 @@ export function onKeyDown(event: KeyboardEvent): void {
                     // First check for collisions.  Using the smooth wall slide collision check used on mouse move is overkill here.
                     for (const sel of selection) {
                         if (gameStore.selectionHelperID === sel.uuid) continue;
-                        delta = calculateDelta(delta, sel);
+                        delta = calculateDelta(delta, sel, true);
                     }
                 }
                 if (delta.length() === 0) return;

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -170,7 +170,7 @@ export default class SelectTool extends Tool {
                     for (const sel of layer.selection) {
                         if (!sel.ownedBy({ editAccess: true })) continue;
                         if (sel.uuid === this.selectionHelper.uuid) continue; // the selection helper should not be treated as a real shape.
-                        delta = calculateDelta(delta, sel);
+                        delta = calculateDelta(delta, sel, true);
                         if (delta !== ogDelta) this.deltaChanged = true;
                     }
                 }

--- a/client/src/game/ui/tools/utils.ts
+++ b/client/src/game/ui/tools/utils.ts
@@ -21,10 +21,14 @@ export type ToolPermission = { name: ToolName; features: number[] };
 
 // This is definitely super convoluted and inefficient but I was tired and really wanted the smooth wall sliding collision stuff to work
 // And it does now, so hey ¯\_(ツ)_/¯
-export function calculateDelta(delta: Vector, sel: Shape): Vector {
+export function calculateDelta(delta: Vector, sel: Shape, shrink = false): Vector {
     if (delta.x === 0 && delta.y === 0) return delta;
-    const centerTriangle = getCDT(TriangulationTarget.MOVEMENT, sel.floor).locate(sel.center().asArray(), null).loc;
-    for (const point of sel.points) {
+    const center = sel.center().asArray();
+    const centerTriangle = getCDT(TriangulationTarget.MOVEMENT, sel.floor).locate(center, null).loc;
+    for (let point of sel.points) {
+        if (shrink) {
+            point = [point[0] - (point[0] - center[0]) * 0.75, point[1] - (point[1] - center[1]) * 0.75];
+        }
         const lt = getCDT(TriangulationTarget.MOVEMENT, sel.floor).locate(point, centerTriangle);
         const triangle = lt.loc;
         if (triangle === null) continue;


### PR DESCRIPTION
This PR changes the behaviour of the collision check to include an optional shrink parameter.

When this paramter is set to true, the provided shape will be shrunk by 3/4th before checking for collision.  This allows shapes to go through doors/hallways that are slightly smaller than the shape itself.

Vision is calculated from the center, so at no point the vision should be impacted.