### PR TITLE
bug(UI): Fix toolbar helpers UI location on mode change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ These usually have no immediately visible impact on regular users
     -   When performing a selection close to a non axis-aligned shape it will no longer select those as well
 -   Do not toggle all tokens when deselecting the last one in the vision tool
 -   Highlight the vision tool in a special colour to signal modified vision state at all times
+-   When changing to a tool mode that the current tool does not support, change to the Select tool
 -   [tech] Upgraded to socket.io v3
 
 ### Fixed
@@ -67,6 +68,7 @@ These usually have no immediately visible impact on regular users
 -   Sorting order in asset manager
 -   Asset manager shift selection acting strange when mixing files and folders
 -   More cases where the ruler and ping tool could get stuck
+-   Tool dialogs now move correctly when changing mode
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -568,7 +568,7 @@ export default class DrawTool extends Tool implements ToolBasics {
 </script>
 
 <template>
-    <div class="tool-detail" v-if="selected" :style="{ '--detailRight': detailRight, '--detailArrow': detailArrow }">
+    <div class="tool-detail" v-if="selected" :style="{ '--detailRight': detailRight(), '--detailArrow': detailArrow }">
         <div v-show="IS_DM" v-t="'game.ui.tools.draw.mode'"></div>
         <div v-show="IS_DM" class="selectgroup">
             <div

--- a/client/src/game/ui/tools/filter.vue
+++ b/client/src/game/ui/tools/filter.vue
@@ -85,7 +85,7 @@ export default class FilterTool extends Tool implements ToolBasics {
 </script>
 
 <template>
-    <div class="tool-detail" v-if="selected" :style="{ '--detailRight': detailRight, '--detailArrow': detailArrow }">
+    <div class="tool-detail" v-if="selected" :style="{ '--detailRight': detailRight(), '--detailArrow': detailArrow }">
         <div id="accordion-container">
             <accordion
                 v-for="category in categories"

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -265,7 +265,7 @@ export default class MapTool extends Tool implements ToolBasics {
     <div
         class="tool-detail map"
         v-if="selected"
-        :style="{ '--detailRight': detailRight, '--detailArrow': detailArrow }"
+        :style="{ '--detailRight': detailRight(), '--detailArrow': detailArrow }"
     >
         <template v-if="shape !== null">
             <div class="row">{{ error }}</div>

--- a/client/src/game/ui/tools/ruler.vue
+++ b/client/src/game/ui/tools/ruler.vue
@@ -179,7 +179,7 @@ export default class RulerTool extends Tool implements ToolBasics {
         id="ruler"
         class="tool-detail"
         v-if="selected"
-        :style="{ '--detailRight': detailRight, '--detailArrow': detailArrow }"
+        :style="{ '--detailRight': detailRight(), '--detailArrow': detailArrow }"
     >
         <button @click="toggle" :aria-pressed="showPublic" v-t="'game.ui.tools.ruler.share'"></button>
     </div>

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -128,6 +128,7 @@ export default class SelectTool extends Tool implements ToolBasics {
         } else {
             if (this.hasFeature(SelectFeatures.Rotate, features)) this.createRotationUi(features);
         }
+        this.$forceUpdate();
     }
 
     onDown(lp: LocalPoint, event: MouseEvent | TouchEvent, features: ToolFeatures<SelectFeatures>): void {
@@ -672,7 +673,7 @@ export default class SelectTool extends Tool implements ToolBasics {
         id="ruler"
         class="tool-detail"
         v-if="selected && hasSelection"
-        :style="{ '--detailRight': detailRight, '--detailArrow': detailArrow }"
+        :style="{ '--detailRight': detailRight(), '--detailArrow': detailArrow }"
     >
         <button @click="toggleShowRuler" :aria-pressed="showRuler">Show ruler</button>
     </div>

--- a/client/src/game/ui/tools/tool.vue
+++ b/client/src/game/ui/tools/tool.vue
@@ -31,13 +31,15 @@ export default class Tool extends Vue implements ToolBasics {
         );
     }
 
-    get detailRight(): string {
+    detailRight(): string {
+        console.log(0);
         const rect = (this.$parent as any).$refs[this.name + "-selector"][0].getBoundingClientRect();
         const mid = rect.left + rect.width / 2;
 
         return `${window.innerWidth - Math.min(window.innerWidth - 25, mid + 75)}px`;
     }
     get detailArrow(): string {
+        console.log(0);
         const rect = (this.$parent as any).$refs[this.name + "-selector"][0].getBoundingClientRect();
         const mid = rect.left + rect.width / 2;
         const right = Math.min(window.innerWidth - 25, mid + 75);
@@ -82,7 +84,17 @@ export default class Tool extends Vue implements ToolBasics {
     onDown(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): void {}
     onUp(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): void {}
     onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): void {}
-    onToolsModeChange(_mode: "Build" | "Play", _features: ToolFeatures): void {}
+    onToolsModeChange(mode: "Build" | "Play", _features: ToolFeatures): void {
+        if (mode === "Build") {
+            if (!this.$parent.buildTools.map(t => t[0]).includes(this.$parent.currentTool)) {
+                this.$parent.currentTool = ToolName.Select;
+            }
+        } else {
+            if (!this.$parent.playTools.map(t => t[0]).includes(this.$parent.currentTool)) {
+                this.$parent.currentTool = ToolName.Select;
+            }
+        }
+    }
 }
 </script>
 

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -179,7 +179,6 @@ export default class Tools extends Vue {
             this.componentMap[permitted.name].onMouseDown(event, permitted.features);
         }
 
-        console.log(1);
         tool.onMouseDown(event, this.getFeatures(targetTool));
 
         for (const permitted of tool.permittedTools) {

--- a/client/src/game/ui/tools/tools.vue
+++ b/client/src/game/ui/tools/tools.vue
@@ -175,7 +175,6 @@ export default class Tools extends Vue {
 
         for (const permitted of tool.permittedTools) {
             if (!(permitted.early ?? false)) continue;
-            console.log(0);
             this.componentMap[permitted.name].onMouseDown(event, permitted.features);
         }
 

--- a/client/src/game/ui/tools/vision.vue
+++ b/client/src/game/ui/tools/vision.vue
@@ -40,7 +40,7 @@ export default class VisionTool extends Tool {
 </script>
 
 <template>
-    <div class="tool-detail" v-if="selected" :style="{ '--detailRight': detailRight, '--detailArrow': detailArrow }">
+    <div class="tool-detail" v-if="selected" :style="{ '--detailRight': detailRight(), '--detailArrow': detailArrow }">
         <div
             v-for="token in tokens"
             :key="token.uuid"


### PR DESCRIPTION
When changing mode the helper UI for some tools would not move and point to a different tool or an empty area on the map