### PR TITLE
bug(Location): Fix shape not disappearing on location move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ All notable changes to this project will be documented in this file.
 -   Mouseleave events where not triggered in some cases (e.g. alt tab), this could cause some shapes (e.g. rulers) to remain on the screen
 -   Map tool resize does not replicate
 -   Center calculation polygons with repeated points
+-   Several bugs related to moving a shape to a different location
+    -   The shape now properly disappears on the old location
 
 ## [0.21.0] - 2020-06-13
 

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -508,10 +508,7 @@ async def move_shapes(sid: str, data: Dict[str, Any]):
 
     for psid, player in game_state.get_users(active_location=pr.active_location):
         await sio.emit(
-            "Shapes.Remove",
-            [sh.as_dict(player, player == pr.room.creator) for sh in shapes],
-            room=psid,
-            namespace=GAME_NS,
+            "Shapes.Remove", [sh.uuid for sh in shapes], room=psid, namespace=GAME_NS,
         )
 
     for shape in shapes:


### PR DESCRIPTION
When moving a shape to a different location, the shape was still available on the old location until a refresh of that location for each player.  This also affected some other things with that shape like initiative being broken.

This is now resolved and fixes #493 .