### PR TITLE
feat(Initiative): Added remove button to initiative effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These usually have no immediately visible impact on regular users
 -   Pressing the Enter button on a single selection will open the edit dialog for that shape
 -   Hexagon support (flat and pointy topped)
 -   Navigate viewport with numpad, 5 will center viewport on origin; tokens can be moved (behaviour depending whether grid is square, flat-top-hex or pointy-topped-hex) with numpad
+-   Remove button to initiative effects
 
 ### Fixed
 

--- a/client/src/game/api/emits/initiative.ts
+++ b/client/src/game/api/emits/initiative.ts
@@ -10,3 +10,6 @@ export const sendInitiativeNewEffect = wrapSocket<{ actor: string; effect: Initi
 export const sendInitiativeUpdateEffect = wrapSocket<{ actor: string; effect: InitiativeEffect }>(
     "Initiative.Effect.Update",
 );
+export const sendInitiativeRemoveEffect = wrapSocket<{ actor: string; effect: InitiativeEffect }>(
+    "Initiative.Effect.Remove",
+);

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -119,6 +119,7 @@
                     "add_timed_effect": "Add timed effect",
                     "toggle_group": "Toggle individual / group initiative",
                     "delete_init": "Delete initiative",
+                    "delete_effect": "Delete effect",
                     "round_N": "Round {n}",
                     "vision_log_msg": "Auto lock vision (only show vision active token)",
                     "camera_log_msg": "Auto camera lock on active token",


### PR DESCRIPTION
This helps the confusion surrounding effects removal (which only triggered upon reaching 0 automatically) as well as the option to remove non-numeric initiatives.

The original remove on 0 behaviour still exists as well.

This closes #390