### PR TITLE
feat(Ruler): Add snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   traditional chinese localization added
--   spawn location tweaks
+-   Traditional chinese localization added
+-   Spawn location tweaks
     -   Multi spawn locations
         -   When moving a shape to a new location that has multiple spawn locations, a box will appear to choose the desired spawn zone
     -   Removal of spawn locations is now possible
--   template system for assets
+-   Template system for assets
     -   Save shape state to its linked asset
     -   On asset drop, choose from the saved templates to prepopulate some fields
+-   Snapping support to the ruler
+    -   Snapping points are the grid corner points, center between two grid points and the complete center of a grid cell
 
 ### Fixed
 


### PR DESCRIPTION
This PR adds snapping behaviour to the ruler.  It follows all snapping rulers in regards to activating (i.e. alt key to alter the behaviour in your client settings).

It can snap to all grid line crossings, grid cell centers and the middle between each set of grid crossings.

This closes #485 