### PR TITLE
feat(Settings): Make grid size a client setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
     -   Better handling of multi group moves
     -   Shape movement now sends less data to server
     -   Pan now only updates the visible floors on move and full recalculate on release
+-   Grid pixel size is now a client setting instead of a DM setting
 
 ### Fixed
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -48,6 +48,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     gameStore.setUsername(options.name);
     gameStore.setDM(options.name === decodeURIComponent(window.location.pathname.split("/")[2]));
 
+    gameStore.setGridSize({ gridSize: options.grid_size, sync: false });
     gameStore.setGridColour({ colour: options.grid_colour, sync: false });
     gameStore.setFOWColour({ colour: options.fow_colour, sync: false });
     gameStore.setRulerColour({ colour: options.ruler_colour, sync: false });

--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -41,8 +41,6 @@ socket.on("Location.Rename", (data: { id: number; name: string }) => {
 });
 
 export function setLocationOptions(id: number | null, options: Partial<ServerLocationOptions>): void {
-    if (options?.grid_size !== undefined)
-        gameSettingsStore.setGridSize({ gridSize: options.grid_size, location: id, sync: false });
     if (options?.unit_size !== undefined)
         gameSettingsStore.setUnitSize({ unitSize: options.unit_size, location: id, sync: false });
     if (options?.unit_size_unit !== undefined)

--- a/client/src/game/comm/types/settings.ts
+++ b/client/src/game/comm/types/settings.ts
@@ -8,7 +8,6 @@ export interface ServerLocationOptions {
     vision_mode: string;
     vision_min_range: number;
     vision_max_range: number;
-    grid_size: number;
     spawn_locations: string;
 }
 
@@ -22,7 +21,6 @@ export interface LocationOptions {
     visionMode: string;
     visionMinRange: number;
     visionMaxRange: number;
-    gridSize: number;
     spawnLocations: string[];
 }
 
@@ -35,6 +33,7 @@ export interface ServerClient {
     pan_x: number;
     pan_y: number;
     zoom_factor: number;
+    grid_size: number;
     active_floor?: string;
     active_layer?: string;
 }
@@ -59,8 +58,6 @@ export const optionsToServer = (options: LocationOptions): ServerLocationOptions
     // eslint-disable-next-line @typescript-eslint/camelcase
     vision_max_range: options.visionMaxRange,
     // eslint-disable-next-line @typescript-eslint/camelcase
-    grid_size: options.gridSize,
-    // eslint-disable-next-line @typescript-eslint/camelcase
     spawn_locations: JSON.stringify(options.spawnLocations),
 });
 
@@ -74,6 +71,5 @@ export const optionsToClient = (options: ServerLocationOptions): LocationOptions
     fowLos: options.fow_los,
     visionMinRange: options.vision_min_range,
     visionMaxRange: options.vision_max_range,
-    gridSize: options.grid_size,
     spawnLocations: JSON.parse(options.spawn_locations),
 });

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -6,12 +6,11 @@ import { gameStore } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
+import { sendShapePositionUpdate } from "../api/events/shape";
 import { EventBus } from "../event-bus";
-import { gameManager } from "../manager";
-import { gameSettingsStore } from "../settings";
 import { floorStore } from "../layers/store";
 import { moveFloor } from "../layers/utils";
