### PR TITLE
feat(Select): Add direct ruler support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ These usually have no immediately visible impact on regular users
 -   Import/Export capabilities to the asset manager
 -   Multiruler support
     -   Pressing space while in the ruler tool will start a new ruler from your lastpoint
+-   Add multiruler option to select
+    -   When moving shapes it's handy when you don't need to swap between tools
 
 ### Changed
 

--- a/client/src/game/ui/tools/ruler.vue
+++ b/client/src/game/ui/tools/ruler.vue
@@ -19,6 +19,10 @@ import { useSnapping } from "@/game/utils";
 import { snapToGridPoint } from "@/game/layers/utils";
 import { SelectFeatures } from "./select.vue";
 
+export enum RulerFeatures {
+    All,
+}
+
 @Component
 export default class RulerTool extends Tool implements ToolBasics {
     name = ToolName.Ruler;
@@ -93,7 +97,7 @@ export default class RulerTool extends Tool implements ToolBasics {
             return;
         }
         this.active = true;
-        this.createNewRuler(this.startPoint, this.startPoint);
+        this.createNewRuler(this.startPoint.clone(), this.startPoint.clone());
         this.text = new Text(this.startPoint.clone(), "", "bold 20px serif", {
             fillColour: "#000",
             strokeColour: "#fff",

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -79,7 +79,7 @@ export default class SelectTool extends Tool implements ToolBasics {
     hasSelection = false;
     showRuler = false;
 
-    permittedTools_: ToolPermission[] = rulerPermission;
+    permittedTools_: ToolPermission[] = [];
 
     get permittedTools(): ToolPermission[] {
         return this.permittedTools_;

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -82,6 +82,7 @@ export default class Tools extends Vue {
             [ToolName.Filter]: this.$refs.filterTool,
             [ToolName.Vision]: this.$refs.visionTool,
         };
+        this.$refs.selectTool.selected = true;
         EventBus.$on("ToolMode.Toggle", this.toggleMode);
     }
 
@@ -147,9 +148,17 @@ export default class Tools extends Vue {
         let targetTool = this.currentTool;
 
         const tool = this.componentMap[targetTool];
-        tool.onKeyUp(event, this.getFeatures(targetTool));
-        for (const permitted of tool.permittedTools)
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
             this.componentMap[permitted.name].onKeyUp(event, permitted.features);
+        }
+
+        tool.onKeyUp(event, this.getFeatures(targetTool));
+
+        for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
+            this.componentMap[permitted.name].onKeyUp(event, permitted.features);
+        }
     }
 
     mousedown(event: MouseEvent): void {
@@ -163,9 +172,20 @@ export default class Tools extends Vue {
         }
 
         const tool = this.componentMap[targetTool];
-        tool.onMouseDown(event, this.getFeatures(targetTool));
-        for (const permitted of tool.permittedTools)
+
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
+            console.log(0);
             this.componentMap[permitted.name].onMouseDown(event, permitted.features);
+        }
+
+        console.log(1);
+        tool.onMouseDown(event, this.getFeatures(targetTool));
+
+        for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
+            this.componentMap[permitted.name].onMouseDown(event, permitted.features);
+        }
     }
     mouseup(event: MouseEvent): void {
         if ((event.target as HTMLElement).tagName !== "CANVAS") return;
@@ -178,9 +198,18 @@ export default class Tools extends Vue {
         }
 
         const tool = this.componentMap[targetTool];
-        tool.onMouseUp(event, this.getFeatures(targetTool));
-        for (const permitted of tool.permittedTools)
+
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
             this.componentMap[permitted.name].onMouseUp(event, permitted.features);
+        }
+
+        tool.onMouseUp(event, this.getFeatures(targetTool));
+
+        for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
+            this.componentMap[permitted.name].onMouseUp(event, permitted.features);
+        }
     }
     mousemove(event: MouseEvent): void {
         if ((event.target as HTMLElement).tagName !== "CANVAS") return;
@@ -194,9 +223,18 @@ export default class Tools extends Vue {
         }
 
         const tool = this.componentMap[targetTool];
-        tool.onMouseMove(event, this.getFeatures(targetTool));
-        for (const permitted of tool.permittedTools)
+
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
             this.componentMap[permitted.name].onMouseMove(event, permitted.features);
+        }
+
+        tool.onMouseMove(event, this.getFeatures(targetTool));
+
+        for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
+            this.componentMap[permitted.name].onMouseMove(event, permitted.features);
+        }
 
         // Annotation hover
         let found = false;
