### PR TITLE
bug(Initiative): New initiative effects do not immediately sync to other clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These usually have no immediately visible impact on regular users
 -   Remember ruler visibility on tool change
 -   `Ctrl 0` now centers viewport on origin (before, it would show origin on the top-left of the viewport)
 -   Initiative effects becoming NaN for non-numeric inputs
+-   New initiative effects not immediately synchronizing until a full client refresh
 
 ## [0.23.1] - 2020-10-25
 

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -162,7 +162,6 @@ export default class Initiative extends Vue {
         this.syncInitiative(actor);
     }
     createEffect(actor: InitiativeData, effect: InitiativeEffect, sync: boolean): void {
-        if (!this.owns(actor)) return;
         actor.effects.push(effect);
         if (sync) sendInitiativeNewEffect({ actor: actor.uuid, effect });
     }


### PR DESCRIPTION
A bug in the initiative code prevented new effects from immediately synchronizing to other clients. They had to refresh their page to see them.