### PR TITLE
bugfix(Rotation): Fix resizing of rotated shapes and some other rotation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
     -   Now the triangulation code will only take the first 10 digits after the dot into consideration to prevent numerical instability.
 -   Mouseleave events where not triggered in some cases (e.g. alt tab), this could cause some shapes (e.g. rulers) to remain on the screen
 -   Map tool resize does not replicate
+-   Center calculation polygons with repeated points
 
 ## [0.21.0] - 2020-06-13
 

--- a/client/src/game/shapes/baserect.ts
+++ b/client/src/game/shapes/baserect.ts
@@ -106,9 +106,12 @@ export abstract class BaseRect extends Shape {
         );
     }
     resize(resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean): number {
+        point = rotateAroundPoint(point, this.center(), -this.angle);
+
         const aspectRatio = this.w / this.h;
         const oldW = this.w;
         const oldH = this.h;
+        const oldPoints = this.points;
 
         switch (resizePoint) {
             case 0: {
@@ -164,6 +167,15 @@ export abstract class BaseRect extends Shape {
             }
         }
 
-        return (resizePoint + 4) % 4;
+        const newResizePoint = (resizePoint + 4) % 4;
+        const oppositeNRP = (newResizePoint + 2) % 4;
+
+        const vec = Vector.fromPoints(
+            GlobalPoint.fromArray(this.points[oppositeNRP]),
+            GlobalPoint.fromArray(oldPoints[oppositeNRP]),
+        );
+        this.refPoint = this.refPoint.add(vec);
+
+        return newResizePoint;
     }
 }

