### PR TITLE
bug(Shape) Fix name syncing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ These usually have no immediately visible impact on regular users
 -   `Ctrl 0` now centers viewport on origin (before, it would show origin on the top-left of the viewport)
 -   Initiative effects becoming NaN for non-numeric inputs
 -   New initiative effects not immediately synchronizing until a full client refresh
+-   Shape name updates not syncing for public names to users that do not own the shape
+-   Shape name updates not always updating on the initiative list
 
 ## [0.23.1] - 2020-10-25
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -54,6 +54,7 @@ import { BoundingRect } from "./variants/boundingrect";
 import { Aura, Label, Tracker } from "./interfaces";
 import { PartialShapeOwner, ShapeAccess, ShapeOwner } from "./owners";
 import { SHAPE_TYPE } from "./types";
+import { EventBus } from "../event-bus";
 
 export abstract class Shape {
     // Used to create class instance from server shape data
@@ -682,6 +683,9 @@ export abstract class Shape {
     setName(name: string, sync: boolean): void {
         if (sync) sendShapeSetName({ shape: this.uuid, value: name });
         this.name = name;
+        // Initiative names are not always updated when renaming shapes
+        // This is due to these shapes not yet being reactive
+        EventBus.$emit("Initiative.ForceUpdate");
     }
 
     setNameVisible(visible: boolean, sync: boolean): void {

--- a/server/api/socket/shape/options.py
+++ b/server/api/socket/shape/options.py
@@ -254,10 +254,19 @@ async def set_name(sid: str, data: ShapeSetStringValue):
     shape.name = data["value"]
     shape.save()
 
-    for sid in get_owner_sids(pr, shape, skip_sid=sid):
+    if shape.name_visible:
         await sio.emit(
-            "Shape.Options.Name.Set", data, room=sid, namespace=GAME_NS,
+            "Shape.Options.Name.Set",
+            data,
+            skip_sid=sid,
+            room=pr.active_location.get_path(),
+            namespace=GAME_NS,
         )
+    else:
+        for sid in get_owner_sids(pr, shape, skip_sid=sid):
+            await sio.emit(
+                "Shape.Options.Name.Set", data, room=sid, namespace=GAME_NS,
+            )
 
 
 @sio.on("Shape.Options.NameVisible.Set", namespace=GAME_NS)


### PR DESCRIPTION
This fixes #385 where changing names of a shape would not always update the representation in the initiative list.

This also fixes a more general issue where updating a public name, those users that do not own the shape would not be informed of the change.