### PR TITLE
feat(Initiative): Show shape name on hover for images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable changes to this project will be documented in this file.
 -   Location removal
 -   Upon floor change all players with edit access will auto move to the same floor
 -   Set any shape as marker and jump to that position from the sidebar [LDeeJay1969]
+-   Initiative token images now have their name shown on hover
 
 ### Changed
 

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -181,6 +181,14 @@ export default class Initiative extends Vue {
     setLock(lock: boolean): void {
         initiativeStore.setLock(lock);
     }
+    getName(actor: InitiativeData): string {
+        const shape = layerManager.UUIDMap.get(actor.uuid);
+        if (shape !== undefined) {
+            if (shape.nameVisible) return shape.name;
+            if (shape.ownedBy({ editAccess: true })) return shape.name;
+        }
+        return actor.source;
+    }
 }
 </script>
 
@@ -217,10 +225,10 @@ export default class Initiative extends Vue {
                             @mouseleave="toggleHighlight(actor, false)"
                         >
                             <template v-if="actor.has_img">
-                                <img :src="actor.source" width="30px" height="30px" alt="" />
+                                <img :src="actor.source" width="30px" height="30px" :title="getName(actor)" alt="" />
                             </template>
                             <template v-else>
-                                <span style="width: auto;">{{ actor.source }}</span>
+                                <span style="width: auto;">{{ getName(actor) }}</span>
                             </template>
                             <input
                                 type="text"


### PR DESCRIPTION
This PR adds a hover text with the name of the shape when you move your mouse over an initiative shape image.

Closes #388