### PR TITLE
bug(Firefox): Fix firefox location scroll when menu open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
- - Danish localization
- - Spanish localization
+-   Danish localization
+-   Spanish localization
 
 ### Fixed
 
- - Aura not displaying when token is outside the visible canvas
+-   Aura not displaying when token is outside the visible canvas
+-   Firefox location scrollbar when left menu is open
 
 ## [0.21.0] - 2020-06-13
 

--- a/client/src/game/ui/menu/locations.vue
+++ b/client/src/game/ui/menu/locations.vue
@@ -20,6 +20,7 @@ import { EventBus } from "../../event-bus";
 })
 export default class LocationBar extends Vue {
     @Prop() active!: boolean;
+    @Prop() menuActive!: boolean;
 
     @Watch("active")
     toggleActive(active: boolean): void {
@@ -165,6 +166,7 @@ export default class LocationBar extends Vue {
             @wheel.native="doHorizontalScroll"
             @scroll.native="doHorizontalScrollA"
             ref="locations"
+            :style="{ maxWidth: 'calc(100vw - 105px - ' + (menuActive ? '200px' : '0px') + ')' }"
         >
             <div class="location" v-for="location in locations" :key="location.id">
                 <div class="location-name" :class="{ 'active-location': activeLocation === location.id }">

--- a/client/src/game/ui/ui.vue
+++ b/client/src/game/ui/ui.vue
@@ -197,7 +197,7 @@ export default class UI extends Vue {
             </div>
         </div>
         <MenuBar></MenuBar>
-        <LocationBar :active="visible.locations"></LocationBar>
+        <LocationBar :active="visible.locations" :menuActive="visible.settings"></LocationBar>
         <Tools ref="tools"></Tools>
         <FloorSelect></FloorSelect>
         <SelectionInfo></SelectionInfo>


### PR DESCRIPTION
When the left sidemenu is open a horizontal bar appears if there are more locations than can fit the horizontal axis.  This is due to firefox misbehaving on overflow in a grid context.

This was partially fixed in the past but didn't address the left menu potentially being open this is now resolved and fixes #437 