### PR TITLE
bug(Aura): Fix public aura sync issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ These usually have no immediately visible impact on regular users
 -   Dropped assets not immediately rendering
 -   Shapes with a broken index value (used for move to back/move to front)
 -   Area in the topcenter of the screen where the mouse could sometimes not be used
+-   Auras that become public are not properly configured as a vision source on other clients
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -718,6 +718,7 @@ export abstract class Shape {
 
     pushAura(aura: Aura): void {
         this.auras.push(aura);
+        this.checkVisionSources();
         this.invalidate(false);
     }
 


### PR DESCRIPTION
When auras are toggled to become publicly visible, the other clients receive this event but do not properly configure the aura as a new vision source. This causes the aura to not actually be visible until a refresh in some cases.