### PR TITLE
bug(Server): Fix location changes sometimes not going through for everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ These usually have no immediately visible impact on regular users
 -   Trackers not providing empty rows until re-opening dialog.
 -   Pasting shapes resulting in extra empty tracker rows.
 -   Rectangle resizing causing position shift.
+-   Location changes sometimes not going through for everyone.
 
 ## [0.23.1] - 2020-10-25
 

--- a/server/api/socket/location.py
+++ b/server/api/socket/location.py
@@ -248,10 +248,14 @@ async def change_location(sid: str, data: LocationChangeData):
             continue
 
         for psid in game_state.get_sids(player=room_player.player, room=pr.room):
-            sio.leave_room(
-                psid, room_player.active_location.get_path(), namespace=GAME_NS
-            )
-            sio.enter_room(psid, new_location.get_path(), namespace=GAME_NS)
+            try:
+                sio.leave_room(
+                    psid, room_player.active_location.get_path(), namespace=GAME_NS
+                )
+                sio.enter_room(psid, new_location.get_path(), namespace=GAME_NS)
+            except KeyError:
+                game_state.remove_sid(psid)
+                continue
             await load_location(psid, new_location)
         room_player.active_location = new_location
         room_player.save()


### PR DESCRIPTION
When players disconnect, it's sometimes possible that a faulty sid is still associated with them and this goes wrong on location change.