### PR TITLE
bug(Assets): Don't rescale all assets to 1 grid cell on drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ These usually have no immediately visible impact on regular users
 -   Auras that become public are not properly configured as a vision source on other clients
 -   Groupselection of rotated shapes
 -   Double entries in the vision tool
+-   Most assets automatically resizing to fit 1 grid cell
+    -   they now retain their original size on drop (unless using templates)
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -98,30 +98,30 @@ export function dropAsset(
     const image = document.createElement("img");
     image.src = baseAdjust(data.imageSource);
     image.onload = () => {
+        const asset = new Asset(
+            image,
+            new GlobalPoint(l2gx(position.x), l2gy(position.y)),
+            l2gz(image.width),
+            l2gz(image.height),
+            { assetId: data.assetId },
+        );
+        asset.src = new URL(image.src).pathname;
+
+        if (options) {
+            asset.setLayer(layer.floor, layer.name); // if we don't set this the asDict will fail
+            asset.fromDict(applyTemplate(asset.asDict(), options));
+        }
+
+        if (gameSettingsStore.useGrid) {
+            const gs = gameStore.gridSize;
+            asset.refPoint = new GlobalPoint(clampGridLine(asset.refPoint.x), clampGridLine(asset.refPoint.y));
+            asset.w = Math.max(clampGridLine(asset.w), gs);
+            asset.h = Math.max(clampGridLine(asset.h), gs);
+        }
+
+        layer.addShape(asset, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);
         layer.invalidate(true);
     };
-    const asset = new Asset(
-        image,
-        new GlobalPoint(l2gx(position.x), l2gy(position.y)),
-        l2gz(image.width),
-        l2gz(image.height),
-        { assetId: data.assetId },
-    );
-    asset.src = new URL(image.src).pathname;
-
-    if (options) {
-        asset.setLayer(layer.floor, layer.name); // if we don't set this the asDict will fail
-        asset.fromDict(applyTemplate(asset.asDict(), options));
-    }
-
-    if (gameSettingsStore.useGrid) {
-        const gs = gameStore.gridSize;
-        asset.refPoint = new GlobalPoint(clampGridLine(asset.refPoint.x), clampGridLine(asset.refPoint.y));
-        asset.w = Math.max(clampGridLine(asset.w), gs);
-        asset.h = Math.max(clampGridLine(asset.h), gs);
-    }
-
-    layer.addShape(asset, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);
 }
 
 export function snapToPoint(layer: Layer, endPoint: GlobalPoint, ignore?: GlobalPoint): [GlobalPoint, boolean] {


### PR DESCRIPTION
When dropping assets on the map, they sometimes would be autorescaled to 1 grid cell (or just empty when not using the grid).

This can be annoying for assets that you would prefer to keep in their original form (e.g. maps etc)