### PR TITLE
bug(UI): Remove a couple of DM only interactions from the player UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 -   Two bugs with location specific options not properly loading/saving
 -   Scrollbar on bottom of page in firefox when location bar does not fit the screen
 -   Players can no longer remove or add floors
+-   Players can no longer move their shape to other layers/floors/locations themselves
 
 ## [0.20.1] - 2020-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 -   Multiple bugs with initiative syncing
 -   Two bugs with location specific options not properly loading/saving
 -   Scrollbar on bottom of page in firefox when location bar does not fit the screen
+-   Players can no longer remove or add floors
 
 ## [0.20.1] - 2020-05-11
 

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -102,14 +102,14 @@ export default class FloorSelect extends Vue {
                         {{ index }}
                     </div>
                     <div class="floor-name">{{ floor }}</div>
-                    <div class="floor-actions" v-show="floors.length > 1">
+                    <div class="floor-actions" v-show="floors.length > 1 && IS_DM">
                         <div @click.stop="removeFloor(index)" :title="$t('game.ui.floors.delete_floor')">
                             <i aria-hidden="true" class="fas fa-trash-alt"></i>
                         </div>
                     </div>
                 </div>
             </template>
-            <div class="floor-add" @click="addFloor" v-t="'game.ui.floors.add_new_floor'"></div>
+            <div class="floor-add" @click="addFloor" v-if="IS_DM" v-t="'game.ui.floors.add_new_floor'"></div>
         </div>
         <div style="display:contents" v-show="layers.length > 1">
             <div
@@ -226,6 +226,7 @@ a {
 }
 
 .floor-index {
+    grid-column-start: 1;
     padding-right: 5px;
     border-right: 1px solid black;
     justify-self: end;

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -61,15 +61,16 @@ export default class ShapeContext extends Vue {
         return layer.selection[0].uuid;
     }
     getFloors(): Floor[] {
-        return layerManager.floors;
+        if (gameStore.IS_DM) return layerManager.floors;
+        return [];
     }
     getLocations(): { id: number; name: string }[] {
-        if (this.hasSpawnToken()) return [];
+        if (!gameStore.IS_DM || this.hasSpawnToken()) return [];
         return gameStore.locations;
     }
     getLayers(): Layer[] {
-        if (this.hasSpawnToken()) return [];
-        return layerManager.floor?.layers.filter(l => l.selectable && (gameStore.IS_DM || l.playerEditable)) || [];
+        if (!gameStore.IS_DM || this.hasSpawnToken()) return [];
+        return layerManager.floor?.layers.filter(l => l.selectable) || [];
     }
     getActiveLayer(): Layer | undefined {
         if (layerManager.floor !== undefined) return layerManager.getLayer(layerManager.floor.name);
@@ -186,7 +187,9 @@ export default class ShapeContext extends Vue {
         return !this.hasSpawnToken();
     }
     showDelete(): boolean {
-        return !this.hasSpawnToken();
+        if (this.hasSpawnToken()) return false;
+        if (gameStore.IS_DM) return true;
+        return this.getSelection().every(s => s.ownedBy({ editAccess: true }));
     }
     getLayerWord(layer: string): string {
         switch (layer) {


### PR DESCRIPTION
This PR removes the delete and add actions in the floor selector for players as well as remove the option to move a shape to a different floor/layer/location.