### PR TITLE
bug(Board): Restrict asset drop to /static images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ All notable changes to this project will be documented in this file.
 -   Map tool resize does not replicate
 -   Center calculation polygons with repeated points
 -   Location moved shape now properly disappears on the old location
+-   Asset drops on the game board that are not images located in /static are no longer accepted
+    -   This fixes the possible spam of "could not load image /game/..." in your console for future cases
+    -   A script has been added in the server/scripts folder to remove existing assets
 
 ## [0.21.0] - 2020-06-13
 

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -87,8 +87,10 @@ function createLayer(layerInfo: ServerLayer, floor: Floor): void {
 export function dropAsset(event: DragEvent): void {
     const layer = floorStore.currentLayer;
     if (layer === undefined || event === null || event.dataTransfer === null) return;
+    const src = event.dataTransfer.getData("text/plain");
+    if (!src.startsWith("/static")) return;
     const image = document.createElement("img");
-    image.src = event.dataTransfer.getData("text/plain");
+    image.src = src;
     const asset = new Asset(
         image,
         new GlobalPoint(l2gx(event.clientX), l2gy(event.clientY)),

--- a/server/scripts/remove_faulty_images.py
+++ b/server/scripts/remove_faulty_images.py
@@ -1,0 +1,24 @@
+"""
+This is a simple script responsible for removing assets that got added as assets to your game by dragging something (e.g. some html element) on the board.
+These should not trigger shape creation, but did in the past and would spam warnings in the console when drawing the game board.
+
+This script should in principle only be ran once after upgrading to 0.22.0. (or regularly if you are on an earlier version and annoyed by the messages).
+
+Usage: 
+"""
+import sys
+from pathlib import Path
+
+# Insert parent folder in the lookup
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from models import AssetRect
+
+
+def remove_assets():
+    removed = AssetRect.delete().where(AssetRect.src.startswith("/game/")).execute()
+    print(f"Removed {removed} assets that should not exist.")
+
+
+if __name__ == "__main__":
+    remove_assets()

--- a/server/scripts/remove_faulty_images.py
+++ b/server/scripts/remove_faulty_images.py
@@ -4,7 +4,7 @@ These should not trigger shape creation, but did in the past and would spam warn
 
 This script should in principle only be ran once after upgrading to 0.22.0. (or regularly if you are on an earlier version and annoyed by the messages).
 
-Usage: 
+Usage: `python remove_faulty_images.py` or `python scripts/remove_faulty_images.py` from the server folder
 """
 import sys
 from pathlib import Path


### PR DESCRIPTION
Asset drops on the game board that are not images located in /static are no longer accepted

-   This fixes the possible spam of "could not load image /game/..." in your console for future cases
-   A script has been added in the server/scripts folder to remove existing assets