### PR TITLE
bug(UI): Fix dead area in topcenter of UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ These usually have no immediately visible impact on regular users
 -   Resizing rotating shapes with snapping now correctly snaps to grid points
 -   Dropped assets not immediately rendering
 -   Shapes with a broken index value (used for move to back/move to front)
+-   Area in the topcenter of the screen where the mouse could sometimes not be used
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -336,7 +336,7 @@ export default class Tools extends Vue {
 </script>
 
 <template>
-    <div style="pointer-events: auto">
+    <div id="tools">
         <Annotation ref="annotation"></Annotation>
         <div id="toolselect">
             <ul>
@@ -374,6 +374,10 @@ export default class Tools extends Vue {
 </template>
 
 <style scoped lang="scss">
+#tools > * {
+    pointer-events: auto;
+}
+
 #toolselect {
     position: absolute;
     bottom: 25px;


### PR DESCRIPTION
There was an area in the topcenter of the screen that under certain circumstances would prevent any mouse actions. This is now resolved.