### PR TITLE
Bug(Pan): Fix wrong behaviour when the mouse leaves the screen

### DIFF
--- a/client/src/game/ui/tools/pan.ts
+++ b/client/src/game/ui/tools/pan.ts
@@ -33,6 +33,7 @@ export default class PanTool extends Tool implements ToolBasics {
     }
 
     onUp(lp: LocalPoint): void {
+        if (!this.active) return;
         this.active = false;
         this.panScreen(lp, true);
         sendClientOptions(gameStore.locationUserOptions);


### PR DESCRIPTION
This PR fixes a bug introduced to a recent change to tool behaviour when the screen loses focus.  The pan tool was left behind with a small inconsistency compared to the other tools.  This fixes #488 