-import { sendShapePositionUpdate } from "../api/events/shape";
+import { gameManager } from "../manager";
 
 export function onKeyUp(event: KeyboardEvent): void {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
@@ -39,7 +38,7 @@ export function onKeyDown(event: KeyboardEvent): void {
         if (event.keyCode >= 37 && event.keyCode <= 40) {
             // Arrow keys - move the selection or the camera
             // todo: this should already be rounded
-            const gridSize = Math.round(gameSettingsStore.gridSize);
+            const gridSize = Math.round(gameStore.gridSize);
             let offsetX = gridSize * (event.keyCode % 2);
             let offsetY = gridSize * (event.keyCode % 2 ? 0 : 1);
             if (layerManager.hasSelection()) {

--- a/client/src/game/layers/grid.ts
+++ b/client/src/game/layers/grid.ts
@@ -25,7 +25,7 @@ export class GridLayer extends Layer {
                 this.clear();
                 ctx.beginPath();
 
-                const gs = gameSettingsStore.gridSize;
+                const gs = gameStore.gridSize;
                 if (gs <= 0 || gs === undefined) {
                     throw new Error("Grid size is not set, while grid is enabled.");
                 }

--- a/client/src/game/layers/grid.ts
+++ b/client/src/game/layers/grid.ts
@@ -1,5 +1,5 @@
 import { Layer } from "@/game/layers/layer";
-import { gameStore } from "@/game/store";
+import { DEFAULT_GRID_SIZE, gameStore } from "@/game/store";
 import { gameSettingsStore } from "../settings";
 import { floorStore } from "./store";
 
@@ -25,16 +25,11 @@ export class GridLayer extends Layer {
                 this.clear();
                 ctx.beginPath();
 
-                const gs = gameStore.gridSize;
-                if (gs <= 0 || gs === undefined) {
-                    throw new Error("Grid size is not set, while grid is enabled.");
-                }
-
-                for (let i = 0; i < this.width; i += gs * gameStore.zoomFactor) {
-                    ctx.moveTo(i + (gameStore.panX % gs) * gameStore.zoomFactor, 0);
-                    ctx.lineTo(i + (gameStore.panX % gs) * gameStore.zoomFactor, this.height);
-                    ctx.moveTo(0, i + (gameStore.panY % gs) * gameStore.zoomFactor);
-                    ctx.lineTo(this.width, i + (gameStore.panY % gs) * gameStore.zoomFactor);
+                for (let i = 0; i < this.width; i += DEFAULT_GRID_SIZE * gameStore.zoomFactor) {
+                    ctx.moveTo(i + (gameStore.panX % DEFAULT_GRID_SIZE) * gameStore.zoomFactor, 0);
+                    ctx.lineTo(i + (gameStore.panX % DEFAULT_GRID_SIZE) * gameStore.zoomFactor, this.height);
+                    ctx.moveTo(0, i + (gameStore.panY % DEFAULT_GRID_SIZE) * gameStore.zoomFactor);
+                    ctx.lineTo(this.width, i + (gameStore.panY % DEFAULT_GRID_SIZE) * gameStore.zoomFactor);
                 }
 
                 ctx.strokeStyle = gameStore.gridColour;

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -15,6 +15,7 @@ import { floorStore } from "./store";
 import { Floor } from "./floor";
 import { Shape } from "../shapes/shape";
 import { socket } from "../api/socket";
+import { gameStore } from "../store";
 
 export function addFloor(serverFloor: ServerFloor): void {
     const floor = { name: serverFloor.name, playerVisible: serverFloor.player_visible };
@@ -93,7 +94,7 @@ export function dropAsset(event: DragEvent): void {
     asset.src = new URL(image.src).pathname;
 
     if (gameSettingsStore.useGrid) {
-        const gs = gameSettingsStore.gridSize;
+        const gs = gameStore.gridSize;
         asset.refPoint = new GlobalPoint(clampGridLine(asset.refPoint.x), clampGridLine(asset.refPoint.y));
         asset.w = Math.max(clampGridLine(asset.w), gs);
         asset.h = Math.max(clampGridLine(asset.h), gs);

--- a/client/src/game/settings.ts
+++ b/client/src/game/settings.ts
@@ -16,7 +16,6 @@ export interface GameSettingsState {
     defaultLocationOptions: LocationOptions | null;
     locationOptions: Partial<LocationOptions>;
 
-    gridSize: number;
     unitSize: number;
     unitSizeUnit: string;
     useGrid: boolean;
@@ -70,10 +69,6 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
 
     get currentLocationOptions(): Partial<LocationOptions> {
         return this.locationOptions[this.activeLocation];
-    }
-
-    get gridSize(): number {
-        return this.currentLocationOptions?.gridSize ?? this.defaultLocationOptions?.gridSize ?? 0;
     }
 
     get unitSize(): number {
@@ -159,20 +154,6 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
             if (data.sync)
                 // eslint-disable-next-line @typescript-eslint/camelcase
                 socket.emit("Location.Options.Set", { options: { use_grid: data.useGrid }, location: data.location });
-        }
-    }
-
-    @Mutation
-    setGridSize(data: { gridSize: number; location: number | null; sync: boolean }): void {
-        if (mutateLocationOption("gridSize", data.gridSize, data.location)) {
-            for (const floor of floorStore.floors) {
-                const gridLayer = layerManager.getGridLayer(floor);
-                if (gridLayer !== undefined) gridLayer.invalidate();
-            }
-
-            if (data.sync)
-                // eslint-disable-next-line @typescript-eslint/camelcase
-                socket.emit("Location.Options.Set", { options: { grid_size: data.gridSize }, location: data.location });
         }
     }
 

--- a/client/src/game/shapes/baserect.ts
+++ b/client/src/game/shapes/baserect.ts
@@ -4,7 +4,7 @@ import { Shape } from "@/game/shapes/shape";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { clampGridLine, g2lx, g2ly } from "@/game/units";
 import { ServerShape } from "../comm/types/shapes";
-import { gameSettingsStore } from "../settings";
+import { gameStore } from "../store";
 import { rotateAroundPoint } from "../utils";
 
 export abstract class BaseRect extends Shape {
@@ -71,7 +71,7 @@ export abstract class BaseRect extends Shape {
         return false;
     }
     snapToGrid(): void {
-        const gs = gameSettingsStore.gridSize;
+        const gs = gameStore.gridSize;
         const center = this.center();
         const mx = center.x;
         const my = center.y;

--- a/client/src/game/shapes/circle.ts
+++ b/client/src/game/shapes/circle.ts
@@ -5,7 +5,7 @@ import { Shape } from "@/game/shapes/shape";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { clampGridLine, g2lz } from "@/game/units";
 import { getFogColour } from "@/game/utils";
-import { gameSettingsStore } from "../settings";
+import { gameStore } from "../store";
 
 export class Circle extends Shape {
     type = "circle";
@@ -71,7 +71,7 @@ export class Circle extends Shape {
         return this.getBoundingBox().visibleInCanvas(canvas);
     }
     snapToGrid(): void {
-        const gs = gameSettingsStore.gridSize;
+        const gs = gameStore.gridSize;
         let targetX;
         let targetY;
         if (((2 * this.r) / gs) % 2 === 0) {
@@ -89,7 +89,7 @@ export class Circle extends Shape {
         this.invalidate(false);
     }
     resizeToGrid(): void {
-        const gs = gameSettingsStore.gridSize;
+        const gs = gameStore.gridSize;
         this.r = Math.max(clampGridLine(this.r), gs / 2);
         this.invalidate(false);
     }

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -12,6 +12,8 @@ import Vue from "vue";
 import { getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
 import { floorStore } from "./layers/store";
 
+export const DEFAULT_GRID_SIZE = 50;
+
 export interface LocationUserOptions {
     panX: number;
     panY: number;
@@ -55,7 +57,7 @@ class GameStore extends VuexModule implements GameState {
     rulerColour = "rgba(255, 0, 0, 1)";
     panX = 0;
     panY = 0;
-    gridSize = 50;
+    gridSize = DEFAULT_GRID_SIZE;
 
     zoomDisplay = 0.5;
     // zoomFactor = 1;
@@ -80,7 +82,8 @@ class GameStore extends VuexModule implements GameState {
     invertAlt = false;
 
     get zoomFactor(): number {
-        return zoomValue(this.zoomDisplay);
+        const gf = gameStore.gridSize / DEFAULT_GRID_SIZE;
+        return zoomValue(this.zoomDisplay) * gf;
     }
 
     get locationUserOptions(): LocationUserOptions {

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -11,7 +11,6 @@ import { rootStore } from "@/store";
 import Vue from "vue";
 import { getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
 import { floorStore } from "./layers/store";
-import { gameSettingsStore } from "./settings";
 
 export interface LocationUserOptions {
     panX: number;
@@ -56,6 +55,7 @@ class GameStore extends VuexModule implements GameState {
     rulerColour = "rgba(255, 0, 0, 1)";
     panX = 0;
     panY = 0;
+    gridSize = 50;
 
     zoomDisplay = 0.5;
     // zoomFactor = 1;
@@ -215,10 +215,10 @@ class GameStore extends VuexModule implements GameState {
     jumpToMarker(marker: string): void {
         const shape = layerManager.UUIDMap.get(marker);
         if (shape == undefined) return;
-        const nh = window.innerWidth / gameSettingsStore.gridSize / zoomValue(this.zoomDisplay) / 2;
-        const nv = window.innerHeight / gameSettingsStore.gridSize / zoomValue(this.zoomDisplay) / 2;
-        this.panX = -shape.refPoint.x + nh * gameSettingsStore.gridSize;
-        this.panY = -shape.refPoint.y + nv * gameSettingsStore.gridSize;
+        const nh = window.innerWidth / this.gridSize / zoomValue(this.zoomDisplay) / 2;
+        const nv = window.innerHeight / this.gridSize / zoomValue(this.zoomDisplay) / 2;
+        this.panX = -shape.refPoint.x + nh * this.gridSize;
+        this.panY = -shape.refPoint.y + nv * this.gridSize;
         sendClientOptions(this.locationUserOptions);
         layerManager.invalidateAllFloors();
     }
@@ -300,6 +300,13 @@ class GameStore extends VuexModule implements GameState {
     @Mutation
     increasePanY(increase: number): void {
         this.panY += increase;
+    }
+
+    @Mutation
+    setGridSize(data: { gridSize: number; sync: boolean }): void {
+        this.gridSize = data.gridSize;
+        layerManager.invalidateAllFloors();
+        if (data.sync) socket.emit("Client.Options.Set", { gridSize: data.gridSize });
     }
 
     @Mutation

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -55,6 +55,13 @@ export default class MenuBar extends Vue {
     set invertAlt(value: boolean) {
         gameStore.setInvertAlt({ invertAlt: value, sync: true });
     }
+    get gridSize(): number {
+        return gameStore.gridSize;
+    }
+    set gridSize(gridSize: number) {
+        if (gridSize < 1) return;
+        gameStore.setGridSize({ gridSize, sync: true });
+    }
     settingsClick(event: { target: HTMLElement }): void {
         if (
             event.target.classList.contains("menu-accordion") &&
@@ -154,6 +161,8 @@ export default class MenuBar extends Vue {
             <button class="menu-accordion" v-t="'game.ui.menu.menu.client_options'"></button>
             <div class="menu-accordion-panel">
                 <div class="menu-accordion-subpanel">
+                    <label for="gridSize" v-t="'game.ui.menu.menu.grid_color_set'"></label>
+                    <div><input id="gridSize" type="number" v-model="gridSize" /></div>
                     <label for="gridColour" v-t="'game.ui.menu.menu.grid_color_set'"></label>
                     <color-picker id="gridColour" :color.sync="gridColour" />
                     <label for="fowColour" v-t="'game.ui.menu.menu.fow_color_set'"></label>

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -161,7 +161,7 @@ export default class MenuBar extends Vue {
             <button class="menu-accordion" v-t="'game.ui.menu.menu.client_options'"></button>
             <div class="menu-accordion-panel">
                 <div class="menu-accordion-subpanel">
-                    <label for="gridSize" v-t="'game.ui.menu.menu.grid_color_set'"></label>
+                    <label for="gridSize" v-t="'game.ui.menu.menu.grid_size_in_pixels'"></label>
                     <div><input id="gridSize" type="number" v-model="gridSize" /></div>
                     <label for="gridColour" v-t="'game.ui.menu.menu.grid_color_set'"></label>
                     <color-picker id="gridColour" :color.sync="gridColour" />

--- a/client/src/game/ui/settings/GridSettings.vue
+++ b/client/src/game/ui/settings/GridSettings.vue
@@ -38,13 +38,6 @@ export default class GridSettings extends Vue {
     set unitSizeUnit(value: string) {
         gameSettingsStore.setUnitSizeUnit({ unitSizeUnit: value, location: this.location, sync: true });
     }
-    get gridSize(): number {
-        return getLocationOption("gridSize", this.location)!;
-    }
-    set gridSize(value: number) {
-        if (typeof value !== "number") return;
-        gameSettingsStore.setGridSize({ gridSize: value, location: this.location, sync: true });
-    }
 
     reset(key: keyof LocationOptions): void {
         if (this.location === null) return;
@@ -75,20 +68,6 @@ export default class GridSettings extends Vue {
             <div
                 v-if="location !== null && options.useGrid !== undefined"
                 @click="reset('useGrid')"
-                :title="$t('game.ui.settings.common.reset_default')"
-            >
-                <font-awesome-icon icon="times-circle" />
-            </div>
-            <div v-else></div>
-        </div>
-        <div class="row" :class="{ overwritten: location !== null && options.gridSize !== undefined }">
-            <label :for="'gridSizeInput-' + location" v-t="'game.ui.settings.GridSettings.grid_size_in_pixels'"></label>
-            <div>
-                <input :id="'gridSizeInput-' + location" type="number" min="0" v-model.number="gridSize" />
-            </div>
-            <div
-                v-if="location !== null && options.gridSize !== undefined"
-                @click="reset('gridSize')"
                 :title="$t('game.ui.settings.common.reset_default')"
             >
                 <font-awesome-icon icon="times-circle" />

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -13,9 +13,9 @@ import { SelectFeatures } from "./select.vue";
 import { ToolName, ToolPermission } from "./utils";
 import { EventBus } from "@/game/event-bus";
 import { Shape } from "@/game/shapes/shape";
-import { gameSettingsStore } from "../../settings";
 import { ToolBasics } from "./ToolBasics";
 import { floorStore } from "@/game/layers/store";
+import { gameStore } from "../../store";
 
 @Component
 export default class MapTool extends Tool implements ToolBasics {
@@ -68,8 +68,8 @@ export default class MapTool extends Tool implements ToolBasics {
         const oldCenter = this.rect.center();
 
         if (this.shape instanceof BaseRect) {
-            const xFactor = (this.xCount * gameSettingsStore.gridSize) / this.rect.w;
-            const yFactor = (this.yCount * gameSettingsStore.gridSize) / this.rect.h;
+            const xFactor = (this.xCount * gameStore.gridSize) / this.rect.w;
+            const yFactor = (this.yCount * gameStore.gridSize) / this.rect.h;
 
             this.shape.w *= xFactor;
             this.shape.h *= yFactor;

--- a/client/src/game/ui/tools/ruler.vue
+++ b/client/src/game/ui/tools/ruler.vue
@@ -64,7 +64,7 @@ export default class RulerTool extends Tool implements ToolBasics {
         const diffsign = Math.sign(endPoint.x - this.startPoint.x) * Math.sign(endPoint.y - this.startPoint.y);
         const xdiff = Math.abs(endPoint.x - this.startPoint.x);
         const ydiff = Math.abs(endPoint.y - this.startPoint.y);
-        const distance = (Math.sqrt(xdiff ** 2 + ydiff ** 2) * gameSettingsStore.unitSize) / gameSettingsStore.gridSize;
+        const distance = (Math.sqrt(xdiff ** 2 + ydiff ** 2) * gameSettingsStore.unitSize) / gameStore.gridSize;
 
         // round to 1 decimal
         const label = Math.round(10 * distance) / 10 + " " + gameSettingsStore.unitSizeUnit;

--- a/client/src/game/ui/tools/ruler.vue
+++ b/client/src/game/ui/tools/ruler.vue
@@ -11,7 +11,7 @@ import { ToolName } from "./utils";
 import { gameSettingsStore } from "../../settings";
 import { ToolBasics } from "./ToolBasics";
 import { Line } from "@/game/shapes/line";
-import { gameStore } from "@/game/store";
+import { gameStore, DEFAULT_GRID_SIZE } from "@/game/store";
 import { Text } from "../../shapes/text";
 import { socket } from "@/game/api/socket";
 import { floorStore } from "@/game/layers/store";
@@ -64,7 +64,7 @@ export default class RulerTool extends Tool implements ToolBasics {
         const diffsign = Math.sign(endPoint.x - this.startPoint.x) * Math.sign(endPoint.y - this.startPoint.y);
         const xdiff = Math.abs(endPoint.x - this.startPoint.x);
         const ydiff = Math.abs(endPoint.y - this.startPoint.y);
-        const distance = (Math.sqrt(xdiff ** 2 + ydiff ** 2) * gameSettingsStore.unitSize) / gameStore.gridSize;
+        const distance = (Math.sqrt(xdiff ** 2 + ydiff ** 2) * gameSettingsStore.unitSize) / DEFAULT_GRID_SIZE;
 
         // round to 1 decimal
         const label = Math.round(10 * distance) / 10 + " " + gameSettingsStore.unitSizeUnit;

--- a/client/src/game/units.ts
+++ b/client/src/game/units.ts
@@ -22,7 +22,7 @@ export function g2lz(z: number): number {
 }
 
 export function getUnitDistance(r: number): number {
-    return (r / gameSettingsStore.unitSize) * gameSettingsStore.gridSize;
+    return (r / gameSettingsStore.unitSize) * gameStore.gridSize;
 }
 
 export function g2lr(r: number): number {
@@ -59,7 +59,7 @@ export function l2gr(r: number): number {
 }
 
 export function clampGridLine(point: number): number {
-    return Math.round(point / gameSettingsStore.gridSize) * gameSettingsStore.gridSize;
+    return Math.round(point / gameStore.gridSize) * gameStore.gridSize;
 }
 
 (<any>window).g2lx = g2lx;

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -141,6 +141,7 @@
                     "dm_options": "SL Optionen",
                     "no_markers": "Keine Markierungen",
                     "client_options": "Client Optionen",
+                    "grid_size_in_pixels": "Gittergröße (in Pixel):",
                     "grid_color_set": "Gitterfarbe:",
                     "fow_color_set": "Farbe „Nebel des Krieges“:",
                     "ruler_color_set": "Linealfarbe:",
@@ -227,7 +228,6 @@
                 "GridSettings": {
                     "unit_size_in_UNIT": "Feldgröße (in {unit})",
                     "use_grid": "Gitter benutzen",
-                    "grid_size_in_pixels": "Gittergröße (in Pixel):",
                     "size_unit": "Längeneinheit"
                 },
                 "location": {

--- a/client/src/locales/dk.json
+++ b/client/src/locales/dk.json
@@ -5,7 +5,7 @@
         "zh": "中文",
         "de": "Deutsch",
         "ru": "Русский",
-		"dk": "Dansk",
+        "dk": "Dansk",
         "es": "Español"
     },
     "assetManager": {
@@ -42,7 +42,7 @@
         "name": "Navn",
         "add": "Tilføj",
         "players": "Spiller",
-        "exit": "Forlad", 
+        "exit": "Forlad",
         "assets": "Materialer",
         "notes": "Noter",
         "markers": "Markører",
@@ -140,6 +140,7 @@
                     "dm_options": "DM Instillinger",
                     "no_markers": "Ingen markører",
                     "client_options": "Klient instillinger",
+                    "grid_size_in_pixels": "Gitterstørrelse (i pixels):",
                     "grid_color_set": "Gitter Farve:",
                     "fow_color_set": "FOW Farve:",
                     "ruler_color_set": "Lineal farve:",
@@ -226,7 +227,6 @@
                 "GridSettings": {
                     "unit_size_in_UNIT": "Feltstørelse (i {unit})",
                     "use_grid": "Brug gitter",
-                    "grid_size_in_pixels": "Gitterstørrelse (i pixels):",
                     "size_unit": "Længdeenhed"
                 },
                 "location": {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -141,6 +141,7 @@
                     "dm_options": "DM Options",
                     "no_markers": "No markers",
                     "client_options": "Client Options",
+                    "grid_size_in_pixels": "Grid Size (in pixels):",
                     "grid_color_set": "Grid Colour:",
                     "fow_color_set": "FOW Colour:",
                     "ruler_color_set": "Ruler Colour:",
@@ -227,7 +228,6 @@
                 "GridSettings": {
                     "unit_size_in_UNIT": "Unit Size (in {unit})",
                     "use_grid": "Use grid",
-                    "grid_size_in_pixels": "Grid Size (in pixels):",
                     "size_unit": "Size Unit"
                 },
                 "location": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -141,6 +141,7 @@
                     "dm_options": "Opciones de DM",
                     "no_markers": "No hay etiquetas",
                     "client_options": "Opciones de cliente",
+                    "grid_size_in_pixels": "Tamaño de la Grilla (en pixeles):",
                     "grid_color_set": "Color de la grilla:",
                     "fow_color_set": "Color de la niebla de guerra:",
                     "ruler_color_set": "Color de la regla:",
@@ -227,7 +228,6 @@
                 "GridSettings": {
                     "unit_size_in_UNIT": "Tamaño de Unidad (en {unit})",
                     "use_grid": "Usar Grilla",
-                    "grid_size_in_pixels": "Tamaño de la Grilla (en pixeles):",
                     "size_unit": "Unidad de longitud"
                 },
                 "location": {

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -140,6 +140,7 @@
                     "dm_options": "Опции для мастера",
                     "no_markers": "Нет маркеров",
                     "client_options": "Опции клиента",
+                    "grid_size_in_pixels": "Размер сетки (в пикселях):",
                     "grid_color_set": "Цвет сетки:",
                     "fow_color_set": "Цвет тумана войны:",
                     "ruler_color_set": "Цвет линейки:",
@@ -226,7 +227,6 @@
                 "GridSettings": {
                     "unit_size_in_UNIT": "Размер клетки (в {unit})",
                     "use_grid": "Использовать сетку",
-                    "grid_size_in_pixels": "Размер сетки (в пикселях):",
                     "size_unit": "Единица измерения"
                 },
                 "location": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -141,6 +141,7 @@
                     "dm_options": "DM选项",
                     "no_markers": "暂无记号",
                     "client_options": "客户端选项",
+                    "grid_size_in_pixels": "网格尺寸（像素）：",
                     "grid_color_set": "网格颜色：",
                     "fow_color_set": "迷雾颜色：",
                     "ruler_color_set": "直尺颜色：",
@@ -227,7 +228,6 @@
                 "GridSettings": {
                     "unit_size_in_UNIT": "单位尺寸（{unit}）",
                     "use_grid": "启用网格",
-                    "grid_size_in_pixels": "网格尺寸（像素）：",
                     "size_unit": "尺寸单位"
                 },
                 "location": {

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -34,6 +34,7 @@ async def set_client(sid: str, data: Dict[str, Any]):
             ("fowColour", "fow_colour"),
             ("rulerColour", "ruler_colour"),
             ("invertAlt", "invert_alt"),
+            ("gridSize", "grid_size"),
         ]:
             if option[0] in data:
                 setattr(pr.player, option[1], data[option[0]])

--- a/server/api/socket/location.py
+++ b/server/api/socket/location.py
@@ -209,7 +209,7 @@ async def change_location(sid: str, data: Dict[str, str]):
         for psid in game_state.get_sids(player=room_player.player, room=pr.room):
             await sio.emit("Location.Change.Start", room=psid, namespace=GAME_NS)
 
-    new_location = Location[data["location"]]
+    new_location = Location.get_by_id(data["location"])
 
     for room_player in pr.room.players:
         if not room_player.player.name in data["users"]:
@@ -237,7 +237,7 @@ async def set_location_options(sid: str, data: Dict[str, Any]):
     if data.get("location", None) is None:
         options = pr.room.default_options
     else:
-        loc = Location[data["location"]]
+        loc = Location.get_by_id(data["location"])
         if loc.options is None:
             loc.options = LocationOptions.create(
                 unit_size=None,
@@ -247,7 +247,6 @@ async def set_location_options(sid: str, data: Dict[str, Any]):
                 fow_opacity=None,
                 fow_los=None,
                 vision_mode=None,
-                grid_size=None,
                 vision_min_range=None,
                 vision_max_range=None,
             )
@@ -304,7 +303,7 @@ async def set_locations_order(sid: str, locations: List[int]):
         return
 
     for i, idx in enumerate(locations):
-        l: Location = Location[idx]
+        l: Location = Location.get_by_id(idx)
         l.index = i + 1
         l.save()
 
@@ -326,7 +325,7 @@ async def rename_location(sid: str, data: Dict[str, str]):
         logger.warning(f"{pr.player.name} attempted to rename a location.")
         return
 
-    location = Location[data["id"]]
+    location = Location.get_by_id(data["id"])
     location.name = data["new"]
     location.save()
 
@@ -344,7 +343,7 @@ async def delete_location(sid: str, location_id: int):
         logger.warning(f"{pr.player.name} attempted to rename a location.")
         return
 
-    location = Location[location_id]
+    location = Location.get_by_id(location_id)
 
     if location.players.count() > 0:
         logger.error(
@@ -364,12 +363,12 @@ async def get_location_spawn_info(sid: str, location_id: int):
         logger.warning(f"{pr.player.name} attempted to retrieve spawn locations.")
         return
 
-    location = Location[location_id]
+    location = Location.get_by_id(location_id)
 
     data = []
 
     for spawn in json.loads(location.options.spawn_locations):
-        shape = Shape[spawn]
+        shape = Shape.get_by_id(spawn)
         data.append(shape.as_dict(pr.player, True))
 
     await sio.emit("Location.Spawn.Info", data=data, room=sid, namespace=GAME_NS)

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -33,7 +33,6 @@ class LocationOptions(BaseModel):
     fow_opacity = FloatField(default=0.3, null=True)
     fow_los = BooleanField(default=False, null=True)
     vision_mode = TextField(default="triangle", null=True)
-    grid_size = IntegerField(default=50, null=True)
     # default is 1km max, 0.5km min
     vision_min_range = FloatField(default=1640, null=True)
     vision_max_range = FloatField(default=3281, null=True)

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -1,5 +1,5 @@
 import bcrypt
-from peewee import fn, BooleanField, ForeignKeyField, TextField
+from peewee import fn, BooleanField, ForeignKeyField, IntegerField, TextField
 from playhouse.shortcuts import model_to_dict
 
 from .base import BaseModel
@@ -16,6 +16,7 @@ class User(BaseModel):
     grid_colour = TextField(default="#000")
     ruler_colour = TextField(default="#F00")
     invert_alt = BooleanField(default=False)
+    grid_size = IntegerField(default=50)
 
     def __repr__(self):
         return f"<User {self.name}>"

--- a/server/save.py
+++ b/server/save.py
@@ -20,7 +20,7 @@ from models import ALL_MODELS, Constants
 from models.db import db
 from utils import OldVersionException, UnknownVersionException
 
-SAVE_VERSION = 35
+SAVE_VERSION = 36
 
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
@@ -556,6 +556,29 @@ def upgrade(version):
                 db.execute_sql(
                     f"UPDATE floor SET 'index' = (SELECT COUNT(*)-1 FROM floor f WHERE f.location_id = {location_id[0]} AND f.id <= floor.id ) WHERE location_id = {location_id[0]}"
                 )
+
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 35:
+        # Move grid size to client options
+        db.foreign_keys = False
+        with db.atomic():
+            db.execute_sql(
+                "CREATE TEMPORARY TABLE _location_options AS SELECT * FROM location_options"
+            )
+            db.execute_sql("DROP TABLE location_options")
+            db.execute_sql(
+                'CREATE TABLE "location_options" ("id" INTEGER NOT NULL PRIMARY KEY, "unit_size" REAL, "unit_size_unit" TEXT, "use_grid" INTEGER, "full_fow" INTEGER, "fow_opacity" REAL, "fow_los" INTEGER, "vision_mode" TEXT, "vision_min_range" REAL, "vision_max_range" REAL, "spawn_locations" TEXT NOT NULL DEFAULT "[]")'
+            )
+            db.execute_sql(
+                'CREATE INDEX IF NOT EXISTS "location_options_id" ON "location" ("options_id")'
+            )
+            db.execute_sql(
+                "INSERT INTO location_options (id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, vision_min_range, vision_max_range, spawn_locations) SELECT id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, vision_min_range, vision_max_range, spawn_locations FROM _location_options"
+            )
+            db.execute_sql(
+                "ALTER TABLE user ADD COLUMN grid_size INTEGER NOT NULL DEFAULT 50"
+            )
 
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()


### PR DESCRIPTION
The grid size (i.e. #pixels 1 grid cell takes) was a DM setting, but this is ultimately better suited as a client setting.  Different users have different computer screens, might be using a projector etc, which all call for different sizes.

This closes #460 