### PR TITLE
feat(UI): Show floor selector ordered from upper to lower floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
     -   Shape movement now sends less data to server
     -   Pan now only updates the visible floors on move and full recalculate on release
 -   Grid pixel size is now a client setting instead of a DM setting
+-   Show floor selector in the more logical order from upper to lower floors
 
 ### Fixed
 

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -108,7 +108,7 @@ export default class FloorSelect extends Vue {
             <a href="#">{{ selectedFloorIndex }}</a>
         </div>
         <div id="floor-detail" v-if="selected">
-            <template v-for="[index, floor] of floors">
+            <template v-for="[index, floor] of [...floors].reverse()">
                 <div class="floor-row" :key="floor.name" @click="selectFloor(floor)">
                     <div class="floor-index">
                         <template v-if="index == selectedFloorIndex">></template>


### PR DESCRIPTION
This changes the order in which the floors were enumerated in the floor selector.  It now matches the direction in which page up/down work as well as the logical stacking of floors on top of eachother.

This closes #461 