### PR TITLE
bug(Resize): Fix rectangle resizing causing position shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ These usually have no immediately visible impact on regular users
 -   Negative values for Auras no longer causes drawing issues.
 -   Trackers not providing empty rows until re-opening dialog.
 -   Pasting shapes resulting in extra empty tracker rows.
+-   Rectangle resizing causing position shift.
 
 ## [0.23.1] - 2020-10-25
 

--- a/client/src/game/api/emits/shape/core.ts
+++ b/client/src/game/api/emits/shape/core.ts
@@ -36,6 +36,8 @@ export function sendShapeSizeUpdate(data: { shape: Shape; temporary: boolean }):
         case "assetrect":
         case "rect": {
             const shape = data.shape as Rect;
+            // a shape resize can move the refpoint!
+            sendShapePositionUpdate([data.shape], data.temporary);
             _sendRectSizeUpdate({ uuid: shape.uuid, w: shape.w, h: shape.h, temporary: data.temporary });
             break;
         }


### PR DESCRIPTION
Rectangles are defined as a reference point (topleft corner) with a certain width, height and angle. When resizing there are cases that the topleft corner moves and this was not handled properly resulting in the width and height to adjust correctly but the refpoint to remain the same causing a shift of the resized shape to the original refpoint.

This fixes #584 