### PR TITLE
bug(UI): Remember ruler visibility state between tool changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ These usually have no immediately visible impact on regular users
 -   Locking shapes via keyboard shortcut did not sync to the server
 -   Annotations from other floors being shown
 -   Floor rename always setting a blank name
+-   Remember ruler visibility on tool change
 
 ## [0.23.1] - 2020-10-25
 

--- a/client/src/game/ui/tools/ruler.vue
+++ b/client/src/game/ui/tools/ruler.vue
@@ -110,8 +110,6 @@ export default class RulerTool extends Tool implements ToolBasics {
         const button = event.target as HTMLButtonElement;
         const state = button.getAttribute("aria-pressed") ?? "false";
         this.showPublic = state === "false";
-        if (state == "false") button.setAttribute("aria-pressed", "true");
-        else button.setAttribute("aria-pressed", "false");
     }
 }
 </script>
@@ -123,7 +121,7 @@ export default class RulerTool extends Tool implements ToolBasics {
         v-if="selected"
         :style="{ '--detailRight': detailRight, '--detailArrow': detailArrow }"
     >
-        <button @click="toggle" aria-pressed="true" v-t="'game.ui.tools.ruler.share'"></button>
+        <button @click="toggle" :aria-pressed="showPublic" v-t="'game.ui.tools.ruler.share'"></button>
     </div>
 </template>
 


### PR DESCRIPTION
This fixes #545 