### PR TITLE
feat(UI): Allow opening of shape context menu in other tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ These usually have no immediately visible impact on regular users
 -   Round counter now starts at 1 instead of 0
 -   Create token modal now auto focuses no the input field
 -   Create token modal now submits when pressing enter in the input field
+-   Most tools now support the right click context menu on selected shapes without having to swap to select
+    -   the two exceptions are draw and map tools
+    -   filter and vision additionally allow a wider set of features from the select tool to be used
+        -   only resize/rotate are not allowed at the moment
 -   [tech] Upgraded to socket.io v3
 
 ### Fixed

--- a/client/src/game/ui/tools/filter.vue
+++ b/client/src/game/ui/tools/filter.vue
@@ -7,8 +7,9 @@ import Tool from "@/game/ui/tools/tool.vue";
 import { socket } from "@/game/api/socket";
 import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
-import { ToolName } from "./utils";
+import { ToolName, ToolPermission } from "./utils";
 import { ToolBasics } from "./ToolBasics";
+import { SelectFeatures } from "./select.vue";
 
 @Component({
     components: {
@@ -18,6 +19,10 @@ import { ToolBasics } from "./ToolBasics";
 export default class FilterTool extends Tool implements ToolBasics {
     name = ToolName.Filter;
     active = false;
+
+    get permittedTools(): ToolPermission[] {
+        return [{ name: ToolName.Select, features: { disabled: [SelectFeatures.Resize, SelectFeatures.Rotate] } }];
+    }
 
     get labels(): { [category: string]: [string, string][] } {
         const cat: { [category: string]: [string, string][] } = { "": [] };

--- a/client/src/game/ui/tools/pan.vue
+++ b/client/src/game/ui/tools/pan.vue
@@ -1,17 +1,25 @@
+<script lang="ts">
+import Component from "vue-class-component";
+
+import Tool from "@/game/ui/tools/tool.vue";
+
 import { LocalPoint } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
-import Tool from "@/game/ui/tools/tool.vue";
-import Component from "vue-class-component";
 import { sendClientLocationOptions } from "../../api/emits/client";
 import { ToolBasics } from "./ToolBasics";
-import { ToolName } from "./utils";
+import { ToolName, ToolPermission } from "./utils";
+import { SelectFeatures } from "./select.vue";
 
 @Component
 export default class PanTool extends Tool implements ToolBasics {
     name = ToolName.Pan;
     panStart = new LocalPoint(0, 0);
     active = false;
+
+    get permittedTools(): ToolPermission[] {
+        return [{ name: ToolName.Select, features: { enabled: [SelectFeatures.Context] } }];
+    }
 
     panScreen(target: LocalPoint, full: boolean): void {
         const distance = target.subtract(this.panStart).multiply(1 / gameStore.zoomFactor);
@@ -39,3 +47,4 @@ export default class PanTool extends Tool implements ToolBasics {
         sendClientLocationOptions();
     }
 }
+</script>

--- a/client/src/game/ui/tools/ping.vue
+++ b/client/src/game/ui/tools/ping.vue
@@ -1,3 +1,4 @@
+<script lang="ts">
 import { InvalidationMode, SyncMode } from "@/core/comm/types";
 import { GlobalPoint, LocalPoint } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
@@ -7,17 +8,22 @@ import Tool from "@/game/ui/tools/tool.vue";
 import { l2g } from "@/game/units";
 import Component from "vue-class-component";
 import { ToolBasics } from "./ToolBasics";
-import { ToolName } from "./utils";
+import { ToolName, ToolPermission } from "./utils";
 import { floorStore } from "../../layers/store";
 import { sendShapePositionUpdate } from "../../api/emits/shape/core";
+import { SelectFeatures } from "./select.vue";
 
 @Component
-export class PingTool extends Tool implements ToolBasics {
+export default class PingTool extends Tool implements ToolBasics {
     name = ToolName.Ping;
     active = false;
     startPoint: GlobalPoint | null = null;
     ping: Circle | null = null;
     border: Circle | null = null;
+
+    get permittedTools(): ToolPermission[] {
+        return [{ name: ToolName.Select, features: { enabled: [SelectFeatures.Context] } }];
+    }
 
     onDown(lp: LocalPoint): void {
         this.startPoint = l2g(lp);
@@ -72,3 +78,4 @@ export class PingTool extends Tool implements ToolBasics {
         layer.invalidate(true);
     }
 }
+</script>

--- a/client/src/game/ui/tools/ruler.vue
+++ b/client/src/game/ui/tools/ruler.vue
@@ -7,7 +7,7 @@ import { GlobalPoint, LocalPoint } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { l2g, l2gz } from "@/game/units";
 import { SyncMode, InvalidationMode } from "../../../core/comm/types";
-import { ToolName } from "./utils";
+import { ToolName, ToolPermission } from "./utils";
 import { gameSettingsStore } from "../../settings";
 import { ToolBasics } from "./ToolBasics";
 import { Line } from "@/game/shapes/variants/line";
@@ -17,6 +17,7 @@ import { floorStore } from "@/game/layers/store";
 import { sendShapePositionUpdate, sendTextUpdate } from "@/game/api/emits/shape/core";
 import { useSnapping } from "@/game/utils";
 import { snapToGridPoint } from "@/game/layers/utils";
+import { SelectFeatures } from "./select.vue";
 
 @Component
 export default class RulerTool extends Tool implements ToolBasics {
@@ -27,6 +28,10 @@ export default class RulerTool extends Tool implements ToolBasics {
     text: Text | null = null;
 
     showPublic = true;
+
+    get permittedTools(): ToolPermission[] {
+        return [{ name: ToolName.Select, features: { enabled: [SelectFeatures.Context] } }];
+    }
 
     get syncMode(): SyncMode {
         if (this.showPublic) return SyncMode.TEMP_SYNC;

--- a/client/src/game/ui/tools/tool.vue
+++ b/client/src/game/ui/tools/tool.vue
@@ -63,9 +63,7 @@ export default class Tool extends Vue implements ToolBasics {
     onPinchStart(_event: TouchEvent, _features: ToolFeatures): void {}
     onPinchMove(_event: TouchEvent, _features: ToolFeatures): void {}
     onPinchEnd(_event: TouchEvent, _features: ToolFeatures): void {}
-    onContextMenu(event: MouseEvent, _features: ToolFeatures): void {
-        this.$parent.$refs.defaultcontext.open(event);
-    }
+    onContextMenu(_event: MouseEvent, _features: ToolFeatures): void {}
 
     onSelect(): void {}
     onDeselect(): void {}

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -7,16 +7,17 @@ import DefaultContext from "@/game/ui/tools/defaultcontext.vue";
 import DrawTool from "@/game/ui/tools/draw.vue";
 import FilterTool from "@/game/ui/tools/filter.vue";
 import MapTool from "@/game/ui/tools/map.vue";
-import PanTool from "@/game/ui/tools/pan";
+import PanTool from "@/game/ui/tools/pan.vue";
+import PingTool from "@/game/ui/tools/ping.vue";
 import RulerTool from "@/game/ui/tools/ruler.vue";
 import SelectTool, { SelectFeatures } from "@/game/ui/tools/select.vue";
+import ShapeContext from "@/game/ui/selection/shapecontext.vue";
 import Tool from "./tool.vue";
 import UI from "../ui.vue";
 import VisionTool from "@/game/ui/tools/vision.vue";
 
 import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
-import { PingTool } from "@/game/ui/tools/ping";
 import { l2g } from "@/game/units";
 import { getLocalPointFromEvent } from "@/game/utils";
 import { ToolName, ToolFeatures } from "./utils";
@@ -34,6 +35,7 @@ import { floorStore } from "@/game/layers/store";
         PingTool,
         RulerTool,
         SelectTool,
+        ShapeContext,
         VisionTool,
     },
     watch: {
@@ -61,6 +63,8 @@ export default class Tools extends Vue {
 
         annotation: Annotation;
         defaultcontext: DefaultContext;
+        // Only used by Select directly, however Select needs to be loaded for other tools to allow Select.Context
+        shapecontext: ShapeContext;
     };
 
     mode: "Build" | "Play" = "Play";
@@ -338,6 +342,8 @@ export default class Tools extends Vue {
 <template>
     <div id="tools">
         <Annotation ref="annotation"></Annotation>
+        <ShapeContext ref="shapecontext"></ShapeContext>
+        <DefaultContext ref="defaultcontext"></DefaultContext>
         <div id="toolselect">
             <ul>
                 <li
@@ -367,7 +373,6 @@ export default class Tools extends Vue {
                 <MapTool v-show="currentTool === 'Map'" ref="mapTool"></MapTool>
                 <FilterTool v-show="currentTool === 'Filter'" ref="filterTool"></FilterTool>
                 <VisionTool v-show="currentTool === 'Vision'" ref="visionTool"></VisionTool>
-                <DefaultContext ref="defaultcontext"></DefaultContext>
             </template>
         </div>
     </div>

--- a/client/src/game/ui/tools/vision.vue
+++ b/client/src/game/ui/tools/vision.vue
@@ -6,12 +6,17 @@ import Tool from "@/game/ui/tools/tool.vue";
 import { layerManager } from "@/game/layers/manager";
 import { gameStore } from "@/game/store";
 import { Shape } from "../../shapes/shape";
-import { ToolName } from "./utils";
+import { ToolName, ToolPermission } from "./utils";
+import { SelectFeatures } from "./select.vue";
 
 @Component
 export default class VisionTool extends Tool {
     name = ToolName.Vision;
     active = false;
+
+    get permittedTools(): ToolPermission[] {
+        return [{ name: ToolName.Select, features: { disabled: [SelectFeatures.Resize, SelectFeatures.Rotate] } }];
+    }
 
     get selection(): string[] {
         return gameStore.activeTokens;


### PR DESCRIPTION
This PR allows other tools to open the shape context menu as well.
This originally was only possible from within the select tool.

Two exceptions on this rule are the Draw and Map tools.
The former has its own use for the right click button and the latter should ideally only be open for the specific map operation.

Additionally the Vision and Filter tools are now able to perform most of the Select tool's features with the exception of rotating and resizing.