### PR TITLE
Removed english in German locale and fixed switched translations

### DIFF
--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -282,9 +282,9 @@
                     "no_category": "keine Kategorie"
                 },
                 "map": {
-                    "drag_to_resize": "Markiere den Bereich, dessen Größe Du verändern willstDrag an area you wish to resize",
-                    "select_shape_msg": "Feld-Zielgröße setzen",
-                    "set_target_grid_cells": "Bitte wähle zuerst eine Form aus.",
+                    "drag_to_resize": "Markiere den Bereich, dessen Größe Du verändern willst",
+                    "select_shape_msg": "Bitte wähle zuerst eine Form aus.",
+                    "set_target_grid_cells": "Feld-Zielgröße setzen",
                     "horizontal": "Horizontal",
                     "vertical": "Vertikal",
                     "apply": "ANWENDEN",


### PR DESCRIPTION
The German locale had leftover english text in one of the fields, and two translations were switched.