--- a/client/src/game/shapes/boundingrect.ts
+++ b/client/src/game/shapes/boundingrect.ts
@@ -31,6 +31,7 @@ export class BoundingRect {
     }
 
     contains(point: GlobalPoint): boolean {
+        if (this.angle !== 0) point = rotateAroundPoint(point, this.center(), -this.angle);
         return (
             this.topLeft.x <= point.x &&
             this.topRight.x >= point.x &&
@@ -109,8 +110,15 @@ export class BoundingRect {
         return { hit: txmin < ray.tMax && txmax > 0, min: txmin, max: txmax };
     }
 
-    center(): GlobalPoint {
-        return this.topLeft.add(new Vector(this.w / 2, this.h / 2));
+    center(): GlobalPoint;
+    center(centerPoint: GlobalPoint): BoundingRect;
+    center(centerPoint?: GlobalPoint): GlobalPoint | BoundingRect {
+        if (centerPoint === undefined) return this.topLeft.add(new Vector(this.w / 2, this.h / 2));
+        return new BoundingRect(
+            new GlobalPoint(centerPoint.x - this.w / 2, centerPoint.y - this.h / 2),
+            this.w,
+            this.h,
+        );
     }
 
     getMaxExtent(): 0 | 1 {

--- a/client/src/game/shapes/polygon.ts
+++ b/client/src/game/shapes/polygon.ts
@@ -42,6 +42,10 @@ export class Polygon extends Shape {
         return [this._refPoint, ...this._vertices];
     }
 
+    get uniqueVertices(): GlobalPoint[] {
+        return this.vertices.filter((val, i, arr) => arr.findIndex(t => t.equals(val)) === i);
+    }
+
     asDict(): ServerPolygon {
         return Object.assign(this.getBaseDict(), {
             vertices: this._vertices.map(v => v.asArray()),
@@ -116,9 +120,10 @@ export class Polygon extends Shape {
     center(centerPoint: GlobalPoint): void;
     center(centerPoint?: GlobalPoint): GlobalPoint | void {
         if (centerPoint === undefined) {
-            const vertexAvg = this.vertices
+            const unique = this.uniqueVertices;
+            const vertexAvg = unique
                 .reduce((acc: Vector, val: GlobalPoint) => acc.add(new Vector(val.x, val.y)), new Vector(0, 0))
-                .multiply(1 / this.vertices.length);
+                .multiply(1 / unique.length);
             return GlobalPoint.fromArray([...vertexAvg]);
         }
         const oldCenter = this.center();

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -162,7 +162,7 @@ export abstract class Shape {
     // abstract rotateAround(point: GlobalPoint, angle: number): void;
     rotateAround(point: GlobalPoint, angle: number): void {
         const center = this.center();
-        this.center(rotateAroundPoint(center, point, angle));
+        if (!point.equals(center)) this.center(rotateAroundPoint(center, point, angle));
         this.angle += angle;
         this.updatePoints();
     }

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -125,7 +125,7 @@ export default class SelectTool extends Tool implements ToolBasics {
                     break;
                 }
             }
-            if (shape.contains(rotateAroundPoint(gp, shape.center(), -shape.angle))) {
+            if (shape.contains(gp)) {
                 if (layer.getSelection().indexOf(shape) === -1) {
                     if (event.ctrlKey) {
                         layer.pushSelection(shape);
@@ -320,11 +320,12 @@ export default class SelectTool extends Tool implements ToolBasics {
                 if (!shape.ownedBy({ movementAccess: true })) continue;
                 const bbox = shape.getBoundingBox();
                 if (!shape.ownedBy({ movementAccess: true })) continue;
+                const topLeft = rotateAroundPoint(this.selectionHelper!.refPoint, bbox.center(), -bbox.angle);
                 if (
-                    this.selectionHelper!.refPoint.x <= bbox.topRight.x &&
-                    this.selectionHelper!.refPoint.x + this.selectionHelper!.w >= bbox.topLeft.x &&
-                    this.selectionHelper!.refPoint.y <= bbox.botLeft.y &&
-                    this.selectionHelper!.refPoint.y + this.selectionHelper!.h >= bbox.topLeft.y
+                    topLeft.x <= bbox.topRight.x &&
+                    topLeft.x + this.selectionHelper!.w >= bbox.topLeft.x &&
+                    topLeft.y <= bbox.botLeft.y &&
+                    topLeft.y + this.selectionHelper!.h >= bbox.topLeft.y
                 ) {
                     if (selection.find(it => it === shape) === undefined) {
                         layer.pushSelection(shape);

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -273,7 +273,8 @@ export default class SelectTool extends Tool implements ToolBasics {
                     else this.snappedToPoint = false;
                     this.resizePoint = sel.resize(
                         this.resizePoint,
-                        rotateAroundPoint(targetPoint, this.rotationBox!.center(), -this.angle),
+                        targetPoint,
+                        // rotateAroundPoint(targetPoint, this.rotationBox!.center(), -this.angle),
                         event.ctrlKey,
                     );
                     // todo: think about calling deleteIntersectVertex directly on the corner point

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -446,8 +446,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             if (recalcMovement) visibilityStore.recalculateMovement(selection[0].floor.name);
             layer.invalidate(false);
 
-            if (this.mode === SelectOperations.Rotate) this.updateRotationUi(features);
-            else {
+            if (this.mode !== SelectOperations.Rotate) {
                 this.removeRotationUi();
                 this.createRotationUi(features);
             }
@@ -568,41 +567,6 @@ export default class SelectTool extends Tool implements ToolBasics {
             layer.removeShape(this.rotationEnd!, SyncMode.NO_SYNC);
             this.rotationAnchor = this.rotationBox = this.rotationEnd = null;
             this.rotationUiActive = false;
-
-            layer.invalidate(true);
-        }
-    }
-
-    updateRotationUi(features: ToolFeatures<SelectFeatures>): void {
-        const layer = floorStore.currentLayer!;
-
-        if (
-            layer.getSelection().length > 0 &&
-            !this.rotationUiActive &&
-            this.hasFeature(SelectFeatures.Rotate, features)
-        ) {
-            this.createRotationUi(features);
-        } else if (this.rotationUiActive) {
-            const selection = layer.getSelection();
-
-            let bbox: BoundingRect;
-            if (selection.length === 1) {
-                bbox = selection[0].getBoundingBox();
-            } else {
-                bbox = selection
-                    .map(s => s.getBoundingBox().rotateAroundAbsolute(this.rotationBox!.center(), 0))
-                    .reduce((acc: BoundingRect, val: BoundingRect) => acc.union(val))
-                    .expand(new Vector(-50, -50))
-                    .rotateAroundAbsolute(this.rotationBox!.center(), this.angle);
-            }
-
-            this.rotationBox!.angle = this.angle;
-            this.rotationAnchor!.rotateAroundAbsolute(bbox.center(), this.angle);
-            this.rotationEnd!.rotateAroundAbsolute(bbox.center(), this.angle);
-
-            for (const rotationShape of [this.rotationAnchor, this.rotationBox, this.rotationEnd]) {
-                rotationShape!.updatePoints();
-            }
 
             layer.invalidate(true);
         }

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -13,7 +13,7 @@ import { Rect } from "@/game/shapes/rect";
 import { gameStore } from "@/game/store";
 import { calculateDelta, ToolName, ToolFeatures } from "@/game/ui/tools/utils";
 import { g2l, g2lx, g2ly, l2g, l2gz } from "@/game/units";
-import { getLocalPointFromEvent, useSnapping, equalPoints } from "@/game/utils";
+import { getLocalPointFromEvent, useSnapping, equalPoints, rotateAroundPoint } from "@/game/utils";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { gameSettingsStore } from "../../settings";
@@ -271,7 +271,11 @@ export default class SelectTool extends Tool implements ToolBasics {
                     if (useSnapping(event) && this.hasFeature(SelectFeatures.Snapping, features))
                         [targetPoint, this.snappedToPoint] = snapToPoint(floorStore.currentLayer!, gp, ignorePoint);
                     else this.snappedToPoint = false;
-                    this.resizePoint = sel.resize(this.resizePoint, targetPoint, event.ctrlKey);
+                    this.resizePoint = sel.resize(
+                        this.resizePoint,
+                        rotateAroundPoint(targetPoint, this.rotationBox!.center(), -this.angle),
+                        event.ctrlKey,
+                    );
                     // todo: think about calling deleteIntersectVertex directly on the corner point
                     if (sel.visionObstruction) {
                         visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: sel });

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -125,7 +125,7 @@ export default class SelectTool extends Tool implements ToolBasics {
                     break;
                 }
             }
-            if (shape.contains(gp)) {
+            if (shape.contains(rotateAroundPoint(gp, shape.center(), -shape.angle))) {
                 if (layer.getSelection().indexOf(shape) === -1) {
                     if (event.ctrlKey) {
                         layer.pushSelection(shape);

--- a/client/src/game/utils.ts
+++ b/client/src/game/utils.ts
@@ -54,6 +54,7 @@ export function useSnapping(event: MouseEvent | TouchEvent): boolean {
 }
 
 export function rotateAroundPoint(point: GlobalPoint, center: GlobalPoint, angle: number): GlobalPoint {
+    if (angle === 0) return point;
     if (equalPoints([...center], [...point])) return point;
 
     const c = Math.cos(angle);

--- a/client/src/game/utils.ts
+++ b/client/src/game/utils.ts
@@ -1,4 +1,4 @@
-import { LocalPoint, GlobalPoint } from "@/game/geom";
+import { GlobalPoint, LocalPoint, Vector } from "@/game/geom";
 import tinycolor from "tinycolor2";
 import { gameSettingsStore } from "./settings";
 import { gameStore } from "./store";
@@ -62,4 +62,15 @@ export function rotateAroundPoint(point: GlobalPoint, center: GlobalPoint, angle
         c * (point.x - center.x) - s * (point.y - center.y) + center.x,
         s * (point.x - center.x) + c * (point.y - center.y) + center.y,
     );
+}
+
+export function filterEqualPoints(points: GlobalPoint[]): GlobalPoint[] {
+    return points.filter((val, i, arr) => arr.findIndex(t => t.equals(val)) === i);
+}
+
+export function getPointsCenter(points: GlobalPoint[]): GlobalPoint {
+    const vertexAvg = points
+        .reduce((acc: Vector, val: GlobalPoint) => acc.add(new Vector(val.x, val.y)), new Vector(0, 0))
+        .multiply(1 / points.length);
+    return GlobalPoint.fromArray([...vertexAvg]);
 }

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -51,7 +51,7 @@ class Shape(BaseModel):
     is_invisible = BooleanField(default=False)
     default_movement_access = BooleanField(default=False)
     is_locked = BooleanField(default=False)
-    angle = IntegerField(default=0)
+    angle = FloatField(default=0)
     stroke_width = IntegerField(default=2)
 
     def __repr__(self):

--- a/server/save.py
+++ b/server/save.py
@@ -20,7 +20,7 @@ from models import ALL_MODELS, Constants
 from models.db import db
 from utils import OldVersionException, UnknownVersionException
 
-SAVE_VERSION = 37
+SAVE_VERSION = 38
 
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
@@ -598,6 +598,30 @@ def upgrade(version):
                     )
                 except json.decoder.JSONDecodeError:
                     print(f"Failed to update polygon vertices! {row}")
+
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 37:
+        # Change shape.angle from integer field to float field
+        db.foreign_keys = False
+        with db.atomic():
+            db.execute_sql("CREATE TEMPORARY TABLE _shape AS SELECT * FROM shape")
+            db.execute_sql("DROP TABLE shape")
+            db.execute_sql(
+                'CREATE TABLE IF NOT EXISTS "shape" ("uuid" TEXT NOT NULL PRIMARY KEY, "layer_id" INTEGER NOT NULL, "type_" TEXT NOT NULL, "x" REAL NOT NULL, "y" REAL NOT NULL, "name" TEXT, "name_visible" INTEGER NOT NULL, "fill_colour" TEXT NOT NULL, "stroke_colour" TEXT NOT NULL, "vision_obstruction" INTEGER NOT NULL, "movement_obstruction" INTEGER NOT NULL, "is_token" INTEGER NOT NULL, "annotation" TEXT NOT NULL, "draw_operator" TEXT NOT NULL, "index" INTEGER NOT NULL, "options" TEXT, "badge" INTEGER NOT NULL, "show_badge" INTEGER NOT NULL, "default_edit_access" INTEGER NOT NULL, "default_vision_access" INTEGER NOT NULL, is_invisible INTEGER NOT NULL DEFAULT 0, default_movement_access INTEGER NOT NULL DEFAULT 0, is_locked INTEGER NOT NULL DEFAULT 0, angle REAL NOT NULL DEFAULT 0, stroke_width INTEGER NOT NULL DEFAULT 2, FOREIGN KEY ("layer_id") REFERENCES "layer" ("id") ON DELETE CASCADE)'
+            )
+            db.execute_sql('CREATE INDEX "shape_layer_id" ON "shape" ("layer_id")')
+            db.execute_sql(
+                "INSERT INTO shape (uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width) SELECT uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width FROM _shape"
+            )
+            db.execute_sql("CREATE TEMPORARY TABLE _text AS SELECT * FROM text")
+            db.execute_sql("DROP TABLE text")
+            db.execute_sql(
+                'CREATE TABLE IF NOT EXISTS "text" ("shape_id" TEXT NOT NULL PRIMARY KEY, "text" TEXT NOT NULL, "font" TEXT NOT NULL, FOREIGN KEY ("shape_id") REFERENCES "shape" ("uuid") ON DELETE CASCADE);'
+            )
+            db.execute_sql(
+                "INSERT INTO text (shape_id, text, font) SELECT shape_id, text, font FROM _text"
+            )
 
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()


### PR DESCRIPTION
It came to my attention last week that resizing/rescaling rotated shapes was fundamentally broken.

This PR fixes #476 as well as some other issues with rotated shapes:
- hit detection was done on the unrotated shape
- bounding box was not always shown correctly
- angles were stored as integers in the database which invalidated a whole set of angles.