### PR TITLE
bug(Initiative): Improve simultaneous inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 -   During shape drag/move use a smaller version to do hitbox tests
     -   This improves behaviour when going through a very tight hallway or a door
+-   Delayed initiative updating during edit
 
 ### Fixed
 

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -178,6 +178,9 @@ export default class Initiative extends Vue {
             gameStore.setActiveTokens(this._activeTokens);
         }
     }
+    setLock(lock: boolean): void {
+        initiativeStore.setLock(lock);
+    }
 }
 </script>
 
@@ -225,6 +228,8 @@ export default class Initiative extends Vue {
                                 v-model.lazy.number="actor.initiative"
                                 :disabled="!owns(actor)"
                                 :class="{ notAllowed: !owns(actor) }"
+                                @focus="setLock(true)"
+                                @blur="setLock(false)"
                                 @change="syncInitiative(actor)"
                             />
                             <div

--- a/client/src/game/ui/initiative/store.ts
+++ b/client/src/game/ui/initiative/store.ts
@@ -11,17 +11,21 @@ export interface InitiativeState {
     data: InitiativeData[];
     currentActor: string | null;
     roundCounter: number;
+    editLock: boolean;
 }
 
 @Module({ dynamic: true, store: rootStore, name: "initiative", namespaced: true })
 class InitiativeStore extends VuexModule implements InitiativeState {
     data: InitiativeData[] = [];
+    dataNew: InitiativeData[] = [];
     currentActor: string | null = null;
     roundCounter = 0;
+    editLock = false;
 
     @Mutation
     clear(): void {
         this.data = [];
+        this.dataNew = [];
         this.currentActor = null;
     }
 
@@ -32,7 +36,8 @@ class InitiativeStore extends VuexModule implements InitiativeState {
 
     @Mutation
     setData(data: InitiativeData[]): void {
-        this.data = data;
+        if (this.editLock) this.dataNew = data;
+        else this.data = data;
     }
 
     @Mutation
@@ -51,6 +56,13 @@ class InitiativeStore extends VuexModule implements InitiativeState {
     @Mutation
     setTurn(actorId: string | null): void {
         this.currentActor = actorId;
+    }
+
+    @Mutation
+    setLock(lock: boolean): void {
+        if (lock) this.dataNew = this.data;
+        else this.data = this.dataNew;
+        this.editLock = lock;
     }
 }
 


### PR DESCRIPTION
In most cases initiative is changed when the DM calls for initiative.  Which means that most players will be interacting with the initiatives at the same time.

When you change a value causing a reorder, it could lead to other player still editing losing their changes.

This PR addresses that problem by delaying changes from other players when you're editing an initiative, only updating them when you release focus on the input field.