### PR TITLE
bug(Floor): Fix floor selection not clickable

### DIFF
--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -154,6 +154,7 @@ a {
 }
 
 #floor-detail {
+    pointer-events: auto;
     position: absolute;
     left: 25px;
     bottom: 80px;


### PR DESCRIPTION
A recent commit to dev fixed various tools not being able to operate in the lower left area.

This css change accidentally prevented the floor UI to be interactable.

This fixes #375 