### PR TITLE
bug(Selection): Fix selection of rotated rectangles and assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ These usually have no immediately visible impact on regular users
 -   Shapes with a broken index value (used for move to back/move to front)
 -   Area in the topcenter of the screen where the mouse could sometimes not be used
 -   Auras that become public are not properly configured as a vision source on other clients
+-   Selection of rotated rectangles and assets
 -   Groupselection of rotated shapes
 -   Double entries in the vision tool
 -   Most assets automatically resizing to fit 1 grid cell

--- a/client/src/game/shapes/variants/baserect.ts
+++ b/client/src/game/shapes/variants/baserect.ts
@@ -60,6 +60,7 @@ export abstract class BaseRect extends Shape {
     }
 
     contains(point: GlobalPoint): boolean {
+        if (this.angle !== 0) point = rotateAroundPoint(point, this.center(), -this.angle);
         return (
             this.refPoint.x <= point.x &&
             this.refPoint.x + this.w >= point.x &&


### PR DESCRIPTION
Another bugfix that addresses selection of rotated shapes, this time not in a groupselect context