### PR TITLE
feat(SpawnLocation): Allow spawn token removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   Multi spawn locations
-    -   When moving a shape to a new location that has multiple spawn locations, a box will appear to choose the desired spawn zone
+-   spawn location tweaks
+    -   Multi spawn locations
+        -   When moving a shape to a new location that has multiple spawn locations, a box will appear to choose the desired spawn zone
+    -   Removal of spawn locations is now possible
 
 # [0.22.2] - 2020-08-28
 

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -140,8 +140,11 @@ export class Layer {
             return false;
         }
         if (gameSettingsStore.currentLocationOptions.spawnLocations!.includes(shape.uuid)) {
-            console.error("attempted to remove spawn location");
-            return false;
+            gameSettingsStore.setSpawnLocations({
+                spawnLocations: gameSettingsStore.currentLocationOptions.spawnLocations!.filter(s => s !== shape.uuid),
+                location: gameSettingsStore.activeLocation,
+                sync: true,
+            });
         }
         this.shapes.splice(idx, 1);
 


### PR DESCRIPTION
This PR adds the ability to remove spawn tokens.  In the past this would cause issues, but now there are proper dialogs in place to inform if a location does not have spawn information.