### PR TITLE
bug(UI): Fix area right of layer selector preventing draw/select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 -   Active layer sometimes resetting on reload
 -   DMs no longer being able to kick themselves
 -   Some UI components not properly updating on shape reset
+-   Area right of layer selector preventing draw/select
 
 ## [0.20.1] - 2020-05-11
 

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -109,7 +109,6 @@ export default class FloorSelect extends Vue {
     list-style: none;
     margin-left: 25px;
     margin-bottom: 25px;
-    pointer-events: auto;
 }
 
 #floor-layer * {
@@ -124,6 +123,7 @@ export default class FloorSelect extends Vue {
 
 #floor-selector,
 .layer {
+    pointer-events: auto;
     background-color: #eee;
     border-right: solid 1px #82c8a0;
 }


### PR DESCRIPTION
It was impossible to draw/select something in the area right of the layer bar due to a faulty pointer css rule