### PR TITLE
Gh 434 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 -   Aura not displaying when token is outside the visible canvas
 -   Firefox location scrollbar when left menu is open
+-   Server now quits, referring to docs/tutorial, if client was not built
 
 ## [0.21.0] - 2020-06-13
 

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -7,7 +7,7 @@ This is the code responsible for starting the backend and reacting to socket IO 
 import sys
 from utils import FILE_DIR
 
-if( (FILE_DIR / "templates").exists() is False):
+if not (FILE_DIR / "templates").exists():
     print('You must gather your par— you must build the client, before starting the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client.')
     sys.exit(1)
 

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -3,6 +3,14 @@ PlanarAlly backend server code.
 This is the code responsible for starting the backend and reacting to socket IO events.
 """
 
+# Check for existence of './templates/' as it is not present if client was not built before
+import os
+import sys
+
+if(os.path.isdir( os.path.dirname( os.path.realpath(__file__) ) + '/templates') is False):
+    print('You need to build the client, before running the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client.')
+    sys.exit(1)
+
 # Mimetype recognition for js files apparently is not always properly setup out of the box for some users out there.
 import mimetypes
 
@@ -15,7 +23,6 @@ save.check_save()
 
 import asyncio
 import configparser
-import sys
 
 from aiohttp import web
 

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -8,7 +8,7 @@ import sys
 from utils import FILE_DIR
 
 if( (FILE_DIR / "templates").exists() is False):
-    print('You need to build the client, before running the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client.')
+    print('You must gather your par— you must build the client, before starting the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client.')
     sys.exit(1)
 
 # Mimetype recognition for js files apparently is not always properly setup out of the box for some users out there.

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -4,10 +4,10 @@ This is the code responsible for starting the backend and reacting to socket IO 
 """
 
 # Check for existence of './templates/' as it is not present if client was not built before
-import os
 import sys
+from utils import FILE_DIR
 
-if(os.path.isdir( os.path.dirname( os.path.realpath(__file__) ) + '/templates') is False):
+if( (FILE_DIR / "templates").exists() is False):
     print('You need to build the client, before running the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client.')
     sys.exit(1)
 


### PR DESCRIPTION
To (further) prevent bug-reports like #434 or #218 the server now provides a helpful error-message, pointing towards the tutorial.

Tested on Linux; not sure whether concatenation in line 10 actually should be done with '/' instead of '+' (does os.isdir() support that?) to support Windows denoting directories with backslash, though.