### PR TITLE
feat(Performance): Add several performance improvements

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-PYTHONPATH=./server/
+PYTHONPATH=./server
+MYPYPATH=./server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to this project will be documented in this file.
     -   The floor the user was last active on is loaded first if possible
     -   Next all floors under the active floor in descending order are loaded
     -   Lastly the floors above in ascending order are loaded
+-   Other performance improvements
+    -   Delay drawloop start until first floor data arrives
+    -   Better handling of multi group moves
+    -   Shape movement now sends less data to server
+    -   Pan now only updates the visible floors on move and full recalculate on release
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 -   Initial state adding unnecessary fog on lower floors
 -   Prefer snapped points over grid snapping
 -   Remove white icon in topleft menu UI
+-   Moving polygons with keyboard woul only move origin point
 
 ## [0.21.0] - 2020-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ All notable changes to this project will be documented in this file.
 -   Floor visibility toggle
     -   "Hidden" floors are not selectable by players, BUT will still render in between other selectable layers
 
+### Changed
+
+-   Floors are now loaded separately on startup this greatly impacts startup time
+    -   The floor the user was last active on is loaded first if possible
+    -   Next all floors under the active floor in descending order are loaded
+    -   Lastly the floors above in ascending order are loaded
+
 ### Fixed
 
 -   Aura not displaying when token is outside the visible canvas

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -85,14 +85,17 @@ export default class Game extends Vue {
     // Touch events
 
     touchend(event: TouchEvent): void {
+        if (this.$refs.ui === undefined) return;
         this.$refs.ui.$refs.tools.touchend(event);
     }
 
     touchstart(event: TouchEvent): void {
+        if (this.$refs.ui === undefined) return;
         this.$refs.ui.$refs.tools.touchstart(event);
     }
 
     touchmove(event: TouchEvent): void {
+        if (this.$refs.ui === undefined) return;
         // limit the number of touch moves to ease server load
         if (!this.throttledtouchmoveSet) {
             this.throttledtouchmoveSet = true;
@@ -105,14 +108,17 @@ export default class Game extends Vue {
     // Mouse events
 
     mousedown(event: MouseEvent): void {
+        if (this.$refs.ui === undefined) return;
         this.$refs.ui.$refs.tools.mousedown(event);
     }
 
     mouseup(event: MouseEvent): void {
+        if (this.$refs.ui === undefined) return;
         this.$refs.ui.$refs.tools.mouseup(event);
     }
 
     mousemove(event: MouseEvent): void {
+        if (this.$refs.ui === undefined) return;
         if (!this.throttledmoveSet) {
             this.throttledmoveSet = true;
             this.throttledmove = throttle(this.$refs.ui.$refs.tools.mousemove, 15);
@@ -121,10 +127,12 @@ export default class Game extends Vue {
     }
 
     mouseleave(event: MouseEvent): void {
+        if (this.$refs.ui === undefined) return;
         this.$refs.ui.$refs.tools.mouseleave(event);
     }
 
     contextmenu(event: MouseEvent): void {
+        if (this.$refs.ui === undefined) return;
         this.$refs.ui.$refs.tools.contextmenu(event);
     }
 
@@ -146,7 +154,7 @@ export default class Game extends Vue {
 
 <template>
     <div id="main" @mouseleave="mouseleave" @wheel="zoom">
-        <ui ref="ui"></ui>
+        <ui v-if="$store.state.game.boardInitialized" ref="ui"></ui>
         <div id="board">
             <div
                 id="layers"

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -18,6 +18,8 @@ import { scrollZoom } from "@/game/input/mouse";
 import { layerManager } from "@/game/layers/manager";
 import { dropAsset } from "./layers/utils";
 import { coreStore } from "@/core/store";
+import { mapGetters } from "vuex";
+import { Watch } from "vue-property-decorator";
 
 @Component({
     components: {
@@ -36,6 +38,9 @@ import { coreStore } from "@/core/store";
     beforeRouteLeave(to, from, next) {
         socket.disconnect();
         next();
+    },
+    computed: {
+        ...mapGetters("game", ["isBoardInitialized"]),
     },
 })
 export default class Game extends Vue {
@@ -68,6 +73,12 @@ export default class Game extends Vue {
         window.removeEventListener("keyup", onKeyUp);
         window.removeEventListener("keydown", onKeyDown);
         this.ready.manager = false;
+    }
+
+    @Watch("isBoardInitialized")
+    onBoardInitialized(newValue: boolean): void {
+        this.throttledmoveSet = false;
+        this.throttledtouchmoveSet = false;
     }
 
     // Window events

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -77,8 +77,10 @@ export default class Game extends Vue {
 
     @Watch("isBoardInitialized")
     onBoardInitialized(newValue: boolean): void {
-        this.throttledmoveSet = false;
-        this.throttledtouchmoveSet = false;
+        if (!newValue) {
+            this.throttledmoveSet = false;
+            this.throttledtouchmoveSet = false;
+        }
     }
 
     // Window events

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -74,6 +74,7 @@ socket.on("Board.Set", (locationInfo: BoardInfo) => {
         visibilityStore.recalculateVision(floor.name);
         visibilityStore.recalculateMovement(floor.name);
     }
+    requestAnimationFrame(layerManager.drawLoop);
     gameStore.setBoardInitialized(true);
 });
 

--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -33,6 +33,7 @@ socket.on("Locations.Order.Set", (locations: { id: number; name: string }[]) => 
 
 socket.on("Location.Change.Start", () => {
     coreStore.setLoading(true);
+    gameStore.setBoardInitialized(false);
 });
 
 socket.on("Location.Rename", (data: { id: number; name: string }) => {

--- a/client/src/game/comm/types/general.ts
+++ b/client/src/game/comm/types/general.ts
@@ -25,6 +25,7 @@ export interface InitiativeEffect {
 }
 
 export interface ServerFloor {
+    index: number;
     name: string;
     layers: ServerLayer[];
     player_visible: boolean;
@@ -32,6 +33,7 @@ export interface ServerFloor {
 
 export interface ServerLayer {
     type_: string;
+    index: number;
     name: string;
     layer: string;
     shapes: ServerShape[];

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -87,7 +87,7 @@ export function onKeyDown(event: KeyboardEvent): void {
                 const floorName = floorStore.currentFloor.name;
                 if (recalculateVision) visibilityStore.recalculateVision(floorName);
                 if (recalculateMovement) visibilityStore.recalculateMovement(floorName);
-                layerManager.getLayer(floorStore.currentFloor)!.invalidate(false);
+                floorStore.currentLayer!.invalidate(false);
             } else {
                 // The pan offsets should be in the opposite direction to give the correct feel.
                 gameStore.increasePanX(offsetX * (event.keyCode <= 38 ? 1 : -1));

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -1,4 +1,3 @@
-import { socket } from "@/game/api/socket";
 import { sendClientOptions } from "@/game/api/utils";
 import { Vector } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -57,6 +57,7 @@ export function onKeyDown(event: KeyboardEvent): void {
                 if (delta.length() === 0) return;
                 let recalculateVision = false;
                 let recalculateMovement = false;
+                const updateList = [];
                 for (const sel of selection) {
                     if (!sel.ownedBy({ movementAccess: true })) continue;
                     if (sel.movementObstruction) {
@@ -80,8 +81,9 @@ export function onKeyDown(event: KeyboardEvent): void {
                         visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: sel });
                     // todo: Fix again
                     // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();
+                    if (!sel.preventSync) updateList.push(sel);
                 }
-                sendShapePositionUpdate(selection, false);
+                sendShapePositionUpdate(updateList, false);
 
                 const floorName = floorStore.currentFloor.name;
                 if (recalculateVision) visibilityStore.recalculateVision(floorName);

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -12,6 +12,7 @@ import { gameManager } from "../manager";
 import { gameSettingsStore } from "../settings";
 import { floorStore } from "../layers/store";
 import { moveFloor } from "../layers/utils";
+import { sendShapePositionUpdate } from "../api/events/shape";
 
 export function onKeyUp(event: KeyboardEvent): void {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
@@ -79,13 +80,9 @@ export function onKeyDown(event: KeyboardEvent): void {
                         visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: sel });
                     // todo: Fix again
                     // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();
-                    if (!sel.preventSync)
-                        socket.emit("Shape.Position.Update", {
-                            shape: sel.asDict(),
-                            redraw: true,
-                            temporary: false,
-                        });
                 }
+                sendShapePositionUpdate(selection, false);
+
                 const floorName = floorStore.currentFloor.name;
                 if (recalculateVision) visibilityStore.recalculateVision(floorName);
                 if (recalculateMovement) visibilityStore.recalculateMovement(floorName);

--- a/client/src/game/layers/fow.ts
+++ b/client/src/game/layers/fow.ts
@@ -17,8 +17,8 @@ export class FOWLayer extends Layer {
     virtualCanvas: HTMLCanvasElement;
     vCtx: CanvasRenderingContext2D;
 
-    constructor(canvas: HTMLCanvasElement, name: string, floor: string) {
-        super(canvas, name, floor);
+    constructor(canvas: HTMLCanvasElement, public name: string, public floor: string, public index: number) {
+        super(canvas, name, floor, index);
         this.virtualCanvas = document.createElement("canvas");
         this.virtualCanvas.width = window.innerWidth;
         this.virtualCanvas.height = window.innerHeight;
@@ -61,7 +61,7 @@ export class FOWLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = floorStore.floors[floorStore.currentFloorindex].name;
+            const activeFloorName = floorStore.currentFloor.name;
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");

--- a/client/src/game/layers/fowplayers.ts
+++ b/client/src/game/layers/fowplayers.ts
@@ -13,8 +13,8 @@ export class FOWPlayersLayer extends Layer {
     virtualCanvas: HTMLCanvasElement;
     vCtx: CanvasRenderingContext2D;
 
-    constructor(canvas: HTMLCanvasElement, name: string, floor: string) {
-        super(canvas, name, floor);
+    constructor(canvas: HTMLCanvasElement, public name: string, public floor: string, public index: number) {
+        super(canvas, name, floor, index);
         this.virtualCanvas = document.createElement("canvas");
         this.virtualCanvas.width = window.innerWidth;
         this.virtualCanvas.height = window.innerHeight;
@@ -49,7 +49,7 @@ export class FOWPlayersLayer extends Layer {
 
             ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
-            const activeFloorName = floorStore.floors[floorStore.currentFloorindex].name;
+            const activeFloorName = floorStore.currentFloor.name;
 
             if (this.floor === activeFloorName && this.canvas.style.display === "none")
                 this.canvas.style.removeProperty("display");

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -244,7 +244,7 @@ export class Layer {
             // First to draw the auras and a second time to draw the shapes themselves
             // Otherwise auras from one shape could overlap another shape.
 
-            const currentLayer = layerManager.getLayer(floorStore.currentFloor);
+            const currentLayer = floorStore.currentLayer;
             // To optimize things slightly, we keep track of the shapes that passed the first round
             const visibleShapes: Shape[] = [];
 

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -14,10 +14,8 @@ import { gameSettingsStore } from "../settings";
 import { floorStore } from "./store";
 
 export class Layer {
-    name: string;
     canvas: HTMLCanvasElement;
     ctx: CanvasRenderingContext2D;
-    floor: string;
 
     selectable = false;
     playerEditable = false;
@@ -39,11 +37,9 @@ export class Layer {
     points: Map<string, Set<string>> = new Map();
     postDrawCallbacks: (() => void)[] = [];
 
-    constructor(canvas: HTMLCanvasElement, name: string, floor: string) {
+    constructor(canvas: HTMLCanvasElement, public name: string, public floor: string, public index: number) {
         this.canvas = canvas;
-        this.name = name;
         this.ctx = canvas.getContext("2d")!;
-        this.floor = floor;
     }
 
     invalidate(skipLightUpdate: boolean): void {

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -12,10 +12,6 @@ class LayerManager {
     // Refresh interval and redraw setter.
     interval = 30;
 
-    constructor() {
-        requestAnimationFrame(this.drawLoop);
-    }
-
     reset(): void {
         this.layerMap = new Map();
         this.UUIDMap = new Map();

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -163,6 +163,14 @@ class LayerManager {
         }
     }
 
+    invalidateVisibleFloors(): void {
+        const current = floorStore.currentFloor;
+        for (const floor of floorStore.floors) {
+            this.invalidate(floor);
+            if (floor === current) break;
+        }
+    }
+
     // Lighting of multiple floors is heavily dependent on eachother
     // This method only updates a single floor and should thus only be used for very specific cases
     // as you typically require the allFloor variant

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -34,6 +34,7 @@ class FloorStore extends VuexModule implements FloorState {
     @Mutation
     reset(): void {
         this._floors = [];
+        this._indices = [];
         this.floorIndex = -1;
     }
 

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -94,7 +94,7 @@ class FloorStore extends VuexModule implements FloorState {
                 else layer.canvas.style.removeProperty("display");
             }
         }
-        layerManager.selectLayer(layerManager.getLayer(floorStore.currentFloor)!.name, data.sync, false);
+        layerManager.selectLayer(floorStore.currentLayer!.name, data.sync, false);
         layerManager.invalidateAllFloors();
     }
 }

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -1,6 +1,7 @@
 import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
 import { rootStore } from "../../store";
 import { Floor } from "./floor";
+import { Layer } from "./layer";
 import { layerManager } from "./manager";
 
 export interface FloorState {
@@ -29,6 +30,10 @@ class FloorStore extends VuexModule implements FloorState {
 
     get currentLayerIndex(): number {
         return this.layerIndex;
+    }
+
+    get currentLayer(): Layer {
+        return layerManager.getLayer(this.currentFloor)!;
     }
 
     @Mutation

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -12,6 +12,8 @@ class FloorStore extends VuexModule implements FloorState {
     private floorIndex = -1;
     private layerIndex = -1;
     private _floors: Floor[] = [];
+    // the following should only be used during startup when loading floors in a different order
+    private _indices: number[] = [];
 
     get floors(): readonly Floor[] {
         return this._floors;
@@ -41,9 +43,23 @@ class FloorStore extends VuexModule implements FloorState {
     }
 
     @Mutation
-    addFloor(floor: Floor): void {
-        this._floors.push(floor);
-        layerManager.addFloor(floor.name);
+    addFloor(data: { floor: Floor; targetIndex?: number }): void {
+        // We do some special magic here to allow out of order loading of floors on startup
+        if (data.targetIndex !== undefined) {
+            const index = data.targetIndex;
+            const I = this._indices.findIndex(i => i > index);
+            if (I >= 0) {
+                this._indices.splice(I, 0, data.targetIndex);
+                this._floors.splice(I, 0, data.floor);
+                if (I <= this.floorIndex) this.floorIndex += 1;
+            } else {
+                this._indices.push(data.targetIndex);
+                this._floors.push(data.floor);
+            }
+        } else {
+            this._floors.push(data.floor);
+        }
+        layerManager.addFloor(data.floor.name);
     }
 
     @Action
@@ -78,24 +94,3 @@ class FloorStore extends VuexModule implements FloorState {
 }
 
 export const floorStore = getModule(FloorStore);
-
-/*
-
-reset(){this.layers = [];
-        this.selectedLayerIndex = -1;}
-
-@Mutation
-    addLayer(name: string): void {
-        this.layers.push(name);
-        if (this.selectedLayerIndex === -1) this.selectedLayerIndex = this.layers.indexOf(name);
-    }
-
-    @Mutation
-    selectLayer(data: { layer: Layer; sync: boolean }): void {
-        let index = this.layers.indexOf(data.layer.name);
-        if (index < 0) index = 0;
-        // else if (index >= this.layers.reduce((acc: number, val: Layer) => val.floor === data.layer.floor))
-        this.selectedLayerIndex = index;
-        if (data.sync) socket.emit("Client.ActiveLayer.Set", { floor: data.layer.floor, layer: data.layer.name });
-    }
-    */

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -80,7 +80,7 @@ function createLayer(layerInfo: ServerLayer, floor: Floor): void {
 }
 
 export function dropAsset(event: DragEvent): void {
-    const layer = layerManager.getLayer(floorStore.currentFloor);
+    const layer = floorStore.currentLayer;
     if (layer === undefined || event === null || event.dataTransfer === null) return;
     const image = document.createElement("img");
     image.src = event.dataTransfer.getData("text/plain");

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -18,9 +18,18 @@ import { socket } from "../api/socket";
 
 export function addFloor(serverFloor: ServerFloor): void {
     const floor = { name: serverFloor.name, playerVisible: serverFloor.player_visible };
-    floorStore.addFloor(floor);
+    floorStore.addFloor({ floor, targetIndex: serverFloor.index });
     addCDT(serverFloor.name);
     for (const layer of serverFloor.layers) createLayer(layer, floor);
+
+    // Recalculate zIndices
+    let i = 0;
+    for (const floor of floorStore.floors) {
+        for (const layer of layerManager.getLayers(floor)) {
+            layer.canvas.style.zIndex = `${i}`;
+            i += 1;
+        }
+    }
 }
 
 export function removeFloor(floorName: string): void {
@@ -45,16 +54,16 @@ export function removeFloor(floorName: string): void {
 function createLayer(layerInfo: ServerLayer, floor: Floor): void {
     // Create canvas element
     const canvas = document.createElement("canvas");
-    canvas.style.zIndex = layerManager.layerLength.toString();
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
 
     // Create the Layer instance
     let layer: Layer;
-    if (layerInfo.type_ === "grid") layer = new GridLayer(canvas, layerInfo.name, floor.name);
-    else if (layerInfo.type_ === "fow") layer = new FOWLayer(canvas, layerInfo.name, floor.name);
-    else if (layerInfo.type_ === "fow-players") layer = new FOWPlayersLayer(canvas, layerInfo.name, floor.name);
-    else layer = new Layer(canvas, layerInfo.name, floor.name);
+    if (layerInfo.type_ === "grid") layer = new GridLayer(canvas, layerInfo.name, floor.name, layerInfo.index);
+    else if (layerInfo.type_ === "fow") layer = new FOWLayer(canvas, layerInfo.name, floor.name, layerInfo.index);
+    else if (layerInfo.type_ === "fow-players")
+        layer = new FOWPlayersLayer(canvas, layerInfo.name, floor.name, layerInfo.index);
+    else layer = new Layer(canvas, layerInfo.name, floor.name, layerInfo.index);
     layer.selectable = layerInfo.selectable;
     layer.playerEditable = layerInfo.player_editable;
     layerManager.addLayer(layer, floor.name);

--- a/client/src/game/manager.ts
+++ b/client/src/game/manager.ts
@@ -52,24 +52,7 @@ export class GameManager {
         const alteredMovement = shape.setMovementBlock(shape.movementObstruction);
         shape.setIsToken(shape.isToken);
         if (data.redraw) {
-            if (shape.visionObstruction && !alteredVision) {
-                visibilityStore.deleteFromTriag({
-                    target: TriangulationTarget.VISION,
-                    shape,
-                });
-                visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape });
-                visibilityStore.recalculateVision(shape.floor.name);
-            }
-            shape.invalidate(false);
-            layerManager.invalidateLightAllFloors();
-            if (shape.movementObstruction && !alteredMovement) {
-                visibilityStore.deleteFromTriag({
-                    target: TriangulationTarget.MOVEMENT,
-                    shape,
-                });
-                visibilityStore.addToTriag({ target: TriangulationTarget.MOVEMENT, shape });
-                visibilityStore.recalculateMovement(shape.floor.name);
-            }
+            shape.updateShapeVision(alteredMovement, alteredVision);
         }
         if (redrawInitiative) EventBus.$emit("Initiative.ForceUpdate");
     }

--- a/client/src/game/manager.ts
+++ b/client/src/game/manager.ts
@@ -8,8 +8,6 @@ import { createShapeFromDict } from "@/game/shapes/utils";
 import { gameStore } from "@/game/store";
 import { AnnotationManager } from "@/game/ui/annotation";
 import { g2l } from "@/game/units";
-import { visibilityStore } from "@/game/visibility/store";
-import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { Shape } from "./shapes/shape";
 
 export class GameManager {

--- a/client/src/game/settings.ts
+++ b/client/src/game/settings.ts
@@ -267,7 +267,7 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
             layerManager
                 .getLayer(floorStore.currentFloor, "dm")!
                 .addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO, false);
-            img.onload = () => shape.layer.invalidate(true);
+            img.onload = () => (gameStore.boardInitialized ? shape.layer.invalidate(true) : undefined);
 
             gameSettingsStore.setSpawnLocations({
                 spawnLocations: [uuid],

--- a/client/src/game/shapes/polygon.ts
+++ b/client/src/game/shapes/polygon.ts
@@ -59,6 +59,15 @@ export class Polygon extends Shape {
         this.lineWidth = data.line_width;
     }
 
+    getPositionRepresentation(): number[][] {
+        return this.vertices.map(v => v.asArray());
+    }
+
+    setPositionRepresentation(points: number[][]): void {
+        this._vertices = points.slice(1).map(p => GlobalPoint.fromArray(p));
+        super.setPositionRepresentation(points);
+    }
+
     get points(): number[][] {
         const center = this.center();
         return this.vertices.map(point => [...rotateAroundPoint(point, center, this.angle)]);

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -343,7 +343,7 @@ export abstract class Shape {
 
     setPositionRepresentation(points: number[][]): void {
         this.refPoint = GlobalPoint.fromArray(points[0]);
-        this.invalidate(true);
+        this.updateShapeVision(false, false);
     }
 
     draw(ctx: CanvasRenderingContext2D): void {
@@ -563,5 +563,26 @@ export abstract class Shape {
                 [],
             ),
         ];
+    }
+
+    updateShapeVision(alteredMovement: boolean, alteredVision: boolean): void {
+        if (this.visionObstruction && !alteredVision) {
+            visibilityStore.deleteFromTriag({
+                target: TriangulationTarget.VISION,
+                shape: this,
+            });
+            visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: this });
+            visibilityStore.recalculateVision(this.floor.name);
+        }
+        this.invalidate(false);
+        layerManager.invalidateLightAllFloors();
+        if (this.movementObstruction && !alteredMovement) {
+            visibilityStore.deleteFromTriag({
+                target: TriangulationTarget.MOVEMENT,
+                shape: this,
+            });
+            visibilityStore.addToTriag({ target: TriangulationTarget.MOVEMENT, shape: this });
+            visibilityStore.recalculateMovement(this.floor.name);
+        }
     }
 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -337,6 +337,15 @@ export abstract class Shape {
         );
     }
 
+    getPositionRepresentation(): number[][] {
+        return [this.refPoint.asArray()];
+    }
+
+    setPositionRepresentation(points: number[][]): void {
+        this.refPoint = GlobalPoint.fromArray(points[0]);
+        this.invalidate(true);
+    }
+
     draw(ctx: CanvasRenderingContext2D): void {
         if (this.globalCompositeOperation !== undefined) ctx.globalCompositeOperation = this.globalCompositeOperation;
         else ctx.globalCompositeOperation = "source-over";

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -85,7 +85,7 @@ export function createShapeFromDict(shape: ServerShape): Shape | undefined {
 }
 
 export function copyShapes(): void {
-    const layer = layerManager.getLayer(floorStore.currentFloor);
+    const layer = floorStore.currentLayer;
     if (!layer) return;
     if (!layer.hasSelection()) return;
     const clipboard: ServerShape[] = [];
@@ -166,11 +166,11 @@ export function pasteShapes(targetLayer?: string): readonly Shape[] {
 
 // todo: refactor with removeShape in api/events/shape
 export function deleteShapes(): void {
-    if (layerManager.getLayer(floorStore.currentFloor) === undefined) {
+    if (floorStore.currentLayer === undefined) {
         console.log("No active layer selected for delete operation");
         return;
     }
-    const l = layerManager.getLayer(floorStore.currentFloor)!;
+    const l = floorStore.currentLayer!;
     for (let i = l.getSelection().length - 1; i >= 0; i--) {
         const sel = l.getSelection()[i];
         if (!sel.ownedBy({ editAccess: true })) continue;

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -393,6 +393,7 @@ class GameStore extends VuexModule implements GameState {
         this.annotations = [];
         this.notes = [];
         this.markers = [];
+        this.boardInitialized = false;
     }
 }
 

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -105,6 +105,10 @@ class GameStore extends VuexModule implements GameState {
         return l2g(g2l(this.screenTopLeft).add(halfScreen));
     }
 
+    get isBoardInitialized(): boolean {
+        return this.boardInitialized;
+    }
+
     @Mutation
     setFakePlayer(value: boolean): void {
         this.FAKE_PLAYER = value;

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -76,7 +76,7 @@ export default class ShapeContext extends Vue {
         return layerManager.getLayers(floorStore.currentFloor).filter(l => l.selectable) || [];
     }
     getActiveLayer(): Layer | undefined {
-        return gameStore.boardInitialized ? layerManager.getLayer(floorStore.currentFloor) : undefined;
+        return gameStore.boardInitialized ? floorStore.currentLayer : undefined;
     }
     getInitiativeWord(): string {
         const layer = this.getActiveLayer()!;

--- a/client/src/game/ui/settings/location/LocationAdminSettings.vue
+++ b/client/src/game/ui/settings/location/LocationAdminSettings.vue
@@ -18,7 +18,7 @@ export default class LocationAdminSettings extends Vue {
     @Prop() location!: number;
 
     get name(): string {
-        return gameStore.locations.find(l => l.id === this.location)!.name;
+        return gameStore.locations.find(l => l.id === this.location)?.name ?? "";
     }
 
     set name(name: string) {

--- a/client/src/game/ui/settings/location/LocationSettings.vue
+++ b/client/src/game/ui/settings/location/LocationSettings.vue
@@ -21,11 +21,11 @@ import { gameStore } from "@/game/store";
     },
 })
 export default class LocationSettings extends Vue {
-    location = gameStore.locations[0].id;
+    location = 0;
     visible = false;
 
     get locationName(): string {
-        return gameStore.locations.find(l => l.id === this.location)!.name;
+        return gameStore.locations.find(l => l.id === this.location)?.name ?? "";
     }
 
     mounted(): void {

--- a/client/src/game/ui/tools/createtoken_modal.vue
+++ b/client/src/game/ui/tools/createtoken_modal.vue
@@ -10,7 +10,6 @@ import Modal from "@/core/components/modals/modal.vue";
 
 import { calcFontScale } from "@/core/utils";
 import { LocalPoint } from "@/game/geom";
-import { layerManager } from "@/game/layers/manager";
 import { CircularToken } from "@/game/shapes/circulartoken";
 import { gameStore } from "@/game/store";
 import { getUnitDistance, l2g } from "@/game/units";

--- a/client/src/game/ui/tools/createtoken_modal.vue
+++ b/client/src/game/ui/tools/createtoken_modal.vue
@@ -59,7 +59,7 @@ export default class CreateTokenModal extends Vue {
         this.y = y;
     }
     submit(): void {
-        const layer = layerManager.getLayer(floorStore.currentFloor);
+        const layer = floorStore.currentLayer;
         if (layer === undefined) return;
         const token = new CircularToken(
             l2g(new LocalPoint(this.x, this.y)),

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -37,13 +37,10 @@ import { Floor } from "@/game/layers/floor";
         "color-picker": ColorPicker,
     },
     computed: {
-        ...mapGetters("floor", ["currentFloor"]),
+        ...mapGetters("floor", ["currentFloor", "currentLayer"]),
     },
 })
 export default class DrawTool extends Tool implements ToolBasics {
-    selectedFloor!: number;
-    selectedLayer!: string;
-
     name = ToolName.Draw;
     active = false;
 
@@ -141,14 +138,14 @@ export default class DrawTool extends Tool implements ToolBasics {
         }
     }
 
-    @Watch("selectedLayer")
-    onLayerChange(newValue: string, oldValue: string): void {
+    @Watch("currentLayer")
+    onLayerChange(newValue: Layer, oldValue: Layer): void {
         if ((<Tools>this.$parent).currentTool === this.name) {
             let mouse: { x: number; y: number } | undefined = undefined;
             if (this.brushHelper !== null) {
                 mouse = { x: this.brushHelper.refPoint.x, y: this.brushHelper.refPoint.y };
             }
-            this.onDeselect({ layer: oldValue });
+            this.onDeselect({ layer: oldValue.name });
             this.onSelect(mouse);
         }
     }

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -171,7 +171,7 @@ export default class DrawTool extends Tool implements ToolBasics {
         if (this.brushHelper === null) return;
 
         const fowLayer = layerManager.getLayer(floorStore.currentFloor, "fow");
-        const normalLayer = layerManager.getLayer(floorStore.currentFloor);
+        const normalLayer = floorStore.currentLayer;
         if (fowLayer === undefined || normalLayer === undefined) return;
 
         this.setupBrush();

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -53,7 +53,7 @@ export default class MapTool extends Tool implements ToolBasics {
 
     removeRect(): void {
         if (this.rect) {
-            const layer = layerManager.getLayer(floorStore.currentFloor)!;
+            const layer = floorStore.currentLayer!;
             layer.removeShape(this.rect, SyncMode.NO_SYNC);
             this.rect = null;
         }
@@ -95,7 +95,7 @@ export default class MapTool extends Tool implements ToolBasics {
         const startPoint = l2g(lp);
 
         this.startPoint = startPoint;
-        const layer = layerManager.getLayer(floorStore.currentFloor);
+        const layer = floorStore.currentLayer;
         if (layer === undefined) {
             console.log("No active layer!");
             return;
@@ -114,7 +114,7 @@ export default class MapTool extends Tool implements ToolBasics {
 
         const endPoint = l2g(lp);
 
-        const layer = layerManager.getLayer(floorStore.currentFloor);
+        const layer = floorStore.currentLayer;
         if (layer === undefined) {
             console.log("No active layer!");
             return;
@@ -131,7 +131,7 @@ export default class MapTool extends Tool implements ToolBasics {
 
     onUp(): void {
         if (!this.active || this.rect === null) return;
-        const layer = layerManager.getLayer(floorStore.currentFloor);
+        const layer = floorStore.currentLayer;
         if (layer === undefined) {
             console.log("No active layer!");
             return;

--- a/client/src/game/ui/tools/pan.ts
+++ b/client/src/game/ui/tools/pan.ts
@@ -13,17 +13,18 @@ export default class PanTool extends Tool implements ToolBasics {
     panStart = new LocalPoint(0, 0);
     active = false;
 
-    panScreen(target: LocalPoint): void {
+    panScreen(target: LocalPoint, full: boolean): void {
         const distance = target.subtract(this.panStart).multiply(1 / gameStore.zoomFactor);
         gameStore.increasePanX(Math.round(distance.x));
         gameStore.increasePanY(Math.round(distance.y));
         this.panStart = target;
-        layerManager.invalidateAllFloors();
+        if (full) layerManager.invalidateAllFloors();
+        else layerManager.invalidateVisibleFloors();
     }
 
     onMove(lp: LocalPoint): void {
         if (!this.active) return;
-        this.panScreen(lp);
+        this.panScreen(lp, false);
     }
 
     onDown(lp: LocalPoint): void {
@@ -31,8 +32,9 @@ export default class PanTool extends Tool implements ToolBasics {
         this.active = true;
     }
 
-    onUp(): void {
+    onUp(lp: LocalPoint): void {
         this.active = false;
+        this.panScreen(lp, true);
         sendClientOptions(gameStore.locationUserOptions);
     }
 }

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -8,7 +8,6 @@ import { socket } from "@/game/api/socket";
 import { EventBus } from "@/game/event-bus";
 import { GlobalPoint, LocalPoint, Ray, Vector } from "@/game/geom";
 import { Layer } from "@/game/layers/layer";
-import { layerManager } from "@/game/layers/manager";
 import { snapToPoint } from "@/game/layers/utils";
 import { Rect } from "@/game/shapes/rect";
 import { gameStore } from "@/game/store";

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -83,7 +83,7 @@ export default class SelectTool extends Tool implements ToolBasics {
 
     onDown(lp: LocalPoint, event: MouseEvent | TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         const gp = l2g(lp);
-        const layer = layerManager.getLayer(floorStore.currentFloor);
+        const layer = floorStore.currentLayer;
         if (layer === undefined) {
             console.log("No active layer!");
             return;
@@ -192,7 +192,7 @@ export default class SelectTool extends Tool implements ToolBasics {
         )
             return;
 
-        const layer = layerManager.getLayer(floorStore.currentFloor);
+        const layer = floorStore.currentLayer;
         if (layer === undefined) {
             console.log("No active layer!");
             return;
@@ -270,11 +270,7 @@ export default class SelectTool extends Tool implements ToolBasics {
                         ignorePoint = GlobalPoint.fromArray(this.originalResizePoints[this.resizePoint]);
                     let targetPoint = gp;
                     if (useSnapping(event) && this.hasFeature(SelectFeatures.Snapping, features))
-                        [targetPoint, this.snappedToPoint] = snapToPoint(
-                            layerManager.getLayer(floorStore.currentFloor)!,
-                            gp,
-                            ignorePoint,
-                        );
+                        [targetPoint, this.snappedToPoint] = snapToPoint(floorStore.currentLayer!, gp, ignorePoint);
                     else this.snappedToPoint = false;
                     this.resizePoint = sel.resize(this.resizePoint, targetPoint, event.ctrlKey);
                     // todo: think about calling deleteIntersectVertex directly on the corner point
@@ -302,11 +298,11 @@ export default class SelectTool extends Tool implements ToolBasics {
 
     onUp(_lp: LocalPoint, event: MouseEvent | TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         if (!this.active) return;
-        if (layerManager.getLayer(floorStore.currentFloor) === undefined) {
+        if (floorStore.currentLayer === undefined) {
             console.log("No active layer!");
             return;
         }
-        const layer = layerManager.getLayer(floorStore.currentFloor)!;
+        const layer = floorStore.currentLayer!;
         let selection = layer.getSelection();
 
         if (selection.some(s => s.isLocked)) return;
@@ -463,11 +459,11 @@ export default class SelectTool extends Tool implements ToolBasics {
 
     onContextMenu(event: MouseEvent, features: ToolFeatures<SelectFeatures>): void {
         if (!this.hasFeature(SelectFeatures.Context, features)) return;
-        if (layerManager.getLayer(floorStore.currentFloor) === undefined) {
+        if (floorStore.currentLayer === undefined) {
             console.log("No active layer!");
             return;
         }
-        const layer = layerManager.getLayer(floorStore.currentFloor)!;
+        const layer = floorStore.currentLayer!;
         const mouse = getLocalPointFromEvent(event);
         const globalMouse = l2g(mouse);
         for (const shape of layer.getSelection()) {
@@ -523,7 +519,7 @@ export default class SelectTool extends Tool implements ToolBasics {
     }
 
     createRotationUi(features: ToolFeatures<SelectFeatures>): void {
-        const layer = layerManager.getLayer(floorStore.currentFloor)!;
+        const layer = floorStore.currentLayer!;
         const selection = layer.getSelection();
 
         if (selection.length === 0 || this.rotationUiActive || !this.hasFeature(SelectFeatures.Rotate, features))
@@ -567,7 +563,7 @@ export default class SelectTool extends Tool implements ToolBasics {
 
     removeRotationUi(): void {
         if (this.rotationUiActive) {
-            const layer = layerManager.getLayer(floorStore.currentFloor)!;
+            const layer = floorStore.currentLayer!;
             layer.removeShape(this.rotationAnchor!, SyncMode.NO_SYNC);
             layer.removeShape(this.rotationBox!, SyncMode.NO_SYNC);
             layer.removeShape(this.rotationEnd!, SyncMode.NO_SYNC);
@@ -579,7 +575,7 @@ export default class SelectTool extends Tool implements ToolBasics {
     }
 
     updateRotationUi(features: ToolFeatures<SelectFeatures>): void {
-        const layer = layerManager.getLayer(floorStore.currentFloor)!;
+        const layer = floorStore.currentLayer!;
 
         if (
             layer.getSelection().length > 0 &&
@@ -614,7 +610,7 @@ export default class SelectTool extends Tool implements ToolBasics {
     }
 
     rotateSelection(newAngle: number, center: GlobalPoint): void {
-        const layer = layerManager.getLayer(floorStore.currentFloor)!;
+        const layer = floorStore.currentLayer!;
         const dA = newAngle - this.angle;
         this.angle = newAngle;
         let recalc = false;

--- a/server/api/http/auth.py
+++ b/server/api/http/auth.py
@@ -1,9 +1,9 @@
 from aiohttp import web
 from aiohttp_security import authorized_userid, forget, remember
 
-from app import logger
 from models import User
 from models.db import db
+from utils import logger
 
 
 async def is_authed(request):

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -24,7 +24,7 @@ from . import (
 
 @sio.on("Client.Options.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_client(sid: int, data: Dict[str, Any]):
+async def set_client(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     with db.atomic():
@@ -50,7 +50,7 @@ async def set_client(sid: int, data: Dict[str, Any]):
 
 @sio.on("Client.ActiveLayer.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_layer(sid: int, data: Dict[str, Any]):
+async def set_layer(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     try:
@@ -66,7 +66,7 @@ async def set_layer(sid: int, data: Dict[str, Any]):
 
 @sio.on("Players.Bring", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def bring_players(sid: int, data: Dict[str, Any]):
+async def bring_players(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     await sio.emit(

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -2,11 +2,12 @@ from typing import Any, Dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import Floor, Layer, LocationUserOption, PlayerRoom
 from models.db import db
 from models.role import Role
 from state.game import game_state
+from utils import logger
 
 from . import (
     asset_manager,

--- a/server/api/socket/asset_manager.py
+++ b/server/api/socket/asset_manager.py
@@ -5,11 +5,11 @@ from aiohttp import web
 from aiohttp_security import authorized_userid
 
 import auth
-from app import app, logger, sio
+from app import app, sio
 from .constants import ASSET_NS
 from models import Asset
 from state.asset import asset_state
-from utils import FILE_DIR
+from utils import FILE_DIR, logger
 
 ASSETS_DIR = FILE_DIR / "static" / "assets"
 if not ASSETS_DIR.exists():

--- a/server/api/socket/asset_manager.py
+++ b/server/api/socket/asset_manager.py
@@ -17,7 +17,7 @@ if not ASSETS_DIR.exists():
 
 
 @sio.on("connect", namespace=ASSET_NS)
-async def assetmgmt_connect(sid: int, environ):
+async def assetmgmt_connect(sid: str, environ):
     user = await authorized_userid(environ["aiohttp.request"])
     if user is None:
         await sio.emit("redirect", "/", room=sid, namespace=ASSET_NS)
@@ -28,7 +28,7 @@ async def assetmgmt_connect(sid: int, environ):
 
 
 @sio.on("Folder.Get", namespace=ASSET_NS)
-async def get_folder(sid: int, folder=None):
+async def get_folder(sid: str, folder=None):
     user = asset_state.get_user(sid)
 
     if folder is None:
@@ -47,7 +47,7 @@ async def get_folder(sid: int, folder=None):
 
 
 @sio.on("Folder.GetByPath", namespace=ASSET_NS)
-async def get_folder_by_path(sid: int, folder):
+async def get_folder_by_path(sid: str, folder):
     user = asset_state.get_user(sid)
 
     folder = folder.strip("/")
@@ -73,7 +73,7 @@ async def get_folder_by_path(sid: int, folder):
 
 @sio.on("Folder.Create", namespace=ASSET_NS)
 @auth.login_required(app, sio)
-async def create_folder(sid: int, data):
+async def create_folder(sid: str, data):
     user = asset_state.get_user(sid)
     parent = data.get("parent", None)
     if parent is None:
@@ -84,7 +84,7 @@ async def create_folder(sid: int, data):
 
 @sio.on("Inode.Move", namespace=ASSET_NS)
 @auth.login_required(app, sio)
-async def move_inode(sid: int, data):
+async def move_inode(sid: str, data):
     user = asset_state.get_user(sid)
     target = data.get("target", None)
     if target is None:
@@ -100,7 +100,7 @@ async def move_inode(sid: int, data):
 
 @sio.on("Asset.Rename", namespace=ASSET_NS)
 @auth.login_required(app, sio)
-async def assetmgmt_rename(sid: int, data):
+async def assetmgmt_rename(sid: str, data):
     user = asset_state.get_user(sid)
     asset = Asset[data["asset"]]
     if asset.owner != user:
@@ -112,7 +112,7 @@ async def assetmgmt_rename(sid: int, data):
 
 @sio.on("Asset.Remove", namespace=ASSET_NS)
 @auth.login_required(app, sio)
-async def assetmgmt_rm(sid: int, data):
+async def assetmgmt_rm(sid: str, data):
     user = asset_state.get_user(sid)
     asset = Asset[data]
     if asset.owner != user:
@@ -130,7 +130,7 @@ async def assetmgmt_rm(sid: int, data):
 
 @sio.on("Asset.Upload", namespace=ASSET_NS)
 @auth.login_required(app, sio)
-async def assetmgmt_upload(sid: int, file_data):
+async def assetmgmt_upload(sid: str, file_data):
     uuid = file_data["uuid"]
 
     if uuid not in asset_state.pending_file_upload_cache:

--- a/server/api/socket/connection.py
+++ b/server/api/socket/connection.py
@@ -46,7 +46,6 @@ async def connect(sid, environ):
     logger.info(f"User {user.name} connected with identifier {sid}")
 
     sio.enter_room(sid, pr.active_location.get_path(), namespace=GAME_NS)
-    await load_location(sid, pr.active_location, complete=True)
 
 
 @sio.on("disconnect", namespace=GAME_NS)

--- a/server/api/socket/connection.py
+++ b/server/api/socket/connection.py
@@ -4,10 +4,11 @@ from aiohttp_security import authorized_userid
 
 from .location import load_location
 from api.socket.constants import GAME_NS
-from app import logger, sio
+from app import sio
 from models import Asset, Label, LabelSelection, Location, PlayerRoom, Room, User
 from models.role import Role
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("connect", namespace=GAME_NS)

--- a/server/api/socket/floor.py
+++ b/server/api/socket/floor.py
@@ -10,7 +10,7 @@ from state.game import game_state
 
 @sio.on("Floor.Create", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def create_floor(sid: int, data: Dict[str, Any]):
+async def create_floor(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:

--- a/server/api/socket/floor.py
+++ b/server/api/socket/floor.py
@@ -2,10 +2,11 @@ from typing import Any, Dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import Floor, Room, PlayerRoom
 from models.role import Role
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Floor.Create", namespace=GAME_NS)

--- a/server/api/socket/initiative.py
+++ b/server/api/socket/initiative.py
@@ -28,7 +28,7 @@ from state.game import game_state
 
 @sio.on("Initiative.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_initiative(sid: int, data: Dict[str, Any]):
+async def update_initiative(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     shape = Shape.get_or_none(uuid=data["uuid"])
@@ -113,7 +113,7 @@ async def update_initiative(sid: int, data: Dict[str, Any]):
 
 @sio.on("Initiative.Remove", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def remove_initiative(sid: int, data: Dict[str, Any]):
+async def remove_initiative(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     shape = Shape.get_or_none(uuid=data)
@@ -140,7 +140,7 @@ async def remove_initiative(sid: int, data: Dict[str, Any]):
 
 @sio.on("Initiative.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_initiative_order(sid: int, data: Dict[str, Any]):
+async def update_initiative_order(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -158,7 +158,7 @@ async def update_initiative_order(sid: int, data: Dict[str, Any]):
 
 @sio.on("Initiative.Turn.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_initiative_turn(sid: int, data: Dict[str, Any]):
+async def update_initiative_turn(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -191,7 +191,7 @@ async def update_initiative_turn(sid: int, data: Dict[str, Any]):
 
 @sio.on("Initiative.Round.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_initiative_round(sid: int, data: Dict[str, Any]):
+async def update_initiative_round(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -214,7 +214,7 @@ async def update_initiative_round(sid: int, data: Dict[str, Any]):
 
 @sio.on("Initiative.Effect.New", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def new_initiative_effect(sid: int, data: Dict[str, Any]):
+async def new_initiative_effect(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if not has_ownership(Shape.get_or_none(uuid=data["actor"]), pr):
@@ -239,7 +239,7 @@ async def new_initiative_effect(sid: int, data: Dict[str, Any]):
 
 @sio.on("Initiative.Effect.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_initiative_effect(sid: int, data: Dict[str, Any]):
+async def update_initiative_effect(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if not has_ownership(Shape.get_or_none(uuid=data["actor"]), pr):

--- a/server/api/socket/initiative.py
+++ b/server/api/socket/initiative.py
@@ -6,7 +6,7 @@ from playhouse.shortcuts import dict_to_model, update_model_from_dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import (
     Initiative,
     InitiativeEffect,
@@ -24,6 +24,7 @@ from models.role import Role
 from models.shape.access import has_ownership, has_ownership_temp
 from models.utils import reduce_data_to_model
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Initiative.Update", namespace=GAME_NS)

--- a/server/api/socket/label.py
+++ b/server/api/socket/label.py
@@ -11,7 +11,7 @@ from state.game import game_state
 
 @sio.on("Label.Add", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def add(sid: int, data: Dict[str, Any]):
+async def add(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     label = Label.get_or_none(uuid=data)
@@ -36,7 +36,7 @@ async def add(sid: int, data: Dict[str, Any]):
 
 @sio.on("Label.Delete", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def delete(sid: int, data: Dict[str, Any]):
+async def delete(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     label = Label.get_or_none(uuid=data)
@@ -61,7 +61,7 @@ async def delete(sid: int, data: Dict[str, Any]):
 
 @sio.on("Label.Visibility.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_visibility(sid: int, data: Dict[str, Any]):
+async def set_visibility(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     label = Label.get_or_none(uuid=data["uuid"])
@@ -101,7 +101,7 @@ async def set_visibility(sid: int, data: Dict[str, Any]):
 
 @sio.on("Labels.Filter.Add", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def add_filter(sid: int, uuid: str):
+async def add_filter(sid: str, uuid: str):
     pr: PlayerRoom = game_state.get(sid)
 
     label = Label.get_or_none(uuid=uuid)
@@ -115,7 +115,7 @@ async def add_filter(sid: int, uuid: str):
 
 @sio.on("Labels.Filter.Remove", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def remove_filter(sid: int, uuid: str):
+async def remove_filter(sid: str, uuid: str):
     pr: PlayerRoom = game_state.get(sid)
 
     label = Label.get_or_none(uuid=uuid)

--- a/server/api/socket/label.py
+++ b/server/api/socket/label.py
@@ -2,11 +2,12 @@ from typing import Any, Dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import Label, LabelSelection, PlayerRoom, User
 from models.db import db
 from models.role import Role
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Label.Add", namespace=GAME_NS)

--- a/server/api/socket/location.py
+++ b/server/api/socket/location.py
@@ -29,7 +29,7 @@ from models.asset import Asset
 
 
 @auth.login_required(app, sio)
-async def load_location(sid: int, location: Location, *, complete=False):
+async def load_location(sid: str, location: Location, *, complete=False):
     pr: PlayerRoom = game_state.get(sid)
     if pr.active_location != location:
         pr.active_location = location
@@ -171,7 +171,7 @@ async def load_location(sid: int, location: Location, *, complete=False):
 
 @sio.on("Location.Change", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def change_location(sid: int, data: Dict[str, str]):
+async def change_location(sid: str, data: Dict[str, str]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -204,7 +204,7 @@ async def change_location(sid: int, data: Dict[str, str]):
 
 @sio.on("Location.Options.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_location_options(sid: int, data: Dict[str, Any]):
+async def set_location_options(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -249,7 +249,7 @@ async def set_location_options(sid: int, data: Dict[str, Any]):
 
 @sio.on("Location.New", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def add_new_location(sid: int, location: str):
+async def add_new_location(sid: str, location: str):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -273,7 +273,7 @@ async def add_new_location(sid: int, location: str):
 
 @sio.on("Locations.Order.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_locations_order(sid: int, locations: List[int]):
+async def set_locations_order(sid: str, locations: List[int]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -296,7 +296,7 @@ async def set_locations_order(sid: int, locations: List[int]):
 
 @sio.on("Location.Rename", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def rename_location(sid: int, data: Dict[str, str]):
+async def rename_location(sid: str, data: Dict[str, str]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -314,7 +314,7 @@ async def rename_location(sid: int, data: Dict[str, str]):
 
 @sio.on("Location.Delete", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def delete_location(sid: int, location_id: int):
+async def delete_location(sid: str, location_id: int):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -334,7 +334,7 @@ async def delete_location(sid: int, location_id: int):
 
 @sio.on("Location.Spawn.Info.Get", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def get_location_spawn_info(sid: int, location_id: int):
+async def get_location_spawn_info(sid: str, location_id: int):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:

--- a/server/api/socket/location.py
+++ b/server/api/socket/location.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import (
     Floor,
     Initiative,
@@ -23,6 +23,7 @@ from models.role import Role
 from peewee import JOIN
 from playhouse.shortcuts import update_model_from_dict
 from state.game import game_state
+from utils import logger
 
 from .initiative import send_client_initiatives
 from models.asset import Asset

--- a/server/api/socket/marker.py
+++ b/server/api/socket/marker.py
@@ -10,7 +10,7 @@ from state.game import game_state
 
 @sio.on("Marker.New", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def new_marker(sid: int, data):
+async def new_marker(sid: str, data):
     pr: PlayerRoom = game_state.get(sid)
 
     marker = Marker.get_or_none(shape=data, user=pr.player)
@@ -23,7 +23,7 @@ async def new_marker(sid: int, data):
 
 @sio.on("Marker.Remove", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def delete_marker(sid: int, uuid: str):
+async def delete_marker(sid: str, uuid: str):
     pr: PlayerRoom = game_state.get(sid)
 
     marker = Marker.get_or_none(shape_id=uuid, user=pr.player)

--- a/server/api/socket/marker.py
+++ b/server/api/socket/marker.py
@@ -2,10 +2,11 @@ from typing import Any, Dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import Marker, PlayerRoom
 from models.db import db
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Marker.New", namespace=GAME_NS)

--- a/server/api/socket/note.py
+++ b/server/api/socket/note.py
@@ -10,7 +10,7 @@ from state.game import game_state
 
 @sio.on("Note.New", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def new_note(sid: int, data: Dict[str, Any]):
+async def new_note(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if Note.get_or_none(uuid=data["uuid"]):
@@ -31,7 +31,7 @@ async def new_note(sid: int, data: Dict[str, Any]):
 
 @sio.on("Note.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_note(sid: int, data: Dict[str, Any]):
+async def update_note(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     note = Note.get_or_none(uuid=data["uuid"])

--- a/server/api/socket/note.py
+++ b/server/api/socket/note.py
@@ -2,10 +2,11 @@ from typing import Any, Dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import Note, PlayerRoom
 from models.db import db
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Note.New", namespace=GAME_NS)

--- a/server/api/socket/room.py
+++ b/server/api/socket/room.py
@@ -2,10 +2,11 @@ import uuid
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import PlayerRoom
 from models.role import Role
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Room.Info.InviteCode.Refresh", namespace=GAME_NS)

--- a/server/api/socket/room.py
+++ b/server/api/socket/room.py
@@ -10,7 +10,7 @@ from state.game import game_state
 
 @sio.on("Room.Info.InviteCode.Refresh", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def refresh_invite_code(sid: int):
+async def refresh_invite_code(sid: str):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -30,7 +30,7 @@ async def refresh_invite_code(sid: int):
 
 @sio.on("Room.Info.Players.Kick", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def kick_player(sid: int, player_id: int):
+async def kick_player(sid: str, player_id: int):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -46,7 +46,7 @@ async def kick_player(sid: int, player_id: int):
 
 @sio.on("Room.Delete", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def delete_session(sid: int):
+async def delete_session(sid: str):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -58,7 +58,7 @@ async def delete_session(sid: int):
 
 @sio.on("Room.Info.Set.Locked", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_locked_game_state(sid: int, is_locked: bool):
+async def set_locked_game_state(sid: str, is_locked: bool):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Generic, List, Tuple
 from typing_extensions import TypedDict

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -55,10 +55,13 @@ async def add_shape(sid: str, data: Dict[str, Any]):
     if "temporary" not in data:
         data["temporary"] = False
 
-    floor = pr.active_location.floors.select().where(
-        Floor.name == data["shape"]["floor"]
-    )[0]
-    layer = floor.layers.where(Layer.name == data["shape"]["layer"])[0]
+    try:
+        floor = pr.active_location.floors.select().where(
+            Floor.name == data["shape"]["floor"]
+        )[0]
+        layer = floor.layers.where(Layer.name == data["shape"]["layer"])[0]
+    except IndexError:
+        return
 
     if pr.role != Role.DM and not layer.player_editable:
         logger.warning(f"{pr.player.name} attempted to add a shape to a dm layer")

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -1,13 +1,15 @@
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, Generic, List, Tuple
+from typing_extensions import TypedDict
 
 from peewee import Case
 from playhouse.shortcuts import update_model_from_dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import (
     Aura,
     Floor,
@@ -27,8 +29,23 @@ from models.role import Role
 from models.shape.access import has_ownership, has_ownership_temp
 from models.utils import get_table, reduce_data_to_model
 from state.game import game_state
+from utils import logger
 
 from . import access, options
+
+
+# DATA CLASSES FOR TYPE CHECKING
+class PositionUpdate(TypedDict):
+    uuid: str
+    points: List[List[float]]
+
+
+class PositionUpdateList(TypedDict):
+    shapes: List[PositionUpdate]
+    temporary: bool
+
+
+# EVENTS
 
 
 @sio.on("Shape.Add", namespace=GAME_NS)
@@ -93,39 +110,48 @@ async def add_shape(sid: str, data: Dict[str, Any]):
             await sio.emit("Shape.Add", data["shape"], room=psid, namespace=GAME_NS)
 
 
-@sio.on("Shape.Position.Update", namespace=GAME_NS)
+@sio.on("Shapes.Position.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_shape_position(sid: str, data: Dict[str, Any]):
+async def update_shape_positions(sid: str, data: PositionUpdateList):
     pr: PlayerRoom = game_state.get(sid)
 
-    if data["temporary"] and not has_ownership_temp(data["shape"], pr):
+    shapes: List[Tuple[Shape, PositionUpdate]] = [
+        (Shape.get_by_id(shape["uuid"]), shape) for shape in data["shapes"]
+    ]
+
+    if data["temporary"] and not all(
+        has_ownership_temp(shape, pr) for shape, _ in shapes
+    ):
         logger.warning(
             f"User {pr.player.name} attempted to move a shape it does not own."
         )
         return
-
-    shape, layer = await _get_shape(data, pr)
-
-    # Overwrite the old data with the new data
-    if not data["temporary"]:
-        if not has_ownership(shape, pr):
+    else:
+        if not all(has_ownership(shape, pr) for shape, _ in shapes):
             logger.warning(
                 f"User {pr.player.name} attempted to move a shape it does not own."
             )
             return
 
         with db.atomic():
-            # Shape
-            update_model_from_dict(shape, reduce_data_to_model(Shape, data["shape"]))
-            shape.save()
-            if shape.type_ == "polygon":
-                # Subshape
-                type_instance = shape.subtype
-                # no backrefs on these tables
-                type_instance.update_from_dict(data["shape"], ignore_unknown=True)
-                type_instance.save()
+            for db_shape, data_shape in shapes:
+                points = data_shape["points"]
+                db_shape.x = points[0][0]
+                db_shape.y = points[0][1]
+                db_shape.save()
 
-    await sync_shape_update(layer, pr, data, sid, shape)
+                if len(points) > 1:
+                    # Subshape
+                    type_instance = db_shape.subtype
+                    type_instance.set_location(points[1:])
+
+    await sio.emit(
+        "Shapes.Position.Update",
+        data["shapes"],
+        room=pr.active_location.get_path(),
+        skip_sid=sid,
+        namespace=GAME_NS,
+    )
 
 
 @sio.on("Shape.Update", namespace=GAME_NS)
@@ -477,12 +503,12 @@ async def move_shapes(sid: str, data: Dict[str, Any]):
         logger.warning(f"{pr.player.name} attempted to move shape locations")
         return
 
-    location = Location[data["target"]["location"]]
+    location = Location.get_by_id(data["target"]["location"])
     floor = location.floors.select().where(Floor.name == data["target"]["floor"])[0]
     x = data["target"]["x"]
     y = data["target"]["y"]
 
-    shapes = [Shape[sh] for sh in data["shapes"]]
+    shapes = [Shape.get_by_id(sh) for sh in data["shapes"]]
 
     for psid, player in game_state.get_users(active_location=pr.active_location):
         await sio.emit(

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -33,7 +33,7 @@ from . import access, options
 
 @sio.on("Shape.Add", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def add_shape(sid: int, data: Dict[str, Any]):
+async def add_shape(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if "temporary" not in data:
@@ -130,7 +130,7 @@ async def update_shape_position(sid: str, data: Dict[str, Any]):
 
 @sio.on("Shape.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_shape(sid: int, data: Dict[str, Any]):
+async def update_shape(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if data["temporary"] and not has_ownership_temp(data["shape"], pr):
@@ -228,7 +228,7 @@ async def update_shape(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shapes.Remove", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def remove_shapes(sid: int, data: Dict[str, Any]):
+async def remove_shapes(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if data["temporary"]:
@@ -271,7 +271,7 @@ async def remove_shapes(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shapes.Floor.Change", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def change_shape_floor(sid: int, data: Dict[str, Any]):
+async def change_shape_floor(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -304,7 +304,7 @@ async def change_shape_floor(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shapes.Layer.Change", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def change_shape_layer(sid: int, data: Dict[str, Any]):
+async def change_shape_layer(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
@@ -374,7 +374,7 @@ async def change_shape_layer(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shape.Order.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def move_shape_order(sid: int, data: Dict[str, Any]):
+async def move_shape_order(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     shape = Shape.get(uuid=data["shape"]["uuid"])
@@ -470,7 +470,7 @@ async def _get_shape(data: Dict[str, Any], pr: PlayerRoom):
 
 @sio.on("Shapes.Location.Move", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def move_shapes(sid: int, data: Dict[str, Any]):
+async def move_shapes(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:

--- a/server/api/socket/shape/access.py
+++ b/server/api/socket/shape/access.py
@@ -12,7 +12,7 @@ from state.game import game_state
 
 @sio.on("Shape.Owner.Add", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def add_shape_owner(sid: int, data: Dict[str, Any]):
+async def add_shape_owner(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     try:
@@ -70,7 +70,7 @@ async def add_shape_owner(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shape.Owner.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_shape_owner(sid: int, data: Dict[str, Any]):
+async def update_shape_owner(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     try:
@@ -119,7 +119,7 @@ async def update_shape_owner(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shape.Owner.Delete", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def delete_shape_owner(sid: int, data: Dict[str, Any]):
+async def delete_shape_owner(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     try:
@@ -161,7 +161,7 @@ async def delete_shape_owner(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shape.Owner.Default.Update", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def update_default_shape_owner(sid: int, data: Dict[str, Any]):
+async def update_default_shape_owner(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     try:

--- a/server/api/socket/shape/access.py
+++ b/server/api/socket/shape/access.py
@@ -3,11 +3,12 @@ from typing import Any, Dict
 import auth
 from api.socket.constants import GAME_NS
 from api.socket.initiative import send_client_initiatives
-from app import app, logger, sio
+from app import app, sio
 from models import Floor, Layer, Location, PlayerRoom, Room, Shape, ShapeOwner, User
 from models.role import Role
 from models.shape.access import has_ownership
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Shape.Owner.Add", namespace=GAME_NS)

--- a/server/api/socket/shape/options.py
+++ b/server/api/socket/shape/options.py
@@ -2,10 +2,11 @@ from typing import Any, Dict
 
 import auth
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from models import PlayerRoom, Shape
 from models.shape.access import has_ownership
 from state.game import game_state
+from utils import logger
 
 
 @sio.on("Shape.Options.Invisible.Set", namespace=GAME_NS)

--- a/server/api/socket/shape/options.py
+++ b/server/api/socket/shape/options.py
@@ -10,7 +10,7 @@ from state.game import game_state
 
 @sio.on("Shape.Options.Invisible.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_invisible(sid: int, data: Dict[str, Any]):
+async def set_invisible(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     try:
@@ -41,7 +41,7 @@ async def set_invisible(sid: int, data: Dict[str, Any]):
 
 @sio.on("Shape.Options.Locked.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
-async def set_locked(sid: int, data: Dict[str, Any]):
+async def set_locked(sid: str, data: Dict[str, Any]):
     pr: PlayerRoom = game_state.get(sid)
 
     try:

--- a/server/app.py
+++ b/server/app.py
@@ -1,8 +1,3 @@
-import logging
-import os
-import sys
-from typing import Dict, Union
-
 import aiohttp_jinja2
 import aiohttp_security
 import aiohttp_session
@@ -14,8 +9,6 @@ from aiohttp_session.cookie_storage import EncryptedCookieStorage
 
 import auth
 from config import config
-from models import PlayerRoom, User
-from utils import FILE_DIR
 
 # SETUP SERVER
 
@@ -30,23 +23,5 @@ aiohttp_security.setup(app, SessionIdentityPolicy(), app["AuthzPolicy"])
 aiohttp_session.setup(app, EncryptedCookieStorage(auth.get_secret_token()))
 aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader("templates"))
 sio.attach(app)
-
-# SETUP PATHS
-os.chdir(FILE_DIR)
-
-# SETUP LOGGING
-
-logger = logging.getLogger("PlanarAllyServer")
-logger.setLevel(logging.INFO)
-file_handler = logging.FileHandler(str(FILE_DIR / "planarallyserver.log"))
-file_handler.setLevel(logging.INFO)
-formatter = logging.Formatter(
-    "%(asctime)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
-)
-file_handler.setFormatter(formatter)
-stream_handler = logging.StreamHandler(sys.stdout)
-stream_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
-logger.addHandler(stream_handler)
 
 app["state"] = {}

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -92,10 +92,13 @@ class Location(BaseModel):
         return data
 
     def create_floor(self, name="ground"):
-        index = (
-            Floor.select(fn.Max(Floor.index)).where(Floor.location == self).scalar()
-            or -1
-        ) + 1
+        if Floor.select().where(Floor.location == self).count() > 0:
+            index = (
+                Floor.select(fn.Max(Floor.index)).where(Floor.location == self).scalar()
+                + 1
+            )
+        else:
+            index = 0
         floor = Floor.create(location=self, name=name, index=index)
         Layer.create(
             location=self,

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -1,8 +1,9 @@
 import json
 from peewee import BooleanField, FloatField, ForeignKeyField, IntegerField, TextField
 from playhouse.shortcuts import model_to_dict, update_model_from_dict
-from typing import Tuple
+from typing import List, Tuple
 
+from utils import logger
 from ..base import BaseModel
 from ..campaign import Layer
 from ..label import Label
@@ -181,6 +182,9 @@ class ShapeType(BaseModel):
     def get_center_offset(self, x: int, y: int) -> Tuple[int, int]:
         return 0, 0
 
+    def set_location(self, points: List[List[int]]) -> None:
+        logger.error("Attempt to set location on shape without location info")
+
 
 class BaseRect(ShapeType):
     abstract = False
@@ -236,6 +240,10 @@ class Polygon(ShapeType):
     def update_from_dict(self, data, *args, **kwargs):
         data["vertices"] = json.dumps(data["vertices"])
         return update_model_from_dict(self, data, *args, **kwargs)
+
+    def set_location(self, points: List[List[int]]) -> None:
+        self.vertices = json.dumps(points)
+        self.save()
 
 
 class Rect(BaseRect):

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -8,7 +8,9 @@ import sys
 from utils import FILE_DIR
 
 if not (FILE_DIR / "templates").exists():
-    print('You must gather your par— you must build the client, before starting the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client.')
+    print(
+        "You must gather your par— you must build the client, before starting the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client."
+    )
     sys.exit(1)
 
 # Mimetype recognition for js files apparently is not always properly setup out of the box for some users out there.
@@ -34,8 +36,9 @@ from state.game import game_state
 # Force loading of socketio routes
 from api.socket import *
 from api.socket.constants import GAME_NS
-from app import app, logger, sio
+from app import app, sio
 from config import config
+from utils import logger
 
 # This is a fix for asyncio problems on windows that make it impossible to do ctrl+c
 if sys.platform.startswith("win"):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,3 +7,4 @@ bcrypt==3.1.7
 cryptography==2.9.2
 python-socketio==4.5.1
 peewee==3.13.3
+typing_extensions==3.7.4.2

--- a/server/routes.py
+++ b/server/routes.py
@@ -4,10 +4,11 @@ import aiohttp_jinja2
 from aiohttp import web
 from aiohttp_security import authorized_userid, check_authorized, forget, remember
 
-from app import app, logger
+from app import app
 from models import Location, PlayerRoom, Room, User
 from models.db import db
 from models.role import Role
+from utils import logger
 
 
 async def root(request):

--- a/server/state/__init__.py
+++ b/server/state/__init__.py
@@ -10,25 +10,25 @@ T = TypeVar("T")
 
 class State(ABC, Generic[T]):
     def __init__(self) -> None:
-        self._sid_map: Dict[int, T] = {}
+        self._sid_map: Dict[str, T] = {}
 
-    async def add_sid(self, sid: int, value: T) -> None:
+    async def add_sid(self, sid: str, value: T) -> None:
         self._sid_map[sid] = value
 
-    async def remove_sid(self, sid: int) -> None:
+    async def remove_sid(self, sid: str) -> None:
         del self._sid_map[sid]
 
-    def has_sid(self, sid: int) -> bool:
+    def has_sid(self, sid: str) -> bool:
         return sid in self._sid_map
 
-    def get(self, sid: int) -> T:
+    def get(self, sid: str) -> T:
         return self._sid_map[sid]
 
     @abstractmethod
-    def get_user(self, sid: int) -> User:
+    def get_user(self, sid: str) -> User:
         pass
 
-    def get_sids(self, skip_sid=None, **options) -> Generator[int, None, None]:
+    def get_sids(self, skip_sid=None, **options) -> Generator[str, None, None]:
         for sid, value in dict(self._sid_map).items():
             if skip_sid == sid:
                 continue
@@ -39,6 +39,6 @@ class State(ABC, Generic[T]):
             ):
                 yield sid
 
-    def get_users(self, **options) -> Generator[Tuple[int, User], None, None]:
+    def get_users(self, **options) -> Generator[Tuple[str, User], None, None]:
         for sid in self.get_sids(**options):
             yield sid, self.get_user(sid)

--- a/server/state/asset.py
+++ b/server/state/asset.py
@@ -10,7 +10,7 @@ class AssetState(State[User]):
         super().__init__()
         self.pending_file_upload_cache: Dict[str, Any] = {}
 
-    def get_user(self, sid: int) -> User:
+    def get_user(self, sid: str) -> User:
         return self._sid_map[sid]
 
 

--- a/server/state/game.py
+++ b/server/state/game.py
@@ -9,28 +9,28 @@ from models import PlayerRoom, User
 class GameState(State[PlayerRoom]):
     def __init__(self) -> None:
         super().__init__()
-        self.client_temporaries: Dict[int, Set[str]] = {}
+        self.client_temporaries: Dict[str, Set[str]] = {}
 
-    def get_user(self, sid: int) -> User:
+    def get_user(self, sid: str) -> User:
         return self._sid_map[sid].player
 
-    async def remove_sid(self, sid: int) -> None:
+    async def remove_sid(self, sid: str) -> None:
         await self.clear_temporaries(sid)
         await super().remove_sid(sid)
 
-    async def clear_temporaries(self, sid: int) -> None:
+    async def clear_temporaries(self, sid: str) -> None:
         if sid in self.client_temporaries:
             await sio.emit(
                 "Temp.Clear", list(self.client_temporaries[sid]), namespace=GAME_NS,
             )
             del self.client_temporaries[sid]
 
-    def add_temp(self, sid: int, uid: str) -> None:
+    def add_temp(self, sid: str, uid: str) -> None:
         if sid not in self.client_temporaries:
             self.client_temporaries[sid] = set()
         self.client_temporaries[sid].add(uid)
 
-    def remove_temp(self, sid: int, uid: str) -> None:
+    def remove_temp(self, sid: str, uid: str) -> None:
         self.client_temporaries[sid].remove(uid)
 
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import sys
 from pathlib import Path
 
@@ -15,6 +17,24 @@ def get_file_dir():
 
 
 FILE_DIR = get_file_dir()
+
+# SETUP PATHS
+os.chdir(FILE_DIR)
+
+# SETUP LOGGING
+
+logger = logging.getLogger("PlanarAllyServer")
+logger.setLevel(logging.INFO)
+file_handler = logging.FileHandler(str(FILE_DIR / "planarallyserver.log"))
+file_handler.setLevel(logging.INFO)
+formatter = logging.Formatter(
+    "%(asctime)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+)
+file_handler.setFormatter(formatter)
+stream_handler = logging.StreamHandler(sys.stdout)
+stream_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+logger.addHandler(stream_handler)
 
 
 class OldVersionException(Exception):


### PR DESCRIPTION
This PR adds a bunch of performance improvements.

The websocket handshake is now performed in such a way that the rest of the page does not hang until all initial data is received.  This greatly improves the time until first visible frame, but might introduce some side effects.

To further improve the startup, the floors are now sent one by one to the client upon joining starting with the floor the player was active on last.

The drawloop (the main game loop) now also only starts when the first floor is received instead of from the start as it was just doing nothing and wasting cpu.

Some operations on groups of shapes are now batched (e.g. movement/removal/floor and layer changing)

Movement of shapes no longer sends a full shape update but only sends the position information.

Pan tool on mousemove only rerenders visible floors.