### PR TITLE
feat(Location): Move tokens on location change

### DIFF
--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -68,6 +68,13 @@ export function setLocationOptions(id: number | null, options: Partial<ServerLoc
             visibilityStore.recalculateMovement(floor.id);
         }
     }
+    if (options.move_player_on_token_change !== undefined) {
+        gameSettingsStore.setMovePlayerOnTokenChange({
+            movePlayerOnTokenChange: options.move_player_on_token_change,
+            location: id,
+            sync: false,
+        });
+    }
     gameSettingsStore.setSpawnLocations({
         spawnLocations: JSON.parse(options.spawn_locations ?? "[]"),
         location: id,

--- a/client/src/game/comm/types/settings.ts
+++ b/client/src/game/comm/types/settings.ts
@@ -9,6 +9,7 @@ export interface ServerLocationOptions {
     vision_min_range: number;
     vision_max_range: number;
     spawn_locations: string;
+    move_player_on_token_change: boolean;
 }
 
 export interface LocationOptions {
@@ -22,6 +23,7 @@ export interface LocationOptions {
     visionMinRange: number;
     visionMaxRange: number;
     spawnLocations: string[];
+    movePlayerOnTokenChange: boolean;
 }
 
 export interface ServerClient extends EditableServerClient, LocationServerClient {
@@ -65,6 +67,8 @@ export const optionsToServer = (options: LocationOptions): ServerLocationOptions
     vision_max_range: options.visionMaxRange,
     // eslint-disable-next-line @typescript-eslint/camelcase
     spawn_locations: JSON.stringify(options.spawnLocations),
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    move_player_on_token_change: options.movePlayerOnTokenChange,
 });
 
 export const optionsToClient = (options: ServerLocationOptions): LocationOptions => ({
@@ -78,4 +82,5 @@ export const optionsToClient = (options: ServerLocationOptions): LocationOptions
     visionMinRange: options.vision_min_range,
     visionMaxRange: options.vision_max_range,
     spawnLocations: JSON.parse(options.spawn_locations),
+    movePlayerOnTokenChange: options.move_player_on_token_change,
 });

--- a/client/src/game/settings.ts
+++ b/client/src/game/settings.ts
@@ -98,6 +98,14 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
         return this.currentLocationOptions.spawnLocations ?? [];
     }
 
+    get movePlayerOnTokenChange(): boolean {
+        return (
+            this.currentLocationOptions.movePlayerOnTokenChange ??
+            this.defaultLocationOptions?.movePlayerOnTokenChange ??
+            false
+        );
+    }
+
     @Mutation
     reset(data: { key: keyof LocationOptions; location: number }): void {
         if (data.key in this.locationOptions[data.location]) {
@@ -226,6 +234,22 @@ class GameSettingsStore extends VuexModule implements GameSettingsState {
                 sendLocationOptions({
                     // eslint-disable-next-line @typescript-eslint/camelcase
                     options: { spawn_locations: JSON.stringify(data.spawnLocations) },
+                    location: data.location,
+                });
+        }
+    }
+
+    @Mutation
+    setMovePlayerOnTokenChange(data: {
+        movePlayerOnTokenChange: boolean;
+        location: number | null;
+        sync: boolean;
+    }): void {
+        if (mutateLocationOption("movePlayerOnTokenChange", data.movePlayerOnTokenChange, data.location)) {
+            if (data.sync)
+                sendLocationOptions({
+                    // eslint-disable-next-line @typescript-eslint/camelcase
+                    options: { move_player_on_token_change: data.movePlayerOnTokenChange },
                     location: data.location,
                 });
         }

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -19,7 +19,7 @@ import { Shape } from "@/game/shapes/shape";
 import { floorStore } from "../../layers/store";
 import { Floor } from "@/game/layers/floor";
 import { moveFloor, moveLayer } from "../../layers/utils";
-import { requestSpawnInfo } from "@/game/api/emits/location";
+import { requestSpawnInfo, sendLocationChange } from "@/game/api/emits/location";
 import { sendShapesMove } from "@/game/api/emits/shape/core";
 import SelectionBox from "@/core/components/modals/SelectionBox.vue";
 import { ServerAsset } from "@/game/comm/types/shapes";
@@ -148,6 +148,13 @@ export default class ShapeContext extends Vue {
             shapes: selection.map(s => s.uuid),
             target: { location: newLocation, ...targetLocation },
         });
+        if (gameSettingsStore.movePlayerOnTokenChange) {
+            const users: Set<string> = new Set();
+            for (const shape of selection) {
+                for (const owner of shape.owners) users.add(owner.user);
+            }
+            sendLocationChange({ location: newLocation, users: [...users] });
+        }
 
         this.close();
     }

--- a/client/src/game/ui/settings/GridSettings.vue
+++ b/client/src/game/ui/settings/GridSettings.vue
@@ -114,7 +114,7 @@ export default class GridSettings extends Vue {
 <style scoped>
 /* Force higher specificity without !important abuse */
 .panel.restore-panel {
-    grid-template-columns: [setting] 1fr [value] 1fr [restore] 30px [end];
+    grid-template-columns: [setting] 1fr [value] auto [restore] 30px [end];
 }
 
 .overwritten,

--- a/client/src/game/ui/settings/VariaSettings.vue
+++ b/client/src/game/ui/settings/VariaSettings.vue
@@ -1,0 +1,89 @@
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import { Prop } from "vue-property-decorator";
+
+import { gameSettingsStore, getLocationOption } from "../../settings";
+import { LocationOptions } from "../../comm/types/settings";
+
+@Component
+export default class VariaSettings extends Vue {
+    @Prop() location!: number | null;
+
+    get defaults(): LocationOptions {
+        return gameSettingsStore.defaultLocationOptions!;
+    }
+
+    get options(): Partial<LocationOptions> {
+        if (this.location === null) return this.defaults;
+        return gameSettingsStore.locationOptions[this.location] ?? {};
+    }
+
+    get movePlayerOnTokenChange(): boolean {
+        return getLocationOption("movePlayerOnTokenChange", this.location)!;
+    }
+    set movePlayerOnTokenChange(value: boolean) {
+        gameSettingsStore.setMovePlayerOnTokenChange({
+            movePlayerOnTokenChange: value,
+            location: this.location,
+            sync: true,
+        });
+    }
+
+    reset(key: keyof LocationOptions): void {
+        if (this.location === null) return;
+        gameSettingsStore.reset({ key, location: this.location });
+    }
+}
+</script>
+
+<template>
+    <div class="panel restore-panel">
+        <div class="spanrow">
+            <template v-if="location === null">
+                <em style="max-width: 40vw">
+                    {{ $t("game.ui.settings.common.overridden_msg") }}
+                </em>
+            </template>
+            <template v-else>
+                <i18n path="game.ui.settings.common.overridden_highlight_path" tag="span">
+                    <span class="overwritten">{{ $t("game.ui.settings.common.overridden_highlight") }}</span>
+                </i18n>
+            </template>
+        </div>
+        <div class="row" :class="{ overwritten: location !== null && options.movePlayerOnTokenChange !== undefined }">
+            <label
+                :for="'movePlayerOnTokenChangeInput-' + location"
+                v-t="'game.ui.settings.VariaSettings.movePlayerOnTokenChange'"
+            ></label>
+            <div>
+                <input
+                    :id="'movePlayerOnTokenChangeInput-' + location"
+                    type="checkbox"
+                    v-model="movePlayerOnTokenChange"
+                />
+            </div>
+            <div
+                v-if="location !== null && options.movePlayerOnTokenChange !== undefined"
+                @click="reset('movePlayerOnTokenChange')"
+                :title="$t('game.ui.settings.common.reset_default')"
+            >
+                <font-awesome-icon icon="times-circle" />
+            </div>
+            <div v-else></div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+/* Force higher specificity without !important abuse */
+.panel.restore-panel {
+    grid-template-columns: [setting] 1fr [value] auto [restore] 30px [end];
+}
+
+.overwritten,
+.restore-panel .row.overwritten * {
+    color: #7c253e;
+    font-weight: bold;
+}
+</style>

--- a/client/src/game/ui/settings/VisionSettings.vue
+++ b/client/src/game/ui/settings/VisionSettings.vue
@@ -213,7 +213,7 @@ export default class VisionSettings extends Vue {
 <style scoped>
 /* Force higher specificity without !important abuse */
 .panel.restore-panel {
-    grid-template-columns: [setting] 1fr [value] 1fr [restore] 30px [end];
+    grid-template-columns: [setting] 1fr [value] auto [restore] 30px [end];
 }
 
 .overwritten,

--- a/client/src/game/ui/settings/dm/DmSettings.vue
+++ b/client/src/game/ui/settings/dm/DmSettings.vue
@@ -9,6 +9,7 @@ import VisionSettings from "../VisionSettings.vue";
 
 import PanelModal from "../../../../core/components/modals/PanelModal.vue";
 import { EventBus } from "@/game/event-bus";
+import VariaSettings from "../VariaSettings.vue";
 
 @Component({
     components: {
@@ -16,6 +17,7 @@ import { EventBus } from "@/game/event-bus";
         GridSettings,
         // PermissionsDmSettings,
         PanelModal,
+        VariaSettings,
         VisionSettings,
     },
 })
@@ -37,6 +39,7 @@ export default class DmSettings extends Vue {
             this.$t("common.admin").toString(),
             this.$t("common.grid").toString(),
             this.$t("common.vision").toString(),
+            this.$t("common.varia").toString(),
         ];
     }
 }
@@ -49,6 +52,7 @@ export default class DmSettings extends Vue {
             <AdminSettings v-show="selection === 0"></AdminSettings>
             <GridSettings :location="null" v-show="selection === 1"></GridSettings>
             <VisionSettings :location="null" v-show="selection === 2"></VisionSettings>
+            <VariaSettings :location="null" v-show="selection === 3"></VariaSettings>
         </template>
     </PanelModal>
 </template>

--- a/client/src/game/ui/settings/location/LocationSettings.vue
+++ b/client/src/game/ui/settings/location/LocationSettings.vue
@@ -10,6 +10,7 @@ import VisionSettings from "../VisionSettings.vue";
 import PanelModal from "../../../../core/components/modals/PanelModal.vue";
 import { EventBus } from "@/game/event-bus";
 import { gameStore } from "@/game/store";
+import VariaSettings from "../VariaSettings.vue";
 
 @Component({
     components: {
@@ -17,6 +18,7 @@ import { gameStore } from "@/game/store";
         // PermissionsDmSettings,
         LocationAdminSettings,
         PanelModal,
+        VariaSettings,
         VisionSettings,
     },
 })
@@ -44,6 +46,7 @@ export default class LocationSettings extends Vue {
             this.$t("common.admin").toString(),
             this.$t("common.grid").toString(),
             this.$t("common.vision").toString(),
+            this.$t("common.varia").toString(),
         ];
     }
 }
