### PR TITLE
[FEAT] Dragging asset while pressing shift key scales it to one grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 -   Shape lock/unlock toggle
     -   Show lock/unlock icon on the selection_info component for quick edit
     -   Only players with edit access can toggle
+-   Dragging asset while pressing 'shift' now scales the shape to fit inside one grid
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 -   Shape lock/unlock toggle
     -   Show lock/unlock icon on the selection_info component for quick edit
     -   Only players with edit access can toggle
--   Dragging asset while pressing 'shift' now scales the shape to fit inside one grid
+-   Dragging asset while pressing 'ctrl' now scales the shape to fit inside one grid
 
 ### Changed
 

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -97,7 +97,7 @@ export function dropAsset(event: DragEvent): void {
         const gs = DEFAULT_GRID_SIZE;
         asset.refPoint = new GlobalPoint(clampGridLine(asset.refPoint.x), clampGridLine(asset.refPoint.y));
 
-        if (event.shiftKey) {
+        if (event.ctrlKey) {
             const ratio = DEFAULT_GRID_SIZE / Math.max(asset.w, asset.h);
             asset.w *= ratio;
             asset.h *= ratio;

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -15,7 +15,7 @@ import { floorStore } from "./store";
 import { Floor } from "./floor";
 import { Shape } from "../shapes/shape";
 import { socket } from "../api/socket";
-import { gameStore } from "../store";
+import { DEFAULT_GRID_SIZE } from "../store";
 
 export function addFloor(serverFloor: ServerFloor): void {
     const floor = { name: serverFloor.name, playerVisible: serverFloor.player_visible };
@@ -94,10 +94,17 @@ export function dropAsset(event: DragEvent): void {
     asset.src = new URL(image.src).pathname;
 
     if (gameSettingsStore.useGrid) {
-        const gs = gameStore.gridSize;
+        const gs = DEFAULT_GRID_SIZE;
         asset.refPoint = new GlobalPoint(clampGridLine(asset.refPoint.x), clampGridLine(asset.refPoint.y));
-        asset.w = Math.max(clampGridLine(asset.w), gs);
-        asset.h = Math.max(clampGridLine(asset.h), gs);
+
+        if (event.shiftKey) {
+            const ratio = DEFAULT_GRID_SIZE / Math.max(asset.w, asset.h);
+            asset.w *= ratio;
+            asset.h *= ratio;
+        } else {
+            asset.w = Math.max(clampGridLine(asset.w), gs);
+            asset.h = Math.max(clampGridLine(asset.h), gs);
+        }
     }
 
     layer.addShape(asset, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);


### PR DESCRIPTION
Makes it easier to drag and drop tokens. And it will keep the aspect ratio.