### PR TITLE
feat(BasicToken): Set the default name to their label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 -   In Play mode (see #added) the select tool will no longer allow resizing
 -   Creating a new floor will no longer automatically move everyone to that floor
 -   The version shown in the topleft area in-game will now be limited to the latest release version
+-   Basic tokens will now have their default name set to their label instead of 'Unknown shape'
 
 ### Fixed
 

--- a/client/src/game/shapes/circulartoken.ts
+++ b/client/src/game/shapes/circulartoken.ts
@@ -24,6 +24,7 @@ export class CircularToken extends Circle {
         super(center, r, fillColour, strokeColour, uuid);
         this.text = text;
         this.font = font;
+        this.name = this.text;
     }
     asDict(): ServerCircularToken {
         return Object.assign(this.getBaseDict(), {


### PR DESCRIPTION
When basic tokens are created their name will default to 'Unknown shape' like all other shapes.  With the basic tokens we have however a more suitable default which is the label given during the creation of the token.

This will now be used as the default.  This closes #384 