### PR TITLE
bug(Scrollbar): Fix firefox scrollbar issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 -   Keyboard center throwing error when no tokens are defined
 -   Multiple bugs with initiative syncing
 -   Two bugs with location specific options not properly loading/saving
+-   Scrollbar on bottom of page in firefox when location bar does not fit the screen
 
 ## [0.20.1] - 2020-05-11
 

--- a/client/src/game/ui/menu/locations.vue
+++ b/client/src/game/ui/menu/locations.vue
@@ -247,7 +247,7 @@ export default class LocationBar extends Vue {
     grid-auto-flow: column;
     grid-gap: 10px;
     overflow-y: hidden;
-    /* overflow-x: auto; */
+    width: calc(100vw - 105px); /* 105 = width of the #create-location div */
 
     scrollbar-width: thin;
     scrollbar-color: var(--secondary) var(--primary);


### PR DESCRIPTION
On firefox when the location bar does not fit the screen, the scrollbar would not be displayed in the location bar, but instead be displayed on the entire page at all times.

This closes #364 