@@ -218,17 +256,35 @@ export default class Tools extends Vue {
     }
     mouseleave(event: MouseEvent): void {
         const tool = this.componentMap[this.currentTool];
-        tool.onMouseUp(event, this.getFeatures(this.currentTool));
-        for (const permitted of tool.permittedTools)
+
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
             this.componentMap[permitted.name].onMouseUp(event, permitted.features);
+        }
+
+        tool.onMouseUp(event, this.getFeatures(this.currentTool));
+
+        for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
+            this.componentMap[permitted.name].onMouseUp(event, permitted.features);
+        }
     }
     contextmenu(event: MouseEvent): void {
         if ((event.target as HTMLElement).tagName !== "CANVAS") return;
         if (event.button !== 2 || (event.target as HTMLElement).tagName !== "CANVAS") return;
         const tool = this.componentMap[this.currentTool];
-        tool.onContextMenu(event, this.getFeatures(this.currentTool));
-        for (const permitted of tool.permittedTools)
+
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
             this.componentMap[permitted.name].onContextMenu(event, permitted.features);
+        }
+
+        tool.onContextMenu(event, this.getFeatures(this.currentTool));
+
+        for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
+            this.componentMap[permitted.name].onContextMenu(event, permitted.features);
+        }
     }
 
     touchstart(event: TouchEvent): void {
@@ -240,9 +296,19 @@ export default class Tools extends Vue {
             tool.scaling = true;
         }
 
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
+            const otherTool = this.componentMap[permitted.name];
+            otherTool.scaling = tool.scaling;
+            if (otherTool.scaling) otherTool.onPinchStart(event, permitted.features);
+            else otherTool.onTouchStart(event, permitted.features);
+        }
+
         if (tool.scaling) tool.onPinchStart(event, this.getFeatures(this.currentTool));
         else tool.onTouchStart(event, this.getFeatures(this.currentTool));
+
         for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
             const otherTool = this.componentMap[permitted.name];
             otherTool.scaling = tool.scaling;
             if (otherTool.scaling) otherTool.onPinchStart(event, permitted.features);
@@ -255,10 +321,20 @@ export default class Tools extends Vue {
 
         const tool = this.componentMap[this.currentTool];
 
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
+            const otherTool = this.componentMap[permitted.name];
+            if (otherTool.scaling) otherTool.onPinchEnd(event, permitted.features);
+            else otherTool.onTouchEnd(event, permitted.features);
+            otherTool.scaling = false;
+        }
+
         if (tool.scaling) tool.onPinchEnd(event, this.getFeatures(this.currentTool));
         else tool.onTouchEnd(event, this.getFeatures(this.currentTool));
         tool.scaling = false;
+
         for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
             const otherTool = this.componentMap[permitted.name];
             if (otherTool.scaling) otherTool.onPinchEnd(event, permitted.features);
             else otherTool.onTouchEnd(event, permitted.features);
@@ -271,6 +347,14 @@ export default class Tools extends Vue {
 
         const tool = this.componentMap[this.currentTool];
 
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
+            const otherTool = this.componentMap[permitted.name];
+            if (otherTool.scaling) otherTool.onPinchMove(event, permitted.features);
+            else if (event.touches.length >= 3) otherTool.onThreeTouchMove(event, permitted.features);
+            else otherTool.onTouchMove(event, permitted.features);
+        }
+
         if (tool.scaling) {
             event.preventDefault();
             tool.onPinchMove(event, this.getFeatures(this.currentTool));
@@ -281,6 +365,7 @@ export default class Tools extends Vue {
         }
 
         for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
             const otherTool = this.componentMap[permitted.name];
             if (otherTool.scaling) otherTool.onPinchMove(event, permitted.features);
             else if (event.touches.length >= 3) otherTool.onThreeTouchMove(event, permitted.features);
@@ -306,9 +391,15 @@ export default class Tools extends Vue {
     toggleMode(): void {
         this.mode = this.mode === "Build" ? "Play" : "Build";
         const tool = this.componentMap[this.currentTool];
-        tool.onToolsModeChange(this.mode, this.getFeatures(this.currentTool));
-        for (const permitted of tool.permittedTools)
+        for (const permitted of tool.permittedTools) {
+            if (!(permitted.early ?? false)) continue;
             this.componentMap[permitted.name].onToolsModeChange(this.mode, permitted.features);
+        }
+        tool.onToolsModeChange(this.mode, this.getFeatures(this.currentTool));
+        for (const permitted of tool.permittedTools) {
+            if (permitted.early ?? false) continue;
+            this.componentMap[permitted.name].onToolsModeChange(this.mode, permitted.features);
+        }
     }
 
     getModeWord(): string {

--- a/client/src/game/ui/tools/utils.ts
+++ b/client/src/game/ui/tools/utils.ts
@@ -15,7 +15,7 @@ export enum ToolName {
     Vision = "Vision",
 }
 
-export type ToolPermission = { name: ToolName; features: ToolFeatures };
+export type ToolPermission = { name: ToolName; features: ToolFeatures; early?: boolean };
 export type ToolFeatures<T = number> = { enabled?: T[]; disabled?: T[] };
 
 // First go through each shape in the selection and see if the delta has to be truncated due to movement blockers


### PR DESCRIPTION
When moving shapes around and seeing if you have enough movement to get somewhere, you often need to swap between select and ruler.  There now is an optional toggle on the select tool to show a ruler while moving shapes.

This also supports the multi ruler feature merged earlier with (space)