### PR TITLE
bug(Lock): Fixed locking shapes via keyboard shortcut did not sync to the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Fixed
+
+-   Locking shapes via keyboard shortcut did not sync to the server
+
 ## [0.23.0] - 2020-10-18
 
 ### Added

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -100,7 +100,7 @@ export function onKeyDown(event: KeyboardEvent): void {
         } else if (event.key === "l" && event.ctrlKey) {
             const selection = layerManager.getSelection() ?? [];
             for (const shape of selection) {
-                shape.isLocked = !shape.isLocked;
+                shape.setLocked(!shape.isLocked, true);
             }
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
This fixes #547.