### PR TITLE
Using LABEL instruction instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM python:3.6-slim
 ARG DOCKER_TAG
 ARG SOURCE_COMMIT
 
-MAINTAINER Kruptein <info@darragh.dev>
+LABEL maintainer="Kruptein <info@darragh.dev>"
 
 EXPOSE 8000
 


### PR DESCRIPTION
Fix #413 
As Dockerfile reference: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated