### PR TITLE
Fixed visibleInCanvas to support aura

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 
  - Danish localization
 
+### Fixed
+
+ - Aura not displaying when token is outside the visible canvas
+
 ## [0.21.0] - 2020-06-13
 
 ### Added

--- a/client/src/game/shapes/circle.ts
+++ b/client/src/game/shapes/circle.ts
@@ -68,8 +68,9 @@ export class Circle extends Shape {
         this.refPoint = centerPoint;
     }
     visibleInCanvas(canvas: HTMLCanvasElement): boolean {
+        if (super.visibleInCanvas(canvas)) return true;
         return this.getBoundingBox().visibleInCanvas(canvas);
-    } // TODO
+    }
     snapToGrid(): void {
         const gs = gameSettingsStore.gridSize;
         let targetX;

--- a/client/src/game/shapes/circulartoken.ts
+++ b/client/src/game/shapes/circulartoken.ts
@@ -6,7 +6,7 @@ import { ServerCircularToken } from "@/game/comm/types/shapes";
 import { GlobalPoint } from "@/game/geom";
 import { Circle } from "@/game/shapes/circle";
 import { gameStore } from "@/game/store";
-import { g2l, g2lz } from "@/game/units";
+import { g2l, g2lz, getUnitDistance } from "@/game/units";
 
 export class CircularToken extends Circle {
     type = "circulartoken";
@@ -64,5 +64,16 @@ export class CircularToken extends Circle {
             effects: [],
             index: Infinity,
         };
+    }
+    visibleInCanvas(canvas: HTMLCanvasElement): boolean {
+        for (const aura of this.auras) {
+            if (aura.value > 0 || aura.dim > 0) {
+                const auraCircle = new Circle(this.center(), getUnitDistance(aura.value + aura.dim));
+                if (auraCircle.visibleInCanvas(canvas)) {
+                    return true;
+                }
+            }
+        }
+        return this.getBoundingBox().visibleInCanvas(canvas);
     }
 }

--- a/client/src/game/shapes/circulartoken.ts
+++ b/client/src/game/shapes/circulartoken.ts
@@ -6,7 +6,7 @@ import { ServerCircularToken } from "@/game/comm/types/shapes";
 import { GlobalPoint } from "@/game/geom";
 import { Circle } from "@/game/shapes/circle";
 import { gameStore } from "@/game/store";
-import { g2l, g2lz, getUnitDistance } from "@/game/units";
+import { g2l, g2lz } from "@/game/units";
 
 export class CircularToken extends Circle {
     type = "circulartoken";
@@ -64,16 +64,5 @@ export class CircularToken extends Circle {
             effects: [],
             index: Infinity,
         };
-    }
-    visibleInCanvas(canvas: HTMLCanvasElement): boolean {
-        for (const aura of this.auras) {
-            if (aura.value > 0 || aura.dim > 0) {
-                const auraCircle = new Circle(this.center(), getUnitDistance(aura.value + aura.dim));
-                if (auraCircle.visibleInCanvas(canvas)) {
-                    return true;
-                }
-            }
-        }
-        return this.getBoundingBox().visibleInCanvas(canvas);
     }
 }

--- a/client/src/game/shapes/line.ts
+++ b/client/src/game/shapes/line.ts
@@ -64,8 +64,9 @@ export class Line extends Shape {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     center(_centerPoint?: GlobalPoint): GlobalPoint | void {} // TODO
     visibleInCanvas(canvas: HTMLCanvasElement): boolean {
+        if (super.visibleInCanvas(canvas)) return true;
         return this.getBoundingBox().visibleInCanvas(canvas);
-    } // TODO
+    }
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     snapToGrid(): void {}
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/client/src/game/shapes/polygon.ts
+++ b/client/src/game/shapes/polygon.ts
@@ -106,8 +106,9 @@ export class Polygon extends Shape {
         return this.getBoundingBox().center();
     }
     visibleInCanvas(canvas: HTMLCanvasElement): boolean {
+        if (super.visibleInCanvas(canvas)) return true;
         return this.getBoundingBox().visibleInCanvas(canvas);
-    } // TODO
+    }
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     snapToGrid(): void {}
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -94,13 +94,13 @@ export abstract class Shape {
 
     abstract center(): GlobalPoint;
     abstract center(centerPoint: GlobalPoint): void;
-    visibleInCanvas(_canvas: HTMLCanvasElement): boolean {
+    visibleInCanvas(canvas: HTMLCanvasElement): boolean {
         for (const aura of this.auras) {
             if (aura.value > 0 || aura.dim > 0) {
                 const r = getUnitDistance(aura.value + aura.dim);
                 const center = this.center();
                 const auraArea = new BoundingRect(new GlobalPoint(center.x - r, center.y - r), r * 2, r * 2);
-                if (auraArea.visibleInCanvas(_canvas)) return true;
+                if (auraArea.visibleInCanvas(canvas)) return true;
             }
         }
         return false;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -6,7 +6,7 @@ import { accessToServer, ownerToClient, ownerToServer, ServerShape } from "@/gam
 import { GlobalPoint, Vector } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
-import { g2l, g2lx, g2ly, g2lz } from "@/game/units";
+import { g2l, g2lx, g2ly, g2lz, getUnitDistance } from "@/game/units";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { addBlocker, getBlockers, getVisionSources, setVisionSources, sliceBlockers } from "@/game/visibility/utils";
@@ -95,12 +95,14 @@ export abstract class Shape {
     abstract center(): GlobalPoint;
     abstract center(centerPoint: GlobalPoint): void;
     visibleInCanvas(_canvas: HTMLCanvasElement): boolean {
-        // for (const aura of this.auras) {
-        //     if (aura.value > 0) {
-        //         const auraCircle = new Circle(this.center(), aura.value);
-        //         if (auraCircle.visibleInCanvas(canvas)) return true;
-        //     }
-        // }
+        for (const aura of this.auras) {
+            if (aura.value > 0 || aura.dim > 0) {
+                const r = getUnitDistance(aura.value + aura.dim);
+                const center = this.center();
+                const auraArea = new BoundingRect(new GlobalPoint(center.x - r, center.y - r), r * 2, r * 2);
+                if (auraArea.visibleInCanvas(_canvas)) return true;
+            }
+        }
         return false;
     }
 

--- a/client/src/game/shapes/text.ts
+++ b/client/src/game/shapes/text.ts
@@ -58,8 +58,9 @@ export class Text extends Shape {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     center(_centerPoint?: GlobalPoint): GlobalPoint | void {} // TODO
     visibleInCanvas(canvas: HTMLCanvasElement): boolean {
+        if (super.visibleInCanvas(canvas)) return true;
         return this.getBoundingBox().visibleInCanvas(canvas);
-    } // TODO
+    }
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     snapToGrid(): void {}
     // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
- [x] Make sure to do your PR on the `dev` branch and NOT on the `master` branch.  This repo uses gitflow which only uses the master branch as a release branch.

- [x] Make sure to update the `CHANGELOG`.
Implemented visibleInCanvas for CircularTokens, thus fixing the bug where auras would not be displayed when the source token is out of frame #427 