### PR TITLE
bug(Template): Fix size not persisting and default templates not always working

### DIFF
--- a/client/src/game/shapes/template.ts
+++ b/client/src/game/shapes/template.ts
@@ -14,7 +14,9 @@ import { createEmptyTracker } from "./tracker";
 
 export function applyTemplate<T extends ServerShape>(shape: T, template: BaseTemplate): T {
     // should be shape[key], but this is something that TS cannot correctly infer (issue #31445)
-    for (const key of BaseTemplateStrings) (shape as any)[key] = template[key];
+    for (const key of BaseTemplateStrings) {
+        if (key in template) (shape as any)[key] = template[key];
+    }
 
     for (const trackerTemplate of template.trackers ?? []) {
         const defaultTracker = createEmptyTracker();
@@ -28,7 +30,9 @@ export function applyTemplate<T extends ServerShape>(shape: T, template: BaseTem
     }
 
     // Shape specific keys
-    for (const key of getTemplateKeys(shape.type_)) (shape as any)[key] = (template as any)[key];
+    for (const key of getTemplateKeys(shape.type_)) {
+        if (key in template) (shape as any)[key] = (template as any)[key];
+    }
 
     return shape;
 }

--- a/client/src/game/shapes/variants/baserect.ts
+++ b/client/src/game/shapes/variants/baserect.ts
@@ -7,6 +7,8 @@ import { ServerShape } from "../../comm/types/shapes";
 import { DEFAULT_GRID_SIZE } from "../../store";
 import { rotateAroundPoint } from "../../utils";
 
+type ServerBaseRect = ServerShape & { width: number; height: number };
+
 export abstract class BaseRect extends Shape {
     w: number;
     h: number;
@@ -20,12 +22,20 @@ export abstract class BaseRect extends Shape {
         this.w = w;
         this.h = h;
     }
-    getBaseDict(): ServerShape & { width: number; height: number } {
+
+    getBaseDict(): ServerBaseRect {
         return Object.assign(super.getBaseDict(), {
             width: this.w,
             height: this.h,
         });
     }
+
+    fromDict(data: ServerBaseRect): void {
+        super.fromDict(data);
+        this.w = data.width;
+        this.h = data.height;
+    }
+
     getBoundingBox(): BoundingRect {
         const bbox = new BoundingRect(this.refPoint, this.w, this.h);
         bbox.angle = this.angle;


### PR DESCRIPTION
This PR fixes two issues with templates.

1) The width and height was not correctly set when placing an asset on the board.
2) When selecting a default empty template the asset would not appear on the board properly.