### PR TITLE
#435 fix (dialog background is cut at the right side in Firefox and some other browsers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
  - Aura not displaying when token is outside the visible canvas
+ - Dialog background was cut on the right side in some browsers because max-width was set to unreasonably low value
+
 
 ## [0.21.0] - 2020-06-13
 

--- a/client/src/game/ui/selection/edit_dialog/dialog.vue
+++ b/client/src/game/ui/selection/edit_dialog/dialog.vue
@@ -467,7 +467,7 @@ export default class EditDialog extends Vue {
 
 .modal-body {
     padding: 10px;
-    max-width: 450px;
+    max-width: 800px;
 }
 
 .grid {


### PR DESCRIPTION
Got your [#435](https://github.com/Kruptein/PlanarAlly/issues/435) quickfixed