### PR TITLE
feat(UI): Add Enter to open edit dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Added
+
+-   Pressing the Enter button on a single selection will open the edit dialog for that shape
+
 ### Fixed
 
 -   Locking shapes via keyboard shortcut did not sync to the server

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -27,6 +27,12 @@ export function onKeyUp(event: KeyboardEvent): void {
             gameManager.setCenterPosition(token.center());
             floorStore.selectFloor({ targetFloor: token.floor.name, sync: true });
         }
+        if (event.key === "Enter") {
+            const selection = layerManager.getSelection();
+            if (selection.length === 1) {
+                EventBus.$emit("EditDialog.Open", selection[0]);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This is a small quality of life improvement that opens the shape edit dialog when one shape is selected. This closes #550 