### PR TITLE
bugfix(Settings): fix firefox showing invalid input for floating point grid sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 -   Polygon server creation with initial vertices list breaks session
 -   Player floor location not being remembered
 -   Ruler not showing decimal points
+-   DM settings/grid unit size showing invalid input on firefox for floating point numbers
 
 ## [0.20.1] - 2020-05-11
 

--- a/client/src/game/ui/settings/GridSettings.vue
+++ b/client/src/game/ui/settings/GridSettings.vue
@@ -112,7 +112,7 @@ export default class GridSettings extends Vue {
                 <label :for="'unitSizeInput-' + location">Unit Size (in {{ unitSizeUnit }})</label>
             </div>
             <div>
-                <input :id="'unitSizeInput-' + location" type="number" v-model.number="unitSize" />
+                <input :id="'unitSizeInput-' + location" type="number" step="any" v-model.number="unitSize" />
             </div>
             <div
                 v-if="location !== null && options.unitSize !== undefined"


### PR DESCRIPTION
On firefox the input field for the grid unit size would show a red border when providing a floating point number.  These numbers are in fact allowed and accepted, but the UI was not aware.

This closes #312 