### PR TITLE
feat(ToolMode): Build/Play mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ All notable changes to this project will be documented in this file.
 -   Shape invisible toggle
     -   Only players with edit access can see and interact with the shape
     -   Public auras are still visible to all players (e.g. invisible creature with a torch would still shed light)
+-   Build/Play mode
+    -   Show different set of tools dependening on the active mode
 
 ### Changed
 
 -   During shape drag/move use a smaller version to do hitbox tests
     -   This improves behaviour when going through a very tight hallway or a door
 -   Delayed initiative updating during edit
+-   In Play mode (see #added) the select tool will no longer allow resizing
 
 ### Fixed
 

--- a/client/src/game/events/keyboard.ts
+++ b/client/src/game/events/keyboard.ts
@@ -7,6 +7,7 @@ import { gameStore } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
+import { EventBus } from "../event-bus";
 import { gameManager } from "../manager";
 import { gameSettingsStore } from "../settings";
 
@@ -23,6 +24,9 @@ export function onKeyUp(event: KeyboardEvent): void {
             const token = tokens[(i + 1) % tokens.length];
             gameManager.setCenterPosition(token.center());
             gameStore.selectFloor({ targetFloor: token.floor, sync: true });
+        }
+        if (event.key === "Tab") {
+            EventBus.$emit("ToolMode.Toggle");
         }
     }
 }

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -28,7 +28,9 @@ export default class MapTool extends Tool {
 
     shapeSelected = false;
 
-    permittedTools_: ToolPermission[] = [{ name: ToolName.Select, features: [SelectFeatures.ChangeSelection] }];
+    permittedTools_: ToolPermission[] = [
+        { name: ToolName.Select, features: { enabled: [SelectFeatures.ChangeSelection] } },
+    ];
 
     get permittedTools(): ToolPermission[] {
         return this.permittedTools_;
@@ -54,7 +56,7 @@ export default class MapTool extends Tool {
             layer.removeShape(this.rect, SyncMode.NO_SYNC);
             this.rect = null;
         }
-        this.permittedTools_ = [{ name: ToolName.Select, features: [SelectFeatures.ChangeSelection] }];
+        this.permittedTools_ = [{ name: ToolName.Select, features: { enabled: [SelectFeatures.ChangeSelection] } }];
         this.shapeSelected = false;
         this.shape = null;
     }
@@ -134,7 +136,9 @@ export default class MapTool extends Tool {
             return;
         }
 
-        this.permittedTools_ = [{ name: ToolName.Select, features: [SelectFeatures.Drag, SelectFeatures.Resize] }];
+        this.permittedTools_ = [
+            { name: ToolName.Select, features: { enabled: [SelectFeatures.Drag, SelectFeatures.Resize] } },
+        ];
     }
 
     onMouseDown(event: MouseEvent): void {

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -13,7 +13,7 @@ import { layerManager } from "@/game/layers/manager";
 import { snapToPoint } from "@/game/layers/utils";
 import { Rect } from "@/game/shapes/rect";
 import { gameStore } from "@/game/store";
-import { calculateDelta, ToolName } from "@/game/ui/tools/utils";
+import { calculateDelta, ToolName, ToolFeatures } from "@/game/ui/tools/utils";
 import { g2l, g2lx, g2ly, l2g, l2gz } from "@/game/units";
 import { getLocalPointFromEvent, useSnapping } from "@/game/utils";
 import { visibilityStore } from "@/game/visibility/store";
@@ -59,7 +59,7 @@ export default class SelectTool extends Tool {
         gameStore.setSelectionHelperId(this.selectionHelper.uuid);
     }
 
-    onDown(lp: LocalPoint, event: MouseEvent | TouchEvent, features: SelectFeatures[]): void {
+    onDown(lp: LocalPoint, event: MouseEvent | TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         const gp = l2g(lp);
         const layer = layerManager.getLayer(layerManager.floor!.name);
         if (layer === undefined) {
@@ -139,7 +139,12 @@ export default class SelectTool extends Tool {
         if (this.mode !== SelectOperations.Noop) this.active = true;
     }
 
-    onMove(lp: LocalPoint, gp: GlobalPoint, event: MouseEvent | TouchEvent, features: SelectFeatures[]): void {
+    onMove(
+        lp: LocalPoint,
+        gp: GlobalPoint,
+        event: MouseEvent | TouchEvent,
+        features: ToolFeatures<SelectFeatures>,
+    ): void {
         // if (!this.active) return;   we require mousemove for the resize cursor
         const layer = layerManager.getLayer(layerManager.floor!.name);
         if (layer === undefined) {
@@ -229,7 +234,7 @@ export default class SelectTool extends Tool {
         }
     }
 
-    onUp(event: MouseEvent | TouchEvent, features: SelectFeatures[]): void {
+    onUp(event: MouseEvent | TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         if (!this.active) return;
         if (layerManager.getLayer(layerManager.floor!.name) === undefined) {
             console.log("No active layer!");
@@ -343,37 +348,37 @@ export default class SelectTool extends Tool {
         this.active = false;
     }
 
-    onMouseDown(event: MouseEvent, features: SelectFeatures[]): void {
+    onMouseDown(event: MouseEvent, features: ToolFeatures<SelectFeatures>): void {
         const localPoint = getLocalPointFromEvent(event);
         this.onDown(localPoint, event, features);
     }
 
-    onMouseMove(event: MouseEvent, features: SelectFeatures[]): void {
+    onMouseMove(event: MouseEvent, features: ToolFeatures<SelectFeatures>): void {
         const localPoint = getLocalPointFromEvent(event);
         const globalPoint = l2g(localPoint);
         this.onMove(localPoint, globalPoint, event, features);
     }
 
-    onMouseUp(event: MouseEvent, features: SelectFeatures[]): void {
+    onMouseUp(event: MouseEvent, features: ToolFeatures<SelectFeatures>): void {
         this.onUp(event, features);
     }
 
-    onTouchStart(event: TouchEvent, features: SelectFeatures[]): void {
+    onTouchStart(event: TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         const localPoint = getLocalPointFromEvent(event);
         this.onDown(localPoint, event, features);
     }
 
-    onTouchMove(event: TouchEvent, features: SelectFeatures[]): void {
+    onTouchMove(event: TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         const localPoint = getLocalPointFromEvent(event);
         const globalPoint = l2g(localPoint);
         this.onMove(localPoint, globalPoint, event, features);
     }
 
-    onTouchEnd(event: TouchEvent, features: SelectFeatures[]): void {
+    onTouchEnd(event: TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         this.onUp(event, features);
     }
 
-    onContextMenu(event: MouseEvent, features: SelectFeatures[]): void {
+    onContextMenu(event: MouseEvent, features: ToolFeatures<SelectFeatures>): void {
         if (!this.hasFeature(SelectFeatures.Context, features)) return;
         if (layerManager.getLayer(layerManager.floor!.name) === undefined) {
             console.log("No active layer!");

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -145,7 +145,9 @@ export default class SelectTool extends Tool {
         event: MouseEvent | TouchEvent,
         features: ToolFeatures<SelectFeatures>,
     ): void {
-        // if (!this.active) return;   we require mousemove for the resize cursor
+        // We require move for the resize cursor
+        if (!this.active && !this.hasFeature(SelectFeatures.Resize, features)) return;
+
         const layer = layerManager.getLayer(layerManager.floor!.name);
         if (layer === undefined) {
             console.log("No active layer!");

--- a/client/src/game/ui/tools/tool.vue
+++ b/client/src/game/ui/tools/tool.vue
@@ -3,7 +3,7 @@ import Vue from "vue";
 import Component from "vue-class-component";
 
 import DefaultContext from "@/game/ui/tools/defaultcontext.vue";
-import { ToolName, ToolPermission } from "./utils";
+import { ToolName, ToolPermission, ToolFeatures } from "./utils";
 
 @Component
 export default class Tool extends Vue {
@@ -16,8 +16,11 @@ export default class Tool extends Vue {
         return [];
     }
 
-    hasFeature(feature: number, features: number[]): boolean {
-        return features.length === 0 || features.includes(feature);
+    hasFeature(feature: number, features: ToolFeatures): boolean {
+        return (
+            (!features.disabled?.includes(feature) ?? true) &&
+            ((features.enabled?.length ?? 0) === 0 || (features.enabled?.includes(feature) ?? false))
+        );
     }
 
     get detailRight(): string {
@@ -35,17 +38,17 @@ export default class Tool extends Vue {
 
     onSelect(): void {}
     onDeselect(): void {}
-    onMouseDown(_event: MouseEvent, _features: number[]): void {}
-    onMouseUp(_event: MouseEvent, _features: number[]): void {}
-    onMouseMove(_event: MouseEvent, _features: number[]): void {}
-    onTouchStart(_event: TouchEvent, _features: number[]): void {}
-    onTouchEnd(_event: TouchEvent, _features: number[]): void {}
-    onTouchMove(_event: TouchEvent, _features: number[]): void {}
-    onThreeTouchMove(_event: TouchEvent, _features: number[]): void {}
-    onPinchStart(_event: TouchEvent, _features: number[]): void {}
-    onPinchMove(_event: TouchEvent, _features: number[]): void {}
-    onPinchEnd(_event: TouchEvent, _features: number[]): void {}
-    onContextMenu(event: MouseEvent, _features: number[]): void {
+    onMouseDown(_event: MouseEvent, _features: ToolFeatures): void {}
+    onMouseUp(_event: MouseEvent, _features: ToolFeatures): void {}
+    onMouseMove(_event: MouseEvent, _features: ToolFeatures): void {}
+    onTouchStart(_event: TouchEvent, _features: ToolFeatures): void {}
+    onTouchEnd(_event: TouchEvent, _features: ToolFeatures): void {}
+    onTouchMove(_event: TouchEvent, _features: ToolFeatures): void {}
+    onThreeTouchMove(_event: TouchEvent, _features: ToolFeatures): void {}
+    onPinchStart(_event: TouchEvent, _features: ToolFeatures): void {}
+    onPinchMove(_event: TouchEvent, _features: ToolFeatures): void {}
+    onPinchEnd(_event: TouchEvent, _features: ToolFeatures): void {}
+    onContextMenu(event: MouseEvent, _features: ToolFeatures): void {
         (<DefaultContext>this.$parent.$refs.defaultcontext).open(event);
     }
 }

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -20,7 +20,7 @@ import { PingTool } from "@/game/ui/tools/ping";
 import { RulerTool } from "@/game/ui/tools/ruler";
 import { l2g } from "@/game/units";
 import { getLocalPointFromEvent } from "@/game/utils";
-import { ToolName, ToolFeatures, ToolPermission } from "./utils";
+import { ToolName, ToolFeatures } from "./utils";
 import { EventBus } from "@/game/event-bus";
 
 @Component({

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -99,7 +99,7 @@ export default class Tools extends Vue {
         [ToolName.Filter, {}],
         [ToolName.Vision, {}],
     ];
-    mode: "Build" | "Play" = "Build";
+    mode: "Build" | "Play" = "Play";
 
     get componentMap(): { [key in ToolName]: InstanceType<typeof Tool> } {
         return this.componentmap_;

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -263,6 +263,7 @@ export default class Tools extends Vue {
                 <li
                     v-for="tool in visibleTools"
                     :key="tool"
+                    class="tool"
                     :class="{ 'tool-selected': currentTool === tool }"
                     :ref="tool + '-selector'"
                     @mousedown="currentTool = tool"
@@ -297,6 +298,8 @@ export default class Tools extends Vue {
     bottom: 25px;
     right: 25px;
     z-index: 10;
+    display: flex;
+    align-items: center;
 }
 
 #toolselect * {
@@ -310,30 +313,33 @@ export default class Tools extends Vue {
     padding: 0;
     margin: 0;
     border: solid 1px #82c8a0;
-    border-radius: 7px;
+    background-color: cadetblue;
+    border-radius: 10px;
 }
 
-#toolselect > ul > li {
-    display: flex;
+
+.tool {
     background-color: #eee;
     border-right: solid 1px #82c8a0;
 }
 
-#toolselect > ul > li:last-child {
-    border-right: none;
-    border-radius: 0px 4px 4px 0px; /* Border radius needs to be two less than the actual border, otherwise there will be a gap */
+.tool:last-child {
+    border-right: solid 1px #82c8a0;
+    border-radius: 0px 10px 10px 0px; /* Border radius needs to be two less than the actual border, otherwise there will be a gap */
 }
 
-#toolselect > ul > li:first-child {
-    border-radius: 4px 0px 0px 4px;
+#toolselect > ul > li:first-child + .tool {
+    border-left: solid 2px #82c8a0;
+    border-radius: 10px 0px 0px 10px;
+    /* box-shadow: #82c8a0 -2px 1px; */
 }
 
-#toolselect > ul > li:hover {
+.tool:hover {
     background-color: #82c8a0;
 }
 
-#toolselect > ul > li a {
-    display: flex;
+.tool a {
+    display: block;
     padding: 10px;
     text-decoration: none;
 }

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -91,7 +91,7 @@ export default class Tools extends Vue {
     }
 
     get visibleTools(): string[] {
-        return this.tools.filter(t => !this.dmTools.includes(t) || this.IS_DM);
+        return this.tools.filter(t => (!this.dmTools.includes(t) || this.IS_DM) && this.toolVisible(t));
     }
 
     toolVisible(tool: string): boolean {
@@ -265,7 +265,6 @@ export default class Tools extends Vue {
                     :key="tool"
                     :class="{ 'tool-selected': currentTool === tool }"
                     :ref="tool + '-selector'"
-                    v-show="toolVisible(tool)"
                     @mousedown="currentTool = tool"
                 >
                     <a href="#">{{ tool }}</a>

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -9,7 +9,7 @@ import DrawTool from "@/game/ui/tools/draw.vue";
 import FilterTool from "@/game/ui/tools/filter.vue";
 import MapTool from "@/game/ui/tools/map.vue";
 import PanTool from "@/game/ui/tools/pan";
-import SelectTool from "@/game/ui/tools/select.vue";
+import SelectTool, { SelectFeatures } from "@/game/ui/tools/select.vue";
 import Tool from "./tool.vue";
 import VisionTool from "@/game/ui/tools/vision.vue";
 
@@ -78,6 +78,18 @@ export default class Tools extends Vue {
     tools = Object.values(ToolName);
     dmTools = [ToolName.Map];
 
+    buildTools = [
+        ToolName.Select,
+        ToolName.Pan,
+        ToolName.Draw,
+        ToolName.Ruler,
+        ToolName.Map,
+        ToolName.Filter,
+        ToolName.Vision,
+    ];
+    playTools: [ToolName, number[]][] = [[ToolName.Select, [SelectFeatures.Resize]]];
+    mode: "Build" | "Play" = "Build";
+
     get componentMap(): { [key in ToolName]: InstanceType<typeof Tool> } {
         return this.componentmap_;
     }
@@ -114,7 +126,7 @@ export default class Tools extends Vue {
         }
 
         const tool = this.componentMap[targetTool];
-        tool.onMouseDown(event, []);
+        tool.onMouseDown(event, {});
         for (const permitted of tool.permittedTools)
             this.componentMap[permitted.name].onMouseDown(event, permitted.features);
     }
@@ -129,7 +141,7 @@ export default class Tools extends Vue {
         }
 
         const tool = this.componentMap[targetTool];
-        tool.onMouseUp(event, []);
+        tool.onMouseUp(event, {});
         for (const permitted of tool.permittedTools)
             this.componentMap[permitted.name].onMouseUp(event, permitted.features);
     }
@@ -145,7 +157,7 @@ export default class Tools extends Vue {
         }
 
         const tool = this.componentMap[targetTool];
-        tool.onMouseMove(event, []);
+        tool.onMouseMove(event, {});
         for (const permitted of tool.permittedTools)
             this.componentMap[permitted.name].onMouseMove(event, permitted.features);
 
@@ -168,7 +180,7 @@ export default class Tools extends Vue {
         // When leaving the window while a mouse is pressed down, act as if it was released
         if ((event.buttons & 1) !== 0) {
             const tool = this.componentMap[this.currentTool];
-            tool.onMouseUp(event, []);
+            tool.onMouseUp(event, {});
             for (const permitted of tool.permittedTools)
                 this.componentMap[permitted.name].onMouseUp(event, permitted.features);
         }
@@ -177,7 +189,7 @@ export default class Tools extends Vue {
         if ((<HTMLElement>event.target).tagName !== "CANVAS") return;
         if (event.button !== 2 || (<HTMLElement>event.target).tagName !== "CANVAS") return;
         const tool = this.componentMap[this.currentTool];
-        tool.onContextMenu(event, []);
+        tool.onContextMenu(event, {});
         for (const permitted of tool.permittedTools)
             this.componentMap[permitted.name].onContextMenu(event, permitted.features);
     }
@@ -191,8 +203,8 @@ export default class Tools extends Vue {
             tool.scaling = true;
         }
 
-        if (tool.scaling) tool.onPinchStart(event, []);
-        else tool.onTouchStart(event, []);
+        if (tool.scaling) tool.onPinchStart(event, {});
+        else tool.onTouchStart(event, {});
         for (const permitted of tool.permittedTools) {
             const otherTool = this.componentMap[permitted.name];
             otherTool.scaling = tool.scaling;
@@ -206,8 +218,8 @@ export default class Tools extends Vue {
 
         const tool = this.componentMap[this.currentTool];
 
-        if (tool.scaling) tool.onPinchEnd(event, []);
-        else tool.onTouchEnd(event, []);
+        if (tool.scaling) tool.onPinchEnd(event, {});
+        else tool.onTouchEnd(event, {});
         tool.scaling = false;
         for (const permitted of tool.permittedTools) {
             const otherTool = this.componentMap[permitted.name];
@@ -224,11 +236,11 @@ export default class Tools extends Vue {
 
         if (tool.scaling) {
             event.preventDefault();
-            tool.onPinchMove(event, []);
+            tool.onPinchMove(event, {});
         } else if (event.touches.length >= 3) {
-            tool.onThreeTouchMove(event, []);
+            tool.onThreeTouchMove(event, {});
         } else {
-            tool.onTouchMove(event, []);
+            tool.onTouchMove(event, {});
         }
 
         for (const permitted of tool.permittedTools) {
@@ -260,6 +272,7 @@ export default class Tools extends Vue {
     <div style="pointer-events: auto;">
         <div id="toolselect">
             <ul>
+                <li id="tool-mode">B</li>
                 <li
                     v-for="tool in visibleTools"
                     :key="tool"
@@ -317,6 +330,11 @@ export default class Tools extends Vue {
     border-radius: 10px;
 }
 
+#tool-mode {
+    align-self: center;
+    border-right: 0;
+    padding: 5px;
+}
 
 .tool {
     background-color: #eee;

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -96,6 +96,7 @@ export default class Tools extends Vue {
         [ToolName.Select, { disabled: [SelectFeatures.Resize] }],
         [ToolName.Pan, {}],
         [ToolName.Ruler, {}],
+        [ToolName.Ping, {}],
         [ToolName.Filter, {}],
         [ToolName.Vision, {}],
     ];

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -21,6 +21,7 @@ import { RulerTool } from "@/game/ui/tools/ruler";
 import { l2g } from "@/game/units";
 import { getLocalPointFromEvent } from "@/game/utils";
 import { ToolName, ToolFeatures, ToolPermission } from "./utils";
+import { EventBus } from "@/game/event-bus";
 
 @Component({
     components: {
@@ -72,6 +73,11 @@ export default class Tools extends Vue {
             [ToolName.Filter]: this.$refs.filterTool,
             [ToolName.Vision]: this.$refs.visionTool,
         };
+        EventBus.$on("ToolMode.Toggle", this.toggleMode);
+    }
+
+    beforeDestroy(): void {
+        EventBus.$off("ToolMode.Toggle");
     }
 
     currentTool = ToolName.Select;

--- a/client/src/game/ui/tools/utils.ts
+++ b/client/src/game/ui/tools/utils.ts
@@ -15,7 +15,8 @@ export enum ToolName {
     Vision = "Vision",
 }
 
-export type ToolPermission = { name: ToolName; features: number[] };
+export type ToolPermission = { name: ToolName; features: ToolFeatures };
+export type ToolFeatures<T = number> = { enabled?: T[]; disabled?: T[] };
 
 // First go through each shape in the selection and see if the delta has to be truncated due to movement blockers
 


### PR DESCRIPTION
This PR introduces the concept of 'Tool Mode'.  The toolbar will now show a different set of tools based on the active mode.  There is a build and a play mode that can be toggled from in the toolbar as well as with the TAB key.

The intent is to make the toolbar a bit less cluttered with different tools that are not all needed during play as well as provide a way to deal with some other annoyances.

For example in play mode you will no longer be able to resize shapes.  This is an uncommon action during play and often leads to frustration when you intend to move a token but accidentally resize it.  You can at all times swap to build mode and do a resize if you desire.