### PR TITLE
feat(Rotation): Add rotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   Danish localization
--   Spanish localization
+-   localization updates
+    -   Danish
+    -   Spanish
+-   Rotation in Select tool with build mode
 
 ### Fixed
 
 -   Aura not displaying when token is outside the visible canvas
 -   Firefox location scrollbar when left menu is open
+-   Some significant performance bottlenecks
 
 ## [0.21.0] - 2020-06-13
 

--- a/client/src/game/comm/types/shapes.ts
+++ b/client/src/game/comm/types/shapes.ts
@@ -5,6 +5,7 @@ export interface ServerShape {
     type_: string;
     x: number;
     y: number;
+    angle: number;
     floor: string;
     layer: string;
     movement_obstruction: boolean;
@@ -16,6 +17,7 @@ export interface ServerShape {
     owners: ServerShapeOwner[];
     fill_colour: string;
     stroke_colour: string;
+    stroke_width: number;
     name: string;
     name_visible: boolean;
     annotation: string;

--- a/client/src/game/geom.ts
+++ b/client/src/game/geom.ts
@@ -24,14 +24,21 @@ export function getDistanceToSegment(p: Point, line: [Point, Point]): number {
 export class Point {
     readonly x: number;
     readonly y: number;
+
     constructor(x: number, y: number) {
         this.x = x;
         this.y = y;
     }
+
+    *[Symbol.iterator](): Generator<number> {
+        yield this.x;
+        yield this.y;
+    }
+
     static fromArray(point: number[]): Point {
         return new Point(point[0], point[1]);
     }
-    add(vec: Vector): this {
+    add(vec: Vector | this): this {
         return new (<any>this).constructor(this.x + vec.x, this.y + vec.y);
     }
     subtract(other: this): Vector {

--- a/client/src/game/geom.ts
+++ b/client/src/game/geom.ts
@@ -41,7 +41,7 @@ export class Point {
     add(vec: Vector | this): this {
         return new (<any>this).constructor(this.x + vec.x, this.y + vec.y);
     }
-    subtract(other: this): Vector {
+    subtract(other: Vector | this): Vector {
         return new Vector(this.x - other.x, this.y - other.y);
     }
     clone(): this {
@@ -85,6 +85,12 @@ export class Vector {
     static fromPoints(p1: Point, p2: Point): Vector {
         return new Vector(p2.x - p1.x, p2.y - p1.y);
     }
+
+    *[Symbol.iterator](): Generator<number> {
+        yield this.x;
+        yield this.y;
+    }
+
     dot(other: Vector): number {
         return this.x * other.x + this.y * other.y;
     }

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -48,7 +48,6 @@ export function onKeyDown(event: KeyboardEvent): void {
                 if (!event.shiftKey || !gameStore.IS_DM) {
                     // First check for collisions.  Using the smooth wall slide collision check used on mouse move is overkill here.
                     for (const sel of selection) {
-                        if (gameStore.selectionHelperID === sel.uuid) continue;
                         delta = calculateDelta(delta, sel, true);
                     }
                 }
@@ -57,7 +56,6 @@ export function onKeyDown(event: KeyboardEvent): void {
                 let recalculateMovement = false;
                 for (const sel of selection) {
                     if (!sel.ownedBy({ movementAccess: true })) continue;
-                    if (gameStore.selectionHelperID === sel.uuid) continue;
                     if (sel.movementObstruction) {
                         recalculateMovement = true;
                         visibilityStore.deleteFromTriag({

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -143,7 +143,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             if (!event.ctrlKey || event.shiftKey) {
                 gameStore.selectFloor({ targetFloor: gameStore.selectedFloorIndex + 1, sync: true });
             }
-            if (event.shiftKey) for (const shape of selection) newLayer.selection.push(shape);
+            if (event.shiftKey) for (const shape of selection) newLayer.pushSelection(shape);
         } else if (event.key === "PageDown" && gameStore.selectedFloorIndex > 0) {
             // Page Down - Move floor down
             // Ctrl + Page Down - Move selected shape floor down
@@ -163,7 +163,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             if (!event.ctrlKey || event.shiftKey) {
                 gameStore.selectFloor({ targetFloor: gameStore.selectedFloorIndex - 1, sync: true });
             }
-            if (event.shiftKey) for (const shape of selection) newLayer.selection.push(shape);
+            if (event.shiftKey) for (const shape of selection) newLayer.pushSelection(shape);
         } else if (event.key === "Tab") {
             event.preventDefault();
             EventBus.$emit("ToolMode.Toggle");

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -93,7 +93,7 @@ export class FOWLayer extends Layer {
                 layerManager.hasLayer(this.floor, "tokens") &&
                 this.floor === gameStore.floors[gameStore.selectedFloorIndex]
             ) {
-                for (const sh of layerManager.getLayer(this.floor, "tokens")!.shapes) {
+                for (const sh of layerManager.getLayer(this.floor, "tokens")!.getShapes()) {
                     if (!sh.ownedBy({ visionAccess: true }) || !sh.isToken) continue;
                     const bb = sh.getBoundingBox();
                     const lcenter = g2l(sh.center());

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -26,10 +26,10 @@ export class Layer {
     valid = false;
     // The collection of shapes that this layer contains.
     // These are ordered on a depth basis.
-    shapes: Shape[] = [];
+    protected shapes: Shape[] = [];
 
     // Collection of shapes that are currently selected
-    selection: Shape[] = [];
+    protected selection: Shape[] = [];
 
     // Extra selection highlighting settings
     selectionColor = "#CC0000";
@@ -50,6 +50,40 @@ export class Layer {
         if (!skipLightUpdate) {
             layerManager.invalidateLight(this.floor);
         }
+    }
+
+    // UI helpers are objects that are created for UI reaons but that are not pertinent to the actual state
+    // They are often not desired unless in specific circumstances
+    getShapes(skipUiHelpers = true): readonly Shape[] {
+        if (!skipUiHelpers) return this.shapes;
+        return this.shapes.filter(s => !s.options.has("UiHelper"));
+    }
+
+    setShapes(...shapes: Shape[]): void {
+        this.shapes = shapes;
+    }
+
+    pushShapes(...shapes: Shape[]): void {
+        this.shapes.push(...shapes);
+    }
+
+    hasSelection(skipUiHelpers = true): boolean {
+        return this.getSelection(skipUiHelpers).length > 0;
+    }
+
+    // UI helpers are objects that are created for UI reaons but that are not pertinent to the actual state
+    // They are often not desired unless in specific circumstances
+    getSelection(skipUiHelpers = true): readonly Shape[] {
+        if (!skipUiHelpers) return this.selection;
+        return this.selection.filter(s => !s.options.has("UiHelper"));
+    }
+
+    setSelection(...selection: Shape[]): void {
+        this.selection = selection;
+    }
+
+    pushSelection(...selection: Shape[]): void {
+        this.selection.push(...selection);
     }
 
     get width(): number {
@@ -88,7 +122,7 @@ export class Layer {
         if (invalidate) this.invalidate(invalidate === InvalidationMode.WITH_LIGHT);
     }
 
-    setShapes(shapes: ServerShape[]): void {
+    setServerShapes(shapes: ServerShape[]): void {
         for (const serverShape of shapes) {
             const shape = createShapeFromDict(serverShape);
             if (shape === undefined) {

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -128,11 +128,10 @@ class LayerManager {
         return selection !== undefined && selection.length > 0;
     }
 
-    // THIS INCLUDES POTENTIALLY THE SelectTool.SelectionHelper !!!
-    getSelection(): Shape[] | undefined {
+    getSelection(skipUiHelpers = true): readonly Shape[] | undefined {
         const layer = this.getLayer(this.floor!.name);
         if (layer === undefined) return undefined;
-        return layer.selection;
+        return layer.getSelection(skipUiHelpers);
     }
 
     clearSelection(): void {

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -67,7 +67,7 @@ export function createLayer(layerInfo: ServerLayer, floor: string): void {
     }
     if (layerInfo.name !== "fow-players") layers.appendChild(canvas);
     // Load layer shapes
-    layer.setShapes(layerInfo.shapes);
+    layer.setServerShapes(layerInfo.shapes);
 }
 
 export function dropAsset(event: DragEvent): void {

--- a/client/src/game/manager.ts
+++ b/client/src/game/manager.ts
@@ -13,8 +13,6 @@ import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { Shape } from "./shapes/shape";
 
 export class GameManager {
-    selectedTool = 0;
-
     annotationManager = new AnnotationManager();
 
     addShape(shape: ServerShape): Shape | undefined {

--- a/client/src/game/shapes/asset.ts
+++ b/client/src/game/shapes/asset.ts
@@ -3,7 +3,7 @@ import { ServerAsset } from "@/game/comm/types/shapes";
 import { GlobalPoint } from "@/game/geom";
 import { BaseRect } from "@/game/shapes/baserect";
 import { gameStore } from "@/game/store";
-import { g2lx, g2ly, g2lz } from "@/game/units";
+import { g2lx, g2ly, g2lz, g2l } from "@/game/units";
 
 export class Asset extends BaseRect {
     type = "assetrect";
@@ -26,8 +26,15 @@ export class Asset extends BaseRect {
     }
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
+        const center = g2l(this.center());
         try {
-            ctx.drawImage(this.img, g2lx(this.refPoint.x), g2ly(this.refPoint.y), g2lz(this.w), g2lz(this.h));
+            ctx.drawImage(
+                this.img,
+                g2lx(this.refPoint.x) - center.x,
+                g2ly(this.refPoint.y) - center.y,
+                g2lz(this.w),
+                g2lz(this.h),
+            );
         } catch (error) {
             console.warn(`Shape ${this.uuid} could not load the image ${this.src}`);
         }

--- a/client/src/game/shapes/baserect.ts
+++ b/client/src/game/shapes/baserect.ts
@@ -5,6 +5,7 @@ import { calculateDelta } from "@/game/ui/tools/utils";
 import { clampGridLine, g2lx, g2ly } from "@/game/units";
 import { ServerShape } from "../comm/types/shapes";
 import { gameSettingsStore } from "../settings";
+import { rotateAroundPoint } from "../utils";
 
 export abstract class BaseRect extends Shape {
     w: number;
@@ -21,20 +22,25 @@ export abstract class BaseRect extends Shape {
         });
     }
     getBoundingBox(): BoundingRect {
-        return new BoundingRect(this.refPoint, this.w, this.h);
+        const bbox = new BoundingRect(this.refPoint, this.w, this.h);
+        bbox.angle = this.angle;
+        return bbox;
     }
 
     get points(): number[][] {
         if (this.w === 0 || this.h === 0) return [[this.refPoint.x, this.refPoint.y]];
-        // note to self: topright and botleft are swapped because I'm retarded.
-        const topright = this.refPoint.add(new Vector(0, this.h));
-        const botright = this.refPoint.add(new Vector(this.w, this.h));
-        const botleft = this.refPoint.add(new Vector(this.w, 0));
+
+        const center = this.center();
+
+        const topleft = rotateAroundPoint(this.refPoint, center, this.angle);
+        const botleft = rotateAroundPoint(this.refPoint.add(new Vector(0, this.h)), center, this.angle);
+        const botright = rotateAroundPoint(this.refPoint.add(new Vector(this.w, this.h)), center, this.angle);
+        const topright = rotateAroundPoint(this.refPoint.add(new Vector(this.w, 0)), center, this.angle);
         return [
-            [this.refPoint.x, this.refPoint.y],
-            [topright.x, topright.y],
-            [botright.x, botright.y],
+            [topleft.x, topleft.y],
             [botleft.x, botleft.y],
+            [botright.x, botright.y],
+            [topright.x, topright.y],
         ];
     }
 

--- a/client/src/game/shapes/boundingrect.ts
+++ b/client/src/game/shapes/boundingrect.ts
@@ -41,6 +41,14 @@ export class BoundingRect {
         return new BoundingRect(this.topLeft.add(vector), this.w, this.h);
     }
 
+    expand(vector: Vector): BoundingRect {
+        return new BoundingRect(
+            this.topLeft.add(vector),
+            this.w + 2 * Math.abs(vector.x),
+            this.h + 2 * Math.abs(vector.y),
+        );
+    }
+
     union(other: BoundingRect): BoundingRect {
         const xmin = Math.min(this.topLeft.x, other.topLeft.x);
         const xmax = Math.max(this.topRight.x, other.topRight.x);

--- a/client/src/game/shapes/circle.ts
+++ b/client/src/game/shapes/circle.ts
@@ -3,7 +3,7 @@ import { GlobalPoint, Vector } from "@/game/geom";
 import { BoundingRect } from "@/game/shapes/boundingrect";
 import { Shape } from "@/game/shapes/shape";
 import { calculateDelta } from "@/game/ui/tools/utils";
-import { clampGridLine, g2l, g2lz } from "@/game/units";
+import { clampGridLine, g2lz } from "@/game/units";
 import { getFogColour } from "@/game/utils";
 import { gameSettingsStore } from "../settings";
 
@@ -44,8 +44,7 @@ export class Circle extends Shape {
         ctx.beginPath();
         if (this.fillColour === "fog") ctx.fillStyle = getFogColour();
         else ctx.fillStyle = this.fillColour;
-        const loc = g2l(this.refPoint);
-        ctx.arc(loc.x, loc.y, g2lz(this.r), 0, 2 * Math.PI);
+        ctx.arc(0, 0, g2lz(this.r), 0, 2 * Math.PI);
         ctx.fill();
         if (this.strokeColour !== "rgba(0, 0, 0, 0)") {
             const borderWidth = 5;
@@ -53,7 +52,7 @@ export class Circle extends Shape {
             ctx.lineWidth = g2lz(borderWidth);
             ctx.strokeStyle = this.strokeColour;
             // Inset the border with - borderWidth / 2
-            ctx.arc(loc.x, loc.y, Math.max(borderWidth / 2, g2lz(this.r - borderWidth / 2)), 0, 2 * Math.PI);
+            ctx.arc(0, 0, Math.max(borderWidth / 2, g2lz(this.r - borderWidth / 2)), 0, 2 * Math.PI);
             ctx.stroke();
         }
         super.drawPost(ctx);

--- a/client/src/game/shapes/circulartoken.ts
+++ b/client/src/game/shapes/circulartoken.ts
@@ -41,16 +41,19 @@ export class CircularToken extends Circle {
     }
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
+
+        const center = g2l(this.center());
+
         ctx.font = this.font;
-        ctx.save();
-        const dest = g2l(this.center());
+
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         const fontScale = calcFontScale(ctx, this.text, g2lz(this.r - 5));
-        ctx.setTransform(fontScale, 0, 0, fontScale, dest.x, dest.y);
+        ctx.setTransform(fontScale, 0, 0, fontScale, center.x, center.y);
+        ctx.rotate(this.angle);
         ctx.fillStyle = tinycolor.mostReadable(this.fillColour, ["#000", "#fff"]).toHexString();
         ctx.fillText(this.text, 0, 0);
-        ctx.restore();
+
         super.drawPost(ctx);
     }
     getInitiativeRepr(): InitiativeData {

--- a/client/src/game/shapes/line.ts
+++ b/client/src/game/shapes/line.ts
@@ -61,8 +61,10 @@ export class Line extends Shape {
 
     center(): GlobalPoint;
     center(centerPoint: GlobalPoint): void;
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    center(_centerPoint?: GlobalPoint): GlobalPoint | void {} // TODO
+    center(centerPoint?: GlobalPoint): GlobalPoint | void {
+        if (centerPoint === undefined) return this.refPoint.add(this.endPoint.subtract(this.refPoint).multiply(1 / 2));
+        // todo: set center
+    }
     visibleInCanvas(canvas: HTMLCanvasElement): boolean {
         if (super.visibleInCanvas(canvas)) return true;
         return this.getBoundingBox().visibleInCanvas(canvas);

--- a/client/src/game/shapes/line.ts
+++ b/client/src/game/shapes/line.ts
@@ -1,8 +1,9 @@
 import { GlobalPoint } from "@/game/geom";
 import { BoundingRect } from "@/game/shapes/boundingrect";
 import { Shape } from "@/game/shapes/shape";
-import { g2lx, g2ly, g2lz } from "@/game/units";
+import { g2lx, g2ly, g2lz, g2l } from "@/game/units";
 import { ServerLine } from "../comm/types/shapes";
+import { rotateAroundPoint } from "../utils";
 
 export class Line extends Shape {
     type = "line";
@@ -34,8 +35,8 @@ export class Line extends Shape {
     }
     get points(): number[][] {
         return [
-            [this.refPoint.x, this.refPoint.y],
-            [this.endPoint.x, this.endPoint.y],
+            [...rotateAroundPoint(this.refPoint, this.center(), this.angle)],
+            [...rotateAroundPoint(this.endPoint, this.center(), this.angle)],
         ];
     }
     getBoundingBox(): BoundingRect {
@@ -47,10 +48,13 @@ export class Line extends Shape {
     }
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
+
+        const center = g2l(this.center());
+
         ctx.strokeStyle = this.strokeColour;
         ctx.beginPath();
-        ctx.moveTo(g2lx(this.refPoint.x), g2ly(this.refPoint.y));
-        ctx.lineTo(g2lx(this.endPoint.x), g2ly(this.endPoint.y));
+        ctx.moveTo(g2lx(this.refPoint.x) - center.x, g2ly(this.refPoint.y) - center.y);
+        ctx.lineTo(g2lx(this.endPoint.x) - center.x, g2ly(this.endPoint.y) - center.y);
         ctx.lineWidth = g2lz(this.lineWidth);
         ctx.stroke();
         super.drawPost(ctx);
@@ -63,7 +67,9 @@ export class Line extends Shape {
     center(centerPoint: GlobalPoint): void;
     center(centerPoint?: GlobalPoint): GlobalPoint | void {
         if (centerPoint === undefined) return this.refPoint.add(this.endPoint.subtract(this.refPoint).multiply(1 / 2));
-        // todo: set center
+        const oldCenter = this.center();
+        this.refPoint = GlobalPoint.fromArray([...centerPoint.subtract(oldCenter.subtract(this.refPoint))]);
+        this.endPoint = GlobalPoint.fromArray([...centerPoint.subtract(oldCenter.subtract(this.endPoint))]);
     }
     visibleInCanvas(canvas: HTMLCanvasElement): boolean {
         if (super.visibleInCanvas(canvas)) return true;

--- a/client/src/game/shapes/rect.ts
+++ b/client/src/game/shapes/rect.ts
@@ -19,12 +19,14 @@ export class Rect extends BaseRect {
         else ctx.fillStyle = this.fillColour;
         const z = gameStore.zoomFactor;
         const loc = g2l(this.refPoint);
-        ctx.fillRect(loc.x, loc.y, this.w * z, this.h * z);
+        const center = g2l(this.center());
+        ctx.fillRect(loc.x - center.x, loc.y - center.y, this.w * z, this.h * z);
         if (this.strokeColour !== "rgba(0, 0, 0, 0)") {
             ctx.strokeStyle = this.strokeColour;
             ctx.lineWidth = this.strokeWidth;
-            ctx.strokeRect(loc.x, loc.y, this.w * z, this.h * z);
+            ctx.strokeRect(loc.x - center.x, loc.y - center.y, this.w * z, this.h * z);
         }
+
         super.drawPost(ctx);
     }
 }

--- a/client/src/game/shapes/rect.ts
+++ b/client/src/game/shapes/rect.ts
@@ -22,7 +22,7 @@ export class Rect extends BaseRect {
         ctx.fillRect(loc.x, loc.y, this.w * z, this.h * z);
         if (this.strokeColour !== "rgba(0, 0, 0, 0)") {
             ctx.strokeStyle = this.strokeColour;
-            ctx.lineWidth = 5;
+            ctx.lineWidth = this.strokeWidth;
             ctx.strokeRect(loc.x, loc.y, this.w * z, this.h * z);
         }
         super.drawPost(ctx);

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -378,8 +378,8 @@ export abstract class Shape {
         if (oldLayer === undefined || newLayer === undefined) return;
         visibilityStore.moveShape({ shape: this, oldFloor: this.floor, newFloor: floor });
         this.floor = floor;
-        oldLayer.shapes.splice(oldLayer.shapes.indexOf(this), 1);
-        newLayer.shapes.push(this);
+        oldLayer.setShapes(...[...oldLayer.getShapes()].splice(oldLayer.getShapes().indexOf(this), 1));
+        newLayer.pushShapes(this);
         oldLayer.invalidate(false);
         newLayer.invalidate(false);
         if (sync) socket.emit("Shape.Floor.Change", { uuid: this.uuid, floor });
@@ -391,8 +391,8 @@ export abstract class Shape {
         if (oldLayer === undefined || newLayer === undefined) return;
         this.layer = layer;
         // Update layer shapes
-        oldLayer.shapes.splice(oldLayer.shapes.indexOf(this), 1);
-        newLayer.shapes.push(this);
+        oldLayer.setShapes(...[...oldLayer.getShapes()].splice(oldLayer.getShapes().indexOf(this), 1));
+        newLayer.pushShapes(this);
         // Revalidate layers  (light should at most be redone once)
         oldLayer.invalidate(true);
         newLayer.invalidate(false);

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -15,6 +15,7 @@ import { PartialBy } from "../../core/types";
 import { gameSettingsStore } from "../settings";
 import { BoundingRect } from "./boundingrect";
 import { PartialShapeOwner, ShapeAccess, ShapeOwner } from "./owners";
+import { rotateAroundPoint } from "../utils";
 
 export abstract class Shape {
     // Used to create class instance from server shape data
@@ -30,7 +31,7 @@ export abstract class Shape {
 
     // A reference point regarding that specific shape's structure
     protected _refPoint: GlobalPoint;
-    angle = 0;
+    protected _angle = 0;
 
     // Fill colour of the shape
     fillColour = "#000";
@@ -90,7 +91,36 @@ export abstract class Shape {
         this._refPoint = point;
     }
 
-    abstract getBoundingBox(): BoundingRect;
+    get angle(): number {
+        return this._angle;
+    }
+
+    set angle(angle: number) {
+        this._angle = angle;
+        this.updatePoints();
+    }
+
+    getAABB(delta = 0): BoundingRect {
+        let minx = this.points[0][0];
+        let maxx = this.points[0][0];
+        let miny = this.points[0][1];
+        let maxy = this.points[0][1];
+        for (const p of this.points.slice(1)) {
+            if (p[0] < minx) minx = p[0];
+            if (p[0] > maxx) maxx = p[0];
+            if (p[1] < miny) miny = p[1];
+            if (p[1] > maxy) maxy = p[1];
+        }
+        return new BoundingRect(
+            new GlobalPoint(minx - delta, miny - delta),
+            maxx - minx + 2 * delta,
+            maxy - miny + 2 * delta,
+        );
+    }
+
+    getBoundingBox(delta = 0): BoundingRect {
+        return this.getAABB(delta);
+    }
 
     abstract contains(point: GlobalPoint, nearbyThreshold?: number): boolean;
 
@@ -113,6 +143,17 @@ export abstract class Shape {
     abstract snapToGrid(): void;
     abstract resizeToGrid(resizePoint: number, retainAspectRatio: boolean): void;
     abstract resize(resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean): number;
+
+    // abstract rotateAround(point: GlobalPoint, angle: number): void;
+    rotateAround(point: GlobalPoint, angle: number): void {
+        const center = this.center();
+        this.center(rotateAroundPoint(center, point, angle));
+        this.angle += angle;
+        this.updatePoints();
+    }
+    rotateAroundAbsolute(point: GlobalPoint, angle: number): void {
+        this.rotateAround(point, angle - this.angle);
+    }
 
     abstract get points(): number[][];
 
@@ -282,6 +323,11 @@ export abstract class Shape {
     draw(ctx: CanvasRenderingContext2D): void {
         if (this.globalCompositeOperation !== undefined) ctx.globalCompositeOperation = this.globalCompositeOperation;
         else ctx.globalCompositeOperation = "source-over";
+
+        const center = g2l(this.center());
+
+        ctx.setTransform(1, 0, 0, 1, center.x, center.y);
+        ctx.rotate(this.angle);
     }
 
     drawPost(ctx: CanvasRenderingContext2D): void {
@@ -309,63 +355,36 @@ export abstract class Shape {
             ctx.strokeStyle = "red";
             ctx.strokeRect(g2lx(bbox.topLeft.x) - 5, g2ly(bbox.topLeft.y) - 5, g2lz(bbox.w) + 10, g2lz(bbox.h) + 10);
         }
+
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
     }
 
     drawSelection(ctx: CanvasRenderingContext2D): void {
-        const center = g2l(this.center());
-
-        ctx.globalCompositeOperation = this.globalCompositeOperation;
-        ctx.setTransform(1, 0, 0, 1, center.x, center.y);
-        ctx.rotate(this.angle);
-
-        const z = gameStore.zoomFactor;
         const bb = this.getBoundingBox();
-        ctx.strokeRect(g2lx(bb.topLeft.x) - center.x, g2ly(bb.topLeft.y) - center.y, bb.w * z, bb.h * z);
+        ctx.beginPath();
+        ctx.moveTo(g2lx(bb.points[0][0]), g2ly(bb.points[0][1]));
+        for (let i = 1; i <= bb.points.length; i++) {
+            const vertex = bb.points[i % bb.points.length];
+            ctx.lineTo(g2lx(vertex[0]), g2ly(vertex[1]));
+        }
+        ctx.stroke();
 
         // Draw vertices
         for (const p of this.points) {
             ctx.beginPath();
-            ctx.arc(g2lx(p[0]) - center.x, g2ly(p[1]) - center.y, 3, 0, 2 * Math.PI);
+            ctx.arc(g2lx(p[0]), g2ly(p[1]), 3, 0, 2 * Math.PI);
             ctx.fill();
         }
 
-        // Draw rotation anchor
-        // if (
-        //     gameStore.toolsMode === "Build" &&
-        //     this.uuid !== gameStore.selectionHelperID &&
-        //     layerManager.getLayer(this.floor, this.layer)!.selection.length === 1
-        // ) {
-        //     const anchor = this.getAnchorLocation();
-
-        //     ctx.beginPath();
-        //     ctx.moveTo(0, -5);
-        //     ctx.lineTo(anchor.x - center.x, anchor.y - center.y);
-        //     ctx.stroke();
-
-        //     ctx.beginPath();
-        //     ctx.arc(0, 0, 5, 0, 2 * Math.PI);
-        //     ctx.stroke();
-
-        //     ctx.beginPath();
-        //     ctx.arc(anchor.x - center.x, anchor.y - center.y, 5, 0, 2 * Math.PI);
-        //     ctx.fill();
-
-        //     // ctx.beginPath();
-        //     // ctx.arc(0, 0, Math.abs(anchor.y - anchor.x) / 2, 0, Math.PI * 2);
-        //     // ctx.stroke();
-        // }
-
         // Draw edges
         ctx.beginPath();
-        ctx.moveTo(g2lx(this.points[0][0]) - center.x, g2ly(this.points[0][1]) - center.y);
+        ctx.moveTo(g2lx(this.points[0][0]), g2ly(this.points[0][1]));
         const j = this.isClosed ? 0 : 1;
         for (let i = 1; i <= this.points.length - j; i++) {
             const vertex = this.points[i % this.points.length];
-            ctx.lineTo(g2lx(vertex[0]) - center.x, g2ly(vertex[1]) - center.y);
+            ctx.lineTo(g2lx(vertex[0]), g2ly(vertex[1]));
         }
         ctx.stroke();
-
-        ctx.setTransform(1, 0, 0, 1, 0, 0);
     }
 
     getAnchorLocation(): LocalPoint {

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -263,6 +263,7 @@ export abstract class Shape {
             uuid: this.uuid,
             x: this.refPoint.x,
             y: this.refPoint.y,
+            angle: this.angle,
             floor: this.floor,
             layer: this.layer,
             draw_operator: this.globalCompositeOperation,
@@ -274,6 +275,7 @@ export abstract class Shape {
             owners: this._owners.map(owner => ownerToServer(owner)),
             fill_colour: this.fillColour,
             stroke_colour: this.strokeColour,
+            stroke_width: this.strokeWidth,
             name: this.name,
             name_visible: this.nameVisible,
             annotation: this.annotation,
@@ -291,6 +293,7 @@ export abstract class Shape {
     fromDict(data: ServerShape): void {
         this.layer = data.layer;
         this.floor = data.floor;
+        this.angle = data.angle;
         this.globalCompositeOperation = data.draw_operator;
         this.movementObstruction = data.movement_obstruction;
         this.visionObstruction = data.vision_obstruction;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -30,10 +30,12 @@ export abstract class Shape {
 
     // A reference point regarding that specific shape's structure
     protected _refPoint: GlobalPoint;
+    angle = 0;
 
     // Fill colour of the shape
     fillColour = "#000";
     strokeColour = "rgba(0,0,0,0)";
+    strokeWidth = 5;
     // The optional name associated with the shape
     name = "Unknown shape";
     nameVisible = true;
@@ -310,46 +312,60 @@ export abstract class Shape {
     }
 
     drawSelection(ctx: CanvasRenderingContext2D): void {
+        const center = g2l(this.center());
+
         ctx.globalCompositeOperation = this.globalCompositeOperation;
+        ctx.setTransform(1, 0, 0, 1, center.x, center.y);
+        ctx.rotate(this.angle);
+
         const z = gameStore.zoomFactor;
         const bb = this.getBoundingBox();
-        ctx.strokeRect(g2lx(bb.topLeft.x), g2ly(bb.topLeft.y), bb.w * z, bb.h * z);
+        ctx.strokeRect(g2lx(bb.topLeft.x) - center.x, g2ly(bb.topLeft.y) - center.y, bb.w * z, bb.h * z);
 
         // Draw vertices
         for (const p of this.points) {
             ctx.beginPath();
-            ctx.arc(g2lx(p[0]), g2ly(p[1]), 3, 0, 2 * Math.PI);
+            ctx.arc(g2lx(p[0]) - center.x, g2ly(p[1]) - center.y, 3, 0, 2 * Math.PI);
             ctx.fill();
         }
 
         // Draw rotation anchor
-        if (gameStore.toolsMode === "Build" && this.uuid !== gameStore.selectionHelperID) {
-            const center = g2l(this.center());
-            const anchor = this.getAnchorLocation();
+        // if (
+        //     gameStore.toolsMode === "Build" &&
+        //     this.uuid !== gameStore.selectionHelperID &&
+        //     layerManager.getLayer(this.floor, this.layer)!.selection.length === 1
+        // ) {
+        //     const anchor = this.getAnchorLocation();
 
-            ctx.beginPath();
-            ctx.moveTo(center.x, center.y - 5);
-            ctx.lineTo(anchor.x, anchor.y);
-            ctx.stroke();
+        //     ctx.beginPath();
+        //     ctx.moveTo(0, -5);
+        //     ctx.lineTo(anchor.x - center.x, anchor.y - center.y);
+        //     ctx.stroke();
 
-            ctx.beginPath();
-            ctx.arc(center.x, center.y, 5, 0, 2 * Math.PI);
-            ctx.stroke();
+        //     ctx.beginPath();
+        //     ctx.arc(0, 0, 5, 0, 2 * Math.PI);
+        //     ctx.stroke();
 
-            ctx.beginPath();
-            ctx.arc(anchor.x, anchor.y, 5, 0, 2 * Math.PI);
-            ctx.fill();
+        //     ctx.beginPath();
+        //     ctx.arc(anchor.x - center.x, anchor.y - center.y, 5, 0, 2 * Math.PI);
+        //     ctx.fill();
 
-            // Draw edges
-            ctx.beginPath();
-            ctx.moveTo(g2lx(this.points[0][0]), g2ly(this.points[0][1]));
-            const j = this.isClosed ? 0 : 1;
-            for (let i = 1; i <= this.points.length - j; i++) {
-                const vertex = this.points[i % this.points.length];
-                ctx.lineTo(g2lx(vertex[0]), g2ly(vertex[1]));
-            }
-            ctx.stroke();
+        //     // ctx.beginPath();
+        //     // ctx.arc(0, 0, Math.abs(anchor.y - anchor.x) / 2, 0, Math.PI * 2);
+        //     // ctx.stroke();
+        // }
+
+        // Draw edges
+        ctx.beginPath();
+        ctx.moveTo(g2lx(this.points[0][0]) - center.x, g2ly(this.points[0][1]) - center.y);
+        const j = this.isClosed ? 0 : 1;
+        for (let i = 1; i <= this.points.length - j; i++) {
+            const vertex = this.points[i % this.points.length];
+            ctx.lineTo(g2lx(vertex[0]) - center.x, g2ly(vertex[1]) - center.y);
         }
+        ctx.stroke();
+
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
     }
 
     getAnchorLocation(): LocalPoint {

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -90,7 +90,6 @@ export function copyShapes(): void {
     const clipboard: ServerShape[] = [];
     for (const shape of layer.getSelection()) {
         if (!shape.ownedBy({ editAccess: true })) continue;
-        if (gameStore.selectionHelperID === shape.uuid) continue;
         clipboard.push(shape.asDict());
     }
     gameStore.setClipboard(clipboard);
@@ -174,12 +173,9 @@ export function deleteShapes(): void {
     for (let i = l.getSelection().length - 1; i >= 0; i--) {
         const sel = l.getSelection()[i];
         if (!sel.ownedBy({ editAccess: true })) continue;
-        if (gameStore.selectionHelperID === sel.uuid) {
-            l.setSelection(...[...l.getSelection()].splice(i, 1));
-            continue;
-        }
         if (l.removeShape(sel, SyncMode.FULL_SYNC)) EventBus.$emit("SelectionInfo.Shape.Set", null);
     }
+    l.setSelection();
 }
 
 export function cutShapes(): void {

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -66,7 +66,7 @@ export function createShapeFromDict(shape: ServerShape): Shape | undefined {
         );
     } else if (shape.type_ === "text") {
         const text = <ServerText>shape;
-        sh = new Text(refPoint, text.text, text.font, text.angle, text.fill_colour, text.stroke_colour, text.uuid);
+        sh = new Text(refPoint, text.text, text.font, text.fill_colour, text.stroke_colour, text.uuid);
     } else if (shape.type_ === "assetrect") {
         const asset = <ServerAsset>shape;
         const img = new Image(asset.width, asset.height);

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -85,8 +85,6 @@ class GameStore extends VuexModule implements GameState {
 
     showUI = true;
 
-    selectionHelperID: string | null = null;
-
     invertAlt = false;
 
     get selectedLayer(): string {
@@ -127,11 +125,6 @@ class GameStore extends VuexModule implements GameState {
     setToolsMode(toolMode: "Build" | "Play"): void {
         this.toolsMode = toolMode;
         layerManager.getLayer(layerManager.floor!.name)?.invalidate(true);
-    }
-
-    @Mutation
-    setSelectionHelperId(id: string): void {
-        this.selectionHelperID = id;
     }
 
     @Mutation

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -38,6 +38,8 @@ class GameStore extends VuexModule implements GameState {
     selectedLayerIndex = -1;
     boardInitialized = false;
 
+    toolsMode: "Build" | "Play" = "Play";
+
     locations: { id: number; name: string }[] = [];
     floors: string[] = [];
     selectedFloorIndex = -1;
@@ -119,6 +121,12 @@ class GameStore extends VuexModule implements GameState {
     get screenCenter(): GlobalPoint {
         const halfScreen = new Vector(window.innerWidth / 2, window.innerHeight / 2);
         return l2g(g2l(this.screenTopLeft).add(halfScreen));
+    }
+
+    @Mutation
+    setToolsMode(toolMode: "Build" | "Play"): void {
+        this.toolsMode = toolMode;
+        layerManager.getLayer(layerManager.floor!.name)?.invalidate(true);
     }
 
     @Mutation

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -38,8 +38,6 @@ class GameStore extends VuexModule implements GameState {
     selectedLayerIndex = -1;
     boardInitialized = false;
 
-    toolsMode: "Build" | "Play" = "Play";
-
     locations: { id: number; name: string }[] = [];
     floors: string[] = [];
     selectedFloorIndex = -1;
@@ -119,12 +117,6 @@ class GameStore extends VuexModule implements GameState {
     get screenCenter(): GlobalPoint {
         const halfScreen = new Vector(window.innerWidth / 2, window.innerHeight / 2);
         return l2g(g2l(this.screenTopLeft).add(halfScreen));
-    }
-
-    @Mutation
-    setToolsMode(toolMode: "Build" | "Play"): void {
-        this.toolsMode = toolMode;
-        layerManager.getLayer(layerManager.floor!.name)?.invalidate(true);
     }
 
     @Mutation

--- a/client/src/game/ui/annotation.ts
+++ b/client/src/game/ui/annotation.ts
@@ -15,7 +15,7 @@ export class AnnotationManager {
 
     constructor() {
         const origin = new GlobalPoint(0, 0);
-        this.annotationText = new Text(origin, "", "bold 20px serif", 0, "rgba(230, 230, 230, 1)");
+        this.annotationText = new Text(origin, "", "bold 20px serif", "rgba(230, 230, 230, 1)");
         this.annotationRect = new Rect(origin, 0, 0, "rgba(0, 0, 0, 0.6)");
     }
 

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -38,8 +38,8 @@ export default class ShapeContext extends Vue {
     x = 0;
     y = 0;
 
-    getSelection(): Shape[] {
-        return this.getActiveLayer()!.selection;
+    getSelection(): readonly Shape[] {
+        return this.getActiveLayer()!.getSelection();
     }
 
     hasSpawnToken(): boolean {
@@ -57,8 +57,8 @@ export default class ShapeContext extends Vue {
     }
     getMarker(): string | undefined {
         const layer = this.getActiveLayer()!;
-        if (layer.selection.length !== 1) return;
-        return layer.selection[0].uuid;
+        if (layer.getSelection().length !== 1) return;
+        return layer.getSelection()[0].uuid;
     }
     getFloors(): Floor[] {
         if (gameStore.IS_DM) return layerManager.floors;
@@ -77,33 +77,33 @@ export default class ShapeContext extends Vue {
     }
     getInitiativeWord(): string {
         const layer = this.getActiveLayer()!;
-        if (layer.selection.length === 1) {
-            return inInitiative(layer.selection[0].uuid)
+        if (layer.getSelection().length === 1) {
+            return inInitiative(layer.getSelection()[0].uuid)
                 ? this.$t("game.ui.selection.shapecontext.show_initiative").toString()
                 : this.$t("game.ui.selection.shapecontext.add_initiative").toString();
         } else {
-            return layer.selection.every(shape => inInitiative(shape.uuid))
+            return layer.getSelection().every(shape => inInitiative(shape.uuid))
                 ? this.$t("game.ui.selection.shapecontext.show_initiative").toString()
                 : this.$t("game.ui.selection.shapecontext.add_all_initiative").toString();
         }
     }
     hasSingleShape(): boolean {
         const layer = this.getActiveLayer()!;
-        return layer.selection.length === 1;
+        return layer.getSelection().length === 1;
     }
     setFloor(floor: Floor): void {
         const layer = this.getActiveLayer()!;
-        layer.selection.forEach(shape => shape.moveFloor(floor.name, true));
+        layer.getSelection().forEach(shape => shape.moveFloor(floor.name, true));
         this.close();
     }
     setLayer(newLayer: string): void {
         const layer = this.getActiveLayer()!;
-        layer.selection.forEach(shape => shape.moveLayer(newLayer, true));
+        layer.getSelection().forEach(shape => shape.moveLayer(newLayer, true));
         layer.clearSelection();
         this.close();
     }
     async setLocation(newLocation: number): Promise<void> {
-        const selection = this.getActiveLayer()!.selection;
+        const selection = this.getActiveLayer()!.getSelection();
 
         const spawnLocations = (gameSettingsStore.locationOptions[newLocation]?.spawnLocations ?? []).length;
         if (spawnLocations === 0) {
@@ -145,17 +145,17 @@ export default class ShapeContext extends Vue {
     }
     moveToBack(): void {
         const layer = this.getActiveLayer()!;
-        layer.selection.forEach(shape => layer.moveShapeOrder(shape, 0, true));
+        layer.getSelection().forEach(shape => layer.moveShapeOrder(shape, 0, true));
         this.close();
     }
     moveToFront(): void {
         const layer = this.getActiveLayer()!;
-        layer.selection.forEach(shape => layer.moveShapeOrder(shape, layer.shapes.length - 1, true));
+        layer.getSelection().forEach(shape => layer.moveShapeOrder(shape, layer.getShapes().length - 1, true));
         this.close();
     }
     addInitiative(): void {
         const layer = this.getActiveLayer()!;
-        layer.selection.forEach(shape => initiativeStore.addInitiative(shape.getInitiativeRepr()));
+        layer.getSelection().forEach(shape => initiativeStore.addInitiative(shape.getInitiativeRepr()));
         EventBus.$emit("Initiative.Show");
         this.close();
     }
@@ -165,21 +165,21 @@ export default class ShapeContext extends Vue {
     }
     openEditDialog(): void {
         const layer = this.getActiveLayer()!;
-        if (layer.selection.length !== 1) return;
-        EventBus.$emit("EditDialog.Open", layer.selection[0]);
+        if (layer.getSelection().length !== 1) return;
+        EventBus.$emit("EditDialog.Open", layer.getSelection()[0]);
         this.close();
     }
     setMarker(): void {
         const layer = this.getActiveLayer()!;
-        if (layer.selection.length !== 1) return;
-        const marker = layer.selection[0].uuid;
+        if (layer.getSelection().length !== 1) return;
+        const marker = layer.getSelection()[0].uuid;
         gameStore.newMarker({ marker, sync: true });
         this.close();
     }
     deleteMarker(): void {
         const layer = this.getActiveLayer()!;
-        if (layer.selection.length !== 1) return;
-        const marker = layer.selection[0].uuid;
+        if (layer.getSelection().length !== 1) return;
+        const marker = layer.getSelection()[0].uuid;
         gameStore.removeMarker({ marker, sync: true });
         this.close();
     }

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -104,8 +104,8 @@ export default class MapTool extends Tool implements ToolBasics {
         this.rect = new Rect(this.startPoint.clone(), 0, 0, "rgba(0,0,0,0)", "black");
         this.rect.preventSync = true;
         layer.addShape(this.rect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
-        this.shape = layer.selection[0];
-        layer.selection = [this.rect];
+        this.shape = layer.getSelection()[0];
+        layer.setSelection(this.rect);
     }
 
     onMove(lp: LocalPoint): void {
@@ -137,7 +137,7 @@ export default class MapTool extends Tool implements ToolBasics {
         }
         this.active = false;
 
-        if (layer.selection.length !== 1) {
+        if (layer.getSelection().length !== 1) {
             this.removeRect();
             return;
         }

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -71,7 +71,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             document.body.style.cursor = "default";
             this.removeRotationUi();
         } else {
-            if (this.hasFeature(SelectFeatures.Rotate, features)) this.createRotationUi();
+            if (this.hasFeature(SelectFeatures.Rotate, features)) this.createRotationUi(features);
         }
     }
 
@@ -110,6 +110,8 @@ export default class SelectTool extends Tool implements ToolBasics {
                 if (this.resizePoint >= 0) {
                     // Resize case, a corner is selected
                     layer.setSelection(shape);
+                    this.removeRotationUi();
+                    this.createRotationUi(features);
                     this.originalResizePoints = shape.points;
                     EventBus.$emit("SelectionInfo.Shape.Set", shape);
                     this.mode = SelectOperations.Resize;
@@ -125,6 +127,8 @@ export default class SelectTool extends Tool implements ToolBasics {
                     } else {
                         layer.setSelection(shape);
                     }
+                    this.removeRotationUi();
+                    this.createRotationUi(features);
                     EventBus.$emit("SelectionInfo.Shape.Set", shape);
                 }
                 // Drag case, a shape is selected
@@ -340,7 +344,7 @@ export default class SelectTool extends Tool implements ToolBasics {
                 !this.rotationUiActive &&
                 this.hasFeature(SelectFeatures.Rotate, features)
             ) {
-                this.createRotationUi();
+                this.createRotationUi(features);
             }
 
             layer.invalidate(true);
@@ -490,11 +494,12 @@ export default class SelectTool extends Tool implements ToolBasics {
         document.body.style.cursor = cursorStyle;
     }
 
-    createRotationUi(): void {
+    createRotationUi(features: ToolFeatures<SelectFeatures>): void {
         const layer = layerManager.getLayer(layerManager.floor!.name)!;
         const selection = layer.getSelection();
 
-        if (selection.length === 0) return;
+        if (selection.length === 0 || this.rotationUiActive || !this.hasFeature(SelectFeatures.Rotate, features))
+            return;
 
         let bbox: BoundingRect;
         if (selection.length === 1) {
@@ -553,7 +558,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             !this.rotationUiActive &&
             this.hasFeature(SelectFeatures.Rotate, features)
         ) {
-            this.createRotationUi();
+            this.createRotationUi(features);
         } else if (this.rotationUiActive) {
             const selection = layer.getSelection();
 

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -295,6 +295,8 @@ export default class SelectTool extends Tool implements ToolBasics {
                         visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: sel });
                         recalc = true;
                     }
+                    if (!sel.preventSync)
+                        socket.emit("Shape.Update", { shape: sel.asDict(), redraw: true, temporary: true });
                 }
                 if (recalc) visibilityStore.recalculateVision(selection[0].floor);
                 this.rotationEnd!.rotateAround(center, dA);
@@ -426,6 +428,10 @@ export default class SelectTool extends Tool implements ToolBasics {
                     if (!sel.preventSync) {
                         socket.emit("Shape.Update", { shape: sel.asDict(), redraw: true, temporary: false });
                     }
+                }
+                if (this.mode === SelectOperations.Rotate) {
+                    if (!sel.preventSync)
+                        socket.emit("Shape.Update", { shape: sel.asDict(), redraw: true, temporary: false });
                 }
                 sel.updatePoints();
             }

--- a/client/src/game/ui/tools/tool.vue
+++ b/client/src/game/ui/tools/tool.vue
@@ -70,6 +70,7 @@ export default class Tool extends Vue implements ToolBasics {
     onDown(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): void {}
     onUp(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): void {}
     onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): void {}
+    onToolsModeChange(_mode: "Build" | "Play", _features: ToolFeatures): void {}
 }
 </script>
 

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -100,7 +100,6 @@ export default class Tools extends Vue {
         [ToolName.Filter, {}],
         [ToolName.Vision, {}],
     ];
-    mode: "Build" | "Play" = "Play";
 
     get componentMap(): { [key in ToolName]: InstanceType<typeof Tool> } {
         return this.componentmap_;
@@ -115,7 +114,7 @@ export default class Tools extends Vue {
     }
 
     get tools(): [ToolName, ToolFeatures][] {
-        return this.mode === "Build" ? this.buildTools : this.playTools;
+        return gameStore.toolsMode === "Build" ? this.buildTools : this.playTools;
     }
 
     get visibleTools(): string[] {
@@ -287,11 +286,11 @@ export default class Tools extends Vue {
     }
 
     toggleMode(): void {
-        this.mode = this.mode === "Build" ? "Play" : "Build";
+        gameStore.setToolsMode(gameStore.toolsMode === "Build" ? "Play" : "Build");
     }
 
     getModeWord(): string {
-        return this.mode === "Build" ? this.$t("tool.Build").toString() : this.$t("tool.Play").toString();
+        return gameStore.toolsMode === "Build" ? this.$t("tool.Build").toString() : this.$t("tool.Play").toString();
     }
 
     getToolWord(tool: string): string {

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -60,6 +60,8 @@ export default class Tools extends Vue {
         visionTool: InstanceType<typeof PanTool>;
     };
 
+    mode: "Build" | "Play" = "Play";
+
     private componentmap_: { [key in ToolName]: InstanceType<typeof Tool> } = <any>{};
 
     mounted(): void {
@@ -93,7 +95,7 @@ export default class Tools extends Vue {
         [ToolName.Vision, {}],
     ];
     playTools: [ToolName, ToolFeatures][] = [
-        [ToolName.Select, { disabled: [SelectFeatures.Resize] }],
+        [ToolName.Select, { disabled: [SelectFeatures.Resize, SelectFeatures.Rotate] }],
         [ToolName.Pan, {}],
         [ToolName.Ruler, {}],
         [ToolName.Ping, {}],
@@ -114,7 +116,7 @@ export default class Tools extends Vue {
     }
 
     get tools(): [ToolName, ToolFeatures][] {
-        return gameStore.toolsMode === "Build" ? this.buildTools : this.playTools;
+        return this.mode === "Build" ? this.buildTools : this.playTools;
     }
 
     get visibleTools(): string[] {
@@ -286,11 +288,15 @@ export default class Tools extends Vue {
     }
 
     toggleMode(): void {
-        gameStore.setToolsMode(gameStore.toolsMode === "Build" ? "Play" : "Build");
+        this.mode = this.mode === "Build" ? "Play" : "Build";
+        const tool = this.componentMap[this.currentTool];
+        tool.onToolsModeChange(this.mode, this.getFeatures(this.currentTool));
+        for (const permitted of tool.permittedTools)
+            this.componentMap[permitted.name].onToolsModeChange(this.mode, permitted.features);
     }
 
     getModeWord(): string {
-        return gameStore.toolsMode === "Build" ? this.$t("tool.Build").toString() : this.$t("tool.Play").toString();
+        return this.mode === "Build" ? this.$t("tool.Build").toString() : this.$t("tool.Play").toString();
     }
 
     getToolWord(tool: string): string {

--- a/client/src/game/utils.ts
+++ b/client/src/game/utils.ts
@@ -45,8 +45,8 @@ export function equalPoint(a: number, b: number, delta = 0.0001): boolean {
     return a - delta < b && a + delta > b;
 }
 
-export function equalPoints(a: number[], b: number[]): boolean {
-    return equalPoint(a[0], b[0]) && equalPoint(a[1], b[1]);
+export function equalPoints(a: number[], b: number[], delta = 0.0001): boolean {
+    return equalPoint(a[0], b[0], delta) && equalPoint(a[1], b[1], delta);
 }
 
 export function useSnapping(event: MouseEvent | TouchEvent): boolean {

--- a/client/src/game/utils.ts
+++ b/client/src/game/utils.ts
@@ -1,4 +1,4 @@
-import { LocalPoint } from "@/game/geom";
+import { LocalPoint, GlobalPoint } from "@/game/geom";
 import tinycolor from "tinycolor2";
 import { gameSettingsStore } from "./settings";
 import { gameStore } from "./store";
@@ -51,4 +51,15 @@ export function equalPoints(a: number[], b: number[], delta = 0.0001): boolean {
 
 export function useSnapping(event: MouseEvent | TouchEvent): boolean {
     return gameStore.invertAlt === event.altKey;
+}
+
+export function rotateAroundPoint(point: GlobalPoint, center: GlobalPoint, angle: number): GlobalPoint {
+    if (equalPoints([...center], [...point])) return point;
+
+    const c = Math.cos(angle);
+    const s = Math.sin(angle);
+    return new GlobalPoint(
+        c * (point.x - center.x) - s * (point.y - center.y) + center.x,
+        s * (point.x - center.x) + c * (point.y - center.y) + center.y,
+    );
 }

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -50,6 +50,8 @@ class Shape(BaseModel):
     is_invisible = BooleanField(default=False)
     default_movement_access = BooleanField(default=False)
     is_locked = BooleanField(default=False)
+    angle = IntegerField(default=0)
+    stroke_width = IntegerField(default=2)
 
     def __repr__(self):
         return f"<Shape {self.get_path()}>"

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -246,4 +246,3 @@ class Text(ShapeType):
     abstract = False
     text = TextField()
     font = TextField()
-    angle = FloatField()

--- a/server/save.py
+++ b/server/save.py
@@ -20,7 +20,7 @@ from models import ALL_MODELS, Constants
 from models.db import db
 from utils import OldVersionException, UnknownVersionException
 
-SAVE_VERSION = 32
+SAVE_VERSION = 33
 
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
@@ -520,6 +520,19 @@ def upgrade(version):
         with db.atomic():
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN is_locked INTEGER NOT NULL DEFAULT 0"
+            )
+
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 32:
+        # Add Shape.angle and Shape.stroke_width
+        db.foreign_keys = False
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE shape ADD COLUMN angle INTEGER NOT NULL DEFAULT 0"
+            )
+            db.execute_sql(
+                "ALTER TABLE shape ADD COLUMN stroke_width INTEGER NOT NULL DEFAULT 2"
             )
 
         db.foreign_keys = True


### PR DESCRIPTION
This PR adds support for rotation.

This includes rotation of individual shapes as well as groups.  Rotation is only possible in build mode to prevent UI clutter.

Currently the rotation UI is already visible, the actual rotation still has to be done.