### PR TITLE
bug(UI): Fix floor rename always setting a blank name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These usually have no immediately visible impact on regular users
 
 -   Locking shapes via keyboard shortcut did not sync to the server
 -   Annotations from other floors being shown
+-   Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25
 

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -78,7 +78,7 @@ export default class FloorSelect extends Vue {
             this.$t("game.ui.floors.rename_header_title").toString(),
         );
         if (value === undefined || getFloorId(value) !== -1) return;
-        floorStore.renameFloor({ index, name, sync: true });
+        floorStore.renameFloor({ index, name: value, sync: true });
     }
 
     async removeFloor(floor: Floor): Promise<void> {


### PR DESCRIPTION
This fixes issue #555.