### PR TITLE
bug(Map): Fix map resize not replicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
     -   Triangulation code could hit a degenerate case when dealing with slight number differences in the order of 1e-15
     -   Now the triangulation code will only take the first 10 digits after the dot into consideration to prevent numerical instability.
 -   Mouseleave events where not triggered in some cases (e.g. alt tab), this could cause some shapes (e.g. rulers) to remain on the screen
+-   Map tool resize does not replicate
 
 ## [0.21.0] - 2020-06-13
 

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -16,6 +16,7 @@ import { Shape } from "@/game/shapes/shape";
 import { ToolBasics } from "./ToolBasics";
 import { floorStore } from "@/game/layers/store";
 import { gameStore } from "../../store";
+import { socket } from "@/game/api/socket";
 
 @Component
 export default class MapTool extends Tool implements ToolBasics {
@@ -77,6 +78,8 @@ export default class MapTool extends Tool implements ToolBasics {
             const delta = oldCenter.subtract(oldRefpoint);
             const newCenter = oldRefpoint.add(new Vector(xFactor * delta.x, yFactor * delta.y));
             this.shape.refPoint = this.shape.refPoint.add(oldCenter.subtract(newCenter));
+
+            socket.emit("Shape.Update", { shape: this.shape.asDict(), redraw: false, temporary: false });
         }
         this.removeRect();
     }


### PR DESCRIPTION
#311 reproducible after PR #451 event-improvements.

Make map tool call `Shape.Update` in `apply()` might fix this.

*Needs further investigation*