### PR TITLE
bug(UI): Fix mouseleave not always triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
 -   Degenerate cases in triangulation
     -   Triangulation code could hit a degenerate case when dealing with slight number differences in the order of 1e-15
     -   Now the triangulation code will only take the first 10 digits after the dot into consideration to prevent numerical instability.
+-   Mouseleave events where not triggered in some cases (e.g. alt tab), this could cause some shapes (e.g. rulers) to remain on the screen
 
 ## [0.21.0] - 2020-06-13
 

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -199,13 +199,10 @@ export default class Tools extends Vue {
         }
     }
     mouseleave(event: MouseEvent): void {
-        // When leaving the window while a mouse is pressed down, act as if it was released
-        if ((event.buttons & 1) !== 0) {
-            const tool = this.componentMap[this.currentTool];
-            tool.onMouseUp(event, this.getFeatures(this.currentTool));
-            for (const permitted of tool.permittedTools)
-                this.componentMap[permitted.name].onMouseUp(event, permitted.features);
-        }
+        const tool = this.componentMap[this.currentTool];
+        tool.onMouseUp(event, this.getFeatures(this.currentTool));
+        for (const permitted of tool.permittedTools)
+            this.componentMap[permitted.name].onMouseUp(event, permitted.features);
     }
     contextmenu(event: MouseEvent): void {
         if ((<HTMLElement>event.target).tagName !== "CANVAS") return;


### PR DESCRIPTION
In some cases mouseleave would not be triggered (e.g. alt tabbing), which caused some shapes to remain on screen (e.g. rulers).

This might solve some of the issues in #278 