@@ -62,6 +65,7 @@ export default class LocationSettings extends Vue {
             ></LocationAdminSettings>
             <GridSettings :location="location" v-show="selection === 1"></GridSettings>
             <VisionSettings :location="location" v-show="selection === 2"></VisionSettings>
+            <VariaSettings :location="location" v-show="selection === 3"></VariaSettings>
         </template>
     </PanelModal>
 </template>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -65,7 +65,8 @@
         "confirm": "Confirm",
         "cancel": "Cancel",
         "insert_one_character": "Please insert at least one character",
-        "name_already_in_use": "This name is already in use!"
+        "name_already_in_use": "This name is already in use!",
+        "varia": "Varia"
     },
     "auth": {
         "login": {
@@ -238,6 +239,9 @@
                     "unit_size_in_UNIT": "Unit Size (in {unit})",
                     "use_grid": "Use grid",
                     "size_unit": "Size Unit"
+                },
+                "VariaSettings": {
+                    "movePlayerOnTokenChange": "Move player(s) when a token they own changes location"
                 },
                 "location": {
                     "LocationAdminSettings": {

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -37,6 +37,7 @@ class LocationOptions(BaseModel):
     vision_min_range = FloatField(default=1640, null=True)
     vision_max_range = FloatField(default=3281, null=True)
     spawn_locations = TextField(default="[]")
+    move_player_on_token_change = BooleanField(default=True, null=True)
 
     def as_dict(self):
         return {

--- a/server/save.py
+++ b/server/save.py
@@ -20,7 +20,7 @@ from models import ALL_MODELS, Constants
 from models.db import db
 from utils import OldVersionException, UnknownVersionException
 
-SAVE_VERSION = 39
+SAVE_VERSION = 40
 
 logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
@@ -641,6 +641,16 @@ def upgrade(version):
                     )
                 except json.decoder.JSONDecodeError:
                     print(f"Failed to update polygon vertices! {row}")
+
+        db.foreign_keys = True
+        Constants.get().update(save_version=Constants.save_version + 1).execute()
+    elif version == 39:
+        # Add spawn locations
+        db.foreign_keys = False
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE location_options ADD COLUMN move_player_on_token_change INTEGER DEFAULT 1"
+            )
 
         db.foreign_keys = True
         Constants.get().update(save_version=Constants.save_version + 1).execute()


### PR DESCRIPTION
This adds a new DM/location setting that when enabled will automatically move a player along with a token if they own a token and the token is being moved to another location/spawn.

The setting will be enabled by default.

This closes #444.