### PR TITLE
feat(SystemNotifications): Implement system notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ client/node_modules/**
 server/planarallyserver.log
 server/planar.save*
 server/planar.sqlite*
+server/save_backups
 server/server_config.cfg
 
 # These folders are all output directories for the vue client build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 [DM] denotes changes only useful for the dungeon master
-[tech] denotes technical changes
+[tech] denotes technical changes or changes specifically for the server owner.
+These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
@@ -22,7 +23,8 @@ All notable changes to this project will be documented in this file.
 -   Markdown support for shape annotations
 -   Italian localization added
 -   [tech] Server can now be hosted on a subpath e.g. somedomain.com/planarally-subpath
--   [tech] Server now also starts an extra admin api server that can be configured separately.
+-   [tech] Server now also starts an extra admin api server that can be configured separately
+-   [tech] API endpoint to create system notifications now exists
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,14 @@ These usually have no immediately visible impact on regular users
     -   Snapping points are the grid corner points, center between two grid points and the complete center of a grid cell
 -   Markdown support for shape annotations
 -   Italian localization added
+-   System notifications
+
+    -   These are custom notifications server owners can send out and will appear in a toast
+    -   By closing a notification you mark it as read and it will not show up any longer
+    -   [tech] Server now also starts an extra admin api server that can be configured separately
+    -   [tech] API endpoint to create system notifications now exists
+
 -   [tech] Server can now be hosted on a subpath e.g. somedomain.com/planarally-subpath
--   [tech] Server now also starts an extra admin api server that can be configured separately
--   [tech] API endpoint to create system notifications now exists
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 -   Annotation UI got a small change to better accomodate the new markdown support
 -   Landing page redesign
     -   register phase is now a seperate step with an optional email field
+-   [tech] During save upgrades, backups will now be stored in the saves_backup folder
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ All notable changes to this project will be documented in this file.
 -   Snapping support to the ruler
     -   Snapping points are the grid corner points, center between two grid points and the complete center of a grid cell
 -   Markdown support for shape annotations
--   [tech] Server can now be hosted on a subpath e.g. somedomain.com/planarally-subpath
 -   Italian localization added
+-   [tech] Server can now be hosted on a subpath e.g. somedomain.com/planarally-subpath
+-   [tech] Server now also starts an extra admin api server that can be configured separately.
 
 ### Changed
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -55,4 +55,9 @@ body,
 .toasted > svg:first-child {
     margin-right: 0.7rem;
 }
+
+body .toasted-container.top-left {
+    top: 1%;
+    left: 3%;
+}
 </style>

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -5,6 +5,7 @@ import "@/game/api/events/floor";
 import "@/game/api/events/initiative";
 import "@/game/api/events/labels";
 import "@/game/api/events/location";
+import "@/game/api/events/notification";
 import "@/game/api/events/room";
 import "@/game/api/events/shape/core";
 import "@/game/api/events/shape/options";

--- a/client/src/game/api/events/notification.ts
+++ b/client/src/game/api/events/notification.ts
@@ -1,0 +1,6 @@
+import { handleNotifications } from "../../../notifications";
+import { socket } from "../socket";
+
+socket.on("Notification.Show", (data: { uuid: string; message: string }) => {
+    handleNotifications([data]);
+});

--- a/client/src/notifications.ts
+++ b/client/src/notifications.ts
@@ -1,0 +1,34 @@
+import Vue from "vue";
+import { ToastObject } from "vue-toasted";
+
+export function handleNotifications(data: { uuid: string; message: string }[]): void {
+    const readNotifications: string[] = JSON.parse(localStorage.getItem("notifications-read") ?? "[]");
+
+    for (const notification of data) {
+        if (readNotifications.includes(notification.uuid)) continue;
+
+        Vue.toasted.show(notification.message, {
+            position: "top-left",
+            icon: "exclamation",
+            action: [
+                {
+                    text: "close",
+                    class: "black",
+                    onClick: (e: HTMLElement, t: ToastObject) => {
+                        t.goAway(0);
+                        markAsRead(notification.uuid);
+                    },
+                },
+            ],
+            onComplete: () => {
+                markAsRead(notification.uuid);
+            },
+        });
+    }
+}
+
+function markAsRead(uuid: string): void {
+    const readNotifications: string[] = JSON.parse(localStorage.getItem("notifications-read") ?? "[]");
+    readNotifications.push(uuid);
+    localStorage.setItem("notifications-read", JSON.stringify(readNotifications));
+}

--- a/server/api/http/__init__.py
+++ b/server/api/http/__init__.py
@@ -2,6 +2,7 @@ from aiohttp import web
 from aiohttp_security import check_authorized
 
 import api.http.auth
+import api.http.notifications
 import api.http.rooms
 import api.http.users
 import api.http.version

--- a/server/api/http/notifications.py
+++ b/server/api/http/notifications.py
@@ -1,0 +1,41 @@
+import uuid
+
+from aiohttp import web
+
+from models import Notification
+
+
+async def create(request: web.Request) -> web.Response:
+    data = await request.json()
+    message = data.get("message", None)
+    if message:
+        try:
+            notification = Notification.create(uuid=uuid.uuid4(), message=message)
+            notification.save()
+        except:
+            return web.HTTPServerError(reason="Failed to create new notification.")
+        return web.HTTPOk(text=f"Created new notification with id {notification.uuid}")
+    else:
+        return web.HTTPBadRequest(reason="Missing mandatory field 'message'")
+
+
+async def collect(request: web.Request) -> web.Response:
+    notifications = [
+        {"uuid": n.uuid, "message": n.message} for n in Notification.select()
+    ]
+    return web.json_response(notifications)
+
+
+async def delete(request: web.Request) -> web.Response:
+    uuid = request.match_info.get("uuid", None)
+    if uuid:
+        try:
+            notification = Notification.get_by_id(uuid)
+        except Notification.DoesNotExist:
+            return web.HTTPNotFound(
+                reason="Notification with given uuid was not found."
+            )
+        notification.delete_instance()
+        return web.HTTPOk(text=f"Removed notification with id {notification.uuid}")
+    else:
+        return web.HTTPBadRequest(reason="Missing uuid.")

--- a/server/app.py
+++ b/server/app.py
@@ -45,4 +45,4 @@ sio.attach(app)
 app["state"] = {}
 
 # API APP
-api_app = setup_app([JWTMiddleware(auth.get_api_token())])
+api_app = setup_app([auth.token_middleware])

--- a/server/app.py
+++ b/server/app.py
@@ -1,27 +1,48 @@
+from typing import Callable, Iterable, List, Type
+
 import aiohttp_jinja2
 import aiohttp_security
 import aiohttp_session
 import jinja2
 import socketio
 from aiohttp import web
+from aiohttp_jwt import JWTMiddleware
 from aiohttp_security import SessionIdentityPolicy
 from aiohttp_session.cookie_storage import EncryptedCookieStorage
 
 import auth
 from config import config
 
-# SETUP SERVER
+runners: List[web.AppRunner] = []
+
+
+def setup_app(middlewares: Iterable[Callable] = ()) -> web.Application:
+    app = web.Application(middlewares=middlewares)
+    app["AuthzPolicy"] = auth.AuthPolicy()
+    aiohttp_security.setup(app, SessionIdentityPolicy(), app["AuthzPolicy"])
+    aiohttp_session.setup(app, EncryptedCookieStorage(auth.get_secret_token()))
+    return app
+
+
+async def setup_runner(app: web.Application, site: Type[web.BaseSite], **kwargs):
+    runner = web.AppRunner(app)
+    runners.append(runner)
+    await runner.setup()
+    s = site(runner, **kwargs)
+    await s.start()
+
+
+# MAIN APP
 
 sio = socketio.AsyncServer(
     async_mode="aiohttp",
     engineio_logger=False,
     cors_allowed_origins=config.get("Webserver", "cors_allowed_origins", fallback=None),
 )
-app = web.Application()
-app["AuthzPolicy"] = auth.AuthPolicy()
-aiohttp_security.setup(app, SessionIdentityPolicy(), app["AuthzPolicy"])
-aiohttp_session.setup(app, EncryptedCookieStorage(auth.get_secret_token()))
+app = setup_app()
 aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader("templates"))
 sio.attach(app)
-
 app["state"] = {}
+
+# API APP
+api_app = setup_app([JWTMiddleware(auth.get_api_token())])

--- a/server/auth.py
+++ b/server/auth.py
@@ -52,3 +52,7 @@ def login_required(app, sio):
 
 def get_secret_token():
     return Constants.get().secret_token
+
+
+def get_api_token():
+    return Constants.get().api_token

--- a/server/auth.py
+++ b/server/auth.py
@@ -1,6 +1,9 @@
 import logging
-from aiohttp_security.abc import AbstractAuthorizationPolicy
 from functools import wraps
+from typing import Coroutine
+
+from aiohttp import web
+from aiohttp_security.abc import AbstractAuthorizationPolicy
 
 from models import Constants, User
 
@@ -56,3 +59,16 @@ def get_secret_token():
 
 def get_api_token():
     return Constants.get().api_token
+
+
+@web.middleware
+async def token_middleware(request: web.Request, handler):
+    try:
+        authorization = request.headers["Authorization"]
+    except KeyError:
+        raise web.HTTPUnauthorized(reason="Missing authorization header")
+
+    if authorization != f"Bearer {get_api_token()}":
+        raise web.HTTPForbidden(reason="Invalid authorization header.")
+
+    return await handler(request)

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -5,6 +5,7 @@ from .campaign import *
 from .general import *
 from .initiative import *
 from .label import *
+from .notifications import *
 from .shape import *
 from .signals import *
 from .user import *

--- a/server/models/general.py
+++ b/server/models/general.py
@@ -1,4 +1,4 @@
-from peewee import BlobField, IntegerField
+from peewee import BlobField, IntegerField, TextField
 
 from .base import BaseModel
 
@@ -9,3 +9,4 @@ __all__ = ["Constants"]
 class Constants(BaseModel):
     save_version = IntegerField()
     secret_token = BlobField()
+    api_token = TextField()

--- a/server/models/notifications.py
+++ b/server/models/notifications.py
@@ -10,4 +10,4 @@ class Notification(BaseModel):
     message = TextField()
 
     def __repr__(self):
-        return f"<Notification {self.uuid} {self.message[:15]}"
+        return f"<Notification {self.uuid} {self.message[:15]}>"

--- a/server/models/notifications.py
+++ b/server/models/notifications.py
@@ -1,0 +1,13 @@
+from peewee import ForeignKeyField, TextField
+
+from .base import BaseModel
+
+__all__ = ["Notification"]
+
+
+class Notification(BaseModel):
+    uuid = TextField(primary_key=True)
+    message = TextField()
+
+    def __repr__(self):
+        return f"<Notification {self.uuid} {self.message[:15]}"

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -37,17 +37,19 @@ from state.game import game_state
 # Force loading of socketio routes
 from api.socket import *
 from api.socket.constants import GAME_NS
-from app import app, sio
+from app import api_app, app as main_app, runners, setup_runner, sio
 from config import config
 from utils import logger
+
+loop = asyncio.get_event_loop()
 
 # This is a fix for asyncio problems on windows that make it impossible to do ctrl+c
 if sys.platform.startswith("win"):
 
     def _wakeup():
-        asyncio.get_event_loop().call_later(0.1, _wakeup)
+        loop.call_later(0.1, _wakeup)
 
-    asyncio.get_event_loop().call_later(0.1, _wakeup)
+    loop.call_later(0.1, _wakeup)
 
 
 async def on_shutdown(_):
@@ -55,39 +57,12 @@ async def on_shutdown(_):
         await sio.disconnect(sid, namespace=GAME_NS)
 
 
-subpath = os.environ.get("PA_BASEPATH", "/")
-if subpath[-1] != "/":
-    subpath = subpath + "/"
-app.router.add_static(f"{subpath}static", "static")
-app.router.add_get(f"{subpath}api/auth", api.http.auth.is_authed)
-app.router.add_post(f"{subpath}api/users/email", api.http.users.set_email)
-app.router.add_post(f"{subpath}api/users/password", api.http.users.set_password)
-app.router.add_post(f"{subpath}api/users/delete", api.http.users.delete_account)
-app.router.add_post(f"{subpath}api/login", api.http.auth.login)
-app.router.add_post(f"{subpath}api/register", api.http.auth.register)
-app.router.add_post(f"{subpath}api/logout", api.http.auth.logout)
-app.router.add_get(f"{subpath}api/rooms", api.http.rooms.get_list)
-app.router.add_post(f"{subpath}api/rooms", api.http.rooms.create)
-app.router.add_post(f"{subpath}api/invite", api.http.claim_invite)
-app.router.add_get(f"{subpath}api/version", api.http.version.get_version)
-app.router.add_get(f"{subpath}api/changelog", api.http.version.get_changelog)
-
-if "dev" in sys.argv:
-    app.router.add_route("*", "/{tail:.*}", routes.root_dev)
-else:
-    app.router.add_route("*", "/{tail:.*}", routes.root)
-
-app.on_shutdown.append(on_shutdown)
-
-
-def start_http(host, port):
+async def start_http(app: web.Application, host, port):
     logger.warning(" RUNNING IN NON SSL CONTEXT ")
-    web.run_app(
-        app, host=host, port=config.getint("Webserver", "port"),
-    )
+    await setup_runner(app, web.TCPSite, host=host, port=port)
 
 
-def start_https(host, port, chain, key):
+async def start_https(app: web.Application, host, port, chain, key):
     import ssl
 
     ctx = ssl.SSLContext()
@@ -97,33 +72,68 @@ def start_https(host, port, chain, key):
         logger.critical("SSL FILES ARE NOT FOUND. ABORTING LAUNCH.")
         sys.exit(2)
 
-    web.run_app(
-        app, host=host, port=port, ssl_context=ctx,
+    await setup_runner(
+        app, web.TCPSite, host=host, port=port, ssl_context=ctx,
     )
 
 
-def start_socket(sock):
-    web.run_app(app, path=sock)
+async def start_socket(app: web.Application, sock):
+    await setup_runner(app, web.UnixSite, path=sock)
 
 
-if __name__ == "__main__":
-    socket = config.get("Webserver", "socket", fallback=None)
+async def start_server(server_section: str):
+    socket = config.get(server_section, "socket", fallback=None)
+    app = main_app
+    method = "unknown"
+    if server_section == "APIserver":
+        app = api_app
+
     if socket:
-        start_socket(socket)
+        await start_socket(app, socket)
+        method = socket
     else:
-        host = config.get("Webserver", "host")
-        port = config.getint("Webserver", "port")
+        host = config.get(server_section, "host")
+        port = config.getint(server_section, "port")
 
-        if config.getboolean("Webserver", "ssl"):
+        if config.getboolean(server_section, "ssl"):
             try:
-                chain = config.get("Webserver", "ssl_fullchain")
-                key = config.get("Webserver", "ssl_privkey")
+                chain = config.get(server_section, "ssl_fullchain")
+                key = config.get(server_section, "ssl_privkey")
             except configparser.NoOptionError:
                 logger.critical(
                     "SSL CONFIGURATION IS NOT CORRECTLY CONFIGURED. ABORTING LAUNCH."
                 )
                 sys.exit(2)
 
-            start_https(host, port, chain, key)
+            await start_https(app, host, port, chain, key)
+            method = f"https://{host}:{port}"
         else:
-            start_http(host, port)
+            await start_http(app, host, port)
+            method = f"http://{host}:{port}"
+
+    print(f"======== Starting {server_section} on {method} ========")
+
+
+async def start_servers():
+    print()
+    await start_server("Webserver")
+    print()
+    await start_server("APIserver")
+    print()
+    print("(Press CTRL+C to quit)")
+    print()
+
+
+main_app.on_shutdown.append(on_shutdown)
+
+
+if __name__ == "__main__":
+    loop.create_task(start_servers())
+
+    try:
+        loop.run_forever()
+    except:
+        pass
+    finally:
+        for runner in runners:
+            loop.run_until_complete(runner.cleanup())

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,7 +1,6 @@
 jinja2==2.11.2
 aiohttp==3.6.2
 aiohttp_jinja2==1.2.0
-aiohttp_jwt==0.6.1
 aiohttp_security==0.4.0
 aiohttp_session==2.9.0
 bcrypt==3.1.7

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,7 @@
 jinja2==2.11.2
 aiohttp==3.6.2
 aiohttp_jinja2==1.2.0
+aiohttp_jwt==0.6.1
 aiohttp_security==0.4.0
 aiohttp_session==2.9.0
 bcrypt==3.1.7

--- a/server/routes.py
+++ b/server/routes.py
@@ -79,3 +79,11 @@ if "dev" in sys.argv:
     main_app.router.add_route("*", "/{tail:.*}", root_dev)
 else:
     main_app.router.add_route("*", "/{tail:.*}", root)
+
+# ADMIN ROUTES
+
+api_app.router.add_post(f"{subpath}api/notifications", api.http.notifications.create)
+api_app.router.add_get(f"{subpath}api/notifications", api.http.notifications.collect)
+api_app.router.add_delete(
+    f"{subpath}api/notifications/{{uuid}}", api.http.notifications.delete
+)

--- a/server/routes.py
+++ b/server/routes.py
@@ -74,6 +74,7 @@ main_app.router.add_post(f"{subpath}api/rooms", api.http.rooms.create)
 main_app.router.add_post(f"{subpath}api/invite", api.http.claim_invite)
 main_app.router.add_get(f"{subpath}api/version", api.http.version.get_version)
 main_app.router.add_get(f"{subpath}api/changelog", api.http.version.get_changelog)
+main_app.router.add_get(f"{subpath}api/notifications", api.http.notifications.collect)
 
 if "dev" in sys.argv:
     main_app.router.add_route("*", "/{tail:.*}", root_dev)

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,10 +1,13 @@
+import os
+import sys
+
 import aiohttp
 import aiohttp_jinja2
-
 from aiohttp import web
 from aiohttp_security import authorized_userid, check_authorized, forget, remember
 
-from app import app
+import api.http
+from app import api_app, app as main_app
 from models import Location, PlayerRoom, Room, User
 from models.db import db
 from models.role import Role
@@ -51,3 +54,28 @@ async def show_room(request):
 @aiohttp_jinja2.template("assets.jinja2")
 async def show_assets(request):
     await check_authorized(request)
+
+
+# MAIN ROUTES
+
+subpath = os.environ.get("PA_BASEPATH", "/")
+if subpath[-1] != "/":
+    subpath = subpath + "/"
+main_app.router.add_static(f"{subpath}static", "static")
+main_app.router.add_get(f"{subpath}api/auth", api.http.auth.is_authed)
+main_app.router.add_post(f"{subpath}api/users/email", api.http.users.set_email)
+main_app.router.add_post(f"{subpath}api/users/password", api.http.users.set_password)
+main_app.router.add_post(f"{subpath}api/users/delete", api.http.users.delete_account)
+main_app.router.add_post(f"{subpath}api/login", api.http.auth.login)
+main_app.router.add_post(f"{subpath}api/register", api.http.auth.register)
+main_app.router.add_post(f"{subpath}api/logout", api.http.auth.logout)
+main_app.router.add_get(f"{subpath}api/rooms", api.http.rooms.get_list)
+main_app.router.add_post(f"{subpath}api/rooms", api.http.rooms.create)
+main_app.router.add_post(f"{subpath}api/invite", api.http.claim_invite)
+main_app.router.add_get(f"{subpath}api/version", api.http.version.get_version)
+main_app.router.add_get(f"{subpath}api/changelog", api.http.version.get_changelog)
+
+if "dev" in sys.argv:
+    main_app.router.add_route("*", "/{tail:.*}", root_dev)
+else:
+    main_app.router.add_route("*", "/{tail:.*}", root)

--- a/server/save.py
+++ b/server/save.py
@@ -5,6 +5,7 @@ import secrets
 import shutil
 import sqlite3
 import sys
+from pathlib import Path
 
 from peewee import (
     BooleanField,
@@ -647,11 +648,15 @@ def check_save():
         updated = False
         while save_version != SAVE_VERSION:
             updated = True
-            logger.warning(
-                f"Backing up old save as {SAVE_FILE}.{constants.save_version}"
+            save_backups = Path("save_backups")
+            if not save_backups.is_dir():
+                save_backups.mkdir()
+            backup_path = (
+                save_backups.resolve() / f"{Path(SAVE_FILE).name}.{save_version}"
             )
-            shutil.copyfile(SAVE_FILE, f"{SAVE_FILE}.{constants.save_version}")
-            logger.warning(f"Starting upgrade to {constants.save_version + 1}")
+            logger.warning(f"Backing up old save as {backup_path}")
+            shutil.copyfile(SAVE_FILE, backup_path)
+            logger.warning(f"Starting upgrade to {save_version + 1}")
             try:
                 upgrade(save_version)
             except Exception as e:

--- a/server/save.py
+++ b/server/save.py
@@ -27,50 +27,27 @@ logger: logging.Logger = logging.getLogger("PlanarAllyServer")
 logger.setLevel(logging.INFO)
 
 
+def get_save_version():
+    return db.execute_sql("SELECT save_version FROM constants").fetchone()[0]
+
+
+def inc_save_version():
+    db.execute_sql("UPDATE constants SET save_version = save_version + 1")
+
+
 def upgrade(version):
-    if version < 16:
+    if version < 18:
         raise OldVersionException(
             f"Upgrade code for this version is >1 year old and is no longer in the active codebase to reduce clutter. You can still find this code on github, contact me for more info."
         )
-    elif version == 16:
+
+    db.foreign_keys = False
+
+    if version == 18:
         migrator = SqliteMigrator(db)
-        db.foreign_keys = False
-        with db.atomic():
-            migrate(
-                migrator.add_column(
-                    "location", "unit_size_unit", TextField(default="ft")
-                )
-            )
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
-    elif version == 17:
-        migrator = SqliteMigrator(db)
-        db.foreign_keys = False
-        with db.atomic():
-            migrate(
-                migrator.add_column(
-                    "polygon", "open_polygon", BooleanField(default=False)
-                ),
-                migrator.add_column("polygon", "line_width", IntegerField(default=2)),
-            )
-            db.execute_sql(
-                "INSERT INTO polygon (shape_id, line_width, vertices, open_polygon) SELECT shape_id, line_width, points, 1 FROM multi_line"
-            )
-            db.execute_sql("DROP TABLE multi_line")
-            db.execute_sql(
-                "UPDATE shape SET type_ = 'polygon' WHERE type_ = 'multiline'"
-            )
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
-    elif version == 18:
-        migrator = SqliteMigrator(db)
-        db.foreign_keys = False
         with db.atomic():
             migrate(migrator.add_column("user", "email", TextField(null=True)))
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 19:
-        db.foreign_keys = False
 
         db.execute_sql(
             'CREATE TABLE IF NOT EXISTS "floor" ("id" INTEGER NOT NULL PRIMARY KEY, "location_id" INTEGER NOT NULL, "name" TEXT, "index" INTEGER NOT NULL, FOREIGN KEY ("location_id") REFERENCES "location" ("id") ON DELETE CASCADE)'
@@ -80,47 +57,35 @@ def upgrade(version):
         )
 
         with db.atomic():
-            db.execute_sql("CREATE TEMPORARY TABLE _layer AS SELECT * FROM layer")
+            db.execute_sql("CREATE TEMPORARY TABLE _layer_19 AS SELECT * FROM layer")
             db.execute_sql("DROP TABLE layer")
             db.execute_sql(
                 'CREATE TABLE IF NOT EXISTS "layer" ("id" INTEGER NOT NULL PRIMARY KEY, "floor_id" INTEGER NOT NULL, "name" TEXT NOT NULL, "type_" TEXT NOT NULL, "player_visible" INTEGER NOT NULL, "player_editable" INTEGER NOT NULL, "selectable" INTEGER NOT NULL, "index" INTEGER NOT NULL, FOREIGN KEY ("floor_id") REFERENCES "floor" ("id") ON DELETE CASCADE)'
             )
             db.execute_sql(
-                'INSERT INTO layer (id, floor_id, name, type_, player_visible, player_editable, selectable, "index") SELECT _layer.id, floor.id, _layer.name, type_, player_visible, player_editable, selectable, _layer."index" FROM _layer INNER JOIN floor ON floor.location_id = _layer.location_id'
+                'INSERT INTO layer (id, floor_id, name, type_, player_visible, player_editable, selectable, "index") SELECT _layer_19.id, floor.id, _layer_19.name, type_, player_visible, player_editable, selectable, _layer_19."index" FROM _layer_19 INNER JOIN floor ON floor.location_id = _layer_19.location_id'
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 20:
         migrator = SqliteMigrator(db)
-        db.foreign_keys = False
         with db.atomic():
             migrate(
                 migrator.add_column("shape", "badge", IntegerField(default=1)),
                 migrator.add_column("shape", "show_badge", BooleanField(default=False)),
             )
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 21:
         migrator = SqliteMigrator(db)
-        db.foreign_keys = False
         with db.atomic():
             migrate(
                 migrator.add_column("user", "invert_alt", BooleanField(default=False))
             )
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 22:
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 'CREATE TABLE IF NOT EXISTS "marker" ("id" INTEGER NOT NULL PRIMARY KEY, "shape_id" TEXT NOT NULL, "user_id" INTEGER NOT NULL, "location_id" INTEGER NOT NULL, FOREIGN KEY ("shape_id") REFERENCES "shape"("uuid") ON DELETE CASCADE, FOREIGN KEY ("location_id") REFERENCES "location" ("id") ON DELETE CASCADE, FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE)'
             )
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 23:
         migrator = SqliteMigrator(db)
-        db.foreign_keys = False
         with db.atomic():
             migrate(
                 migrator.add_column(
@@ -136,16 +101,11 @@ def upgrade(version):
                     "shape", "default_vision_access", BooleanField(default=False)
                 ),
             )
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 24:
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 'DELETE FROM "player_room" WHERE id IN (SELECT pr.id FROM "player_room" pr INNER JOIN "room" r ON r.id = pr.room_id WHERE r.creator_id = pr.player_id )'
             )
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 25:
         # Move Room.dm_location and Room.player_location to PlayerRoom.active_location
         # Add PlayerRoom.role
@@ -153,7 +113,6 @@ def upgrade(version):
         from models import Location
 
         migrator = SqliteMigrator(db)
-        db.foreign_keys = False
         with db.atomic():
             migrate(
                 migrator.add_column(
@@ -185,8 +144,6 @@ def upgrade(version):
                 migrator.add_not_null("player_room", "active_location_id"),
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 26:
         # Move Location settings to a separate LocationSettings table
         # Add a default_settings field to Room that refers to such a LocationSettings row
@@ -194,7 +151,6 @@ def upgrade(version):
 
         migrator = SqliteMigrator(db)
 
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 'CREATE TABLE IF NOT EXISTS "location_options" ("id" INTEGER NOT NULL PRIMARY KEY, "unit_size" REAL DEFAULT 5, "unit_size_unit" TEXT DEFAULT "ft", "use_grid" INTEGER DEFAULT 1, "full_fow" INTEGER DEFAULT 0, "fow_opacity" REAL DEFAULT 0.3, "fow_los" INTEGER DEFAULT 0, "vision_mode" TEXT DEFAULT "triangle", "vision_min_range" REAL DEFAULT 1640, "vision_max_range" REAL DEFAULT 3281, "grid_size" INTEGER DEFAULT 50)'
@@ -286,13 +242,10 @@ def upgrade(version):
             )
             db.execute_sql("DROP TABLE 'grid_layer'")
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 27:
         # Fix broken schemas from older save upgrades
-        db.foreign_keys = False
         with db.atomic():
-            db.execute_sql("CREATE TEMPORARY TABLE _floor AS SELECT * FROM floor")
+            db.execute_sql("CREATE TEMPORARY TABLE _floor_27 AS SELECT * FROM floor")
             db.execute_sql("DROP TABLE floor")
             db.execute_sql(
                 'CREATE TABLE "floor" ("id" INTEGER NOT NULL PRIMARY KEY, "location_id" INTEGER NOT NULL, "index" INTEGER NOT NULL, "name" TEXT NOT NULL, FOREIGN KEY ("location_id") REFERENCES "location" ("id") ON DELETE CASCADE)'
@@ -301,10 +254,10 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "floor_location_id" ON "floor" ("location_id")'
             )
             db.execute_sql(
-                'INSERT INTO floor (id, location_id, "index", name) SELECT id, location_id, "index", name FROM _floor'
+                'INSERT INTO floor (id, location_id, "index", name) SELECT id, location_id, "index", name FROM _floor_27'
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _label AS SELECT * FROM label")
+            db.execute_sql("CREATE TEMPORARY TABLE _label_27 AS SELECT * FROM label")
             db.execute_sql("DROP TABLE label")
             db.execute_sql(
                 'CREATE TABLE "label" ("uuid" TEXT NOT NULL PRIMARY KEY, "user_id" INTEGER NOT NULL, "category" TEXT, "name" TEXT NOT NULL, "visible" INTEGER NOT NULL, FOREIGN KEY ("user_id") REFERENCES "user" ("id") ON DELETE CASCADE)'
@@ -313,10 +266,10 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "label_user_id" ON "label" ("user_id")'
             )
             db.execute_sql(
-                "INSERT INTO label (uuid, user_id, category, name, visible) SELECT uuid, user_id, category, name, visible FROM _label"
+                "INSERT INTO label (uuid, user_id, category, name, visible) SELECT uuid, user_id, category, name, visible FROM _label_27"
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _layer AS SELECT * FROM layer")
+            db.execute_sql("CREATE TEMPORARY TABLE _layer_27 AS SELECT * FROM layer")
             db.execute_sql("DROP TABLE layer")
             db.execute_sql(
                 'CREATE TABLE "layer" ("id" INTEGER NOT NULL PRIMARY KEY, "floor_id" INTEGER NOT NULL, "name" TEXT NOT NULL, "type_" TEXT NOT NULL, "player_visible" INTEGER NOT NULL, "player_editable" INTEGER NOT NULL, "selectable" INTEGER NOT NULL, "index" INTEGER NOT NULL, FOREIGN KEY ("floor_id") REFERENCES "floor" ("id") ON DELETE CASCADE)'
@@ -331,10 +284,12 @@ def upgrade(version):
                 'CREATE UNIQUE INDEX "layer_floor_id_name" ON "layer" ("floor_id", "name")'
             )
             db.execute_sql(
-                'INSERT INTO layer (id, floor_id, name, type_, player_visible, player_editable, selectable, "index") SELECT id, floor_id, name, type_, player_visible, player_editable, selectable, "index" FROM _layer'
+                'INSERT INTO layer (id, floor_id, name, type_, player_visible, player_editable, selectable, "index") SELECT id, floor_id, name, type_, player_visible, player_editable, selectable, "index" FROM _layer_27'
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _location AS SELECT * FROM location")
+            db.execute_sql(
+                "CREATE TEMPORARY TABLE _location_27 AS SELECT * FROM location"
+            )
             db.execute_sql("DROP TABLE location")
             db.execute_sql(
                 'CREATE TABLE "location" ("id" INTEGER NOT NULL PRIMARY KEY, "room_id" INTEGER NOT NULL, "name" TEXT NOT NULL, "options_id" INTEGER, "index" INTEGER NOT NULL, FOREIGN KEY ("room_id") REFERENCES "room" ("id") ON DELETE CASCADE, FOREIGN KEY ("options_id") REFERENCES "location_options" ("id") ON DELETE CASCADE)'
@@ -343,11 +298,11 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "location_room_id" ON "location" ("room_id")'
             )
             db.execute_sql(
-                'INSERT INTO location (id, room_id, name, options_id, "index") SELECT id, room_id, name, options_id, "index" FROM _location'
+                'INSERT INTO location (id, room_id, name, options_id, "index") SELECT id, room_id, name, options_id, "index" FROM _location_27'
             )
 
             db.execute_sql(
-                "CREATE TEMPORARY TABLE _location_options AS SELECT * FROM location_options"
+                "CREATE TEMPORARY TABLE _location_options_27 AS SELECT * FROM location_options"
             )
             db.execute_sql("DROP TABLE location_options")
             db.execute_sql(
@@ -357,11 +312,11 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "location_options_id" ON "location" ("options_id")'
             )
             db.execute_sql(
-                "INSERT INTO location_options (id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, grid_size, vision_min_range, vision_max_range) SELECT id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, grid_size, vision_min_range, vision_max_range FROM _location_options"
+                "INSERT INTO location_options (id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, grid_size, vision_min_range, vision_max_range) SELECT id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, grid_size, vision_min_range, vision_max_range FROM _location_options_27"
             )
 
             db.execute_sql(
-                "CREATE TEMPORARY TABLE _location_user_option AS SELECT * FROM location_user_option"
+                "CREATE TEMPORARY TABLE _location_user_option_27 AS SELECT * FROM location_user_option"
             )
             db.execute_sql("DROP TABLE location_user_option")
             db.execute_sql(
@@ -380,10 +335,10 @@ def upgrade(version):
                 'CREATE UNIQUE INDEX "location_user_option_location_id_user_id" ON "location_user_option" ("location_id", "user_id")'
             )
             db.execute_sql(
-                "INSERT INTO location_user_option (id, location_id, user_id, pan_x, pan_y, zoom_factor, active_layer_id) SELECT id, location_id, user_id, pan_x, pan_y, zoom_factor, active_layer_id FROM _location_user_option"
+                "INSERT INTO location_user_option (id, location_id, user_id, pan_x, pan_y, zoom_factor, active_layer_id) SELECT id, location_id, user_id, pan_x, pan_y, zoom_factor, active_layer_id FROM _location_user_option_27"
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _marker AS SELECT * FROM marker")
+            db.execute_sql("CREATE TEMPORARY TABLE _marker_27 AS SELECT * FROM marker")
             db.execute_sql("DROP TABLE marker")
             db.execute_sql(
                 'CREATE TABLE "marker" ("id" INTEGER NOT NULL PRIMARY KEY, "shape_id" TEXT NOT NULL, "user_id" INTEGER NOT NULL, "location_id" INTEGER NOT NULL, FOREIGN KEY ("shape_id") REFERENCES "shape" ("uuid") ON DELETE CASCADE, FOREIGN KEY ("user_id") REFERENCES "user" ("id") ON DELETE CASCADE, FOREIGN KEY ("location_id") REFERENCES "location" ("id") ON DELETE CASCADE)'
@@ -401,11 +356,11 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "marker_location_id" ON "marker" ("location_id")'
             )
             db.execute_sql(
-                "INSERT INTO marker (id, shape_id, user_id, location_id) SELECT id, shape_id, user_id, location_id FROM _marker"
+                "INSERT INTO marker (id, shape_id, user_id, location_id) SELECT id, shape_id, user_id, location_id FROM _marker_27"
             )
 
             db.execute_sql(
-                "CREATE TEMPORARY TABLE _player_room AS SELECT * FROM player_room"
+                "CREATE TEMPORARY TABLE _player_room_27 AS SELECT * FROM player_room"
             )
             db.execute_sql("DROP TABLE player_room")
             db.execute_sql(
@@ -421,19 +376,21 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "player_room_room_id" ON "player_room" ("room_id")'
             )
             db.execute_sql(
-                "INSERT INTO player_room (id, role, player_id, room_id, active_location_id) SELECT id, role, player_id, room_id, active_location_id FROM _player_room"
+                "INSERT INTO player_room (id, role, player_id, room_id, active_location_id) SELECT id, role, player_id, room_id, active_location_id FROM _player_room_27"
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _polygon AS SELECT * FROM polygon")
+            db.execute_sql(
+                "CREATE TEMPORARY TABLE _polygon_27 AS SELECT * FROM polygon"
+            )
             db.execute_sql("DROP TABLE polygon")
             db.execute_sql(
                 'CREATE TABLE "polygon" ("shape_id" TEXT NOT NULL PRIMARY KEY, "vertices" TEXT NOT NULL, "line_width" INTEGER NOT NULL, "open_polygon" INTEGER NOT NULL, FOREIGN KEY ("shape_id") REFERENCES "shape" ("uuid") ON DELETE CASCADE)'
             )
             db.execute_sql(
-                "INSERT INTO polygon (shape_id,vertices, line_width, open_polygon) SELECT shape_id,vertices, line_width, open_polygon FROM _polygon"
+                "INSERT INTO polygon (shape_id,vertices, line_width, open_polygon) SELECT shape_id,vertices, line_width, open_polygon FROM _polygon_27"
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _room AS SELECT * FROM room")
+            db.execute_sql("CREATE TEMPORARY TABLE _room_27 AS SELECT * FROM room")
             db.execute_sql("DROP TABLE room")
             db.execute_sql(
                 'CREATE TABLE "room" ("id" INTEGER NOT NULL PRIMARY KEY, "name" TEXT NOT NULL, "creator_id" INTEGER NOT NULL, "invitation_code" TEXT NOT NULL, "is_locked" INTEGER NOT NULL, "default_options_id" INTEGER NOT NULL, FOREIGN KEY ("creator_id") REFERENCES "user" ("id") ON DELETE CASCADE, FOREIGN KEY ("default_options_id") REFERENCES "location_options" ("id") ON DELETE CASCADE)'
@@ -451,10 +408,10 @@ def upgrade(version):
                 'CREATE UNIQUE INDEX "room_name_creator_id" ON "room" ("name", "creator_id")'
             )
             db.execute_sql(
-                "INSERT INTO room (id, name, creator_id, invitation_code, is_locked, default_options_id) SELECT id, name, creator_id, invitation_code, is_locked, default_options_id FROM _room"
+                "INSERT INTO room (id, name, creator_id, invitation_code, is_locked, default_options_id) SELECT id, name, creator_id, invitation_code, is_locked, default_options_id FROM _room_27"
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _shape AS SELECT * FROM shape")
+            db.execute_sql("CREATE TEMPORARY TABLE _shape_27 AS SELECT * FROM shape")
             db.execute_sql("DROP TABLE shape")
             db.execute_sql(
                 'CREATE TABLE "shape" ("uuid" TEXT NOT NULL PRIMARY KEY, "layer_id" INTEGER NOT NULL, "type_" TEXT NOT NULL, "x" REAL NOT NULL, "y" REAL NOT NULL, "name" TEXT, "name_visible" INTEGER NOT NULL, "fill_colour" TEXT NOT NULL, "stroke_colour" TEXT NOT NULL, "vision_obstruction" INTEGER NOT NULL, "movement_obstruction" INTEGER NOT NULL, "is_token" INTEGER NOT NULL, "annotation" TEXT NOT NULL, "draw_operator" TEXT NOT NULL, "index" INTEGER NOT NULL, "options" TEXT, "badge" INTEGER NOT NULL, "show_badge" INTEGER NOT NULL, "default_edit_access" INTEGER NOT NULL, "default_vision_access" INTEGER NOT NULL, FOREIGN KEY ("layer_id") REFERENCES "layer" ("id") ON DELETE CASCADE)'
@@ -463,35 +420,29 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "shape_layer_id" ON "shape" ("layer_id")'
             )
             db.execute_sql(
-                'INSERT INTO shape (uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, "index", options, badge, show_badge, default_edit_access, default_vision_access) SELECT uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, "index", options, badge, show_badge, default_edit_access, default_vision_access FROM _shape'
+                'INSERT INTO shape (uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, "index", options, badge, show_badge, default_edit_access, default_vision_access) SELECT uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, "index", options, badge, show_badge, default_edit_access, default_vision_access FROM _shape_27'
             )
 
-            db.execute_sql("CREATE TEMPORARY TABLE _user AS SELECT * FROM user")
+            db.execute_sql("CREATE TEMPORARY TABLE _user_27 AS SELECT * FROM user")
             db.execute_sql("DROP TABLE user")
             db.execute_sql(
                 'CREATE TABLE "user" ("id" INTEGER NOT NULL PRIMARY KEY, "name" TEXT NOT NULL, "email" TEXT, "password_hash" TEXT NOT NULL, "fow_colour" TEXT NOT NULL, "grid_colour" TEXT NOT NULL, "ruler_colour" TEXT NOT NULL, "invert_alt" INTEGER NOT NULL)'
             )
             db.execute_sql(
-                "INSERT INTO user (id, name, email, password_hash, fow_colour, grid_colour, ruler_colour, invert_alt) SELECT id, name, email, password_hash, fow_colour, grid_colour, ruler_colour, invert_alt FROM _user"
+                "INSERT INTO user (id, name, email, password_hash, fow_colour, grid_colour, ruler_colour, invert_alt) SELECT id, name, email, password_hash, fow_colour, grid_colour, ruler_colour, invert_alt FROM _user_27"
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 28:
         # Add invisibility toggle to shapes
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN is_invisible INTEGER NOT NULL DEFAULT 0"
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 29:
         # Add movement access permission
         migrator = SqliteMigrator(db)
 
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN default_movement_access INTEGER NOT NULL DEFAULT 0"
@@ -503,31 +454,22 @@ def upgrade(version):
 
             migrate(migrator.add_not_null("shape_owner", "movement_access"),)
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 30:
         # Add spawn locations
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 'ALTER TABLE location_options ADD COLUMN spawn_locations TEXT NOT NULL DEFAULT "[]"'
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 31:
         # Add shape movement lock
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN is_locked INTEGER NOT NULL DEFAULT 0"
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 32:
         # Add Shape.angle and Shape.stroke_width
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN angle INTEGER NOT NULL DEFAULT 0"
@@ -536,21 +478,15 @@ def upgrade(version):
                 "ALTER TABLE shape ADD COLUMN stroke_width INTEGER NOT NULL DEFAULT 2"
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 33:
         # Add Floor.player_visible
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
                 "ALTER TABLE floor ADD COLUMN player_visible INTEGER NOT NULL DEFAULT 1"
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 34:
         # Fix Floor.index
-        db.foreign_keys = False
         with db.atomic():
             data = db.execute_sql("SELECT id FROM location")
             for location_id in data.fetchall():
@@ -558,14 +494,11 @@ def upgrade(version):
                     f"UPDATE floor SET 'index' = (SELECT COUNT(*)-1 FROM floor f WHERE f.location_id = {location_id[0]} AND f.id <= floor.id ) WHERE location_id = {location_id[0]}"
                 )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 35:
         # Move grid size to client options
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql(
-                "CREATE TEMPORARY TABLE _location_options AS SELECT * FROM location_options"
+                "CREATE TEMPORARY TABLE _location_options_35 AS SELECT * FROM location_options"
             )
             db.execute_sql("DROP TABLE location_options")
             db.execute_sql(
@@ -575,17 +508,14 @@ def upgrade(version):
                 'CREATE INDEX IF NOT EXISTS "location_options_id" ON "location" ("options_id")'
             )
             db.execute_sql(
-                "INSERT INTO location_options (id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, vision_min_range, vision_max_range, spawn_locations) SELECT id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, vision_min_range, vision_max_range, spawn_locations FROM _location_options"
+                "INSERT INTO location_options (id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, vision_min_range, vision_max_range, spawn_locations) SELECT id, unit_size, unit_size_unit, use_grid, full_fow, fow_opacity, fow_los, vision_mode, vision_min_range, vision_max_range, spawn_locations FROM _location_options_35"
             )
             db.execute_sql(
                 "ALTER TABLE user ADD COLUMN grid_size INTEGER NOT NULL DEFAULT 50"
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 36:
         # Change polygon vertices format from { x: number, y: number } to number[]
-        db.foreign_keys = False
         with db.atomic():
             data = db.execute_sql("SELECT shape_id, vertices FROM polygon")
             for row in data.fetchall():
@@ -600,35 +530,29 @@ def upgrade(version):
                 except json.decoder.JSONDecodeError:
                     print(f"Failed to update polygon vertices! {row}")
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 37:
         # Change shape.angle from integer field to float field
-        db.foreign_keys = False
         with db.atomic():
-            db.execute_sql("CREATE TEMPORARY TABLE _shape AS SELECT * FROM shape")
+            db.execute_sql("CREATE TEMPORARY TABLE _shape_37 AS SELECT * FROM shape")
             db.execute_sql("DROP TABLE shape")
             db.execute_sql(
                 'CREATE TABLE IF NOT EXISTS "shape" ("uuid" TEXT NOT NULL PRIMARY KEY, "layer_id" INTEGER NOT NULL, "type_" TEXT NOT NULL, "x" REAL NOT NULL, "y" REAL NOT NULL, "name" TEXT, "name_visible" INTEGER NOT NULL, "fill_colour" TEXT NOT NULL, "stroke_colour" TEXT NOT NULL, "vision_obstruction" INTEGER NOT NULL, "movement_obstruction" INTEGER NOT NULL, "is_token" INTEGER NOT NULL, "annotation" TEXT NOT NULL, "draw_operator" TEXT NOT NULL, "index" INTEGER NOT NULL, "options" TEXT, "badge" INTEGER NOT NULL, "show_badge" INTEGER NOT NULL, "default_edit_access" INTEGER NOT NULL, "default_vision_access" INTEGER NOT NULL, is_invisible INTEGER NOT NULL DEFAULT 0, default_movement_access INTEGER NOT NULL DEFAULT 0, is_locked INTEGER NOT NULL DEFAULT 0, angle REAL NOT NULL DEFAULT 0, stroke_width INTEGER NOT NULL DEFAULT 2, FOREIGN KEY ("layer_id") REFERENCES "layer" ("id") ON DELETE CASCADE)'
             )
             db.execute_sql('CREATE INDEX "shape_layer_id" ON "shape" ("layer_id")')
             db.execute_sql(
-                "INSERT INTO shape (uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width) SELECT uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width FROM _shape"
+                "INSERT INTO shape (uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width) SELECT uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width FROM _shape_37"
             )
-            db.execute_sql("CREATE TEMPORARY TABLE _text AS SELECT * FROM text")
+            db.execute_sql("CREATE TEMPORARY TABLE _text_37 AS SELECT * FROM text")
             db.execute_sql("DROP TABLE text")
             db.execute_sql(
                 'CREATE TABLE IF NOT EXISTS "text" ("shape_id" TEXT NOT NULL PRIMARY KEY, "text" TEXT NOT NULL, "font" TEXT NOT NULL, FOREIGN KEY ("shape_id") REFERENCES "shape" ("uuid") ON DELETE CASCADE);'
             )
             db.execute_sql(
-                "INSERT INTO text (shape_id, text, font) SELECT shape_id, text, font FROM _text"
+                "INSERT INTO text (shape_id, text, font) SELECT shape_id, text, font FROM _text_37"
             )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 38:
         # Change polygon vertices format from { x: number, y: number } to number[]
-        db.foreign_keys = False
         with db.atomic():
             data = db.execute_sql("SELECT shape_id, vertices FROM polygon")
             for row in data.fetchall():
@@ -643,26 +567,23 @@ def upgrade(version):
                 except json.decoder.JSONDecodeError:
                     print(f"Failed to update polygon vertices! {row}")
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 39:
         # Fix Shape.index being set to 'index'
         from models import Layer
 
-        db.foreign_keys = False
         with db.atomic():
-            with db.atomic():
-                for layer in Layer.select():
-                    shapes = layer.shapes.select()
-                    for i, shape in enumerate(shapes):
-                        shape.index = i
-                        shape.save()
+            data = db.execute_sql("SELECT id FROM layer")
+            for row in data.fetchall():
+                shape_query = db.execute_sql(
+                    f"SELECT uuid FROM shape WHERE layer_id = '{row[0]}'"
+                )
+                for i, shape_row in enumerate(shape_query.fetchall()):
+                    db.execute_sql(
+                        f"UPDATE shape SET 'index' = {i} WHERE uuid = '{shape_row[0]}'"
+                    )
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 40:
         # Add move_player_on_token_change to location_options
-        db.foreign_keys = False
         with db.atomic():
             try:
                 db.execute_sql(
@@ -676,15 +597,12 @@ def upgrade(version):
                 else:
                     raise e
 
-        db.foreign_keys = True
-        Constants.get().update(save_version=Constants.save_version + 1).execute()
     elif version == 41:
         # Add Asset.options and Shape.asset
-        db.foreign_keys = False
         with db.atomic():
             db.execute_sql("ALTER TABLE asset ADD COLUMN options TEXT")
 
-            db.execute_sql("CREATE TEMPORARY TABLE _shape AS SELECT * FROM shape")
+            db.execute_sql("CREATE TEMPORARY TABLE _shape_41 AS SELECT * FROM shape")
             db.execute_sql("DROP TABLE shape")
             db.execute_sql(
                 'CREATE TABLE IF NOT EXISTS "shape" ("uuid" TEXT NOT NULL PRIMARY KEY, "layer_id" INTEGER NOT NULL, "type_" TEXT NOT NULL, "x" REAL NOT NULL, "y" REAL NOT NULL, "name" TEXT, "name_visible" INTEGER NOT NULL, "fill_colour" TEXT NOT NULL, "stroke_colour" TEXT NOT NULL, "vision_obstruction" INTEGER NOT NULL, "movement_obstruction" INTEGER NOT NULL, "is_token" INTEGER NOT NULL, "annotation" TEXT NOT NULL, "draw_operator" TEXT NOT NULL, "index" INTEGER NOT NULL, "options" TEXT, "badge" INTEGER NOT NULL, "show_badge" INTEGER NOT NULL, "default_edit_access" INTEGER NOT NULL, "default_vision_access" INTEGER NOT NULL, is_invisible INTEGER NOT NULL DEFAULT 0, default_movement_access INTEGER NOT NULL DEFAULT 0, is_locked INTEGER NOT NULL DEFAULT 0, angle REAL NOT NULL DEFAULT 0, stroke_width INTEGER NOT NULL DEFAULT 2, asset_id INTEGER, FOREIGN KEY ("layer_id") REFERENCES "layer" ("id") ON DELETE CASCADE, FOREIGN KEY ("asset_id") REFERENCES "asset" ("id"))'
@@ -692,7 +610,7 @@ def upgrade(version):
             db.execute_sql('CREATE INDEX "shape_layer_id" ON "shape" ("layer_id")')
             db.execute_sql('CREATE INDEX "shape_asset_id" ON "shape" ("asset_id")')
             db.execute_sql(
-                "INSERT INTO shape (uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width) SELECT uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width FROM _shape"
+                "INSERT INTO shape (uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width) SELECT uuid, layer_id, type_, x, y, name, name_visible, fill_colour, stroke_colour, vision_obstruction, movement_obstruction, is_token, annotation, draw_operator, 'index', options, badge, show_badge, default_edit_access, default_vision_access, is_invisible, default_movement_access, is_locked, angle, stroke_width FROM _shape_41"
             )
 
         db.foreign_keys = True
@@ -701,6 +619,8 @@ def upgrade(version):
         raise UnknownVersionException(
             f"No upgrade code for save format {version} was found."
         )
+    inc_save_version()
+    db.foreign_keys = True
 
 
 def check_save():
@@ -711,20 +631,21 @@ def check_save():
             save_version=SAVE_VERSION, secret_token=secrets.token_bytes(32)
         )
     else:
-        constants = Constants.get_or_none()
-        if constants is None:
+        try:
+            save_version = get_save_version()
+        except:
             logger.error(
                 "Database does not conform to expected format. Failed to start."
             )
             sys.exit(2)
-        if constants.save_version != SAVE_VERSION:
+        if save_version != SAVE_VERSION:
             logger.warning(
-                f"Save format {constants.save_version} does not match the required version {SAVE_VERSION}!"
+                f"Save format {save_version} does not match the required version {SAVE_VERSION}!"
             )
             logger.warning("Attempting upgrade")
 
         updated = False
-        while constants.save_version != SAVE_VERSION:
+        while save_version != SAVE_VERSION:
             updated = True
             logger.warning(
                 f"Backing up old save as {SAVE_FILE}.{constants.save_version}"
@@ -732,15 +653,15 @@ def check_save():
             shutil.copyfile(SAVE_FILE, f"{SAVE_FILE}.{constants.save_version}")
             logger.warning(f"Starting upgrade to {constants.save_version + 1}")
             try:
-                upgrade(constants.save_version)
+                upgrade(save_version)
             except Exception as e:
                 logger.exception(e)
                 logger.error("ERROR: Could not start server")
                 sys.exit(2)
                 break
             else:
-                logger.warning(f"Upgrade to {constants.save_version + 1} done.")
-                constants = Constants.get()
+                logger.warning(f"Upgrade to {save_version + 1} done.")
+                save_version = get_save_version()
         else:
             if updated:
                 logger.warning("Upgrade process completed successfully.")

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -20,3 +20,27 @@ ssl_privkey = cert/privkey.pem
 
 [General]
 save_file = planar.sqlite
+
+[APIserver]
+# The API server is an administration server on which some API calls can be made.
+# It should use a different port or socket than the main webserver.
+# It's hosted on localhost by default instead of 0.0.0.0
+
+# You can choose to use a HOST:PORT connection or a socket file to listen on
+# If you specifiy a socket, it will be used instead of the HTTP:PORT connection
+host = localhost
+port = 8001
+# socket = /tmp/planarally.sock
+
+ssl = false
+# the ssl_ options are only required if ssl is set
+# modify these to your actual keys!
+ssl_fullchain = cert/fullchain.pem
+ssl_privkey = cert/privkey.pem
+
+# Allowed CORS origins
+#     If not specified, only the host runnig the server is allowed
+#     Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
+#     More information on the meaning of these values can be found at
+#     https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+# cors_allowed_origins = ['*']


### PR DESCRIPTION
This PR adds the ability to create system notifications as requested in #453.

These notifications are shown as toasts in the topleft corner and will be fetched on normal http requests on any endpoint. Additionally when new messages are published, any client already in-game will also receive and display the notification instantly using the existing websockets.

When the user closes a notification, it is marked as read in localstorage and will no longer show up.

# API server
In order to manage these notifications a separate API server is launched next to the main server.  A new section has been created in the server_config to configure this to your liking. By default it will listen on 'localhost' instead of the default '0.0.0.0' that the main webserver has.

# API endpoints
The admin API server currently consists of:
GET /api/notifications
    this lists all existing notifications (uuid and message).
    this endpoint is also available on the main webserver.
POST /api/notifications
    You should provide a 'message' with this request to create a new notification.
DELETE /api/notifications/{uuid}
    Deletes the provided notification if it exists.

# Authorization

In order to authorize yourself against the API you need to provide a Bearer token.
A new api token has automatically been generated and stored in the Constants table.
Your free to change/rotate the value of this token as you see.

You can get the current api_token with:
```python
import auth
auth.get_api_token()
```

# Examples

These examples use curl, but any application/website capable of standard web/rest operations should be able to perform these.

Creating a new notification: `curl -X POST http://localhost:8001/api/notifications -H 'Authorization: Bearer 0b9f515e153e0e07782e9e41a0ebf0bf7137d0fd655a03ebc4991f24302c313e' -d '{"message": "EXPECTED SERVER MAINTENANCE  SUNDAY 11/10/2020 AT 15:50 GMT+2"}'`