### PR TITLE
bug(Layer): Fix setLayerIndex by setting to 2 (token layer)

### DIFF
--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -76,7 +76,7 @@ class LayerManager {
             if (floor.name === floorName) {
                 this.getLayers(floor).push(layer);
                 if (floorStore.currentLayerIndex < 0) {
-                    floorStore.setLayerIndex(0);
+                    floorStore.setLayerIndex(2);
                 }
                 return;
             }


### PR DESCRIPTION
Players entered the map layer instead of the token layer, so they could not operate their tokens.

This PR fixes it by changing the default layer index from 0 (the map layer) to 2 (the token layer).

*Needs further investigation.*