### PR TITLE
feat(Floors): player floor selection limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
     -   Danish
     -   Spanish
 -   Rotation in Select tool with build mode
+-   Floor visibility toggle
+    -   "Hidden" floors are not selectable by players, BUT will still render in between other selectable layers
 
 ### Fixed
 

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -146,7 +146,7 @@ export default class Game extends Vue {
 
 <template>
     <div id="main" @mouseleave="mouseleave" @wheel="zoom">
-        <ui ref="ui" v-if="ready.manager"></ui>
+        <ui ref="ui"></ui>
         <div id="board">
             <div
                 id="layers"

--- a/client/src/game/api/events/floor.ts
+++ b/client/src/game/api/events/floor.ts
@@ -1,12 +1,21 @@
 import { coreStore } from "../../../core/store";
 import { ServerFloor } from "../../comm/types/general";
+import { EventBus } from "../../event-bus";
+import { layerManager } from "../../layers/manager";
+import { floorStore } from "../../layers/store";
 import { addFloor, removeFloor } from "../../layers/utils";
-import { gameStore } from "../../store";
 import { socket } from "../socket";
 
 socket.on("Floor.Create", (data: { floor: ServerFloor; creator: string }) => {
     addFloor(data.floor);
-    if (data.creator === coreStore.username) gameStore.selectFloor({ targetFloor: data.floor.name, sync: true });
+    if (data.creator === coreStore.username) floorStore.selectFloor({ targetFloor: data.floor.name, sync: true });
 });
 
 socket.on("Floor.Remove", removeFloor);
+
+socket.on("Floor.Visible.Set", (data: { name: string; visible: boolean }) => {
+    const floor = layerManager.getFloor(data.name);
+    if (floor === undefined) return;
+    floor.playerVisible = data.visible;
+    EventBus.$emit("Floor.Visible.Set");
+});

--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -2,7 +2,7 @@ import { coreStore } from "../../../core/store";
 import { ServerLocation } from "../../comm/types/general";
 import { ServerLocationOptions } from "../../comm/types/settings";
 import { EventBus } from "../../event-bus";
-import { layerManager } from "../../layers/manager";
+import { floorStore } from "../../layers/store";
 import { gameSettingsStore } from "../../settings";
 import { gameStore } from "../../store";
 import { VisibilityMode, visibilityStore } from "../../visibility/store";
@@ -11,7 +11,6 @@ import { socket } from "../socket";
 // Bootup Sequence
 
 socket.on("Location.Set", (data: ServerLocation) => {
-    coreStore.setLoading(false);
     gameSettingsStore.setActiveLocation(data.id);
     gameStore.updatePlayer({ player: gameStore.username, location: data.id });
     setLocationOptions(data.id, data.options);
@@ -64,7 +63,7 @@ export function setLocationOptions(id: number | null, options: Partial<ServerLoc
             mode: VisibilityMode[<keyof typeof VisibilityMode>options.vision_mode],
             sync: false,
         });
-        for (const floor of layerManager.floors) {
+        for (const floor of floorStore.floors) {
             visibilityStore.recalculateVision(floor.name);
             visibilityStore.recalculateMovement(floor.name);
         }

--- a/client/src/game/comm/types/general.ts
+++ b/client/src/game/comm/types/general.ts
@@ -27,6 +27,7 @@ export interface InitiativeEffect {
 export interface ServerFloor {
     name: string;
     layers: ServerLayer[];
+    player_visible: boolean;
 }
 
 export interface ServerLayer {

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -11,6 +11,7 @@ import { EventBus } from "../event-bus";
 import { gameManager } from "../manager";
 import { gameSettingsStore } from "../settings";
 import { floorStore } from "../layers/store";
+import { moveFloor } from "../layers/utils";
 
 export function onKeyUp(event: KeyboardEvent): void {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
@@ -138,9 +139,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             const newLayer = layerManager.getLayer(newFloor)!;
 
             if (event.ctrlKey) {
-                for (const shape of selection) {
-                    shape.moveFloor(newFloor.name, true);
-                }
+                moveFloor([...selection], newFloor, true);
             }
             layerManager.clearSelection();
             if (!event.ctrlKey || event.shiftKey) {
@@ -166,9 +165,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             const newLayer = layerManager.getLayer(newFloor)!;
 
             if (event.ctrlKey) {
-                for (const shape of selection) {
-                    shape.moveFloor(newFloor.name, true);
-                }
+                moveFloor([...selection], newFloor, true);
             }
             if (!event.shiftKey) layerManager.clearSelection();
             if (!event.ctrlKey || event.shiftKey) {

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -122,14 +122,14 @@ export function onKeyDown(event: KeyboardEvent): void {
         } else if (event.key === "v" && event.ctrlKey) {
             // Ctrl-v - Paste
             pasteShapes();
-        } else if (event.key === "PageUp" && gameStore.selectedFloorIndex < gameStore.floors.length - 1) {
+        } else if (event.key === "PageUp" && gameStore.selectedFloorIndex < gameStore.visibleFloors.length - 1) {
             // Page Up - Move floor up
             // Ctrl + Page Up - Move selected shapes floor up
             // Ctrl + Shift + Page Up - Move selected shapes floor up AND move floor up
             event.preventDefault();
-            if (gameStore.selectedFloorIndex + 1 >= gameStore.floors.length) return;
+            if (gameStore.selectedFloorIndex + 1 >= gameStore.visibleFloors.length) return;
             const selection = layerManager.getSelection() ?? [];
-            const newFloor = gameStore.floors[gameStore.selectedFloorIndex + 1];
+            const newFloor = gameStore.visibleFloors[gameStore.selectedFloorIndex + 1];
             const newLayer = layerManager.getLayer(newFloor)!;
 
             if (event.ctrlKey) {
@@ -149,7 +149,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             event.preventDefault();
             if (gameStore.selectedFloorIndex - 1 < 0) return;
             const selection = layerManager.getSelection() ?? [];
-            const newFloor = gameStore.floors[gameStore.selectedFloorIndex - 1];
+            const newFloor = gameStore.visibleFloors[gameStore.selectedFloorIndex - 1];
             const newLayer = layerManager.getLayer(newFloor)!;
 
             if (event.ctrlKey) {

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -10,6 +10,7 @@ import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { EventBus } from "../event-bus";
 import { gameManager } from "../manager";
 import { gameSettingsStore } from "../settings";
+import { floorStore } from "../layers/store";
 
 export function onKeyUp(event: KeyboardEvent): void {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
@@ -24,7 +25,7 @@ export function onKeyUp(event: KeyboardEvent): void {
             const i = tokens.findIndex(o => o.center().equals(gameStore.screenCenter));
             const token = tokens[(i + 1) % tokens.length];
             gameManager.setCenterPosition(token.center());
-            gameStore.selectFloor({ targetFloor: token.floor, sync: true });
+            floorStore.selectFloor({ targetFloor: token.floor.name, sync: true });
         }
     }
 }
@@ -84,10 +85,10 @@ export function onKeyDown(event: KeyboardEvent): void {
                             temporary: false,
                         });
                 }
-                const floorName = layerManager.floor!.name;
+                const floorName = floorStore.currentFloor.name;
                 if (recalculateVision) visibilityStore.recalculateVision(floorName);
                 if (recalculateMovement) visibilityStore.recalculateMovement(floorName);
-                layerManager.getLayer(layerManager.floor!.name)!.invalidate(false);
+                layerManager.getLayer(floorStore.currentFloor)!.invalidate(false);
             } else {
                 // The pan offsets should be in the opposite direction to give the correct feel.
                 gameStore.increasePanX(offsetX * (event.keyCode <= 38 ? 1 : -1));
@@ -122,44 +123,44 @@ export function onKeyDown(event: KeyboardEvent): void {
         } else if (event.key === "v" && event.ctrlKey) {
             // Ctrl-v - Paste
             pasteShapes();
-        } else if (event.key === "PageUp" && gameStore.selectedFloorIndex < gameStore.visibleFloors.length - 1) {
+        } else if (event.key === "PageUp" && floorStore.currentFloorindex < floorStore.visibleFloors.length - 1) {
             // Page Up - Move floor up
             // Ctrl + Page Up - Move selected shapes floor up
             // Ctrl + Shift + Page Up - Move selected shapes floor up AND move floor up
             event.preventDefault();
-            if (gameStore.selectedFloorIndex + 1 >= gameStore.visibleFloors.length) return;
+            if (floorStore.currentFloorindex + 1 >= floorStore.visibleFloors.length) return;
             const selection = layerManager.getSelection() ?? [];
-            const newFloor = gameStore.visibleFloors[gameStore.selectedFloorIndex + 1];
+            const newFloor = floorStore.visibleFloors[floorStore.currentFloorindex + 1];
             const newLayer = layerManager.getLayer(newFloor)!;
 
             if (event.ctrlKey) {
                 for (const shape of selection) {
-                    shape.moveFloor(newFloor, true);
+                    shape.moveFloor(newFloor.name, true);
                 }
             }
             layerManager.clearSelection();
             if (!event.ctrlKey || event.shiftKey) {
-                gameStore.selectFloor({ targetFloor: gameStore.selectedFloorIndex + 1, sync: true });
+                floorStore.selectFloor({ targetFloor: floorStore.currentFloorindex + 1, sync: true });
             }
             if (event.shiftKey) for (const shape of selection) newLayer.pushSelection(shape);
-        } else if (event.key === "PageDown" && gameStore.selectedFloorIndex > 0) {
+        } else if (event.key === "PageDown" && floorStore.currentFloorindex > 0) {
             // Page Down - Move floor down
             // Ctrl + Page Down - Move selected shape floor down
             // Ctrl + Shift + Page Down - Move selected shapes floor down AND move floor down
             event.preventDefault();
-            if (gameStore.selectedFloorIndex - 1 < 0) return;
+            if (floorStore.currentFloorindex - 1 < 0) return;
             const selection = layerManager.getSelection() ?? [];
-            const newFloor = gameStore.visibleFloors[gameStore.selectedFloorIndex - 1];
+            const newFloor = floorStore.visibleFloors[floorStore.currentFloorindex - 1];
             const newLayer = layerManager.getLayer(newFloor)!;
 
             if (event.ctrlKey) {
                 for (const shape of selection) {
-                    shape.moveFloor(newFloor, true);
+                    shape.moveFloor(newFloor.name, true);
                 }
             }
             if (!event.shiftKey) layerManager.clearSelection();
             if (!event.ctrlKey || event.shiftKey) {
-                gameStore.selectFloor({ targetFloor: gameStore.selectedFloorIndex - 1, sync: true });
+                floorStore.selectFloor({ targetFloor: floorStore.currentFloorindex - 1, sync: true });
             }
             if (event.shiftKey) for (const shape of selection) newLayer.pushSelection(shape);
         } else if (event.key === "Tab") {

--- a/client/src/game/layers/floor.ts
+++ b/client/src/game/layers/floor.ts
@@ -1,0 +1,4 @@
+export interface Floor {
+    name: string;
+    playerVisible: boolean;
+}

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -3,13 +3,13 @@ import { Layer } from "@/game/layers/layer";
 import { layerManager } from "@/game/layers/manager";
 import { Circle } from "@/game/shapes/circle";
 import { Shape } from "@/game/shapes/shape";
-import { gameStore } from "@/game/store";
 import { g2l, g2lr, g2lx, g2ly, g2lz, getUnitDistance } from "@/game/units";
 import { getFogColour } from "@/game/utils";
 import { getVisionSources } from "@/game/visibility/utils";
 import { gameSettingsStore } from "../settings";
 import { TriangulationTarget } from "../visibility/te/pa";
 import { computeVisibility } from "../visibility/te/te";
+import { floorStore } from "./store";
 
 export class FOWLayer extends Layer {
     isVisionLayer = true;
@@ -61,23 +61,23 @@ export class FOWLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = gameStore.visibleFloors[gameStore.selectedFloorIndex];
+            const activeFloorName = floorStore.visibleFloors[floorStore.currentFloorindex].name;
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");
             else if (this.floor !== activeFloorName && this.canvas.style.display !== "none")
                 this.canvas.style.display = "none";
 
-            if (this.floor === activeFloorName && layerManager.floors.length > 1) {
-                for (const floor of layerManager.floors) {
-                    if (floor.name !== gameStore.visibleFloors[0]) {
-                        const mapl = layerManager.getLayer(floor.name, "map");
+            if (this.floor === activeFloorName && floorStore.floors.length > 1) {
+                for (const floor of floorStore.floors) {
+                    if (floor.name !== floorStore.visibleFloors[0].name) {
+                        const mapl = layerManager.getLayer(floor, "map");
                         if (mapl === undefined) continue;
                         ctx.globalCompositeOperation = "destination-out";
                         ctx.drawImage(mapl.canvas, 0, 0);
                     }
                     if (floor.name !== activeFloorName) {
-                        const fowl = layerManager.getLayer(floor.name, this.name);
+                        const fowl = layerManager.getLayer(floor, this.name);
                         if (fowl === undefined) continue;
                         ctx.globalCompositeOperation = "source-over";
                         ctx.drawImage(fowl.canvas, 0, 0);
@@ -90,10 +90,10 @@ export class FOWLayer extends Layer {
             // At all times provide a minimal vision range to prevent losing your tokens in fog.
             if (
                 gameSettingsStore.fullFow &&
-                layerManager.hasLayer(this.floor, "tokens") &&
-                this.floor === gameStore.visibleFloors[gameStore.selectedFloorIndex]
+                layerManager.hasLayer(floorStore.currentFloor, "tokens") &&
+                floorStore.currentFloor === floorStore.visibleFloors[floorStore.currentFloorindex]
             ) {
-                for (const sh of layerManager.getLayer(this.floor, "tokens")!.getShapes()) {
+                for (const sh of layerManager.getLayer(floorStore.currentFloor, "tokens")!.getShapes()) {
                     if (!sh.ownedBy({ visionAccess: true }) || !sh.isToken) continue;
                     const bb = sh.getBoundingBox();
                     const lcenter = g2l(sh.center());
@@ -128,7 +128,7 @@ export class FOWLayer extends Layer {
 
                 this.vCtx.globalCompositeOperation = "source-over";
                 this.vCtx.fillStyle = "rgba(0, 0, 0, 1)";
-                const polygon = computeVisibility(center, TriangulationTarget.VISION, shape.floor);
+                const polygon = computeVisibility(center, TriangulationTarget.VISION, shape.floor.name);
                 this.vCtx.beginPath();
                 this.vCtx.moveTo(g2lx(polygon[0][0]), g2ly(polygon[0][1]));
                 for (const point of polygon) this.vCtx.lineTo(g2lx(point[0]), g2ly(point[1]));
@@ -161,7 +161,7 @@ export class FOWLayer extends Layer {
 
             if (gameSettingsStore.fowLos && this.floor === activeFloorName) {
                 ctx.globalCompositeOperation = "source-in";
-                ctx.drawImage(layerManager.getLayer(this.floor, "fow-players")!.canvas, 0, 0);
+                ctx.drawImage(layerManager.getLayer(floorStore.currentFloor, "fow-players")!.canvas, 0, 0);
             }
 
             for (const preShape of this.preFogShapes) {

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -61,7 +61,7 @@ export class FOWLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = gameStore.floors[gameStore.selectedFloorIndex];
+            const activeFloorName = gameStore.visibleFloors[gameStore.selectedFloorIndex];
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");
@@ -70,7 +70,7 @@ export class FOWLayer extends Layer {
 
             if (this.floor === activeFloorName && layerManager.floors.length > 1) {
                 for (const floor of layerManager.floors) {
-                    if (floor.name !== gameStore.floors[0]) {
+                    if (floor.name !== gameStore.visibleFloors[0]) {
                         const mapl = layerManager.getLayer(floor.name, "map");
                         if (mapl === undefined) continue;
                         ctx.globalCompositeOperation = "destination-out";
@@ -91,7 +91,7 @@ export class FOWLayer extends Layer {
             if (
                 gameSettingsStore.fullFow &&
                 layerManager.hasLayer(this.floor, "tokens") &&
-                this.floor === gameStore.floors[gameStore.selectedFloorIndex]
+                this.floor === gameStore.visibleFloors[gameStore.selectedFloorIndex]
             ) {
                 for (const sh of layerManager.getLayer(this.floor, "tokens")!.getShapes()) {
                     if (!sh.ownedBy({ visionAccess: true }) || !sh.isToken) continue;

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -61,7 +61,7 @@ export class FOWLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = floorStore.visibleFloors[floorStore.currentFloorindex].name;
+            const activeFloorName = floorStore.floors[floorStore.currentFloorindex].name;
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");
@@ -70,7 +70,7 @@ export class FOWLayer extends Layer {
 
             if (this.floor === activeFloorName && floorStore.floors.length > 1) {
                 for (const floor of floorStore.floors) {
-                    if (floor.name !== floorStore.visibleFloors[0].name) {
+                    if (floor.name !== floorStore.floors[0].name) {
                         const mapl = layerManager.getLayer(floor, "map");
                         if (mapl === undefined) continue;
                         ctx.globalCompositeOperation = "destination-out";
@@ -91,7 +91,7 @@ export class FOWLayer extends Layer {
             if (
                 gameSettingsStore.fullFow &&
                 layerManager.hasLayer(floorStore.currentFloor, "tokens") &&
-                floorStore.currentFloor === floorStore.visibleFloors[floorStore.currentFloorindex]
+                floorStore.currentFloor === floorStore.floors[floorStore.currentFloorindex]
             ) {
                 for (const sh of layerManager.getLayer(floorStore.currentFloor, "tokens")!.getShapes()) {
                     if (!sh.ownedBy({ visionAccess: true }) || !sh.isToken) continue;

--- a/client/src/game/layers/fowplayers.ts
+++ b/client/src/game/layers/fowplayers.ts
@@ -48,7 +48,7 @@ export class FOWPlayersLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = gameStore.floors[gameStore.selectedFloorIndex];
+            const activeFloorName = gameStore.visibleFloors[gameStore.selectedFloorIndex];
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");
@@ -57,7 +57,7 @@ export class FOWPlayersLayer extends Layer {
 
             if (this.floor === activeFloorName && layerManager.floors.length > 1) {
                 for (const floor of layerManager.floors) {
-                    if (floor.name !== gameStore.floors[0]) {
+                    if (floor.name !== gameStore.visibleFloors[0]) {
                         const mapl = layerManager.getLayer(floor.name, "map");
                         if (mapl === undefined) continue;
                         ctx.globalCompositeOperation = "destination-out";

--- a/client/src/game/layers/fowplayers.ts
+++ b/client/src/game/layers/fowplayers.ts
@@ -49,7 +49,7 @@ export class FOWPlayersLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = floorStore.visibleFloors[floorStore.currentFloorindex].name;
+            const activeFloorName = floorStore.floors[floorStore.currentFloorindex].name;
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");

--- a/client/src/game/layers/fowplayers.ts
+++ b/client/src/game/layers/fowplayers.ts
@@ -5,6 +5,7 @@ import { g2l, g2lr, g2lx, g2ly } from "@/game/units";
 import { gameSettingsStore } from "../settings";
 import { TriangulationTarget } from "../visibility/te/pa";
 import { computeVisibility } from "../visibility/te/te";
+import { floorStore } from "./store";
 
 export class FOWPlayersLayer extends Layer {
     isVisionLayer = true;
@@ -48,23 +49,23 @@ export class FOWPlayersLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = gameStore.visibleFloors[gameStore.selectedFloorIndex];
+            const activeFloorName = floorStore.visibleFloors[floorStore.currentFloorindex].name;
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");
             else if (this.floor !== activeFloorName && this.canvas.style.display !== "none")
                 this.canvas.style.display = "none";
 
-            if (this.floor === activeFloorName && layerManager.floors.length > 1) {
-                for (const floor of layerManager.floors) {
-                    if (floor.name !== gameStore.visibleFloors[0]) {
-                        const mapl = layerManager.getLayer(floor.name, "map");
+            if (this.floor === activeFloorName && floorStore.floors.length > 1) {
+                for (const floor of floorStore.floors) {
+                    if (floor.name !== floorStore.floors[0].name) {
+                        const mapl = layerManager.getLayer(floor, "map");
                         if (mapl === undefined) continue;
                         ctx.globalCompositeOperation = "destination-out";
                         ctx.drawImage(mapl.canvas, 0, 0);
                     }
                     if (floor.name !== activeFloorName) {
-                        const fowl = layerManager.getLayer(floor.name, this.name);
+                        const fowl = layerManager.getLayer(floor, this.name);
                         if (fowl === undefined) continue;
                         ctx.globalCompositeOperation = "source-over";
                         ctx.drawImage(fowl.canvas, 0, 0);
@@ -81,7 +82,7 @@ export class FOWPlayersLayer extends Layer {
 
             for (const tokenId of gameStore.activeTokens) {
                 const token = layerManager.UUIDMap.get(tokenId);
-                if (token === undefined || token.floor !== this.floor) continue;
+                if (token === undefined || token.floor.name !== this.floor) continue;
                 const center = token.center();
                 const lcenter = g2l(center);
 
@@ -102,7 +103,7 @@ export class FOWPlayersLayer extends Layer {
                     ctx.fillStyle = "rgba(0, 0, 0, 1)";
                 }
                 try {
-                    const polygon = computeVisibility(token.center(), TriangulationTarget.VISION, token.floor);
+                    const polygon = computeVisibility(token.center(), TriangulationTarget.VISION, token.floor.name);
                     ctx.beginPath();
                     ctx.moveTo(g2lx(polygon[0][0]), g2ly(polygon[0][1]));
                     for (const point of polygon) ctx.lineTo(g2lx(point[0]), g2ly(point[1]));
@@ -113,15 +114,15 @@ export class FOWPlayersLayer extends Layer {
                 }
             }
 
-            if (this.floor === activeFloorName && layerManager.floors.length > 1) {
-                for (let f = layerManager.floors.length - 1; f > gameStore.selectedFloorIndex; f--) {
-                    const floor = layerManager.floors[f];
+            if (this.floor === activeFloorName && floorStore.floors.length > 1) {
+                for (let f = floorStore.floors.length - 1; f > floorStore.currentFloorindex; f--) {
+                    const floor = floorStore.floors[f];
                     if (floor.name === activeFloorName) break;
-                    const fowl = layerManager.getLayer(floor.name, this.name);
+                    const fowl = layerManager.getLayer(floor, this.name);
                     if (fowl === undefined) continue;
                     this.vCtx.globalCompositeOperation = "destination-over";
                     this.vCtx.drawImage(fowl.canvas, 0, 0);
-                    const mapl = layerManager.getLayer(floor.name, "map");
+                    const mapl = layerManager.getLayer(floor, "map");
                     if (mapl === undefined) continue;
                     this.vCtx.globalCompositeOperation = "destination-out";
                     this.vCtx.drawImage(mapl.canvas, 0, 0);

--- a/client/src/game/layers/grid.ts
+++ b/client/src/game/layers/grid.ts
@@ -1,20 +1,20 @@
 import { Layer } from "@/game/layers/layer";
 import { gameStore } from "@/game/store";
 import { gameSettingsStore } from "../settings";
-import { layerManager } from "./manager";
+import { floorStore } from "./store";
 
 export class GridLayer extends Layer {
     invalidate(): void {
         this.valid = false;
     }
     show(): void {
-        if (gameSettingsStore.useGrid && this.floor === layerManager.floor?.name)
+        if (gameSettingsStore.useGrid && this.floor === floorStore.currentFloor.name)
             this.canvas.style.removeProperty("display");
     }
     draw(_doClear?: boolean): void {
         if (!this.valid) {
             if (gameSettingsStore.useGrid) {
-                const activeFowFloorName = layerManager.floor?.name;
+                const activeFowFloorName = floorStore.currentFloor.name;
 
                 if (this.floor === activeFowFloorName && this.canvas.style.display === "none")
                     this.canvas.style.removeProperty("display");

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -166,7 +166,7 @@ export class Layer {
         }
 
         if (sync !== SyncMode.NO_SYNC && !shape.preventSync)
-            socket.emit("Shape.Remove", { shape: shape.asDict(), temporary: sync === SyncMode.TEMP_SYNC });
+            socket.emit("Shapes.Remove", { uuids: [shape.uuid], temporary: sync === SyncMode.TEMP_SYNC });
 
         const visionSources = getVisionSources(this.floor);
         const visionBlockers = getBlockers(TriangulationTarget.VISION, this.floor);

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -11,6 +11,7 @@ import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { getBlockers, getVisionSources, sliceBlockers, sliceVisionSources } from "@/game/visibility/utils";
 import { drawAuras } from "../shapes/aura";
 import { gameSettingsStore } from "../settings";
+import { floorStore } from "./store";
 
 export class Layer {
     name: string;
@@ -48,7 +49,7 @@ export class Layer {
     invalidate(skipLightUpdate: boolean): void {
         this.valid = false;
         if (!skipLightUpdate) {
-            layerManager.invalidateLight(this.floor);
+            layerManager.invalidateLight(layerManager.getFloor(this.floor)!);
         }
     }
 
@@ -103,8 +104,7 @@ export class Layer {
     }
 
     addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, snappable = true): void {
-        shape.layer = this.name;
-        shape.floor = this.floor;
+        shape.setLayer(this.floor, this.name);
         this.shapes.push(shape);
         layerManager.UUIDMap.set(shape.uuid, shape);
         shape.checkVisionSources(invalidate !== InvalidationMode.NO);
@@ -250,9 +250,13 @@ export class Layer {
 
             for (const shape of this.shapes) {
                 if (shape.options.has("skipDraw") && shape.options.get("skipDraw")) continue;
-                if (layerManager.getLayer(this.floor) === undefined) continue;
+                if (layerManager.getLayer(layerManager.getFloor(this.floor)!) === undefined) continue;
                 if (!shape.visibleInCanvas(this.canvas)) continue;
-                if (this.name === "fow" && layerManager.getLayer(this.floor)!.name !== this.name) continue;
+                if (
+                    this.name === "fow" &&
+                    layerManager.getLayer(layerManager.getFloor(this.floor)!)!.name !== this.name
+                )
+                    continue;
                 drawAuras(shape, ctx);
             }
             for (const shape of this.shapes) {
@@ -265,9 +269,13 @@ export class Layer {
                     !shape.labels.some(l => gameStore.labelFilters.includes(l.uuid))
                 )
                     continue;
-                if (layerManager.getLayer(this.floor) === undefined) continue;
+                if (layerManager.getLayer(layerManager.getFloor(this.floor)!) === undefined) continue;
                 if (!shape.visibleInCanvas(this.canvas)) continue;
-                if (this.name === "fow" && layerManager.getLayer(this.floor)!.name !== this.name) continue;
+                if (
+                    this.name === "fow" &&
+                    layerManager.getLayer(layerManager.getFloor(this.floor)!)!.name !== this.name
+                )
+                    continue;
                 shape.draw(ctx);
             }
 
@@ -281,10 +289,11 @@ export class Layer {
             }
 
             // If this is the last layer of the floor below, render some shadow
-            if (gameStore.selectedFloorIndex > 0) {
-                const lowerFloor = layerManager.floors[gameStore.selectedFloorIndex - 1];
+            if (floorStore.currentFloorindex > 0) {
+                const lowerFloor = floorStore.floors[floorStore.currentFloorindex - 1];
                 if (lowerFloor.name === this.floor) {
-                    if (lowerFloor.layers[lowerFloor.layers.length - 1].name === this.name) {
+                    const layers = layerManager.getLayers(lowerFloor);
+                    if (layers[layers.length - 1].name === this.name) {
                         ctx.fillStyle = "rgba(0, 0, 0, 0.3)";
                         ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
                     }

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -6,6 +6,7 @@ import { gameStore } from "@/game/store";
 export interface Floor {
     name: string;
     layers: Layer[];
+    playerVisible: boolean;
 }
 
 class LayerManager {

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -1,18 +1,13 @@
 import { GridLayer } from "@/game/layers/grid";
 import { Layer } from "@/game/layers/layer";
 import { Shape } from "@/game/shapes/shape";
-import { gameStore } from "@/game/store";
-
-export interface Floor {
-    name: string;
-    layers: Layer[];
-    playerVisible: boolean;
-}
+import { Floor } from "./floor";
+import { floorStore } from "./store";
+import { socket } from "../api/socket";
 
 class LayerManager {
-    floors: Floor[] = [];
-
     UUIDMap: Map<string, Shape> = new Map();
+    private layerMap: Map<string, Layer[]> = new Map();
 
     // Refresh interval and redraw setter.
     interval = 30;
@@ -22,13 +17,21 @@ class LayerManager {
     }
 
     reset(): void {
-        this.floors = [];
+        this.layerMap = new Map();
         this.UUIDMap = new Map();
+    }
+
+    addFloor(name: string): void {
+        this.layerMap.set(name, []);
+    }
+
+    removeFloor(name: string): void {
+        this.layerMap.delete(name);
     }
 
     private drawFloor(floor: Floor): void {
         let fowLayer: Layer | undefined;
-        for (const layer of floor.layers) {
+        for (const layer of this.getLayers(floor)) {
             layer.hide();
             // we need to draw fow later because it depends on fow-players
             // and historically we did the draw loop in the other direction
@@ -43,76 +46,80 @@ class LayerManager {
 
     drawLoop = (): void => {
         // First process all other floors
-        for (const [f, floor] of this.floors.entries()) {
-            if (f === gameStore.selectedFloorIndex) continue;
+        for (const [f, floor] of floorStore.floors.entries()) {
+            if (f === floorStore.currentFloorindex) continue;
             this.drawFloor(floor);
         }
         // Then process the current floor
-        if (this.floor !== undefined) {
-            this.drawFloor(this.floor);
+        if (floorStore.currentFloor !== undefined) {
+            this.drawFloor(floorStore.currentFloor);
         }
-        for (let i = gameStore.selectedFloorIndex; i >= 0; i--) {
-            for (const layer of this.floors[i].layers) {
-                if (i === gameStore.selectedFloorIndex || !layer.isVisionLayer) layer.show();
+        for (let i = floorStore.currentFloorindex; i >= 0; i--) {
+            const floor = floorStore.floors[i];
+            for (const layer of this.getLayers(floor)) {
+                if (i === floorStore.currentFloorindex || !layer.isVisionLayer) layer.show();
             }
         }
         requestAnimationFrame(this.drawLoop);
     };
 
-    get floor(): Floor | undefined {
-        return this.floors[gameStore.selectedFloorIndex];
-    }
-
     setWidth(width: number): void {
-        for (const layer of this.floors.flatMap(f => f.layers)) {
+        for (const layer of [...this.layerMap.values()].flat()) {
             layer.width = width;
         }
     }
 
     setHeight(height: number): void {
-        for (const layer of this.floors.flatMap(f => f.layers)) {
+        for (const layer of [...this.layerMap.values()].flat()) {
             layer.height = height;
         }
     }
 
     addLayer(layer: Layer, floorName: string): void {
-        for (const floor of this.floors) {
+        for (const floor of floorStore.floors) {
             if (floor.name === floorName) {
-                floor.layers.push(layer);
-                if (!gameStore.IS_DM && !layer.playerEditable) return;
-                if (layer.selectable && floorName === this.floor?.name) gameStore.addLayer(layer.name);
+                this.getLayers(floor).push(layer);
+                if (floorStore.currentLayerIndex < 0) {
+                    floorStore.setLayerIndex(0);
+                }
                 return;
             }
         }
         console.error(`Attempt to add layer to unknown floor ${floorName}`);
     }
 
-    hasLayer(floor: string, name: string): boolean {
-        return this.getFloor(floor)!.layers.some(l => l.name === name);
+    getLayers(floor: Floor): Layer[] {
+        return this.layerMap.get(floor.name)!;
     }
 
-    getLayer(floor: string, name?: string): Layer | undefined {
-        name = name === undefined ? gameStore.selectedLayer : name;
-        for (const layer of this.getFloor(floor)?.layers || []) {
+    hasLayer(floor: Floor, name: string): boolean {
+        return this.getLayers(floor).some(l => l.name === name);
+    }
+
+    getLayer(floor: Floor, name?: string): Layer | undefined {
+        const layers = this.getLayers(floor);
+        if (name === undefined) return layers[floorStore.currentLayerIndex];
+        for (const layer of layers) {
             if (layer.name === name) return layer;
         }
     }
 
     getFloor(name?: string): Floor | undefined {
-        if (name === undefined) return this.floor;
-        for (const floor of this.floors) if (floor.name === name) return floor;
+        if (name === undefined) return floorStore.currentFloor;
+        return floorStore.floors.find(f => f.name === name);
     }
 
     selectLayer(name: string, sync = true, invalidate = true): void {
         let found = false;
-        for (const layer of this.floor!.layers) {
+        for (const [index, layer] of this.getLayers(floorStore.currentFloor).entries()) {
             if (!layer.selectable) continue;
             if (found && layer.name !== "fow") layer.ctx.globalAlpha = 0.3;
             else layer.ctx.globalAlpha = 1.0;
 
             if (name === layer.name) {
-                gameStore.selectLayer({ layer, sync });
+                floorStore.setLayerIndex(index);
                 found = true;
+                if (sync) socket.emit("Client.ActiveLayer.Set", { floor: layer.floor, layer: layer.name });
             }
 
             layer.clearSelection();
@@ -120,7 +127,7 @@ class LayerManager {
         }
     }
 
-    getGridLayer(floor: string): GridLayer | undefined {
+    getGridLayer(floor: Floor): GridLayer | undefined {
         return <GridLayer>this.getLayer(floor, "grid");
     }
 
@@ -130,49 +137,44 @@ class LayerManager {
     }
 
     getSelection(skipUiHelpers = true): readonly Shape[] | undefined {
-        const layer = this.getLayer(this.floor!.name);
+        const layer = this.getLayer(floorStore.currentFloor);
         if (layer === undefined) return undefined;
         return layer.getSelection(skipUiHelpers);
     }
 
     clearSelection(): void {
-        const layer = this.getLayer(layerManager.floor!.name);
+        const layer = this.getLayer(floorStore.currentFloor);
         if (layer) {
             layer.clearSelection();
             layer.invalidate(true);
         }
     }
 
-    invalidate(floorName: string): void {
-        const floor = this.getFloor(floorName)!;
-        for (let i = floor.layers.length - 1; i >= 0; i--) {
-            floor.layers[i].invalidate(true);
+    invalidate(floor: Floor): void {
+        const layers = this.getLayers(floor);
+        for (let i = layers.length - 1; i >= 0; i--) {
+            layers[i].invalidate(true);
         }
     }
 
     invalidateAllFloors(): void {
-        for (const floor of this.floors) {
-            this.invalidate(floor.name);
+        for (const floor of floorStore.floors) {
+            this.invalidate(floor);
         }
     }
 
     // Lighting of multiple floors is heavily dependent on eachother
     // This method only updates a single floor and should thus only be used for very specific cases
     // as you typically require the allFloor variant
-    invalidateLight(floorName: string): void {
-        const floor = this.getFloor(floorName);
-        if (floor === undefined) {
-            console.error(`Unknown floor ${floorName} requested light invalidation`);
-            return;
-        }
-        for (let i = floor.layers.length - 1; i >= 0; i--)
-            if (floor.layers[i].isVisionLayer) floor.layers[i].invalidate(true);
+    invalidateLight(floor: Floor): void {
+        const layers = this.getLayers(floor);
+        for (let i = layers.length - 1; i >= 0; i--) if (layers[i].isVisionLayer) layers[i].invalidate(true);
     }
 
     invalidateLightAllFloors(): void {
-        for (const [f, floor] of this.floors.entries()) {
-            if (f > gameStore.selectedFloorIndex) return;
-            this.invalidateLight(floor.name);
+        for (const [f, floor] of floorStore.floors.entries()) {
+            if (f > floorStore.currentFloorindex) return;
+            this.invalidateLight(floor);
         }
     }
 }

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -18,11 +18,6 @@ class FloorStore extends VuexModule implements FloorState {
         return this._floors;
     }
 
-    get visibleFloors(): readonly Floor[] {
-        if (gameStore.IS_DM) return this.floors;
-        return this.floors.filter(f => f.playerVisible);
-    }
-
     get currentFloor(): Floor {
         return this.floors[this.floorIndex];
     }

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -1,6 +1,5 @@
 import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
 import { rootStore } from "../../store";
-import { gameStore } from "../store";
 import { Floor } from "./floor";
 import { layerManager } from "./manager";
 

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -1,0 +1,107 @@
+import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
+import { rootStore } from "../../store";
+import { gameStore } from "../store";
+import { Floor } from "./floor";
+import { layerManager } from "./manager";
+
+export interface FloorState {
+    currentFloorindex: number;
+}
+
+@Module({ dynamic: true, store: rootStore, name: "floor", namespaced: true })
+class FloorStore extends VuexModule implements FloorState {
+    private floorIndex = -1;
+    private layerIndex = -1;
+    private _floors: Floor[] = [];
+
+    get floors(): readonly Floor[] {
+        return this._floors;
+    }
+
+    get visibleFloors(): readonly Floor[] {
+        if (gameStore.IS_DM) return this.floors;
+        return this.floors.filter(f => f.playerVisible);
+    }
+
+    get currentFloor(): Floor {
+        return this.floors[this.floorIndex];
+    }
+
+    get currentFloorindex(): number {
+        return this.floorIndex;
+    }
+
+    get currentLayerIndex(): number {
+        return this.layerIndex;
+    }
+
+    @Mutation
+    reset(): void {
+        this._floors = [];
+        this.floorIndex = -1;
+    }
+
+    @Mutation
+    setLayerIndex(index: number): void {
+        this.layerIndex = index;
+    }
+
+    @Mutation
+    addFloor(floor: Floor): void {
+        this._floors.push(floor);
+        layerManager.addFloor(floor.name);
+    }
+
+    @Action
+    removeFloor(floor: Floor): void {
+        const index = this._floors.findIndex(f => f === floor);
+        this._floors.splice(index, 1);
+        layerManager.removeFloor(floor.name);
+        if (this.floorIndex === index) this.context.commit("selectFloor", { targetFloor: index - 1, sync: true });
+    }
+
+    @Mutation
+    selectFloor(data: { targetFloor: Floor | number | string; sync: boolean }): void {
+        let targetFloorIndex: number;
+        if (typeof data.targetFloor === "string") {
+            targetFloorIndex = floorStore.floors.findIndex(f => f.name === data.targetFloor);
+        } else if (typeof data.targetFloor === "number") {
+            targetFloorIndex = data.targetFloor;
+        } else {
+            targetFloorIndex = floorStore.floors.findIndex(f => f === data.targetFloor);
+        }
+        if (targetFloorIndex === this.floorIndex) return;
+        this.floorIndex = targetFloorIndex;
+        for (const [f, floor] of floorStore.floors.entries()) {
+            for (const layer of layerManager.getLayers(floor)) {
+                if (f > targetFloorIndex) layer.canvas.style.display = "none";
+                else layer.canvas.style.removeProperty("display");
+            }
+        }
+        layerManager.selectLayer(layerManager.getLayer(floorStore.currentFloor)!.name, data.sync, false);
+        layerManager.invalidateAllFloors();
+    }
+}
+
+export const floorStore = getModule(FloorStore);
+
+/*
+
+reset(){this.layers = [];
+        this.selectedLayerIndex = -1;}
+
+@Mutation
+    addLayer(name: string): void {
+        this.layers.push(name);
+        if (this.selectedLayerIndex === -1) this.selectedLayerIndex = this.layers.indexOf(name);
+    }
+
+    @Mutation
+    selectLayer(data: { layer: Layer; sync: boolean }): void {
+        let index = this.layers.indexOf(data.layer.name);
+        if (index < 0) index = 0;
+        // else if (index >= this.layers.reduce((acc: number, val: Layer) => val.floor === data.layer.floor))
+        this.selectedLayerIndex = index;
+        if (data.sync) socket.emit("Client.ActiveLayer.Set", { floor: data.layer.floor, layer: data.layer.name });
+    }
+    */

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -14,9 +14,9 @@ import { addCDT, removeCDT } from "@/game/visibility/te/pa";
 import { gameSettingsStore } from "../settings";
 
 export function addFloor(floor: ServerFloor): void {
-    gameStore.floors.push(floor.name);
+    gameStore.addFloor(floor.name);
     addCDT(floor.name);
-    layerManager.floors.push({ name: floor.name, layers: [] });
+    layerManager.floors.push({ name: floor.name, layers: [], playerVisible: floor.player_visible });
     for (const layer of floor.layers) createLayer(layer, floor.name);
 }
 
@@ -34,10 +34,10 @@ export function removeFloor(floor: string): void {
         visibilityStore.visionSources.findIndex(vs => vs.floor === floor),
         1,
     );
-    const index = gameStore.floors.findIndex(f => f === floor);
+    const index = gameStore.visibleFloors.findIndex(f => f === floor);
     for (const layer of layerManager.floors[index].layers) layer.canvas.remove();
     // todo: once vue 3 hits, fix this split up
-    gameStore.floors.splice(index, 1);
+    gameStore.visibleFloors.splice(index, 1);
     layerManager.floors.splice(index, 1);
     if (gameStore.selectedFloorIndex === index) gameStore.selectFloor({ targetFloor: index - 1, sync: true });
 }

--- a/client/src/game/manager.ts
+++ b/client/src/game/manager.ts
@@ -16,11 +16,11 @@ export class GameManager {
     annotationManager = new AnnotationManager();
 
     addShape(shape: ServerShape): Shape | undefined {
-        if (!layerManager.hasLayer(shape.floor, shape.layer)) {
+        if (!layerManager.hasLayer(layerManager.getFloor(shape.floor)!, shape.layer)) {
             console.log(`Shape with unknown layer ${shape.layer} could not be added`);
             return;
         }
-        const layer = layerManager.getLayer(shape.floor, shape.layer)!;
+        const layer = layerManager.getLayer(layerManager.getFloor(shape.floor)!, shape.layer)!;
         const sh = createShapeFromDict(shape);
         if (sh === undefined) {
             console.log(`Shape with unknown type ${shape.type_} could not be added`);
@@ -32,7 +32,7 @@ export class GameManager {
     }
 
     updateShape(data: { shape: ServerShape; redraw: boolean }): void {
-        if (!layerManager.hasLayer(data.shape.floor, data.shape.layer)) {
+        if (!layerManager.hasLayer(layerManager.getFloor(data.shape.floor)!, data.shape.layer)) {
             console.log(`Shape with unknown layer ${data.shape.layer} could not be added`);
             return;
         }
@@ -58,9 +58,9 @@ export class GameManager {
                     shape,
                 });
                 visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape });
-                visibilityStore.recalculateVision(shape.floor);
+                visibilityStore.recalculateVision(shape.floor.name);
             }
-            layerManager.getLayer(data.shape.floor, data.shape.layer)!.invalidate(false);
+            shape.invalidate(false);
             layerManager.invalidateLightAllFloors();
             if (shape.movementObstruction && !alteredMovement) {
                 visibilityStore.deleteFromTriag({
@@ -68,7 +68,7 @@ export class GameManager {
                     shape,
                 });
                 visibilityStore.addToTriag({ target: TriangulationTarget.MOVEMENT, shape });
-                visibilityStore.recalculateMovement(shape.floor);
+                visibilityStore.recalculateMovement(shape.floor.name);
             }
         }
         if (redrawInitiative) EventBus.$emit("Initiative.ForceUpdate");

--- a/client/src/game/settings.ts
+++ b/client/src/game/settings.ts
@@ -8,6 +8,7 @@ import { LocationOptions } from "./comm/types/settings";
 import { layerManager } from "./layers/manager";
 import { Asset } from "./shapes/asset";
 import { gameStore } from "./store";
+import { floorStore } from "./layers/store";
 
 export interface GameSettingsState {
     activeLocation: number;
@@ -148,8 +149,8 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
     @Mutation
     setUseGrid(data: { useGrid: boolean; location: number | null; sync: boolean }): void {
         if (mutateLocationOption("useGrid", data.useGrid, data.location)) {
-            for (const floor of layerManager.floors) {
-                const gridLayer = layerManager.getGridLayer(floor.name)!;
+            for (const floor of floorStore.floors) {
+                const gridLayer = layerManager.getGridLayer(floor)!;
                 if (data.useGrid) gridLayer.canvas.style.display = "block";
                 else gridLayer.canvas.style.display = "none";
                 gridLayer.invalidate();
@@ -164,8 +165,8 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
     @Mutation
     setGridSize(data: { gridSize: number; location: number | null; sync: boolean }): void {
         if (mutateLocationOption("gridSize", data.gridSize, data.location)) {
-            for (const floor of layerManager.floors) {
-                const gridLayer = layerManager.getGridLayer(floor.name);
+            for (const floor of floorStore.floors) {
+                const gridLayer = layerManager.getGridLayer(floor);
                 if (gridLayer !== undefined) gridLayer.invalidate();
             }
 
@@ -264,11 +265,9 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
             shape.src = img.src;
 
             layerManager
-                .getLayer(layerManager.getFloor()!.name, "dm")!
+                .getLayer(floorStore.currentFloor, "dm")!
                 .addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO, false);
-            img.onload = () => {
-                layerManager.getLayer(shape.floor, shape.layer)!.invalidate(true);
-            };
+            img.onload = () => shape.layer.invalidate(true);
 
             gameSettingsStore.setSpawnLocations({
                 spawnLocations: [uuid],

--- a/client/src/game/shapes/aura.ts
+++ b/client/src/game/shapes/aura.ts
@@ -35,7 +35,7 @@ export function drawAuras(shape: Shape, ctx: CanvasRenderingContext2D): void {
             ctx.arc(loc.x, loc.y, innerRange, 0, 2 * Math.PI);
             ctx.fill();
         } else {
-            const polygon = computeVisibility(shape.center(), TriangulationTarget.VISION, shape.floor);
+            const polygon = computeVisibility(shape.center(), TriangulationTarget.VISION, shape.floor.name);
             aura.lastPath = updateAuraPath(polygon, shape.center(), getUnitDistance(aura.value + aura.dim));
             try {
                 ctx.fill(aura.lastPath);

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -424,21 +424,6 @@ export abstract class Shape {
         };
     }
 
-    moveLayer(layer: string, sync: boolean): void {
-        const oldLayer = this.layer;
-        const newLayer = layerManager.getLayer(layerManager.getFloor(this._floor)!, layer);
-        if (oldLayer === undefined || newLayer === undefined) return;
-        this._layer = layer;
-        // Update layer shapes
-        oldLayer.setShapes(...[...oldLayer.getShapes()].splice(oldLayer.getShapes().indexOf(this), 1));
-        newLayer.pushShapes(this);
-        // Revalidate layers  (light should at most be redone once)
-        oldLayer.invalidate(true);
-        newLayer.invalidate(false);
-        // Sync!
-        if (sync) socket.emit("Shape.Layer.Change", { uuid: this.uuid, layer, floor: newLayer.floor });
-    }
-
     // This screws up vetur if typed as `readonly string[]`
     // eslint-disable-next-line @typescript-eslint/array-type
     get owners(): ReadonlyArray<ShapeOwner> {

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -424,19 +424,6 @@ export abstract class Shape {
         };
     }
 
-    moveFloor(floor: string, sync: boolean): void {
-        const oldLayer = this.layer;
-        const newLayer = layerManager.getLayer(layerManager.getFloor(floor)!, this._layer);
-        if (oldLayer === undefined || newLayer === undefined) return;
-        visibilityStore.moveShape({ shape: this, oldFloor: this._floor, newFloor: floor });
-        this._floor = floor;
-        oldLayer.setShapes(...[...oldLayer.getShapes()].splice(oldLayer.getShapes().indexOf(this), 1));
-        newLayer.pushShapes(this);
-        oldLayer.invalidate(false);
-        newLayer.invalidate(false);
-        if (sync) socket.emit("Shape.Floor.Change", { uuid: this.uuid, floor });
-    }
-
     moveLayer(layer: string, sync: boolean): void {
         const oldLayer = this.layer;
         const newLayer = layerManager.getLayer(layerManager.getFloor(this._floor)!, layer);

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -24,6 +24,7 @@ import { EventBus } from "../event-bus";
 import { gameStore } from "../store";
 import { Polygon } from "./polygon";
 import { socket } from "../api/socket";
+import { floorStore } from "../layers/store";
 
 export function createShapeFromDict(shape: ServerShape): Shape | undefined {
     let sh: Shape;
@@ -74,7 +75,7 @@ export function createShapeFromDict(shape: ServerShape): Shape | undefined {
         else img.src = asset.src;
         sh = new Asset(img, refPoint, asset.width, asset.height, asset.uuid);
         img.onload = () => {
-            layerManager.getLayer(shape.floor, shape.layer)!.invalidate(true);
+            layerManager.getLayer(layerManager.getFloor(shape.floor)!, shape.layer)!.invalidate(true);
         };
     } else {
         return undefined;
@@ -84,7 +85,7 @@ export function createShapeFromDict(shape: ServerShape): Shape | undefined {
 }
 
 export function copyShapes(): void {
-    const layer = layerManager.getLayer(layerManager.floor!.name);
+    const layer = layerManager.getLayer(floorStore.currentFloor);
     if (!layer) return;
     if (!layer.hasSelection()) return;
     const clipboard: ServerShape[] = [];
@@ -97,7 +98,7 @@ export function copyShapes(): void {
 }
 
 export function pasteShapes(targetLayer?: string): readonly Shape[] {
-    const layer = layerManager.getLayer(layerManager.floor!.name, targetLayer);
+    const layer = layerManager.getLayer(floorStore.currentFloor, targetLayer);
     if (!layer) return [];
     if (!gameStore.clipboard) return [];
     layer.setSelection();
@@ -165,11 +166,11 @@ export function pasteShapes(targetLayer?: string): readonly Shape[] {
 
 // todo: refactor with removeShape in api/events/shape
 export function deleteShapes(): void {
-    if (layerManager.getLayer(layerManager.floor!.name) === undefined) {
+    if (layerManager.getLayer(floorStore.currentFloor) === undefined) {
         console.log("No active layer selected for delete operation");
         return;
     }
-    const l = layerManager.getLayer(layerManager.floor!.name)!;
+    const l = layerManager.getLayer(floorStore.currentFloor)!;
     for (let i = l.getSelection().length - 1; i >= 0; i--) {
         const sel = l.getSelection()[i];
         if (!sel.ownedBy({ editAccess: true })) continue;

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -39,7 +39,7 @@ class GameStore extends VuexModule implements GameState {
     boardInitialized = false;
 
     locations: { id: number; name: string }[] = [];
-    floors: string[] = [];
+    private floors: string[] = [];
     selectedFloorIndex = -1;
 
     assets: AssetList = {};
@@ -117,6 +117,16 @@ class GameStore extends VuexModule implements GameState {
     get screenCenter(): GlobalPoint {
         const halfScreen = new Vector(window.innerWidth / 2, window.innerHeight / 2);
         return l2g(g2l(this.screenTopLeft).add(halfScreen));
+    }
+
+    get visibleFloors(): string[] {
+        if (this.IS_DM) return this.floors;
+        return this.floors.filter(f => layerManager.getFloor(f)?.playerVisible ?? false);
+    }
+
+    @Mutation
+    addFloor(name: string): void {
+        this.floors.push(name);
     }
 
     @Mutation

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -10,7 +10,7 @@ import { zoomValue } from "@/game/utils";
 import { rootStore } from "@/store";
 import Vue from "vue";
 import { getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
-import { Layer } from "./layers/layer";
+import { floorStore } from "./layers/store";
 import { gameSettingsStore } from "./settings";
 
 export interface LocationUserOptions {
@@ -32,15 +32,9 @@ export interface GameState {
 
 @Module({ dynamic: true, store: rootStore, name: "game", namespaced: true })
 class GameStore extends VuexModule implements GameState {
-    // This is a limited view of selectable layers that is used to generate the layer selection UI and ability to switch layers
-    // See the layerManager for proper layer management tools
-    layers: string[] = [];
-    selectedLayerIndex = -1;
     boardInitialized = false;
 
     locations: { id: number; name: string }[] = [];
-    private floors: string[] = [];
-    selectedFloorIndex = -1;
 
     assets: AssetList = {};
 
@@ -85,14 +79,6 @@ class GameStore extends VuexModule implements GameState {
 
     invertAlt = false;
 
-    get selectedLayer(): string {
-        return this.layers[this.selectedLayerIndex];
-    }
-
-    get selectedFloor(): string {
-        return this.floors[this.selectedFloorIndex];
-    }
-
     get zoomFactor(): number {
         return zoomValue(this.zoomDisplay);
     }
@@ -117,16 +103,6 @@ class GameStore extends VuexModule implements GameState {
     get screenCenter(): GlobalPoint {
         const halfScreen = new Vector(window.innerWidth / 2, window.innerHeight / 2);
         return l2g(g2l(this.screenTopLeft).add(halfScreen));
-    }
-
-    get visibleFloors(): string[] {
-        if (this.IS_DM) return this.floors;
-        return this.floors.filter(f => layerManager.getFloor(f)?.playerVisible ?? false);
-    }
-
-    @Mutation
-    addFloor(name: string): void {
-        this.floors.push(name);
     }
 
     @Mutation
@@ -179,7 +155,7 @@ class GameStore extends VuexModule implements GameState {
             const i = shape.labels.indexOf(label);
             if (i >= 0) {
                 shape.labels.splice(i, 1);
-                layerManager.getLayer(shape.floor, shape.layer)!.invalidate(false);
+                shape.layer.invalidate(false);
             }
         }
         Vue.delete(this.labels, data.uuid);
@@ -208,49 +184,6 @@ class GameStore extends VuexModule implements GameState {
     @Mutation
     setInvitationCode(code: string): void {
         this.invitationCode = code;
-    }
-
-    @Mutation
-    addLayer(name: string): void {
-        this.layers.push(name);
-        if (this.selectedLayerIndex === -1) this.selectedLayerIndex = this.layers.indexOf(name);
-    }
-
-    @Mutation
-    selectLayer(data: { layer: Layer; sync: boolean }): void {
-        let index = this.layers.indexOf(data.layer.name);
-        if (index < 0) index = 0;
-        // else if (index >= this.layers.reduce((acc: number, val: Layer) => val.floor === data.layer.floor))
-        this.selectedLayerIndex = index;
-        if (data.sync) socket.emit("Client.ActiveLayer.Set", { floor: data.layer.floor, layer: data.layer.name });
-    }
-
-    @Mutation
-    selectFloor(data: { targetFloor: number | string; sync: boolean }): void {
-        let targetFloorIndex: number;
-        if (typeof data.targetFloor === "string") {
-            targetFloorIndex = layerManager.floors.findIndex(f => f.name === data.targetFloor);
-        } else {
-            targetFloorIndex = data.targetFloor;
-        }
-        if (targetFloorIndex === this.selectedFloorIndex) return;
-
-        this.selectedFloorIndex = targetFloorIndex;
-        this.layers = layerManager.floor!.layers.reduce(
-            (acc: string[], val: Layer) =>
-                val.selectable && (val.playerEditable || this.IS_DM) ? [...acc, val.name] : acc,
-            [],
-        );
-        if (this.selectedLayerIndex < 0) this.selectedLayerIndex = 0;
-
-        for (const [f, floor] of layerManager.floors.entries()) {
-            for (const layer of floor.layers) {
-                if (f > targetFloorIndex) layer.canvas.style.display = "none";
-                else layer.canvas.style.removeProperty("display");
-            }
-        }
-        layerManager.selectLayer(layerManager.getLayer(layerManager.floor!.name)!.name, data.sync, false);
-        layerManager.invalidateAllFloors();
     }
 
     @Mutation
@@ -308,14 +241,6 @@ class GameStore extends VuexModule implements GameState {
     }
 
     @Mutation
-    resetLayerInfo(): void {
-        this.floors = [];
-        this.selectedFloorIndex = -1;
-        this.layers = [];
-        this.selectedLayerIndex = -1;
-    }
-
-    @Mutation
     updateZoom(data: { newZoomDisplay: number; zoomLocation: GlobalPoint }): void {
         if (data.newZoomDisplay === this.zoomDisplay) return;
         if (data.newZoomDisplay < 0) data.newZoomDisplay = 0;
@@ -334,8 +259,8 @@ class GameStore extends VuexModule implements GameState {
     @Mutation
     setGridColour(data: { colour: string; sync: boolean }): void {
         this.gridColour = data.colour;
-        for (const floor of layerManager.floors) {
-            layerManager.getGridLayer(floor.name)!.invalidate();
+        for (const floor of floorStore.floors) {
+            layerManager.getGridLayer(floor)!.invalidate();
         }
         if (data.sync) socket.emit("Client.Options.Set", { gridColour: data.colour });
     }

--- a/client/src/game/ui/annotation.ts
+++ b/client/src/game/ui/annotation.ts
@@ -1,3 +1,4 @@
+import { InvalidationMode, SyncMode } from "@/core/comm/types";
 import { GlobalPoint, LocalPoint } from "@/game/geom";
 import { Layer } from "@/game/layers/layer";
 import { layerManager } from "@/game/layers/manager";
@@ -5,7 +6,7 @@ import { Rect } from "@/game/shapes/rect";
 import { Text } from "@/game/shapes/text";
 import { gameStore } from "@/game/store";
 import { l2g } from "@/game/units";
-import { SyncMode, InvalidationMode } from "@/core/comm/types";
+import { floorStore } from "../layers/store";
 
 export class AnnotationManager {
     annotationText: Text;
@@ -20,8 +21,8 @@ export class AnnotationManager {
     }
 
     setActiveText(text: string): void {
-        if (layerManager.hasLayer(layerManager.floor!.name, "draw")) {
-            this.layer = layerManager.getLayer(layerManager.floor!.name, "draw")!;
+        if (layerManager.hasLayer(floorStore.currentFloor, "draw")) {
+            this.layer = layerManager.getLayer(floorStore.currentFloor, "draw")!;
             this.layer.addShape(this.annotationRect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
             this.layer.addShape(this.annotationText, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
         } else {

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -18,7 +18,7 @@ export default class FloorSelect extends Vue {
     }
 
     get floors(): string[] {
-        return gameStore.floors;
+        return gameStore.visibleFloors;
     }
 
     get selectedFloorIndex(): number {
@@ -56,7 +56,7 @@ export default class FloorSelect extends Vue {
 
     async removeFloor(index: number): Promise<void> {
         if (this.floors.length <= 1) return;
-        const floor = gameStore.floors[index];
+        const floor = this.floors[index];
         if (
             !(await (<Game>this.$parent.$parent).$refs.confirm.open(
                 this.$t("common.warning").toString(),

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -8,20 +8,12 @@ import { socket } from "@/game/api/socket";
 import { layerManager } from "@/game/layers/manager";
 import { removeFloor } from "@/game/layers/utils";
 import { gameStore } from "@/game/store";
-import { EventBus } from "../event-bus";
 import { Floor } from "../layers/floor";
 import { floorStore } from "../layers/store";
-import { layer } from "@fortawesome/fontawesome-svg-core";
 
 @Component
 export default class FloorSelect extends Vue {
     selected = false;
-
-    mounted(): void {
-        EventBus.$on("Floor.Visible.Set", () => {
-            this.$forceUpdate();
-        });
-    }
 
     get IS_DM(): boolean {
         return gameStore.IS_DM || gameStore.FAKE_PLAYER;
@@ -85,7 +77,6 @@ export default class FloorSelect extends Vue {
     toggleVisible(floor: Floor): void {
         floor.playerVisible = !floor.playerVisible;
         socket.emit("Floor.Visible.Set", { name: floor.name, visible: floor.playerVisible });
-        this.$forceUpdate();
     }
 
     getLayerWord(layer: string): string {
@@ -125,8 +116,8 @@ export default class FloorSelect extends Vue {
                     <div class="floor-actions" v-show="IS_DM">
                         <div
                             @click.stop="toggleVisible(floor)"
-                            :style="{ opacity: floor.playerVisible ? 1.0 : 0.3 }"
-                            :title="$t('game.ui.floors.delete_floor')"
+                            :style="{ opacity: floor.playerVisible ? 1.0 : 0.3, marginRight: '5px' }"
+                            :title="$t('game.ui.floors.toggle_visibility')"
                         >
                             <font-awesome-icon icon="eye" />
                         </div>

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -89,7 +89,7 @@ export default class Initiative extends Vue {
         if (shape === undefined) return;
         if (shape.showHighlight) {
             shape.showHighlight = false;
-            layerManager.getLayer(shape.floor, shape.layer)!.invalidate(true);
+            shape.layer.invalidate(true);
         }
     }
     updateOrder(): void {
@@ -143,7 +143,7 @@ export default class Initiative extends Vue {
         const shape = layerManager.UUIDMap.get(actor.uuid);
         if (shape === undefined) return;
         shape.showHighlight = show;
-        layerManager.getLayer(shape.floor, shape.layer)!.invalidate(true);
+        shape.layer.invalidate(true);
     }
     toggleOption(actor: InitiativeData, option: "visible" | "group"): void {
         if (!this.owns(actor)) return;

--- a/client/src/game/ui/menu/locations.vue
+++ b/client/src/game/ui/menu/locations.vue
@@ -5,7 +5,7 @@ import Component from "vue-class-component";
 import { mapState } from "vuex";
 import { Prop, Watch } from "vue-property-decorator";
 
-import Game from "@/game/game.vue";
+import Game from "@/game/Game.vue";
 
 import { gameStore } from "@/game/store";
 import { socket } from "@/game/api/socket";

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -5,7 +5,7 @@ import Component from "vue-class-component";
 import { mapState } from "vuex";
 
 import ColorPicker from "@/core/components/colorpicker.vue";
-import Game from "@/game/game.vue";
+import Game from "@/game/Game.vue";
 import AssetNode from "@/game/ui/menu/asset_node.vue";
 import LanguageDropdown from "@/core/components/languageDropdown.vue";
 

--- a/client/src/game/ui/note.vue
+++ b/client/src/game/ui/note.vue
@@ -3,7 +3,7 @@ import Vue from "vue";
 import Component from "vue-class-component";
 
 import Modal from "@/core/components/modals/modal.vue";
-import Game from "@/game/game.vue";
+import Game from "@/game/Game.vue";
 
 import { Note } from "@/game/comm/types/general";
 import { gameStore } from "@/game/store";

--- a/client/src/game/ui/selection/edit_dialog/dialog.vue
+++ b/client/src/game/ui/selection/edit_dialog/dialog.vue
@@ -15,6 +15,7 @@ import { layerManager } from "@/game/layers/manager";
 import { Shape } from "@/game/shapes/shape";
 import { gameStore } from "@/game/store";
 import { getVisionSources, addVisionSource, sliceVisionSources } from "@/game/visibility/utils";
+import { floorStore } from "@/game/layers/store";
 
 @Component({
     components: {
@@ -126,12 +127,12 @@ export default class EditDialog extends Vue {
         this.shape.annotation = event.target.value;
         if (this.shape.annotation !== "" && !hadAnnotation) {
             gameStore.annotations.push(this.shape.uuid);
-            if (layerManager.hasLayer(layerManager.floor!.name, "draw"))
-                layerManager.getLayer(layerManager.floor!.name, "draw")!.invalidate(true);
+            if (layerManager.hasLayer(floorStore.currentFloor, "draw"))
+                layerManager.getLayer(floorStore.currentFloor, "draw")!.invalidate(true);
         } else if (this.shape.annotation === "" && hadAnnotation) {
             gameStore.annotations.splice(gameStore.annotations.findIndex(an => an === this.shape.uuid));
-            if (layerManager.hasLayer(layerManager.floor!.name, "draw"))
-                layerManager.getLayer(layerManager.floor!.name, "draw")!.invalidate(true);
+            if (layerManager.hasLayer(floorStore.currentFloor, "draw"))
+                layerManager.getLayer(floorStore.currentFloor, "draw")!.invalidate(true);
         }
         this.updateShape(false);
     }
@@ -149,18 +150,16 @@ export default class EditDialog extends Vue {
     updateAuraVisionSource(aura: Aura): void {
         if (!this.owned) return;
         aura.visionSource = !aura.visionSource;
-        const visionSources = getVisionSources(this.shape.floor);
+        const visionSources = getVisionSources(this.shape.floor.name);
         const i = visionSources.findIndex(ls => ls.aura === aura.uuid);
         if (aura.visionSource && i === -1)
-            addVisionSource({ shape: this.shape.uuid, aura: aura.uuid }, this.shape.floor);
-        else if (!aura.visionSource && i >= 0) sliceVisionSources(i, this.shape.floor);
+            addVisionSource({ shape: this.shape.uuid, aura: aura.uuid }, this.shape.floor.name);
+        else if (!aura.visionSource && i >= 0) sliceVisionSources(i, this.shape.floor.name);
         this.updateShape(true);
     }
     updateAuraColour(aura: Aura, _colour: string): void {
         if (!this.owned) return;
-        const layer = layerManager.getLayer(this.shape.floor, this.shape.layer);
-        if (layer === undefined) return;
-        layer.invalidate(!aura.visionSource);
+        this.shape.layer.invalidate(!aura.visionSource);
     }
     openLabelManager(): void {
         EventBus.$emit("LabelManager.Open");

--- a/client/src/game/ui/selection/selection_info.vue
+++ b/client/src/game/ui/selection/selection_info.vue
@@ -2,7 +2,7 @@
 import Vue from "vue";
 import Component from "vue-class-component";
 
-import Game from "@/game/game.vue";
+import Game from "@/game/Game.vue";
 import EditDialog from "@/game/ui/selection/edit_dialog/dialog.vue";
 
 import { socket } from "@/game/api/socket";

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -9,15 +9,17 @@ import Prompt from "@/core/components/modals/prompt.vue";
 
 import { socket } from "@/game/api/socket";
 import { EventBus } from "@/game/event-bus";
-import { layerManager, Floor } from "@/game/layers/manager";
+import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
 import { deleteShapes } from "../../shapes/utils";
 import { initiativeStore, inInitiative } from "../initiative/store";
 import { Layer } from "../../layers/layer";
 import { gameSettingsStore } from "../../settings";
-import Game from "@/game/game.vue";
+import Game from "@/game/Game.vue";
 import { ServerAsset } from "../../comm/types/shapes";
 import { Shape } from "@/game/shapes/shape";
+import { floorStore } from "../../layers/store";
+import { Floor } from "@/game/layers/floor";
 
 @Component({
     components: {
@@ -60,8 +62,8 @@ export default class ShapeContext extends Vue {
         if (layer.getSelection().length !== 1) return;
         return layer.getSelection()[0].uuid;
     }
-    getFloors(): Floor[] {
-        if (gameStore.IS_DM) return layerManager.floors;
+    getFloors(): readonly Floor[] {
+        if (gameStore.IS_DM) return floorStore.floors;
         return [];
     }
     getLocations(): { id: number; name: string }[] {
@@ -70,10 +72,10 @@ export default class ShapeContext extends Vue {
     }
     getLayers(): Layer[] {
         if (!gameStore.IS_DM || this.hasSpawnToken()) return [];
-        return layerManager.floor?.layers.filter(l => l.selectable) || [];
+        return layerManager.getLayers(floorStore.currentFloor).filter(l => l.selectable) || [];
     }
     getActiveLayer(): Layer | undefined {
-        if (layerManager.floor !== undefined) return layerManager.getLayer(layerManager.floor.name);
+        return gameStore.boardInitialized ? layerManager.getLayer(floorStore.currentFloor) : undefined;
     }
     getInitiativeWord(): string {
         const layer = this.getActiveLayer()!;

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -20,6 +20,7 @@ import { ServerAsset } from "../../comm/types/shapes";
 import { Shape } from "@/game/shapes/shape";
 import { floorStore } from "../../layers/store";
 import { Floor } from "@/game/layers/floor";
+import { moveFloor } from "../../layers/utils";
 
 @Component({
     components: {
@@ -95,7 +96,7 @@ export default class ShapeContext extends Vue {
     }
     setFloor(floor: Floor): void {
         const layer = this.getActiveLayer()!;
-        layer.getSelection().forEach(shape => shape.moveFloor(floor.name, true));
+        moveFloor([...layer.getSelection()], floor, true);
         this.close();
     }
     setLayer(newLayer: string): void {

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -20,7 +20,7 @@ import { ServerAsset } from "../../comm/types/shapes";
 import { Shape } from "@/game/shapes/shape";
 import { floorStore } from "../../layers/store";
 import { Floor } from "@/game/layers/floor";
-import { moveFloor } from "../../layers/utils";
+import { moveFloor, moveLayer } from "../../layers/utils";
 
 @Component({
     components: {
@@ -101,7 +101,7 @@ export default class ShapeContext extends Vue {
     }
     setLayer(newLayer: string): void {
         const layer = this.getActiveLayer()!;
-        layer.getSelection().forEach(shape => shape.moveLayer(newLayer, true));
+        moveLayer([...layer.getSelection()], layerManager.getLayer(floorStore.currentFloor, newLayer)!, true);
         layer.clearSelection();
         this.close();
     }

--- a/client/src/game/ui/settings/VisionSettings.vue
+++ b/client/src/game/ui/settings/VisionSettings.vue
@@ -8,6 +8,7 @@ import { VisibilityMode, visibilityStore } from "@/game/visibility/store";
 import { layerManager } from "@/game/layers/manager";
 import { gameSettingsStore, getLocationOption } from "../../settings";
 import { LocationOptions } from "@/game/comm/types/settings";
+import { floorStore } from "../../layers/store";
 
 @Component
 export default class VisionSettings extends Vue {
@@ -72,7 +73,7 @@ export default class VisionSettings extends Vue {
             mode = VisibilityMode.TRIANGLE_ITERATIVE;
         else return;
         visibilityStore.setVisionMode({ mode, sync: true });
-        for (const floor of layerManager.floors) {
+        for (const floor of floorStore.floors) {
             visibilityStore.recalculateVision(floor.name);
             visibilityStore.recalculateMovement(floor.name);
         }

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -3,7 +3,7 @@ import Vue from "vue";
 import Component from "vue-class-component";
 
 import InputCopyElement from "@/core/components/inputCopy.vue";
-import Game from "../../../game.vue";
+import Game from "../../../Game.vue";
 import { socket } from "@/game/api/socket";
 import { EventBus } from "@/game/event-bus";
 import { gameStore, Player } from "@/game/store";

--- a/client/src/game/ui/settings/location/LocationAdminSettings.vue
+++ b/client/src/game/ui/settings/location/LocationAdminSettings.vue
@@ -4,7 +4,7 @@ import Component from "vue-class-component";
 import { Prop } from "vue-property-decorator";
 
 import InputCopyElement from "@/core/components/inputCopy.vue";
-import Game from "@/game/game.vue";
+import Game from "@/game/Game.vue";
 import { socket } from "@/game/api/socket";
 import { gameStore } from "@/game/store";
 import { renameLocation } from "../../../api/events/location";

--- a/client/src/game/ui/tools/createtoken_modal.vue
+++ b/client/src/game/ui/tools/createtoken_modal.vue
@@ -17,6 +17,7 @@ import { getUnitDistance, l2g } from "@/game/units";
 import { Watch } from "vue-property-decorator";
 import { SyncMode, InvalidationMode } from "../../../core/comm/types";
 import { gameSettingsStore } from "../../settings";
+import { floorStore } from "@/game/layers/store";
 
 @Component({
     components: {
@@ -58,7 +59,7 @@ export default class CreateTokenModal extends Vue {
         this.y = y;
     }
     submit(): void {
-        const layer = layerManager.getLayer(layerManager.floor!.name);
+        const layer = layerManager.getLayer(floorStore.currentFloor);
         if (layer === undefined) return;
         const token = new CircularToken(
             l2g(new LocalPoint(this.x, this.y)),

--- a/client/src/game/ui/tools/defaultcontext.vue
+++ b/client/src/game/ui/tools/defaultcontext.vue
@@ -8,7 +8,7 @@ import { socket } from "@/game/api/socket";
 import { EventBus } from "@/game/event-bus";
 import { gameStore } from "@/game/store";
 import { l2gx, l2gy } from "@/game/units";
-import { layerManager } from "../../layers/manager";
+import { floorStore } from "@/game/layers/store";
 
 @Component({
     components: {
@@ -36,7 +36,7 @@ export default class DefaultContext extends Vue {
     bringPlayers(): void {
         if (!gameStore.IS_DM) return;
         socket.emit("Players.Bring", {
-            floor: layerManager.floor!.name,
+            floor: floorStore.currentFloor.name,
             x: l2gx(this.x),
             y: l2gy(this.y),
             zoom: gameStore.zoomDisplay,

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -15,6 +15,7 @@ import { EventBus } from "@/game/event-bus";
 import { Shape } from "@/game/shapes/shape";
 import { gameSettingsStore } from "../../settings";
 import { ToolBasics } from "./ToolBasics";
+import { floorStore } from "@/game/layers/store";
 
 @Component
 export default class MapTool extends Tool implements ToolBasics {
@@ -52,7 +53,7 @@ export default class MapTool extends Tool implements ToolBasics {
 
     removeRect(): void {
         if (this.rect) {
-            const layer = layerManager.getLayer(layerManager.floor!.name)!;
+            const layer = layerManager.getLayer(floorStore.currentFloor)!;
             layer.removeShape(this.rect, SyncMode.NO_SYNC);
             this.rect = null;
         }
@@ -94,7 +95,7 @@ export default class MapTool extends Tool implements ToolBasics {
         const startPoint = l2g(lp);
 
         this.startPoint = startPoint;
-        const layer = layerManager.getLayer(layerManager.floor!.name);
+        const layer = layerManager.getLayer(floorStore.currentFloor);
         if (layer === undefined) {
             console.log("No active layer!");
             return;
@@ -113,7 +114,7 @@ export default class MapTool extends Tool implements ToolBasics {
 
         const endPoint = l2g(lp);
 
-        const layer = layerManager.getLayer(layerManager.floor!.name);
+        const layer = layerManager.getLayer(floorStore.currentFloor);
         if (layer === undefined) {
             console.log("No active layer!");
             return;
@@ -130,7 +131,7 @@ export default class MapTool extends Tool implements ToolBasics {
 
     onUp(): void {
         if (!this.active || this.rect === null) return;
-        const layer = layerManager.getLayer(layerManager.floor!.name);
+        const layer = layerManager.getLayer(floorStore.currentFloor);
         if (layer === undefined) {
             console.log("No active layer!");
             return;

--- a/client/src/game/ui/tools/ping.ts
+++ b/client/src/game/ui/tools/ping.ts
@@ -9,6 +9,7 @@ import { l2g } from "@/game/units";
 import Component from "vue-class-component";
 import { ToolBasics } from "./ToolBasics";
 import { ToolName } from "./utils";
+import { floorStore } from "../../layers/store";
 
 @Component
 export class PingTool extends Tool implements ToolBasics {
@@ -20,7 +21,7 @@ export class PingTool extends Tool implements ToolBasics {
 
     onDown(lp: LocalPoint): void {
         this.startPoint = l2g(lp);
-        const layer = layerManager.getLayer(layerManager.floor!.name, "draw");
+        const layer = layerManager.getLayer(floorStore.currentFloor, "draw");
 
         if (layer === undefined) {
             console.log("No draw layer!");
@@ -39,7 +40,7 @@ export class PingTool extends Tool implements ToolBasics {
     onUp(): void {
         if (!this.active || this.ping === null || this.border === null || this.startPoint === null) return;
 
-        const layer = layerManager.getLayer(layerManager.floor!.name, "draw");
+        const layer = layerManager.getLayer(floorStore.currentFloor, "draw");
         if (layer === undefined) {
             console.log("No active layer!");
             return;
@@ -57,7 +58,7 @@ export class PingTool extends Tool implements ToolBasics {
 
         const gp = l2g(lp);
 
-        const layer = layerManager.getLayer(layerManager.floor!.name, "draw");
+        const layer = layerManager.getLayer(floorStore.currentFloor, "draw");
         if (layer === undefined) {
             console.log("No draw layer!");
             return;

--- a/client/src/game/ui/tools/ruler.vue
+++ b/client/src/game/ui/tools/ruler.vue
@@ -14,6 +14,7 @@ import { Line } from "@/game/shapes/line";
 import { gameStore } from "@/game/store";
 import { Text } from "../../shapes/text";
 import { socket } from "@/game/api/socket";
+import { floorStore } from "@/game/layers/store";
 
 @Component
 export default class RulerTool extends Tool implements ToolBasics {
@@ -33,7 +34,7 @@ export default class RulerTool extends Tool implements ToolBasics {
     onDown(lp: LocalPoint): void {
         this.startPoint = l2g(lp);
 
-        const layer = layerManager.getLayer(layerManager.floor!.name, "draw");
+        const layer = layerManager.getLayer(floorStore.currentFloor, "draw");
         if (layer === undefined) {
             console.log("No draw layer!");
             return;
@@ -51,7 +52,7 @@ export default class RulerTool extends Tool implements ToolBasics {
         const endPoint = l2g(lp);
         if (!this.active || this.ruler === null || this.startPoint === null || this.text === null) return;
 
-        const layer = layerManager.getLayer(layerManager.floor!.name, "draw");
+        const layer = layerManager.getLayer(floorStore.currentFloor, "draw");
         if (layer === undefined) {
             console.log("No draw layer!");
             return;
@@ -80,7 +81,7 @@ export default class RulerTool extends Tool implements ToolBasics {
     onUp(): void {
         if (!this.active || this.ruler === null || this.startPoint === null || this.text === null) return;
 
-        const layer = layerManager.getLayer(layerManager.floor!.name, "draw");
+        const layer = layerManager.getLayer(floorStore.currentFloor, "draw");
         if (layer === undefined) {
             console.log("No active layer!");
             return;

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -22,6 +22,7 @@ import { l2g } from "@/game/units";
 import { getLocalPointFromEvent } from "@/game/utils";
 import { ToolName, ToolFeatures } from "./utils";
 import { EventBus } from "@/game/event-bus";
+import { floorStore } from "@/game/layers/store";
 
 @Component({
     components: {
@@ -185,7 +186,7 @@ export default class Tools extends Vue {
         // Annotation hover
         let found = false;
         for (const uuid of gameStore.annotations) {
-            if (layerManager.UUIDMap.has(uuid) && layerManager.hasLayer(layerManager.floor!.name, "draw")) {
+            if (layerManager.UUIDMap.has(uuid) && layerManager.hasLayer(floorStore.currentFloor, "draw")) {
                 const shape = layerManager.UUIDMap.get(uuid)!;
                 if (shape.contains(l2g(getLocalPointFromEvent(event)))) {
                     found = true;
@@ -274,7 +275,7 @@ export default class Tools extends Vue {
         // Annotation hover
         let found = false;
         for (const uuid of gameStore.annotations) {
-            if (layerManager.UUIDMap.has(uuid) && layerManager.hasLayer(layerManager.floor!.name, "draw")) {
+            if (layerManager.UUIDMap.has(uuid) && layerManager.hasLayer(floorStore.currentFloor, "draw")) {
                 const shape = layerManager.UUIDMap.get(uuid)!;
                 if (shape.contains(l2g(getLocalPointFromEvent(event)))) {
                     found = true;

--- a/client/src/game/ui/tools/utils.ts
+++ b/client/src/game/ui/tools/utils.ts
@@ -25,12 +25,12 @@ export type ToolFeatures<T = number> = { enabled?: T[]; disabled?: T[] };
 export function calculateDelta(delta: Vector, sel: Shape, shrink = false): Vector {
     if (delta.x === 0 && delta.y === 0) return delta;
     const center = sel.center().asArray();
-    const centerTriangle = getCDT(TriangulationTarget.MOVEMENT, sel.floor).locate(center, null).loc;
+    const centerTriangle = getCDT(TriangulationTarget.MOVEMENT, sel.floor.name).locate(center, null).loc;
     for (let point of sel.points) {
         if (shrink) {
             point = [point[0] - (point[0] - center[0]) * 0.75, point[1] - (point[1] - center[1]) * 0.75];
         }
-        const lt = getCDT(TriangulationTarget.MOVEMENT, sel.floor).locate(point, centerTriangle);
+        const lt = getCDT(TriangulationTarget.MOVEMENT, sel.floor.name).locate(point, centerTriangle);
         const triangle = lt.loc;
         if (triangle === null) continue;
         delta = checkTriangle(point, triangle, delta);

--- a/client/src/game/visibility/te/draw.ts
+++ b/client/src/game/visibility/te/draw.ts
@@ -1,10 +1,11 @@
 import { layerManager } from "@/game/layers/manager";
 import { g2lx, g2ly } from "@/game/units";
-import { EdgeIterator, TDS, Edge } from "./tds";
+import { floorStore } from "../../layers/store";
+import { Edge, EdgeIterator, TDS } from "./tds";
 import { ccw, cw } from "./triag";
 
 export function drawPoint(point: number[], r: number, colour?: string): void {
-    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
+    const dl = layerManager.getLayer(floorStore.currentFloor, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.lineJoin = "round";
@@ -18,7 +19,7 @@ export function drawPoint(point: number[], r: number, colour?: string): void {
 }
 
 export function drawPointL(point: number[], r: number, colour?: string): void {
-    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
+    const dl = layerManager.getLayer(floorStore.currentFloor, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.lineJoin = "round";
@@ -32,7 +33,7 @@ export function drawPointL(point: number[], r: number, colour?: string): void {
 }
 
 export function drawPolygon(polygon: number[][], colour?: string): void {
-    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
+    const dl = layerManager.getLayer(floorStore.currentFloor, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.lineJoin = "round";
@@ -50,7 +51,7 @@ export function drawPolygon(polygon: number[][], colour?: string): void {
 }
 
 export function drawPolygonL(polygon: number[][], colour?: string): void {
-    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
+    const dl = layerManager.getLayer(floorStore.currentFloor, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.lineJoin = "round";
@@ -88,7 +89,7 @@ function drl(from: number[], to: number[], constrained: boolean, local: boolean)
     // } else {
     //     console.log(" ", from, to);
     // }
-    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
+    const dl = layerManager.getLayer(floorStore.currentFloor, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.beginPath();
@@ -102,7 +103,7 @@ function drl(from: number[], to: number[], constrained: boolean, local: boolean)
 export function drawEdge(edge: Edge, colour: string, local = false): void {
     const from = edge.first!.vertices[edge.second === 0 ? 1 : 0]!.point!;
     const to = edge.first!.vertices[edge.second === 2 ? 1 : 2]!.point!;
-    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
+    const dl = layerManager.getLayer(floorStore.currentFloor, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     ctx.beginPath();
@@ -117,7 +118,7 @@ export function drawPolygonT(tds: TDS, local = true, clear = true, logs: 0 | 1 |
     I = 0;
     J = 0;
     let T = 0;
-    const dl = layerManager.getLayer(layerManager.floor!.name, "draw");
+    const dl = layerManager.getLayer(floorStore.currentFloor, "draw");
     if (dl === undefined) return;
     const ctx = dl.ctx;
     if (clear) ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
@@ -195,7 +196,7 @@ export function drawPolygonT(tds: TDS, local = true, clear = true, logs: 0 | 1 |
 //     const POINTS = 	[[[2204.40109629713,1502.9370921248671],[2194.4969483467376,1501.8032381745284],[2182.960505429924,849.4588854915166],[2195.2603028653853,848.4339023718949],[2195.2603028653853,1094.4298510811182],[2221.909863975551,1099.554766679227],[2220.8848808559296,1105.7046653969574],[2190.135387267276,1107.7546316362009],[2197.310269104629,1306.6013568428232],[2254.7093238034477,1302.5014243643361],[2255.734306923069,1306.6013568428232],[2193.2103366261417,1314.8012217997973]],
 //         [[200,-1350],[200,4350],[750,4350],[750,-1350]],
 //         [[3556.1308949025706,368.2067431718624],[3556.1308949025706,4099.326575833981],[4125.828761825174,4099.326575833981],[4125.828761825174,368.2067431718624]]];
-//     for (const [i, shape] of (<Polygon[]>layerManager.getLayer(layerManager.floor!.name, )!.shapes).entries()) {
+//     for (const [i, shape] of (<Polygon[]>layerManager.getLayer(floorStore.currentFloor.name, )!.shapes).entries()) {
 //         shape.refPoint = GlobalPoint.fromArray(POINTS[i][0]);
 //         shape._vertices = POINTS[i].slice(1).map(p => GlobalPoint.fromArray(p));
 //         socket.emit("Shape.Position.Update", { shape: shape.asDict(), redraw: true, temporary: false });
@@ -208,5 +209,5 @@ export function drawPolygonT(tds: TDS, local = true, clear = true, logs: 0 | 1 |
 //         s += `${triag.uid}\t${triag.vertices.map(v => v === null ? '0,0' : v.point!.join(",")).join("\t")}\t${triag.neighbours.map(n=>n!.uid).join("\t")}\n`;
 //     }
 //     console.log(s);
-//     deleteShapeFromTriag(TriangulationTarget.VISION, layerManager.getLayer(layerManager.floor!.name, )!.shapes[2]);
+//     deleteShapeFromTriag(TriangulationTarget.VISION, layerManager.getLayer(floorStore.currentFloor.name, )!.shapes[2]);
 // }

--- a/client/src/game/visibility/te/iterative.ts
+++ b/client/src/game/visibility/te/iterative.ts
@@ -64,7 +64,7 @@ export class IterativeDelete {
         this.handledPoints = [];
         this.finalConstraints = [];
 
-        this.cdt = getCDT(target, shape.floor);
+        this.cdt = getCDT(target, shape.floor.name);
         this.shape = shape;
 
         this.deleteVertices();
@@ -159,7 +159,7 @@ export class IterativeDelete {
         for (const edge of vertex.getIncidentEdges(true)) {
             const ccwv = edge.first!.vertices[ccw(edge.second)]!;
             const ccwp = ccwv.point!;
-            // layerManager.getLayer(layerManager.floor!.name, "draw")!.clear();
+            // layerManager.getLayer(floorStore.currentFloor.name, "draw")!.clear();
             // drawPoint(vertex.point!, 10, "blue");
             // drawPoint(ccwp, 10, "green");
             const edgeCovered = equalPoints(ccwp, from.point!) || collinearInOrder(vertex.point!, ccwp, from.point!);

--- a/client/src/game/visibility/te/pa.ts
+++ b/client/src/game/visibility/te/pa.ts
@@ -32,7 +32,7 @@ export function removeCDT(floor: string): void {
 }
 
 export function insertConstraint(target: TriangulationTarget, shape: Shape, pa: number[], pb: number[]): void {
-    const cdt = getCDT(target, shape.floor);
+    const cdt = getCDT(target, shape.floor.name);
     const { va, vb } = cdt.insertConstraint(pa, pb);
     va.shapes.add(shape);
     vb.shapes.add(shape);
@@ -46,7 +46,7 @@ export function triangulate(target: TriangulationTarget, floor: string): void {
 
     for (const sh of shapes) {
         const shape = layerManager.UUIDMap.get(sh)!;
-        if (shape.floor !== floor) continue;
+        if (shape.floor.name !== floor) continue;
         const j = shape.isClosed ? 0 : 1;
         for (let i = 0; i < shape.points.length - j; i++) {
             const pa = shape.points[i];

--- a/client/src/game/visibility/te/te.ts
+++ b/client/src/game/visibility/te/te.ts
@@ -62,7 +62,7 @@ function expandEdge(
     const ro = orientation(q, right, nvh.point!);
     const lo = orientation(q, left, nvh.point!);
 
-    // const ctx = layerManager.getLayer(layerManager.floor!.name, "draw")!.ctx;
+    // const ctx = layerManager.getLayer(floorStore.currentFloor.name, "draw")!.ctx;
     // ctx.beginPath();
     // ctx.strokeStyle = "red";
     // ctx.lineJoin = "round";

--- a/client/src/game/visibility/utils.ts
+++ b/client/src/game/visibility/utils.ts
@@ -1,28 +1,28 @@
-import { layerManager } from "@/game/layers/manager";
+import { floorStore } from "../layers/store";
 import { visibilityStore } from "./store";
 import { TriangulationTarget } from "./te/pa";
 
 export function getBlockers(target: TriangulationTarget, floor?: string): readonly string[] {
-    if (floor === undefined) floor = layerManager.floor!.name;
+    if (floor === undefined) floor = floorStore.currentFloor.name;
     const blockers =
         target === TriangulationTarget.VISION ? visibilityStore.visionBlockers : visibilityStore.movementBlockers;
     return blockers.find(vb => vb.floor === floor)?.blockers || [];
 }
 
 export function getVisionSources(floor?: string): readonly { shape: string; aura: string }[] {
-    if (floor === undefined) floor = layerManager.floor!.name;
+    if (floor === undefined) floor = floorStore.currentFloor.name;
     return visibilityStore.visionSources.find(vs => vs.floor === floor)?.sources || [];
 }
 
 export function setVisionSources(sources: { shape: string; aura: string }[], floor?: string): void {
-    if (floor === undefined) floor = layerManager.floor!.name;
+    if (floor === undefined) floor = floorStore.currentFloor.name;
     const obj = visibilityStore.visionSources.find(vs => vs.floor === floor);
     if (obj === undefined) throw new Error("setVisionSources got an unknown floor");
     obj.sources = sources;
 }
 
 function setBlockers(target: TriangulationTarget, blockers: string[], floor?: string): void {
-    if (floor === undefined) floor = layerManager.floor!.name;
+    if (floor === undefined) floor = floorStore.currentFloor.name;
     const targetBlockers =
         target === TriangulationTarget.VISION ? visibilityStore.visionBlockers : visibilityStore.movementBlockers;
     const obj = targetBlockers.find(b => b.floor === floor);

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -97,7 +97,8 @@
                 "creation": "Floor Creation",
                 "warning_msg_Z": "Are you sure you wish to remove the {z} floor?",
                 "delete_floor": "Delete floor",
-                "add_new_floor": "Add new floor"
+                "add_new_floor": "Add new floor",
+                "toggle_visibility": "Toggle floor visibility for players"
             },
             "initiative": {
                 "initiative": {

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -9,7 +9,7 @@ import Login from "@/auth/login.vue";
 import Logout from "@/auth/logout";
 import Dashboard from "@/dashboard/main.vue";
 import Settings from "@/settings/settings.vue";
-import Game from "@/game/game.vue";
+import Game from "@/game/Game.vue";
 import Invitation from "@/invitation/invitation";
 
 import { coreStore } from "@/core/store";
@@ -65,6 +65,7 @@ export const router = new Router({
         {
             path: "/game/:creator/:room",
             component: Game,
+            name: "game",
             meta: {
                 auth: true,
             },

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -3,6 +3,7 @@ import { CoreState } from "@/core/store";
 import { GameState } from "@/game/store";
 import Vue from "vue";
 import Vuex from "vuex";
+import { FloorState } from "./game/layers/store";
 import { GameSettingsState } from "./game/settings";
 import { InitiativeState } from "./game/ui/initiative/store";
 import { VisibilityState } from "./game/visibility/store";
@@ -12,6 +13,7 @@ Vue.use(Vuex);
 export interface RootState {
     assets: AssetState;
     core: CoreState;
+    floor: FloorState;
     game: GameState;
     gameSettings: GameSettingsState;
     initiative: InitiativeState;

--- a/client/tests/unit/game/visibility/te/pa.test.ts
+++ b/client/tests/unit/game/visibility/te/pa.test.ts
@@ -5,6 +5,7 @@ import { Rect } from "@/game/shapes/rect";
 import { CDT } from "@/game/visibility/te/cdt";
 import { addShapesToTriag, deleteShapeFromTriag, TriangulationTarget, setCDT } from "@/game/visibility/te/pa";
 import { rotateAroundOrigin, xySmaller } from "@/game/visibility/te/triag";
+import { BaseRect } from "../../../../../src/game/shapes/baserect";
 
 jest.mock("@/game/api/socket", () => ({
     get socket() {
@@ -59,6 +60,11 @@ function _rotateShape(shape: Shape): void {
 
 describe("PA test suite.", () => {
     describe("deleteShapeFromTriag", () => {
+        beforeAll(() => {
+            // Spying on Shape directly didn't work so we do both shapes used here.
+            jest.spyOn(BaseRect.prototype, "floor", "get").mockReturnValue({ name: "testfloor", playerVisible: true });
+            jest.spyOn(Polygon.prototype, "floor", "get").mockReturnValue({ name: "testfloor", playerVisible: true });
+        });
         it("0,0", () => {
             const shape = new Rect(new GlobalPoint(0, 0), 10, 10);
             const shape2 = new Rect(new GlobalPoint(15, 0), 10, 10);

--- a/client/tests/unit/game/visibility/te/pa.test.ts
+++ b/client/tests/unit/game/visibility/te/pa.test.ts
@@ -27,7 +27,7 @@ function _expectRemoveSuccess(shape1: Shape, shape2: Shape): void {
 }
 function _expectRemoveSuccessRotation(shape1: Shape, shape2: Shape, rotate: boolean): void {
     cdt = new CDT();
-    setCDT(TriangulationTarget.VISION, shape1.floor, cdt);
+    setCDT(TriangulationTarget.VISION, shape1.floor.name, cdt);
     cdt.tds.clearTriagVertices(shape1.uuid);
     cdt.tds.clearTriagVertices(shape2.uuid);
     if (rotate) {
@@ -167,7 +167,7 @@ describe("PA test suite.", () => {
                 new GlobalPoint(10, 10),
             ]);
             cdt = new CDT();
-            setCDT(TriangulationTarget.VISION, shape.floor, cdt);
+            setCDT(TriangulationTarget.VISION, shape.floor.name, cdt);
             addShapesToTriag(TriangulationTarget.VISION, shape, shape2);
             deleteShapeFromTriag(TriangulationTarget.VISION, shape2);
             expect(cdt.tds.numberOfVertices(false)).toBe(4);

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -226,64 +226,47 @@ async def update_shape(sid: int, data: Dict[str, Any]):
     await sync_shape_update(layer, pr, data, sid, shape)
 
 
-@sio.on("Shape.Remove", namespace=GAME_NS)
+@sio.on("Shapes.Remove", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def remove_shape(sid: int, data: Dict[str, Any]):
+async def remove_shapes(sid: int, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
-    # We're first gonna retrieve the existing server side shape for some validation checks
     if data["temporary"]:
-        if not has_ownership_temp(data["shape"], pr):
-            logger.warning(
-                f"User {pr.player.name} tried to update a shape it does not own."
-            )
-            return
-
         # This stuff is not stored so we cannot do any server side validation /shrug
-        shape = data["shape"]
-        floor = pr.active_location.floors.select().where(
-            Floor.name == data["shape"]["floor"]
-        )[0]
-        layer = floor.layers.where(Layer.name == data["shape"]["layer"])[0]
+        for shape in data["uuids"]:
+            game_state.remove_temp(sid, shape)
     else:
-        # Use the server version of the shape.
+        # Use the server version of the shapes.
         try:
-            shape = Shape.get(uuid=data["shape"]["uuid"])
+            shapes: List[Shape] = [
+                s for s in Shape.select().where(Shape.uuid << data["uuids"])
+            ]
         except Shape.DoesNotExist:
             logger.warning(f"Attempt to update unknown shape by {pr.player.name}")
             return
-        layer = shape.layer
 
-        if not has_ownership(shape, pr):
-            logger.warning(
-                f"User {pr.player.name} tried to update a shape it does not own."
-            )
-            return
+        layer = shapes[0].layer
 
-    if data["temporary"]:
-        game_state.remove_temp(sid, data["shape"]["uuid"])
-    else:
-        old_index = shape.index
-        shape.delete_instance(True)
-        Shape.update(index=Shape.index - 1).where(
-            (Shape.layer == layer) & (Shape.index >= old_index)
-        ).execute()
+        for shape in shapes:
+            if not has_ownership(shape, pr):
+                logger.warning(
+                    f"User {pr.player.name} tried to update a shape it does not own."
+                )
+                return
 
-    if layer.player_visible:
-        await sio.emit(
-            "Shape.Remove",
-            data["shape"],
-            room=pr.active_location.get_path(),
-            skip_sid=sid,
-            namespace=GAME_NS,
-        )
-    else:
-        for csid in game_state.get_sids(
-            player=pr.room.creator, active_location=pr.active_location
-        ):
-            if csid == sid:
-                continue
-            await sio.emit("Shape.Remove", data["shape"], room=csid, namespace=GAME_NS)
+            old_index = shape.index
+            shape.delete_instance(True)
+            Shape.update(index=Shape.index - 1).where(
+                (Shape.layer == layer) & (Shape.index >= old_index)
+            ).execute()
+
+    await sio.emit(
+        "Shapes.Remove",
+        data["uuids"],
+        room=pr.active_location.get_path(),
+        skip_sid=sid,
+        namespace=GAME_NS,
+    )
 
 
 @sio.on("Shapes.Floor.Change", namespace=GAME_NS)

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -319,7 +319,7 @@ async def change_shape_floor(sid: int, data: Dict[str, Any]):
     )
 
 
-@sio.on("Shape.Layer.Change", namespace=GAME_NS)
+@sio.on("Shapes.Layer.Change", namespace=GAME_NS)
 @auth.login_required(app, sio)
 async def change_shape_layer(sid: int, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
@@ -349,16 +349,16 @@ async def change_shape_layer(sid: int, data: Dict[str, Any]):
     for shape in shapes:
         old_index = shape.index
 
-    shape.layer = layer
-    shape.index = layer.shapes.count()
-    shape.save()
-    Shape.update(index=Shape.index - 1).where(
-        (Shape.layer == old_layer) & (Shape.index >= old_index)
-    ).execute()
+        shape.layer = layer
+        shape.index = layer.shapes.count()
+        shape.save()
+        Shape.update(index=Shape.index - 1).where(
+            (Shape.layer == old_layer) & (Shape.index >= old_index)
+        ).execute()
 
     if old_layer.player_visible and layer.player_visible:
         await sio.emit(
-            "Shape.Layer.Change",
+            "Shapes.Layer.Change",
             data,
             room=pr.active_location.get_path(),
             skip_sid=sid,
@@ -374,7 +374,7 @@ async def change_shape_layer(sid: int, data: Dict[str, Any]):
             ):
                 if is_dm:
                     await sio.emit(
-                        "Shape.Layer.Change",
+                        "Shapes.Layer.Change",
                         data,
                         room=pr.active_location.get_path(),
                         skip_sid=sid,

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -187,6 +187,7 @@ class Floor(BaseModel):
     location = ForeignKeyField(Location, backref="floors", on_delete="CASCADE")
     index = IntegerField()
     name = TextField()
+    player_visible = BooleanField(default=False)
 
     def __repr__(self):
         return f"<Floor {self.name} {[self.index]}>"

--- a/server/save.py
+++ b/server/save.py
@@ -20,7 +20,7 @@ from models import ALL_MODELS, Constants
 from models.db import db
 from utils import OldVersionException, UnknownVersionException
 
-SAVE_VERSION = 33
+SAVE_VERSION = 34
 
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
@@ -533,6 +533,16 @@ def upgrade(version):
             )
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN stroke_width INTEGER NOT NULL DEFAULT 2"
+            )
+
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 33:
+        # Add Floor.player_visible
+        db.foreign_keys = False
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE floor ADD COLUMN player_visible INTEGER NOT NULL DEFAULT 1"
             )
 
         db.foreign_keys = True


### PR DESCRIPTION
This PR allows DMs to limit which floors can be selected by players to move between.

This does NOT hide floors that are rendered between two selectable floors as those are relevant for lighting.

This PR touches a lot of files because the floor system has been refactored to improve reactivity.

Additionally I also added some performance improvements to multi shape floor/layer changes and removal