### PR TITLE
feat(Selection): Use accurate shape detection on shape select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ These usually have no immediately visible impact on regular users
     -   the two exceptions are draw and map tools
     -   filter and vision additionally allow a wider set of features from the select tool to be used
         -   only resize/rotate are not allowed at the moment
+-   Use exact shape detection on shape select
+    -   When performing a selection close to a non axis-aligned shape it will no longer select those as well
 -   [tech] Upgraded to socket.io v3
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ These usually have no immediately visible impact on regular users
 -   Shapes with a broken index value (used for move to back/move to front)
 -   Area in the topcenter of the screen where the mouse could sometimes not be used
 -   Auras that become public are not properly configured as a vision source on other clients
+-   Groupselection of rotated shapes
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/geom.ts
+++ b/client/src/game/geom.ts
@@ -94,8 +94,12 @@ export class Vector {
     dot(other: Vector): number {
         return this.x * other.x + this.y * other.y;
     }
+    /**
+     * This will return (+/-)Infinity for x/y if they are 0.
+     * This is intended behaviour! (otherwise BoundingRect.containsRay will not work properly)
+     */
     inverse(): Vector {
-        return new Vector(this.x === 0 ? 0 : 1 / this.x, this.y === 0 ? 0 : 1 / this.y);
+        return new Vector(1 / this.x, 1 / this.y);
     }
     squaredLength(): number {
         return Math.pow(this.x, 2) + Math.pow(this.y, 2);

--- a/client/src/game/shapes/variants/boundingrect.ts
+++ b/client/src/game/shapes/variants/boundingrect.ts
@@ -99,7 +99,9 @@ export class BoundingRect {
         );
     }
 
-    intersectP(ray: Ray<Point>, invDir: Vector, dirIsNeg: boolean[]): { hit: boolean; min: number; max: number } {
+    containsRay(ray: Ray<Point>): { hit: boolean; min: number; max: number } {
+        const invDir = ray.direction.inverse();
+        const dirIsNeg = [invDir.x < 0, invDir.y < 0];
         let txmin = invDir.x * (this.getDiagCorner(dirIsNeg[0]).x - ray.origin.x);
         let txmax = invDir.x * (this.getDiagCorner(!dirIsNeg[0]).x - ray.origin.x);
         const tymin = invDir.y * (this.getDiagCorner(dirIsNeg[1]).y - ray.origin.y);


### PR DESCRIPTION
When making a selection, an algorithm runs to decide which shapes should be selected as a result.

This PR changes the algorithm used.  The new algorithm is accurate but does require more calculations.
This fixes things like selecting a region that falls in the bounding box of a polygon, but does not actually include the polygon itself like the following image:
![image](https://user-images.githubusercontent.com/1814713/102517634-92f61080-4090-11eb-8eb8-569615bcd046.png)

It also coincidentally fixes a bug with selecting rotated shapes