### PR TITLE
bug(UI): Fix unlocking shape starting drag mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Run docker container as non-root
+-   Unlocking shape via quick menu no longer puts shape in drag mode
 
 ## [0.22.3] - 2020-08-30
 

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -311,6 +311,8 @@ export default class SelectTool extends Tool implements ToolBasics {
 
     onUp(_lp: LocalPoint, event: MouseEvent | TouchEvent, features: ToolFeatures<SelectFeatures>): void {
         if (!this.active) return;
+        this.active = false;
+
         if (floorStore.currentLayer === undefined) {
             console.log("No active layer!");
             return;
@@ -466,7 +468,6 @@ export default class SelectTool extends Tool implements ToolBasics {
             }
         }
         this.mode = SelectOperations.Noop;
-        this.active = false;
     }
 
     onContextMenu(event: MouseEvent, features: ToolFeatures<SelectFeatures>): void {


### PR DESCRIPTION
This fixes #504, where unlocking a shape using the quick selection info, would put the shape in drag mode.