### PR TITLE
bug(DmSettings): Fix DM no longer being able to kick themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 -   Server showing JSON decode errors
 -   Players not being able to update initiative effects
 -   Active layer sometimes resetting on reload
+-   DMs no longer being able to kick themselves
 
 ## [0.20.1] - 2020-05-11
 

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -19,6 +19,13 @@ export interface LocationUserOptions {
     zoomFactor: number;
 }
 
+export interface Player {
+    id: number;
+    name: string;
+    location: number;
+    role: number;
+}
+
 export interface GameState {
     boardInitialized: boolean;
 }
@@ -48,7 +55,7 @@ class GameStore extends VuexModule implements GameState {
     roomName = "";
     roomCreator = "";
     invitationCode = "";
-    players: { id: number; name: string; location: number; role: number }[] = [];
+    players: Player[] = [];
 
     gridColour = "rgba(0, 0, 0, 1)";
     fowColour = "rgba(0, 0, 0, 1)";
@@ -415,12 +422,12 @@ class GameStore extends VuexModule implements GameState {
     }
 
     @Mutation
-    setPlayers(players: { id: number; name: string; location: number; role: number }[]): void {
+    setPlayers(players: Player[]): void {
         this.players = players;
     }
 
     @Mutation
-    addPlayer(player: { id: number; name: string; location: number; role: number }): void {
+    addPlayer(player: Player): void {
         this.players.push(player);
     }
 

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -6,7 +6,7 @@ import InputCopyElement from "@/core/components/inputCopy.vue";
 import Game from "../../../game.vue";
 import { socket } from "@/game/api/socket";
 import { EventBus } from "@/game/event-bus";
-import { gameStore } from "@/game/store";
+import { gameStore, Player } from "@/game/store";
 
 @Component({
     components: {
@@ -32,6 +32,10 @@ export default class AdminSettings extends Vue {
     }
     get locked(): boolean {
         return gameStore.isLocked;
+    }
+
+    get players(): Player[] {
+        return gameStore.players.filter(p => p.role !== 1);
     }
 
     refreshInviteCode(): void {
@@ -61,13 +65,13 @@ export default class AdminSettings extends Vue {
 <template>
     <div class="panel">
         <div class="spanrow header">Players</div>
-        <div class="row smallrow" v-for="player in $store.state.game.players" :key="player.id">
+        <div class="row smallrow" v-for="player in players" :key="player.id">
             <div>{{ player.name }}</div>
             <div>
                 <div @click="kickPlayer(player.id)">Kick</div>
             </div>
         </div>
-        <div class="row smallrow" v-if="Object.values($store.state.game.players).length === 0">
+        <div class="row smallrow" v-if="Object.values(players).length === 0">
             <div class="spanrow">There are no players yet, invite some using the link below!</div>
         </div>
         <div class="spanrow header">Invite code</div>


### PR DESCRIPTION
The DM was listed in the player list in the admin DM settings and thus could be kicked.  This is no longer the case.

This fixes #356 