### PR TITLE
bugfix(Floor): Player active floor not memorised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Polygon server creation with initial vertices list breaks session
+-   Player floor location not being remembered
 
 ## [0.20.1] - 2020-05-11
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -76,7 +76,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     gameStore.setZoomDisplay(zoomDisplay(options.zoom_factor));
     // gameStore.setZoomDisplay(0.5);
     if (options.active_layer && options.active_floor) {
-        gameStore.selectFloor(options.active_floor);
+        gameStore.selectFloor({ targetFloor: options.active_floor, sync: false });
         layerManager.selectLayer(options.active_layer, false);
     }
     for (const floor of layerManager.floors) {
@@ -84,7 +84,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     }
 });
 socket.on("Position.Set", (data: { floor: string; x: number; y: number; zoom: number }) => {
-    gameStore.selectFloor(data.floor);
+    gameStore.selectFloor({ targetFloor: data.floor, sync: false });
     gameStore.setZoomDisplay(data.zoom);
     gameManager.setCenterPosition(new GlobalPoint(data.x, data.y));
 });
@@ -110,7 +110,7 @@ socket.on("Board.Set", (locationInfo: BoardInfo) => {
         visibilityStore.recalculateVision(floor.name);
         visibilityStore.recalculateMovement(floor.name);
     }
-    gameStore.selectFloor(0);
+    gameStore.selectFloor({ targetFloor: 0, sync: false });
     gameStore.setBoardInitialized(true);
 });
 socket.on("Floor.Create", addFloor);
@@ -148,7 +148,7 @@ socket.on("Shape.Floor.Change", (data: { uuid: string; floor: string }) => {
     const shape = layerManager.UUIDMap.get(data.uuid);
     if (shape === undefined) return;
     shape.moveFloor(data.floor, false);
-    if (shape.ownedBy({ editAccess: true })) gameStore.selectFloor(data.floor);
+    if (shape.ownedBy({ editAccess: true })) gameStore.selectFloor({ targetFloor: data.floor, sync: false });
 });
 socket.on("Shape.Layer.Change", (data: { uuid: string; layer: string }) => {
     const shape = layerManager.UUIDMap.get(data.uuid);

--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -22,7 +22,7 @@ export function onKeyUp(event: KeyboardEvent): void {
             const i = tokens.findIndex(o => o.center().equals(gameStore.screenCenter));
             const token = tokens[(i + 1) % tokens.length];
             gameManager.setCenterPosition(token.center());
-            gameStore.selectFloor(token.floor);
+            gameStore.selectFloor({ targetFloor: token.floor, sync: true });
         }
     }
 }
@@ -131,7 +131,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             }
             layerManager.clearSelection();
             if (!event.ctrlKey || event.shiftKey) {
-                gameStore.selectFloor(gameStore.selectedFloorIndex + 1);
+                gameStore.selectFloor({ targetFloor: gameStore.selectedFloorIndex + 1, sync: true });
             }
             if (event.shiftKey) for (const shape of selection) newLayer.selection.push(shape);
         } else if (event.key === "PageDown" && gameStore.selectedFloorIndex > 0) {
@@ -151,7 +151,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             }
             if (!event.shiftKey) layerManager.clearSelection();
             if (!event.ctrlKey || event.shiftKey) {
-                gameStore.selectFloor(gameStore.selectedFloorIndex - 1);
+                gameStore.selectFloor({ targetFloor: gameStore.selectedFloorIndex - 1, sync: true });
             }
             if (event.shiftKey) for (const shape of selection) newLayer.selection.push(shape);
         }

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -18,7 +18,7 @@ export function addFloor(floor: ServerFloor): void {
     addCDT(floor.name);
     layerManager.floors.push({ name: floor.name, layers: [] });
     for (const layer of floor.layers) createLayer(layer, floor.name);
-    gameStore.selectFloor(gameStore.floors.length - 1);
+    gameStore.selectFloor({ targetFloor: gameStore.floors.length - 1, sync: true });
 }
 
 export function removeFloor(floor: string): void {
@@ -40,7 +40,7 @@ export function removeFloor(floor: string): void {
     // todo: once vue 3 hits, fix this split up
     gameStore.floors.splice(index, 1);
     layerManager.floors.splice(index, 1);
-    if (gameStore.selectedFloorIndex === index) gameStore.selectFloor(index - 1);
+    if (gameStore.selectedFloorIndex === index) gameStore.selectFloor({ targetFloor: index - 1, sync: true });
 }
 
 export function createLayer(layerInfo: ServerLayer, floor: string): void {

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -216,12 +216,12 @@ class GameStore extends VuexModule implements GameState {
     }
 
     @Mutation
-    selectFloor(targetFloor: number | string): void {
+    selectFloor(data: { targetFloor: number | string; sync: boolean }): void {
         let targetFloorIndex: number;
-        if (typeof targetFloor === "string") {
-            targetFloorIndex = layerManager.floors.findIndex(f => f.name === targetFloor);
+        if (typeof data.targetFloor === "string") {
+            targetFloorIndex = layerManager.floors.findIndex(f => f.name === data.targetFloor);
         } else {
-            targetFloorIndex = targetFloor;
+            targetFloorIndex = data.targetFloor;
         }
         if (targetFloorIndex === this.selectedFloorIndex) return;
 
@@ -239,7 +239,7 @@ class GameStore extends VuexModule implements GameState {
                 else layer.canvas.style.removeProperty("display");
             }
         }
-        layerManager.selectLayer(layerManager.getLayer(layerManager.floor!.name)!.name, false, false);
+        layerManager.selectLayer(layerManager.getLayer(layerManager.floor!.name)!.name, data.sync, false);
         layerManager.invalidateAllFloors();
     }
 

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -48,7 +48,7 @@ export default class FloorSelect extends Vue {
     }
 
     selectFloor(index: number): void {
-        gameStore.selectFloor(index);
+        gameStore.selectFloor({ targetFloor: index, sync: true });
     }
 
     async removeFloor(index: number): Promise<void> {


### PR DESCRIPTION
When changing floors the intent is that on reconnect the player is automatically put on that floor again.  This was bugged for players.