### PR TITLE
bug(Shape): Fix shape position update not persisting

### DIFF
--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -126,6 +126,7 @@ async def update_shape_positions(sid: str, data: PositionUpdateList):
                 f"User {pr.player.name} attempted to move a shape it does not own."
             )
             return
+        shapes.append((shape, sh))
 
     if not data["temporary"]:
         with db.atomic():


### PR DESCRIPTION
Moving a shape would properly sync across clients, but would never actually persist in the database and thus reset on reload.

This closes #464 