### PR TITLE
Contain body to disable pull refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 -   Creating a new floor will no longer automatically move everyone to that floor
 -   The version shown in the topleft area in-game will now be limited to the latest release version
 -   Basic tokens will now have their default name set to their label instead of 'Unknown shape'
+-   Mobile device users are now unable to trigger overscroll refresh by simply moving around
 
 ### Fixed
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -27,6 +27,10 @@ export default class App extends Vue {
 @import url("https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css");
 @import url("https://fonts.googleapis.com/css?family=Open+Sans");
 
+body {
+  overscroll-behavior: contain;
+}
+
 html,
 body,
 #app {


### PR DESCRIPTION
Use `overscroll-behavior` to disable overscroll refresh feature that Android Chrome implemented.

While using touch screen device, playing and using pan to move, if scroling down, most likely it'll trigger refresh and make it very hard to play on Android Chrome.

Related to #324, and this simple fix is to improve the touch screen experience.



