### PR TITLE
bug(Layer): Fix active layer sometimes resetting on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 -   During shape drag/move use a smaller version to do hitbox tests
     -   This improves behaviour when going through a very tight hallway or a door
 -   Delayed initiative updating during edit
+-   Creating a new floor will no longer automatically move everyone to that floor
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 -   DM settings/grid unit size showing invalid input on firefox for floating point numbers
 -   Server showing JSON decode errors
 -   Players not being able to update initiative effects
+-   Active layer sometimes resetting on reload
 
 ## [0.20.1] - 2020-05-11
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -4,7 +4,7 @@ import "@/game/api/events/location";
 import "@/game/api/events/shape";
 import { setLocationOptions } from "@/game/api/events/location";
 import { socket } from "@/game/api/socket";
-import { BoardInfo, Note } from "@/game/comm/types/general";
+import { BoardInfo, Note, ServerFloor } from "@/game/comm/types/general";
 import { ServerShape } from "@/game/comm/types/shapes";
 import { EventBus } from "@/game/event-bus";
 import { GlobalPoint } from "@/game/geom";
@@ -18,6 +18,7 @@ import { gameSettingsStore } from "../settings";
 import { createShapeFromDict } from "../shapes/utils";
 import { zoomDisplay } from "../utils";
 import { visibilityStore } from "../visibility/store";
+import { coreStore } from "../../core/store";
 
 socket.on("connect", () => {
     console.log("Connected");
@@ -114,7 +115,10 @@ socket.on("Board.Set", (locationInfo: BoardInfo) => {
     gameStore.selectFloor({ targetFloor: 0, sync: false });
     gameStore.setBoardInitialized(true);
 });
-socket.on("Floor.Create", addFloor);
+socket.on("Floor.Create", (data: { floor: ServerFloor; creator: string }) => {
+    addFloor(data.floor);
+    if (data.creator === coreStore.username) gameStore.selectFloor({ targetFloor: data.floor.name, sync: true });
+});
 socket.on("Floor.Remove", removeFloor);
 socket.on("Shape.Add", (shape: ServerShape) => {
     gameManager.addShape(shape);

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -18,7 +18,6 @@ export function addFloor(floor: ServerFloor): void {
     addCDT(floor.name);
     layerManager.floors.push({ name: floor.name, layers: [] });
     for (const layer of floor.layers) createLayer(layer, floor.name);
-    gameStore.selectFloor({ targetFloor: gameStore.floors.length - 1, sync: true });
 }
 
 export function removeFloor(floor: string): void {

--- a/server/api/socket/floor.py
+++ b/server/api/socket/floor.py
@@ -21,7 +21,7 @@ async def create_floor(sid: int, data: Dict[str, Any]):
     for psid, player in game_state.get_users(active_location=pr.active_location):
         await sio.emit(
             "Floor.Create",
-            floor.as_dict(player, player == pr.room.creator),
+            { "floor": floor.as_dict(player, player == pr.room.creator), "creator": pr.player.name },
             room=psid,
             namespace="/planarally",
         )


### PR DESCRIPTION
When reloading there was a possibility that you reset to the map layer instead of the layer you previously had active.

Additionally when creating a new floor it will no longer move everyone to it immediately.