### PR TITLE
feat(UI): Restructure reusable components

### DIFF
--- a/client/src/assetManager/manager.vue
+++ b/client/src/assetManager/manager.vue
@@ -6,7 +6,6 @@ import { Route, NavigationGuard } from "vue-router";
 import { mapGetters } from "vuex";
 
 import AssetContextMenu from "@/assetManager/contextMenu.vue";
-import ConfirmDialog from "@/core/components/modals/confirm.vue";
 import Prompt from "@/core/components/modals/prompt.vue";
 
 import { socket } from "@/assetManager/socket";
@@ -19,7 +18,6 @@ Component.registerHooks(["beforeRouteEnter"]);
 @Component({
     components: {
         Prompt,
-        ConfirmDialog,
         AssetContextMenu,
     },
     computed: {
@@ -42,6 +40,10 @@ Component.registerHooks(["beforeRouteEnter"]);
     },
 })
 export default class AssetManager extends Vue {
+    $refs!: {
+        prompt: Prompt;
+    };
+
     currentFolder!: number;
     fildes!: number[];
     firstSelectedFile!: Asset | null;
@@ -65,9 +67,9 @@ export default class AssetManager extends Vue {
         assetStore.clearSelected();
         socket.emit("Folder.Get", this.currentFolder);
     }
-    createDirectory(): void {
-        const name = window.prompt(this.$t("assetManager.manager.new_folder_name").toString());
-        if (name !== null) {
+    async createDirectory(): Promise<void> {
+        const name = await this.$refs.prompt.prompt(this.$t("assetManager.manager.new_folder_name").toString(), "?");
+        if (name !== undefined) {
             socket.emit("Folder.Create", { name, parent: this.currentFolder });
         }
     }
@@ -237,7 +239,6 @@ export default class AssetManager extends Vue {
         </div>
         <AssetContextMenu ref="cm"></AssetContextMenu>
         <Prompt ref="prompt"></Prompt>
-        <ConfirmDialog ref="confirm"></ConfirmDialog>
     </div>
 </template>
 

--- a/client/src/core/components/modals/confirm.vue
+++ b/client/src/core/components/modals/confirm.vue
@@ -23,7 +23,7 @@ export default class ConfirmDialog extends Vue {
     text = "";
     focus: "confirm" | "deny" = "deny";
 
-    resolve: (ok: boolean) => void = (_ok: boolean) => {};
+    resolve: (ok: boolean | undefined) => void = (_ok: boolean | undefined) => {};
     reject: () => void = () => {};
 
     confirm(): void {
@@ -35,14 +35,14 @@ export default class ConfirmDialog extends Vue {
         this.close();
     }
     close(): void {
-        this.reject();
+        this.resolve(undefined);
         this.visible = false;
     }
     open(
         title: string,
         text = "",
         buttons?: { yes?: string; no?: string; focus?: "confirm" | "deny"; showNo?: boolean },
-    ): Promise<boolean> {
+    ): Promise<boolean | undefined> {
         this.yes = buttons?.yes ?? "yes";
         this.no = buttons?.no ?? "no";
         this.showNo = buttons?.showNo ?? true;

--- a/client/src/core/components/modals/modal.vue
+++ b/client/src/core/components/modals/modal.vue
@@ -111,6 +111,7 @@ export default class Modal extends Vue {
 }
 
 .modal-mask {
+    pointer-events: all;
     background-color: rgba(0, 0, 0, 0.5);
     transition: opacity 0.3s ease;
 }

--- a/client/src/core/components/modals/modal.vue
+++ b/client/src/core/components/modals/modal.vue
@@ -33,11 +33,11 @@ export default class Modal extends Vue {
         this.$emit("close");
     }
     updatePosition(): void {
+        if (this.$refs.container === undefined) return;
         if (!this.positioned) {
-            const container = this.$refs.container as any;
-            if (container.offsetWidth === 0 && container.offsetHeight === 0) return;
-            this.$refs.container.style.left = (window.innerWidth - container.offsetWidth) / 2 + "px";
-            this.$refs.container.style.top = (window.innerHeight - container.offsetHeight) / 2 + "px";
+            if (this.$refs.container.offsetWidth === 0 && this.$refs.container.offsetHeight === 0) return;
+            this.$refs.container.style.left = (window.innerWidth - this.$refs.container.offsetWidth) / 2 + "px";
+            this.$refs.container.style.top = (window.innerHeight - this.$refs.container.offsetHeight) / 2 + "px";
             this.positioned = true;
         }
     }
@@ -46,7 +46,7 @@ export default class Modal extends Vue {
         event.dataTransfer.setData("Hack", "");
         // Because the drag event is happening on the header, we have to change the drag image
         // in order to give the impression that the entire modal is dragged.
-        event.dataTransfer.setDragImage(this.$refs.container as Element, event.offsetX, event.offsetY);
+        event.dataTransfer.setDragImage(this.$refs.container, event.offsetX, event.offsetY);
         this.offsetX = event.offsetX;
         this.offsetY = event.offsetY;
         this.screenX = event.screenX;

--- a/client/src/core/components/modals/prompt.vue
+++ b/client/src/core/components/modals/prompt.vue
@@ -23,7 +23,7 @@ export default class Prompt extends Vue {
     validation: (value: string) => { valid: true } | { valid: false; reason: string } = _value => ({
         valid: true,
     });
-    resolve: (value: string) => void = (_value: string) => {};
+    resolve: (value: string | undefined) => void = (_value: string | undefined) => {};
     reject: () => void = () => {};
 
     submit(): void {
@@ -37,7 +37,7 @@ export default class Prompt extends Vue {
     }
 
     close(): void {
-        this.reject();
+        this.resolve(undefined);
         this.visible = false;
     }
 
@@ -45,7 +45,7 @@ export default class Prompt extends Vue {
         question: string,
         title: string,
         validation?: (value: string) => { valid: true } | { valid: false; reason: string },
-    ): Promise<string> {
+    ): Promise<string | undefined> {
         this.answer = "";
         this.question = question;
         this.title = title;
@@ -78,7 +78,7 @@ export default class Prompt extends Vue {
         <div class="modal-body">
             <div id="question">{{ question }}</div>
             <div id="error" v-if="error">{{ error }}</div>
-            <input id="answer" type="text" ref="answer" v-model="answer" @keyup.enter="submit" />
+            <input type="text" ref="answer" v-model="answer" @keyup.enter="submit" />
         </div>
         <div class="modal-footer">
             <button @click="submit" v-t="'common.submit'"></button>

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -6,11 +6,8 @@ import Component from "vue-class-component";
 import "@/game/api/events";
 
 import ConfirmDialog from "@/core/components/modals/confirm.vue";
-import Prompt from "@/core/components/modals/prompt.vue";
 import SelectionBox from "@/core/components/modals/SelectionBox.vue";
 import Initiative from "@/game/ui/initiative/initiative.vue";
-import LabelManager from "@/game/ui/labels.vue";
-import NoteDialog from "@/game/ui/note.vue";
 import UI from "./ui/ui.vue";
 
 import { createConnection, socket } from "@/game/api/socket";
@@ -26,13 +23,10 @@ import { BaseTemplate } from "./comm/types/templates";
 
 @Component({
     components: {
-        "prompt-dialog": Prompt,
-        "confirm-dialog": ConfirmDialog,
-        "initiative-dialog": Initiative,
-        "note-dialog": NoteDialog,
-        "label-dialog": LabelManager,
-        "selection-box": SelectionBox,
-        ui: UI,
+        ConfirmDialog,
+        Initiative,
+        SelectionBox,
+        UI,
     },
     beforeRouteEnter(to, from, next) {
         coreStore.setLoading(true);
@@ -49,11 +43,9 @@ import { BaseTemplate } from "./comm/types/templates";
 })
 export default class Game extends Vue {
     $refs!: {
-        confirm: InstanceType<typeof ConfirmDialog>;
-        note: InstanceType<typeof NoteDialog>;
-        prompt: InstanceType<typeof Prompt>;
-        selectionbox: InstanceType<typeof SelectionBox>;
-        ui: InstanceType<typeof UI>;
+        confirm: ConfirmDialog;
+        selectionbox: SelectionBox;
+        ui: UI;
     };
 
     ready = {
@@ -178,6 +170,7 @@ export default class Game extends Vue {
                                 this.$t("game.ui.templates.choose").toString(),
                                 choices,
                             );
+                            if (choice === undefined) return;
                             options = response.options!.templates[choice];
                         } catch {
                             // no-op ; action cancelled
@@ -193,7 +186,7 @@ export default class Game extends Vue {
 
 <template>
     <div id="main" @mouseleave="mouseleave" @wheel="zoom">
-        <ui v-if="$store.state.game.boardInitialized" ref="ui"></ui>
+        <UI v-if="$store.state.game.boardInitialized" ref="ui"></UI>
         <div id="board">
             <div
                 id="layers"
@@ -208,12 +201,9 @@ export default class Game extends Vue {
                 @touchend="touchend"
             ></div>
         </div>
-        <initiative-dialog ref="initiative" id="initiativedialog"></initiative-dialog>
-        <note-dialog ref="note"></note-dialog>
-        <label-dialog ref="labels"></label-dialog>
-        <prompt-dialog ref="prompt"></prompt-dialog>
-        <confirm-dialog ref="confirm"></confirm-dialog>
-        <selection-box ref="selectionbox"></selection-box>
+        <Initiative ref="initiative" id="initiativedialog"></Initiative>
+        <ConfirmDialog ref="confirm"></ConfirmDialog>
+        <SelectionBox ref="selectionbox"></SelectionBox>
     </div>
 </template>
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -65,7 +65,7 @@ socket.on("Board.Floor.Set", async (floor: ServerFloor) => {
     await addFloor(floor);
     visibilityStore.recalculateVision(getFloorId(floor.name));
     visibilityStore.recalculateMovement(getFloorId(floor.name));
-    console.log(floor.name);
+
     if (selectFloor) {
         floorStore.selectFloor({ targetFloor: floor.name, sync: false });
         requestAnimationFrame(layerManager.drawLoop);

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -42,7 +42,6 @@ socket.on("Shape.Options.Tracker.Update", (data: { uuid: string; shape: string }
 });
 
 socket.on("Shape.Options.Aura.Create", (data: ServerAura): void => {
-    console.log(data);
     const shape = layerManager.UUIDMap.get(data.shape);
     if (shape === undefined) return;
     shape.pushAura(aurasFromServer(data)[0]);

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -147,7 +147,7 @@ export function snapToGridPoint(point: GlobalPoint): [GlobalPoint, boolean] {
     let originShifted = new GlobalPoint(point.x % DEFAULT_GRID_SIZE, point.y % DEFAULT_GRID_SIZE);
     if (originShifted.x < 0) originShifted = originShifted.add(new Vector(DEFAULT_GRID_SIZE, 0));
     if (originShifted.y < 0) originShifted = originShifted.add(new Vector(0, DEFAULT_GRID_SIZE));
-    console.log(originShifted.asArray());
+
     const targets = [
         new GlobalPoint(0, 0),
         new GlobalPoint(0, DEFAULT_GRID_SIZE),

--- a/client/src/game/shapes/template.ts
+++ b/client/src/game/shapes/template.ts
@@ -26,7 +26,6 @@ export function applyTemplate<T extends ServerShape>(shape: T, template: BaseTem
     for (const auraTemplate of template.auras ?? []) {
         const defaultAura = aurasToServer(shape.uuid, [createEmptyAura()], false)[0];
         shape.auras.push({ ...defaultAura, ...auraTemplate });
-        console.log(shape.auras[shape.auras.length - 1]);
     }
 
     // Shape specific keys

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -3,7 +3,8 @@ import Vue from "vue";
 import Component from "vue-class-component";
 import draggable from "vuedraggable";
 
-import Game from "@/game/Game.vue";
+import ConfirmDialog from "@/core/components/modals/confirm.vue";
+import Prompt from "@/core/components/modals/prompt.vue";
 
 import { layerManager } from "@/game/layers/manager";
 import { removeFloor } from "@/game/layers/utils";
@@ -14,10 +15,17 @@ import { sendCreateFloor, sendRemoveFloor, sendFloorSetVisible } from "../api/em
 
 @Component({
     components: {
+        ConfirmDialog,
         draggable,
+        Prompt,
     },
 })
 export default class FloorSelect extends Vue {
+    $refs!: {
+        confirm: ConfirmDialog;
+        prompt: Prompt;
+    };
+
     selected = false;
 
     get IS_DM(): boolean {
@@ -60,7 +68,7 @@ export default class FloorSelect extends Vue {
     }
 
     async addFloor(): Promise<void> {
-        const value = await (this.$parent.$parent as Game).$refs.prompt.prompt(
+        const value = await this.$refs.prompt.prompt(
             this.$t("game.ui.floors.new_name").toString(),
             this.$t("game.ui.floors.creation").toString(),
         );
@@ -73,7 +81,7 @@ export default class FloorSelect extends Vue {
     }
 
     async renameFloor(index: number): Promise<void> {
-        const value = await (this.$parent.$parent as Game).$refs.prompt.prompt(
+        const value = await this.$refs.prompt.prompt(
             this.$t("game.ui.floors.new_name").toString(),
             this.$t("game.ui.floors.rename_header_title").toString(),
         );
@@ -84,7 +92,7 @@ export default class FloorSelect extends Vue {
     async removeFloor(floor: Floor): Promise<void> {
         if (this.floors.length <= 1) return;
         if (
-            !(await (this.$parent.$parent as Game).$refs.confirm.open(
+            !(await this.$refs.confirm.open(
                 this.$t("common.warning").toString(),
                 this.$t("game.ui.floors.warning_msg_Z", { z: floor.name }).toString(),
             ))
@@ -122,6 +130,8 @@ export default class FloorSelect extends Vue {
 
 <template>
     <div id="floor-layer">
+        <ConfirmDialog ref="confirm"></ConfirmDialog>
+        <Prompt ref="prompt"></Prompt>
         <div id="floor-selector" @click="selected = !selected" v-if="showFloorSelector">
             <a href="#">{{ selectedFloorIndex }}</a>
         </div>

--- a/client/src/game/ui/labels.vue
+++ b/client/src/game/ui/labels.vue
@@ -21,17 +21,11 @@ export default class LabelManager extends Vue {
     newName = "";
     search = "";
 
-    mounted(): void {
-        EventBus.$on("LabelManager.Open", () => {
-            this.visible = true;
-            this.newCategory = "";
-            this.newName = "";
-            this.$nextTick(() => (this.$refs.search as HTMLInputElement).focus());
-        });
-    }
-
-    beforeDestroy(): void {
-        EventBus.$off("LabelManager.Open");
+    open(): void {
+        this.visible = true;
+        this.newCategory = "";
+        this.newName = "";
+        this.$nextTick(() => (this.$refs.search as HTMLInputElement).focus());
     }
 
     get labels(): { [category: string]: Label[] } {
@@ -107,14 +101,14 @@ export default class LabelManager extends Vue {
         </div>
         <div class="modal-body">
             <div class="grid">
-                <div class="header">
+                <div>
                     <abbr :title="$t('game.ui.labels.category')" v-t="'game.ui.labels.cat_abbr'"></abbr>
                 </div>
-                <div class="header name" v-t="'common.name'"></div>
-                <div class="header">
+                <div class="name" v-t="'common.name'"></div>
+                <div>
                     <abbr :title="$t('game.ui.labels.visible')" v-t="'game.ui.labels.vis_abbr'"></abbr>
                 </div>
-                <div class="header">
+                <div>
                     <abbr :title="$t('game.ui.labels.delete')" v-t="'game.ui.labels.del_abbr'"></abbr>
                 </div>
                 <div class="separator spanrow" style="margin: 0 0 7px"></div>

--- a/client/src/game/ui/menu/menu.vue
+++ b/client/src/game/ui/menu/menu.vue
@@ -5,9 +5,9 @@ import Component from "vue-class-component";
 import { mapState } from "vuex";
 
 import ColorPicker from "@/core/components/colorpicker.vue";
-import Game from "@/game/Game.vue";
 import AssetNode from "@/game/ui/menu/asset_node.vue";
 import LanguageSelect from "@/core/components/languageSelect.vue";
+import NoteDialog from "@/game/ui/note.vue";
 
 import { uuidv4 } from "@/core/utils";
 import { Note } from "@/game/comm/types/general";
@@ -20,12 +20,17 @@ import { EventBus } from "../../event-bus";
         "color-picker": ColorPicker,
         "asset-node": AssetNode,
         LanguageSelect,
+        NoteDialog,
     },
     computed: {
         ...mapState("game", ["assets", "notes", "markers"]),
     },
 })
 export default class MenuBar extends Vue {
+    $refs!: {
+        note: NoteDialog;
+    };
+
     assetSearch = "";
 
     get IS_DM(): boolean {
@@ -76,7 +81,7 @@ export default class MenuBar extends Vue {
         this.openNote(note);
     }
     openNote(note: Note): void {
-        (this.$parent.$parent as Game).$refs.note.open(note);
+        this.$refs.note.open(note);
     }
 
     openDmSettings(): void {
@@ -105,6 +110,7 @@ export default class MenuBar extends Vue {
 <template>
     <!-- SETTINGS -->
     <div id="menu" @click="settingsClick" ref="settings">
+        <NoteDialog ref="note"></NoteDialog>
         <div style="width: 200px; overflow-y: auto; overflow-x: hidden">
             <!-- ASSETS -->
             <template v-if="IS_DM">

--- a/client/src/game/ui/note.vue
+++ b/client/src/game/ui/note.vue
@@ -2,18 +2,24 @@
 import Vue from "vue";
 import Component from "vue-class-component";
 
+import ConfirmDialog from "@/core/components/modals/confirm.vue";
 import Modal from "@/core/components/modals/modal.vue";
-import Game from "@/game/Game.vue";
 
 import { Note } from "@/game/comm/types/general";
 import { gameStore } from "@/game/store";
 
 @Component({
     components: {
+        ConfirmDialog,
         Modal,
     },
 })
 export default class NoteDialog extends Vue {
+    $refs!: {
+        confirm: ConfirmDialog;
+        textarea: HTMLTextAreaElement;
+    };
+
     visible = false;
     note: Note | null = null;
 
@@ -26,7 +32,7 @@ export default class NoteDialog extends Vue {
     }
     calcHeight(): void {
         if (this.$refs.textarea) {
-            const el = this.$refs.textarea as HTMLElement;
+            const el = this.$refs.textarea;
             el.style.height = "auto";
             el.style.height = el.scrollHeight + "px";
         }
@@ -35,7 +41,7 @@ export default class NoteDialog extends Vue {
         if (this.note) gameStore.updateNote({ note: this.note, sync: true });
     }
     async removeNote(): Promise<void> {
-        const result = await (this.$parent as Game).$refs.confirm.open(this.$t("game.ui.note.warning_msg").toString());
+        const result = await this.$refs.confirm.open(this.$t("game.ui.note.warning_msg").toString());
         if (result && this.note) {
             gameStore.removeNote({ note: this.note, sync: true });
             this.visible = false;
@@ -46,6 +52,7 @@ export default class NoteDialog extends Vue {
 
 <template>
     <modal v-if="note !== null" :visible="visible" @close="visible = false" :mask="false">
+        <ConfirmDialog ref="confirm"></ConfirmDialog>
         <div
             class="modal-header"
             slot="header"

--- a/client/src/game/ui/note.vue
+++ b/client/src/game/ui/note.vue
@@ -25,7 +25,6 @@ export default class NoteDialog extends Vue {
         });
     }
     calcHeight(): void {
-        console.log(this.$refs.textarea);
         if (this.$refs.textarea) {
             const el = this.$refs.textarea as HTMLElement;
             el.style.height = "auto";

--- a/client/src/game/ui/selection/edit_dialog/ExtraSettings.vue
+++ b/client/src/game/ui/selection/edit_dialog/ExtraSettings.vue
@@ -4,16 +4,18 @@ import Component from "vue-class-component";
 
 import { Prop, Watch } from "vue-property-decorator";
 
-import { Shape } from "@/game/shapes/shape";
-import { EventBus } from "@/game/event-bus";
+import LabelManager from "@/game/ui/labels.vue";
 
-@Component
+import { Shape } from "@/game/shapes/shape";
+
+@Component({ components: { LabelManager } })
 export default class AccessSettings extends Vue {
     @Prop() owned!: boolean;
     @Prop() shape!: Shape;
     @Prop() active!: boolean;
 
     $refs!: {
+        labels: LabelManager;
         textarea: HTMLTextAreaElement;
     };
 
@@ -29,7 +31,7 @@ export default class AccessSettings extends Vue {
     }
 
     openLabelManager(): void {
-        EventBus.$emit("LabelManager.Open");
+        this.$refs.labels.open();
     }
 
     removeLabel(uuid: string): void {
@@ -49,6 +51,7 @@ export default class AccessSettings extends Vue {
 
 <template>
     <div class="panel restore-panel">
+        <LabelManager ref="labels"></LabelManager>
         <div class="spanrow header" v-t="'common.labels'"></div>
         <div id="labels" class="spanrow">
             <div v-for="label in shape.labels" class="label" :key="label.uuid">

--- a/client/src/game/ui/selection/selection_info.vue
+++ b/client/src/game/ui/selection/selection_info.vue
@@ -2,7 +2,7 @@
 import Vue from "vue";
 import Component from "vue-class-component";
 
-import Game from "@/game/Game.vue";
+import Prompt from "@/core/components/modals/prompt.vue";
 import ShapeSettings from "@/game/ui/selection/edit_dialog/ShapeSettings.vue";
 
 import { EventBus } from "@/game/event-bus";
@@ -13,10 +13,16 @@ import { Aura, Tracker } from "@/game/shapes/interfaces";
 
 @Component({
     components: {
+        Prompt,
         ShapeSettings,
     },
 })
 export default class SelectionInfo extends Vue {
+    $refs!: {
+        prompt: Prompt;
+        shapeSettings: ShapeSettings;
+    };
+
     shape: Shape | null = null;
 
     mounted(): void {
@@ -52,15 +58,16 @@ export default class SelectionInfo extends Vue {
     }
 
     openEditDialog(): void {
-        (this.$refs.shapeSettings as any)[0].visible = true;
+        this.$refs.shapeSettings.visible = true;
     }
     async changeValue(object: Tracker | Aura, isAura: boolean): Promise<void> {
         if (this.shape === null) return;
-        const value = await (this.$parent.$parent as Game).$refs.prompt.prompt(
+        const value = await this.$refs.prompt.prompt(
             this.$t("game.ui.selection.select_info.new_value_NAME", { name: object.name }).toString(),
             this.$t("game.ui.selection.select_info.updating_NAME", { name: object.name }).toString(),
         );
-        if (this.shape === null) return;
+        if (value === undefined || this.shape === null) return;
+
         const ogValue = object.value;
 
         if (value[0] === "+" || value[0] === "-") object.value += parseInt(value, 10);
@@ -77,6 +84,7 @@ export default class SelectionInfo extends Vue {
 
 <template>
     <div v-show="shapes.length > 0">
+        <Prompt ref="prompt"></Prompt>
         <div v-for="shape in shapes" :key="shape.uuid">
             <div id="selection-menu">
                 <div

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -6,7 +6,6 @@ import { mapState } from "vuex";
 
 import ConfirmDialog from "@/core/components/modals/confirm.vue";
 import ContextMenu from "@/core/components/contextmenu.vue";
-import Game from "@/game/Game.vue";
 import Prompt from "@/core/components/modals/prompt.vue";
 import SelectionBox from "@/core/components/modals/SelectionBox.vue";
 
@@ -124,7 +123,7 @@ export default class ShapeContext extends Vue {
 
         switch (spawnInfo.length) {
             case 0:
-                await (this.$parent.$parent.$parent as Game).$refs.confirm.open(
+                await this.$refs.confirmDialog.open(
                     this.$t("game.ui.selection.shapecontext.no_spawn_set_title").toString(),
                     this.$t("game.ui.selection.shapecontext.no_spawn_set_text").toString(),
                     { showNo: false, yes: "Ok" },
@@ -139,6 +138,7 @@ export default class ShapeContext extends Vue {
                     "Choose the desired spawn location",
                     spawnInfo.map(s => s.name),
                 );
+                if (choice === undefined) return;
                 const choiceShape = spawnInfo.find(s => s.name === choice);
                 if (choiceShape === undefined) return;
                 spawnLocation = choiceShape;
@@ -181,11 +181,13 @@ export default class ShapeContext extends Vue {
         const selection = layer.getSelection();
         let groupInitiatives = false;
         if (new Set(selection.map(s => s.groupId)).size < selection.length) {
-            groupInitiatives = await this.$refs.confirmDialog.open(
+            const answer = await this.$refs.confirmDialog.open(
                 "Adding initiative",
                 "Some of the selected shapes belong to the same group. Do you wish to add 1 entry for these?",
                 { no: "no, create a separate entry for each", focus: "confirm" },
             );
+            if (answer === undefined) return;
+            groupInitiatives = answer;
         }
         const groupsProcessed = new Set();
         for (const shape of selection) {
@@ -263,6 +265,7 @@ export default class ShapeContext extends Vue {
                 defaultButton: this.$t("game.ui.templates.overwrite").toString(),
                 customButton: this.$t("game.ui.templates.create_new").toString(),
             });
+            if (choice === undefined) return;
             assetOptions.templates[choice] = toTemplate(shape.asDict());
             sendAssetOptions(shape.assetId, assetOptions);
         } catch {
@@ -321,6 +324,7 @@ export default class ShapeContext extends Vue {
                 no: "No, reset them",
             },
         );
+        if (keepBadges === undefined) return;
         createNewGroupForShapes(
             this.getSelection().map(s => s.uuid),
             keepBadges,
@@ -336,6 +340,7 @@ export default class ShapeContext extends Vue {
                 no: "No, reset them",
             },
         );
+        if (keepBadges === undefined) return;
         let targetGroup: string | undefined;
         const membersToMove: { uuid: string; badge?: number }[] = [];
         for (const shape of this.getSelection()) {

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -181,14 +181,12 @@ export default class ShapeContext extends Vue {
         const selection = layer.getSelection();
         let groupInitiatives = false;
         if (new Set(selection.map(s => s.groupId)).size < selection.length) {
-            console.log(6);
             groupInitiatives = await this.$refs.confirmDialog.open(
                 "Adding initiative",
                 "Some of the selected shapes belong to the same group. Do you wish to add 1 entry for these?",
                 { no: "no, create a separate entry for each", focus: "confirm" },
             );
         }
-        console.log(groupInitiatives, selection);
         const groupsProcessed = new Set();
         for (const shape of selection) {
             if (!groupInitiatives || shape.groupId === undefined || !groupsProcessed.has(shape.groupId)) {

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -3,7 +3,8 @@ import Vue from "vue";
 import Component from "vue-class-component";
 
 import InputCopyElement from "@/core/components/inputCopy.vue";
-import Game from "../../../Game.vue";
+import Prompt from "@/core/components/modals/prompt.vue";
+
 import { socket } from "@/game/api/socket";
 import { EventBus } from "@/game/event-bus";
 import { gameStore, Player } from "@/game/store";
@@ -11,9 +12,14 @@ import { gameStore, Player } from "@/game/store";
 @Component({
     components: {
         InputCopyElement,
+        Prompt,
     },
 })
 export default class AdminSettings extends Vue {
+    $refs!: {
+        prompt: Prompt;
+    };
+
     showRefreshState = false;
     refreshState = "pending";
 
@@ -50,7 +56,7 @@ export default class AdminSettings extends Vue {
         gameStore.setIsLocked({ isLocked: !gameStore.isLocked, sync: true });
     }
     async deleteSession(): Promise<void> {
-        const value = await (this.$parent.$parent.$parent.$parent.$parent as Game).$refs.prompt.prompt(
+        const value = await this.$refs.prompt.prompt(
             this.$t("game.ui.settings.dm.AdminSettings.delete_session_msg_CREATOR_ROOM", {
                 creator: gameStore.roomCreator,
                 room: gameStore.roomName,
@@ -66,6 +72,7 @@ export default class AdminSettings extends Vue {
 
 <template>
     <div class="panel">
+        <Prompt ref="prompt"></Prompt>
         <div class="spanrow header" v-t="'common.players'"></div>
         <div class="row smallrow" v-for="player in players" :key="player.id">
             <div>{{ player.name }}</div>

--- a/client/src/game/ui/settings/location/LocationAdminSettings.vue
+++ b/client/src/game/ui/settings/location/LocationAdminSettings.vue
@@ -3,18 +3,23 @@ import Vue from "vue";
 import Component from "vue-class-component";
 import { Prop } from "vue-property-decorator";
 
+import ConfirmDialog from "@/core/components/modals/confirm.vue";
 import InputCopyElement from "@/core/components/inputCopy.vue";
-import Game from "@/game/Game.vue";
+
 import { gameStore } from "@/game/store";
 import { renameLocation } from "../../../api/events/location";
 
 @Component({
     components: {
+        ConfirmDialog,
         InputCopyElement,
     },
 })
 export default class LocationAdminSettings extends Vue {
     @Prop() location!: number;
+    $refs!: {
+        confirm: ConfirmDialog;
+    };
 
     get name(): string {
         return gameStore.locations.find(l => l.id === this.location)?.name ?? "";
@@ -29,7 +34,7 @@ export default class LocationAdminSettings extends Vue {
     }
 
     async deleteLocation(): Promise<void> {
-        const remove = await (this.$parent.$parent.$parent.$parent.$parent as Game).$refs.confirm.open(
+        const remove = await this.$refs.confirm.open(
             this.$t("common.warning").toString(),
             this.$t("game.ui.settings.location.LocationAdminSettings.remove_location_msg_NAME", {
                 name: this.name,
@@ -49,6 +54,7 @@ export default class LocationAdminSettings extends Vue {
 
 <template>
     <div class="panel">
+        <ConfirmDialog ref="confirm"></ConfirmDialog>
         <div class="row">
             <div>
                 <label :for="'rename-' + location" v-t="'common.name'"></label>

--- a/client/src/game/ui/tools/defaultcontext.vue
+++ b/client/src/game/ui/tools/defaultcontext.vue
@@ -3,14 +3,14 @@ import Vue from "vue";
 import Component from "vue-class-component";
 
 import ContextMenu from "@/core/components/contextmenu.vue";
+import CreateTokenModal from "./createtoken_modal.vue";
+import Prompt from "@/core/components/modals/prompt.vue";
 
 import { sendBringPlayers } from "@/game/api/emits/players";
 import { EventBus } from "@/game/event-bus";
 import { gameStore } from "@/game/store";
 import { l2gx, l2gy, l2g } from "@/game/units";
 import { floorStore } from "@/game/layers/store";
-import CreateTokenModal from "./createtoken_modal.vue";
-import Prompt from "@/core/components/modals/prompt.vue";
 import { gameSettingsStore } from "@/game/settings";
 import { layerManager } from "@/game/layers/manager";
 import { baseAdjust, uuidv4 } from "@/core/utils";
@@ -21,9 +21,16 @@ import { LocalPoint } from "@/game/geom";
 @Component({
     components: {
         ContextMenu,
+        CreateTokenModal,
+        Prompt,
     },
 })
 export default class DefaultContext extends Vue {
+    $refs!: {
+        createtokendialog: CreateTokenModal;
+        prompt: Prompt;
+    };
+
     visible = false;
     x = 0;
     y = 0;
@@ -55,14 +62,14 @@ export default class DefaultContext extends Vue {
     }
 
     createToken(): void {
-        (this.$parent.$refs.createtokendialog as CreateTokenModal).open(this.x, this.y);
+        this.$refs.createtokendialog.open(this.x, this.y);
         this.close();
     }
 
     async createSpawnLocation(): Promise<void> {
         if (!gameStore.IS_DM) return;
         const spawnLocations = gameSettingsStore.spawnLocations;
-        const spawnName = await (this.$parent.$parent.$parent.$refs.prompt as Prompt).prompt(
+        const spawnName = await this.$refs.prompt.prompt(
             this.$t("game.ui.tools.defaultcontext.new_spawn_question").toString(),
             this.$t("game.ui.tools.defaultcontext.new_spawn_title").toString(),
             (value: string) => {
@@ -73,7 +80,7 @@ export default class DefaultContext extends Vue {
                 return { valid: true };
             },
         );
-        if (spawnName === "") return;
+        if (spawnName === undefined || spawnName === "") return;
         const uuid = uuidv4();
 
         const src = "/static/img/spawn.png";
@@ -107,6 +114,9 @@ export default class DefaultContext extends Vue {
 
 <template>
     <ContextMenu :visible="visible" :left="x + 'px'" :top="y + 'px'" @close="close">
+        <CreateTokenModal ref="createtokendialog"></CreateTokenModal>
+        <Prompt ref="prompt"></Prompt>
+
         <li @click="bringPlayers" v-if="IS_DM" v-t="'game.ui.tools.defaultcontext.bring_pl'"></li>
         <li @click="createToken" v-t="'game.ui.tools.defaultcontext.create_basic_token'"></li>
         <li @click="showInitiative" v-t="'game.ui.tools.defaultcontext.show_initiative'"></li>

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -5,7 +5,6 @@ import { Watch } from "vue-property-decorator";
 import { mapGetters } from "vuex";
 
 import ColorPicker from "@/core/components/colorpicker.vue";
-import DefaultContext from "./defaultcontext.vue";
 import Tool from "./tool.vue";
 import Tools from "./tools.vue";
 
@@ -41,6 +40,8 @@ import { sendShapeSizeUpdate } from "@/game/api/emits/shape/core";
     },
 })
 export default class DrawTool extends Tool implements ToolBasics {
+    $parent!: Tools;
+
     name = ToolName.Draw;
     active = false;
 
@@ -128,7 +129,7 @@ export default class DrawTool extends Tool implements ToolBasics {
 
     @Watch("currentFloor")
     onFloorChange(newValue: Floor, oldValue: Floor): void {
-        if ((this.$parent as Tools).currentTool === this.name) {
+        if (this.$parent.currentTool === this.name) {
             let mouse: { x: number; y: number } | undefined = undefined;
             if (this.brushHelper !== null) {
                 mouse = { x: this.brushHelper.refPoint.x, y: this.brushHelper.refPoint.y };
@@ -140,7 +141,7 @@ export default class DrawTool extends Tool implements ToolBasics {
 
     @Watch("currentLayer")
     onLayerChange(newValue: Layer, oldValue: Layer): void {
-        if ((this.$parent as Tools).currentTool === this.name) {
+        if (this.$parent.currentTool === this.name) {
             let mouse: { x: number; y: number } | undefined = undefined;
             if (this.brushHelper !== null) {
                 mouse = { x: this.brushHelper.refPoint.x, y: this.brushHelper.refPoint.y };
@@ -439,7 +440,7 @@ export default class DrawTool extends Tool implements ToolBasics {
             }
             this.finaliseShape();
         } else if (!this.active) {
-            (this.$parent.$refs.defaultcontext as DefaultContext).open(event);
+            this.$parent.$refs.defaultcontext.open(event);
         }
     }
 

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -48,8 +48,13 @@ const start = new GlobalPoint(-1000, -1000);
 
 const ANGLE_SNAP = (45 * Math.PI) / 180; // Calculate 45 degrees in radians just once
 
-@Component
+@Component({ components: { ShapeContext } })
 export default class SelectTool extends Tool implements ToolBasics {
+    $parent!: Tools;
+    $refs!: {
+        shapecontext: ShapeContext;
+    };
+
     name = ToolName.Select;
     showContextMenu = false;
     active = false;
@@ -78,7 +83,7 @@ export default class SelectTool extends Tool implements ToolBasics {
         EventBus.$on("SelectionInfo.Shapes.Set", (shapes: Shape[]) => {
             this.removeRotationUi();
             // We don't have feature information, might want to store this as a property instead ?
-            if ((this.$parent as Tools).mode === "Build" && shapes.length > 0) this.createRotationUi({});
+            if (this.$parent.mode === "Build" && shapes.length > 0) this.createRotationUi({});
         });
     }
 
@@ -482,7 +487,7 @@ export default class SelectTool extends Tool implements ToolBasics {
         for (const shape of layer.getSelection()) {
             if (shape.contains(globalMouse)) {
                 layer.invalidate(true);
-                (this.$parent.$refs.shapecontext as ShapeContext).open(event);
+                this.$refs.shapecontext.open(event);
                 return;
             }
         }
@@ -493,7 +498,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             if (shape.contains(globalMouse)) {
                 layer.setSelection(shape);
                 layer.invalidate(true);
-                (this.$parent.$refs.shapecontext as ShapeContext).open(event);
+                this.$refs.shapecontext.open(event);
                 return;
             }
         }
@@ -617,3 +622,7 @@ export default class SelectTool extends Tool implements ToolBasics {
     }
 }
 </script>
+
+<template>
+    <ShapeContext ref="shapecontext"></ShapeContext>
+</template>

--- a/client/src/game/ui/tools/tool.vue
+++ b/client/src/game/ui/tools/tool.vue
@@ -2,14 +2,16 @@
 import Vue from "vue";
 import Component from "vue-class-component";
 
-import DefaultContext from "@/game/ui/tools/defaultcontext.vue";
 import { ToolName, ToolPermission, ToolFeatures } from "./utils";
 import { LocalPoint } from "../../geom";
 import { getLocalPointFromEvent } from "@/game/utils";
 import { ToolBasics } from "./ToolBasics";
+import Tools from "./tools.vue";
 
 @Component
 export default class Tool extends Vue implements ToolBasics {
+    $parent!: Tools;
+
     name: ToolName | null = null;
     selected = false;
     active = false;
@@ -27,13 +29,13 @@ export default class Tool extends Vue implements ToolBasics {
     }
 
     get detailRight(): string {
-        const rect = (this.$parent.$refs[this.name + "-selector"] as any)[0].getBoundingClientRect();
+        const rect = (this.$parent as any).$refs[this.name + "-selector"][0].getBoundingClientRect();
         const mid = rect.left + rect.width / 2;
 
         return `${window.innerWidth - Math.min(window.innerWidth - 25, mid + 75)}px`;
     }
     get detailArrow(): string {
-        const rect = (this.$parent.$refs[this.name + "-selector"] as any)[0].getBoundingClientRect();
+        const rect = (this.$parent as any).$refs[this.name + "-selector"][0].getBoundingClientRect();
         const mid = rect.left + rect.width / 2;
         const right = Math.min(window.innerWidth - 25, mid + 75);
         return `${right - mid - 14}px`; // border width
@@ -62,7 +64,7 @@ export default class Tool extends Vue implements ToolBasics {
     onPinchMove(_event: TouchEvent, _features: ToolFeatures): void {}
     onPinchEnd(_event: TouchEvent, _features: ToolFeatures): void {}
     onContextMenu(event: MouseEvent, _features: ToolFeatures): void {
-        (this.$parent.$refs.defaultcontext as DefaultContext).open(event);
+        this.$parent.$refs.defaultcontext.open(event);
     }
 
     onSelect(): void {}

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -2,8 +2,7 @@
 import Vue from "vue";
 import Component from "vue-class-component";
 
-import ShapeContext from "@/game/ui/selection/shapecontext.vue";
-import CreateTokenModal from "@/game/ui/tools/createtoken_modal.vue";
+import Annotation from "../Annotation.vue";
 import DefaultContext from "@/game/ui/tools/defaultcontext.vue";
 import DrawTool from "@/game/ui/tools/draw.vue";
 import FilterTool from "@/game/ui/tools/filter.vue";
@@ -12,6 +11,7 @@ import PanTool from "@/game/ui/tools/pan";
 import RulerTool from "@/game/ui/tools/ruler.vue";
 import SelectTool, { SelectFeatures } from "@/game/ui/tools/select.vue";
 import Tool from "./tool.vue";
+import UI from "../ui.vue";
 import VisionTool from "@/game/ui/tools/vision.vue";
 
 import { layerManager } from "@/game/layers/manager";
@@ -22,21 +22,19 @@ import { getLocalPointFromEvent } from "@/game/utils";
 import { ToolName, ToolFeatures } from "./utils";
 import { EventBus } from "@/game/event-bus";
 import { floorStore } from "@/game/layers/store";
-import UI from "../ui.vue";
 
 @Component({
     components: {
-        SelectTool,
-        PanTool,
-        DrawTool,
-        RulerTool,
-        PingTool,
-        MapTool,
-        FilterTool,
-        VisionTool,
-        ShapeContext,
+        Annotation,
         DefaultContext,
-        CreateTokenModal,
+        DrawTool,
+        FilterTool,
+        MapTool,
+        PanTool,
+        PingTool,
+        RulerTool,
+        SelectTool,
+        VisionTool,
     },
     watch: {
         currentTool(newValue: ToolName, oldValue: ToolName) {
@@ -50,20 +48,24 @@ import UI from "../ui.vue";
     },
 })
 export default class Tools extends Vue {
+    $parent!: UI;
     $refs!: {
-        selectTool: InstanceType<typeof SelectTool>;
-        panTool: InstanceType<typeof PanTool>;
-        drawTool: InstanceType<typeof PanTool>;
-        rulerTool: InstanceType<typeof PanTool>;
-        pingTool: InstanceType<typeof PanTool>;
-        mapTool: InstanceType<typeof PanTool>;
-        filterTool: InstanceType<typeof PanTool>;
-        visionTool: InstanceType<typeof PanTool>;
+        selectTool: SelectTool;
+        panTool: PanTool;
+        drawTool: PanTool;
+        rulerTool: PanTool;
+        pingTool: PanTool;
+        mapTool: PanTool;
+        filterTool: PanTool;
+        visionTool: PanTool;
+
+        annotation: Annotation;
+        defaultcontext: DefaultContext;
     };
 
     mode: "Build" | "Play" = "Play";
 
-    private componentmap_: { [key in ToolName]: InstanceType<typeof Tool> } = {} as any;
+    private componentmap_: { [key in ToolName]: Tool } = {} as any;
 
     mounted(): void {
         this.componentmap_ = {
@@ -104,7 +106,7 @@ export default class Tools extends Vue {
         [ToolName.Vision, {}],
     ];
 
-    get componentMap(): { [key in ToolName]: InstanceType<typeof Tool> } {
+    get componentMap(): { [key in ToolName]: Tool } {
         return this.componentmap_;
     }
 
@@ -193,12 +195,12 @@ export default class Tools extends Vue {
                     shape.contains(l2g(getLocalPointFromEvent(event)))
                 ) {
                     found = true;
-                    (this.$parent as UI).$refs.annotation.setActiveText(shape.annotation);
+                    this.$refs.annotation.setActiveText(shape.annotation);
                 }
             }
         }
         if (!found) {
-            (this.$parent as UI).$refs.annotation.setActiveText("");
+            this.$refs.annotation.setActiveText("");
         }
     }
     mouseleave(event: MouseEvent): void {
@@ -279,12 +281,12 @@ export default class Tools extends Vue {
                 const shape = layerManager.UUIDMap.get(uuid)!;
                 if (shape.contains(l2g(getLocalPointFromEvent(event)))) {
                     found = true;
-                    (this.$parent as UI).$refs.annotation.setActiveText(shape.annotation);
+                    this.$refs.annotation.setActiveText(shape.annotation);
                 }
             }
         }
         if (!found) {
-            (this.$parent as UI).$refs.annotation.setActiveText("");
+            this.$refs.annotation.setActiveText("");
         }
     }
 
@@ -335,6 +337,7 @@ export default class Tools extends Vue {
 
 <template>
     <div style="pointer-events: auto">
+        <Annotation ref="annotation"></Annotation>
         <div id="toolselect">
             <ul>
                 <li
@@ -364,9 +367,7 @@ export default class Tools extends Vue {
                 <MapTool v-show="currentTool === 'Map'" ref="mapTool"></MapTool>
                 <FilterTool v-show="currentTool === 'Filter'" ref="filterTool"></FilterTool>
                 <VisionTool v-show="currentTool === 'Vision'" ref="visionTool"></VisionTool>
-                <ShapeContext ref="shapecontext"></ShapeContext>
                 <DefaultContext ref="defaultcontext"></DefaultContext>
-                <CreateTokenModal ref="createtokendialog"></CreateTokenModal>
             </template>
         </div>
     </div>

--- a/client/src/game/ui/ui.vue
+++ b/client/src/game/ui/ui.vue
@@ -6,7 +6,6 @@ import Component from "vue-class-component";
 
 import { mapState } from "vuex";
 
-import Annotation from "./Annotation.vue";
 import DmSettings from "@/game/ui/settings/dm/DmSettings.vue";
 import FloorSelect from "@/game/ui/floors.vue";
 import LocationBar from "./menu/locations.vue";
@@ -23,7 +22,6 @@ import { coreStore } from "../../core/store";
 
 @Component({
     components: {
-        Annotation,
         DmSettings,
         FloorSelect,
         LocationBar,
@@ -40,8 +38,7 @@ import { coreStore } from "../../core/store";
 })
 export default class UI extends Vue {
     $refs!: {
-        annotation: InstanceType<typeof Annotation>;
-        tools: InstanceType<typeof Tools>;
+        tools: Tools;
     };
 
     visible = {
@@ -209,7 +206,6 @@ export default class UI extends Vue {
         <MarkdownModal v-if="showChangelog" :title="$t('game.ui.ui.new_ver_msg')">
             {{ $t("game.ui.ui.changelog_RELEASE_LOG", { release: version.release, log: changelog }) }}
         </MarkdownModal>
-        <Annotation ref="annotation"></Annotation>
         <!-- When updating zoom boundaries, also update store updateZoom function;
             should probably do this using a store variable-->
         <vueSlider

--- a/client/src/settings/account.vue
+++ b/client/src/settings/account.vue
@@ -14,7 +14,7 @@ import { postFetch, getErrorReason } from "../core/utils";
 })
 export default class AccountSettings extends Vue {
     $refs!: {
-        confirm: InstanceType<typeof ConfirmDialog>;
+        confirm: ConfirmDialog;
         changePasswordButton: HTMLButtonElement;
         passwordResetField: HTMLInputElement;
         passwordRepeatField: HTMLInputElement;


### PR DESCRIPTION
This is a change behind the scenes that gets rid of some $parent.$parent chains to reuse dialog components. Instead these components are now just created multiple times in the relevant place.