### PR TITLE
feat(Shape): invisible shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+-   Shape invisible toggle
+    -   Only players with edit access can see and interact with the shape
+    -   Public auras are still visible to all players (e.g. invisible creature with a torch would still shed light)
+
 ### Changed
 
 -   During shape drag/move use a smaller version to do hitbox tests

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -1,6 +1,7 @@
 import { AssetList, InvalidationMode, SyncMode } from "@/core/comm/types";
 import "@/game/api/events/access";
 import "@/game/api/events/location";
+import "@/game/api/events/shape";
 import { setLocationOptions } from "@/game/api/events/location";
 import { socket } from "@/game/api/socket";
 import { BoardInfo, Note } from "@/game/comm/types/general";

--- a/client/src/game/api/events/shape.ts
+++ b/client/src/game/api/events/shape.ts
@@ -1,0 +1,8 @@
+import { socket } from "../socket";
+import { layerManager } from "../../layers/manager";
+
+socket.on("Shape.Options.Invisible.Set", (data: { shape: string; is_invisible: boolean }) => {
+    const shape = layerManager.UUIDMap.get(data.shape);
+    if (shape === undefined) return;
+    shape.setInvisible(data.is_invisible, false);
+});

--- a/client/src/game/comm/types/shapes.ts
+++ b/client/src/game/comm/types/shapes.ts
@@ -20,6 +20,7 @@ export interface ServerShape {
     name_visible: boolean;
     annotation: string;
     is_token: boolean;
+    is_invisible: boolean;
     options?: string;
     badge: number;
     show_badge: boolean;

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -214,6 +214,7 @@ export class Layer {
             }
             for (const shape of this.shapes) {
                 if (shape.options.has("skipDraw") && shape.options.get("skipDraw")) continue;
+                if (shape.isInvisible && !shape.ownedBy({ editAccess: true })) continue;
                 if (shape.labels.length === 0 && gameStore.filterNoLabel) continue;
                 if (
                     shape.labels.length &&

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -47,6 +47,7 @@ export abstract class Shape {
     movementObstruction = false;
     // Does this shape represent a playable token
     isToken = false;
+    isInvisible = false;
     // Show a highlight box
     showHighlight = false;
 
@@ -192,6 +193,13 @@ export abstract class Shape {
         }
     }
 
+    setInvisible(isInvisible: boolean, sync: boolean): void {
+        this.isInvisible = isInvisible;
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        if (sync) socket.emit("Shape.Options.Invisible.Set", { shape: this.uuid, is_invisible: isInvisible });
+        this.invalidate(true);
+    }
+
     abstract asDict(): ServerShape;
     getBaseDict(): ServerShape {
         /* eslint-disable @typescript-eslint/camelcase */
@@ -215,6 +223,7 @@ export abstract class Shape {
             name_visible: this.nameVisible,
             annotation: this.annotation,
             is_token: this.isToken,
+            is_invisible: this.isInvisible,
             options: JSON.stringify([...this.options]),
             badge: this.badge,
             show_badge: this.showBadge,
@@ -235,6 +244,7 @@ export abstract class Shape {
         this.fillColour = data.fill_colour;
         this.strokeColour = data.stroke_colour;
         this.isToken = data.is_token;
+        this.isInvisible = data.is_invisible;
         this.nameVisible = data.name_visible;
         this.badge = data.badge;
         this.showBadge = data.show_badge;

--- a/client/src/game/ui/selection/edit_dialog/dialog.vue
+++ b/client/src/game/ui/selection/edit_dialog/dialog.vue
@@ -88,6 +88,10 @@ export default class EditDialog extends Vue {
         this.shape.setIsToken(event.target.checked);
         this.updateShape(true);
     }
+    setInvisible(event: { target: HTMLInputElement }): void {
+        if (!this.owned) return;
+        this.shape.setInvisible(event.target.checked, true);
+    }
     toggleBadge(_event: { target: HTMLInputElement }): void {
         if (!this.owned) return;
         const groupMembers = this.shape.getGroupMembers();
@@ -207,6 +211,16 @@ export default class EditDialog extends Vue {
                     id="shapeselectiondialog-istoken"
                     :checked="shape.isToken"
                     @click="setToken"
+                    style="grid-column-start: remove;"
+                    class="styled-checkbox"
+                    :disabled="!owned"
+                />
+                <label for="shapeselectiondialog-is-invisible">Is invisible</label>
+                <input
+                    type="checkbox"
+                    id="shapeselectiondialog-is-invisible"
+                    :checked="shape.isInvisible"
+                    @click="setInvisible"
                     style="grid-column-start: remove;"
                     class="styled-checkbox"
                     :disabled="!owned"

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -81,6 +81,7 @@ export default class SelectTool extends Tool {
 
         for (let i = selectionStack.length - 1; i >= 0; i--) {
             const shape = selectionStack[i];
+            if (shape.isInvisible && !shape.ownedBy({ editAccess: true })) continue;
 
             this.resizePoint = shape.getPointIndex(gp, l2gz(5));
 

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -6,7 +6,7 @@ from peewee import Case
 from playhouse.shortcuts import update_model_from_dict
 
 import auth
-from . import access
+from . import access, options
 from app import app, logger, sio
 from models import (
     Aura,

--- a/server/api/socket/shape/options.py
+++ b/server/api/socket/shape/options.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict
+
+import auth
+from app import app, logger, sio
+from models import PlayerRoom, Shape
+from models.shape.access import has_ownership
+from state.game import game_state
+
+
+@sio.on("Shape.Options.Invisible.Set", namespace="/planarally")
+@auth.login_required(app, sio)
+async def add_shape(sid: int, data: Dict[str, Any]):
+    pr: PlayerRoom = game_state.get(sid)
+
+    try:
+        shape: Shape = Shape.get(uuid=data["shape"])
+    except Shape.DoesNotExist as exc:
+        logger.warning(
+            f"Attempt to update invisibility of unknown shape by {pr.player.name} [{data['shape']}]"
+        )
+        raise exc
+
+    if not has_ownership(shape, pr):
+        logger.warning(
+            f"{pr.player.name} attempted to change invisibility of a shape it does not own"
+        )
+        return
+
+    shape.is_invisible = data["is_invisible"]
+    shape.save()
+
+    await sio.emit(
+        "Shape.Options.Invisible.Set",
+        data,
+        room=pr.active_location.get_path(),
+        namespace="/planarally",
+    )

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -46,6 +46,7 @@ class Shape(BaseModel):
     show_badge = BooleanField(default=False)
     default_edit_access = BooleanField(default=False)
     default_vision_access = BooleanField(default=False)
+    is_invisible = BooleanField(default=False)
 
     def __repr__(self):
         return f"<Shape {self.get_path()}>"

--- a/server/save.py
+++ b/server/save.py
@@ -19,7 +19,7 @@ from config import SAVE_FILE
 from models import ALL_MODELS, Constants
 from models.db import db
 
-SAVE_VERSION = 28
+SAVE_VERSION = 29
 
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
@@ -553,6 +553,18 @@ def upgrade(version):
             )
             db.execute_sql(
                 "INSERT INTO user (id, name, email, password_hash, fow_colour, grid_colour, ruler_colour, invert_alt) SELECT id, name, email, password_hash, fow_colour, grid_colour, ruler_colour, invert_alt FROM _user"
+            )
+
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 28:
+        # Add invisibility toggle to shapes
+        migrator = SqliteMigrator(db)
+
+        db.foreign_keys = False
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE shape ADD COLUMN is_invisible INTEGER NOT NULL DEFAULT 0"
             )
 
         db.foreign_keys = True


### PR DESCRIPTION
This PR introduces a toggle in the shape dialog to mark a shape as invisible.

When invisible a shape is only visible for players with edit_access.  Do note that public auras are still visible for all players as an invisible creature with a torch would still shed light.

This closes #318 