### PR TITLE
bug(Trackers): Fix extra empty tracker rows when pasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ These usually have no immediately visible impact on regular users
 -   Various bugs with initiative permission updates
 -   Negative values for Auras no longer causes drawing issues.
 -   Trackers not providing empty rows until re-opening dialog.
+-   Pasting shapes resulting in extra empty tracker rows.
 
 ## [0.23.1] - 2020-10-25
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -293,7 +293,7 @@ export abstract class Shape {
             movement_obstruction: this.movementObstruction,
             vision_obstruction: this.visionObstruction,
             auras: aurasToServer(this.uuid, this.auras),
-            trackers: this.trackers,
+            trackers: this.trackers.filter(t => !t.temporary),
             labels: this.labels,
             owners: this._owners.map(owner => ownerToServer(owner)),
             fill_colour: this.fillColour,


### PR DESCRIPTION
This fixes #586 