### PR TITLE
bug(Trackers): Fix trackers not providing empty rows until re-opening dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ These usually have no immediately visible impact on regular users
 -   Moving shapes with default movement permissions not working
 -   Various bugs with initiative permission updates
 -   Negative values for Auras no longer causes drawing issues.
+-   Trackers not providing empty rows until re-opening dialog.
 
 ## [0.23.1] - 2020-10-25
 

--- a/client/src/game/ui/selection/edit_dialog/ShapeSettings.vue
+++ b/client/src/game/ui/selection/edit_dialog/ShapeSettings.vue
@@ -12,8 +12,6 @@ import { EventBus } from "@/game/event-bus";
 import { Shape } from "@/game/shapes/shape";
 import { Prop } from "vue-property-decorator";
 import { gameStore } from "@/game/store";
-import { createEmptyTracker } from "@/game/shapes/tracker";
-import { createEmptyAura } from "@/game/shapes/aura";
 
 @Component({
     components: {
@@ -53,17 +51,6 @@ export default class ShapeSettings extends Vue {
 
     get categoryNames(): string[] {
         return ["Properties", "Trackers", "Access", "Extra"];
-    }
-
-    updated(): void {
-        this.addEmpty();
-    }
-
-    addEmpty(): void {
-        if (this.shape.trackers.length === 0 || !this.shape.trackers[this.shape.trackers.length - 1].temporary)
-            this.shape.pushTracker(createEmptyTracker());
-        if (this.shape.auras.length === 0 || !this.shape.auras[this.shape.auras.length - 1].temporary)
-            this.shape.pushAura(createEmptyAura());
     }
 }
 </script>

--- a/client/src/game/ui/selection/edit_dialog/TrackerSettings.vue
+++ b/client/src/game/ui/selection/edit_dialog/TrackerSettings.vue
@@ -8,6 +8,8 @@ import ColorPicker from "@/core/components/colorpicker.vue";
 
 import { Shape } from "@/game/shapes/shape";
 import { Aura, Tracker } from "@/game/shapes/interfaces";
+import { createEmptyTracker } from "../../../shapes/tracker";
+import { createEmptyAura } from "../../../shapes/aura";
 
 @Component({ components: { ColorPicker } })
 export default class TrackerSettings extends Vue {
@@ -44,6 +46,21 @@ export default class TrackerSettings extends Vue {
     removeAura(uuid: string): void {
         if (!this.owned) return;
         this.shape.removeAura(uuid, true);
+    }
+
+    mounted(): void {
+        this.addEmpty();
+    }
+
+    updated(): void {
+        this.addEmpty();
+    }
+
+    addEmpty(): void {
+        if (this.shape.trackers.length === 0 || !this.shape.trackers[this.shape.trackers.length - 1].temporary)
+            this.shape.pushTracker(createEmptyTracker());
+        if (this.shape.auras.length === 0 || !this.shape.auras[this.shape.auras.length - 1].temporary)
+            this.shape.pushAura(createEmptyAura());
     }
 }
 </script>


### PR DESCRIPTION
This fixes #585 . 