### PR TITLE
bug(Resizing): Fix snapping on rotated resize operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ These usually have no immediately visible impact on regular users
 -   Pasting shapes resulting in extra empty tracker rows
 -   Rectangle resizing causing position shift
 -   Location changes sometimes not going through for everyone
+-   Resizing rotating shapes with snapping now correctly snaps to grid points
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/shapes/variants/baserect.ts
+++ b/client/src/game/shapes/variants/baserect.ts
@@ -2,7 +2,7 @@ import { GlobalPoint, Vector } from "@/game/geom";
 import { BoundingRect } from "@/game/shapes/variants/boundingrect";
 import { Shape } from "@/game/shapes/shape";
 import { calculateDelta } from "@/game/ui/tools/utils";
-import { clampGridLine, g2lx, g2ly } from "@/game/units";
+import { clampGridLine, clampToGrid, g2lx, g2ly } from "@/game/units";
 import { ServerShape } from "../../comm/types/shapes";
 import { DEFAULT_GRID_SIZE } from "../../store";
 import { rotateAroundPoint } from "../../utils";
@@ -111,15 +111,18 @@ export abstract class BaseRect extends Shape {
         this.invalidate(false);
     }
     resizeToGrid(resizePoint: number, retainAspectRatio: boolean): void {
+        const targetPoint = new GlobalPoint(
+            this.refPoint.x + (resizePoint > 1 ? this.w : 0),
+            this.refPoint.y + ([1, 2].includes(resizePoint) ? this.h : 0),
+        );
         this.resize(
             resizePoint,
-            new GlobalPoint(
-                clampGridLine(this.refPoint.x + (resizePoint > 1 ? this.w : 0)),
-                clampGridLine(this.refPoint.y + ([1, 2].includes(resizePoint) ? this.h : 0)),
-            ),
+            clampToGrid(rotateAroundPoint(targetPoint, this.center(), this.angle)),
             retainAspectRatio,
         );
     }
+
+    // point is expected to be the point as on the map, irregardless of rotation
     resize(resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean): number {
         point = rotateAroundPoint(point, this.center(), -this.angle);
 

--- a/client/src/game/units.ts
+++ b/client/src/game/units.ts
@@ -64,5 +64,9 @@ export function clampGridLine(point: number): number {
     return Math.round(point / DEFAULT_GRID_SIZE) * DEFAULT_GRID_SIZE;
 }
 
+export function clampToGrid(point: GlobalPoint): GlobalPoint {
+    return new GlobalPoint(clampGridLine(point.x), clampGridLine(point.y));
+}
+
 (window as any).g2lx = g2lx;
 (window as any).g2ly = g2ly;


### PR DESCRIPTION
When resizing a rotated shape, snapping operations would produce wonky results.

This is now fixed and closes #595 