### PR TITLE
Fix snap to grid and keyboard move

### DIFF
--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -2,7 +2,7 @@ import { sendClientOptions } from "@/game/api/utils";
 import { Vector } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { copyShapes, deleteShapes, pasteShapes } from "@/game/shapes/utils";
-import { gameStore } from "@/game/store";
+import { gameStore, DEFAULT_GRID_SIZE } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
@@ -38,7 +38,7 @@ export function onKeyDown(event: KeyboardEvent): void {
         if (event.keyCode >= 37 && event.keyCode <= 40) {
             // Arrow keys - move the selection or the camera
             // todo: this should already be rounded
-            const gridSize = Math.round(gameStore.gridSize);
+            const gridSize = DEFAULT_GRID_SIZE;
             let offsetX = gridSize * (event.keyCode % 2);
             let offsetY = gridSize * (event.keyCode % 2 ? 0 : 1);
             if (layerManager.hasSelection()) {

--- a/client/src/game/shapes/baserect.ts
+++ b/client/src/game/shapes/baserect.ts
@@ -4,7 +4,7 @@ import { Shape } from "@/game/shapes/shape";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { clampGridLine, g2lx, g2ly } from "@/game/units";
 import { ServerShape } from "../comm/types/shapes";
-import { gameStore } from "../store";
+import { DEFAULT_GRID_SIZE } from "../store";
 import { rotateAroundPoint } from "../utils";
 
 export abstract class BaseRect extends Shape {
@@ -71,7 +71,7 @@ export abstract class BaseRect extends Shape {
         return false;
     }
     snapToGrid(): void {
-        const gs = gameStore.gridSize;
+        const gs = DEFAULT_GRID_SIZE;
         const center = this.center();
         const mx = center.x;
         const my = center.y;

--- a/client/src/game/shapes/circle.ts
+++ b/client/src/game/shapes/circle.ts
@@ -5,7 +5,7 @@ import { Shape } from "@/game/shapes/shape";
 import { calculateDelta } from "@/game/ui/tools/utils";
 import { clampGridLine, g2lz } from "@/game/units";
 import { getFogColour } from "@/game/utils";
-import { gameStore } from "../store";
+import { DEFAULT_GRID_SIZE } from "../store";
 
 export class Circle extends Shape {
     type = "circle";
@@ -71,7 +71,7 @@ export class Circle extends Shape {
         return this.getBoundingBox().visibleInCanvas(canvas);
     }
     snapToGrid(): void {
-        const gs = gameStore.gridSize;
+        const gs = DEFAULT_GRID_SIZE;
         let targetX;
         let targetY;
         if (((2 * this.r) / gs) % 2 === 0) {
@@ -89,7 +89,7 @@ export class Circle extends Shape {
         this.invalidate(false);
     }
     resizeToGrid(): void {
-        const gs = gameStore.gridSize;
+        const gs = DEFAULT_GRID_SIZE;
         this.r = Math.max(clampGridLine(this.r), gs / 2);
         this.invalidate(false);
     }

--- a/client/src/game/units.ts
+++ b/client/src/game/units.ts
@@ -1,5 +1,5 @@
 import { GlobalPoint, LocalPoint, Ray } from "@/game/geom";
-import { gameStore } from "@/game/store";
+import { gameStore, DEFAULT_GRID_SIZE } from "@/game/store";
 import { gameSettingsStore } from "./settings";
 
 export function g2l(obj: GlobalPoint): LocalPoint {
@@ -59,7 +59,7 @@ export function l2gr(r: number): number {
 }
 
 export function clampGridLine(point: number): number {
-    return Math.round(point / gameStore.gridSize) * gameStore.gridSize;
+    return Math.round(point / DEFAULT_GRID_SIZE) * DEFAULT_GRID_SIZE;
 }
 
 (<any>window).g2lx = g2lx;


### PR DESCRIPTION
 - `snapToGrid`/`resizeToGrid` used grid size in client options instead of default grid size (50), make it snap incorrectly.
 - arrow keys moving shapes used client set grid size too.

This PR fixed these two incorrect behaviors by changing to `DEFAULT_GRID_SIZE` from `gameStore`.