### PR TITLE
bug(Grid): Fix various issues with modified client gridsizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+Due to a bugfix with zoom for non-default gridsizes, you will likely encounter your first load on a map to be slightly off centered
+from where you had your camera last time. This should normally not be far off from the original location.
+If you have issues finding your stuff back try the space bar to center on your tokens or ctrl+0 to go to the world center.
+If you still have issues contact me and I can give you some console code.
+
 ### Added
 
 -   Pressing the Enter button on a single selection will open the edit dialog for that shape
@@ -75,6 +80,8 @@ These usually have no immediately visible impact on regular users
 -   Selection including shapes out of vision
 -   Adding/Removing labels no longer being synced by the server
 -   Current floor no longer being highlighted in context menu
+-   Fix multiple issues when having a modified client gridsize
+    -   auras/zoom/map would all use wrong math(s)
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/api/emits/client.ts
+++ b/client/src/game/api/emits/client.ts
@@ -4,7 +4,7 @@ import { socket } from "../socket";
 import { wrapSocket } from "../helpers";
 
 export function sendClientLocationOptions(): void {
-    _sendClientLocationOptions({ pan_x: gameStore.panX, pan_y: gameStore.panY, zoom_factor: gameStore.zoomFactor });
+    _sendClientLocationOptions({ pan_x: gameStore.panX, pan_y: gameStore.panY, zoom_factor: gameStore.zoomDisplay });
 }
 
 function _sendClientLocationOptions(locationOptions: LocationServerClient): void {

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -2,7 +2,6 @@ import { ServerClient } from "../../comm/types/settings";
 import { EventBus } from "../../event-bus";
 import { layerManager } from "../../layers/manager";
 import { gameStore } from "../../store";
-import { zoomDisplay } from "../../utils";
 import { socket } from "../socket";
 
 socket.on("Client.Options.Set", (options: ServerClient) => {
@@ -17,7 +16,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     gameStore.setInvertAlt({ invertAlt: options.invert_alt, sync: false });
     gameStore.setPanX(options.pan_x);
     gameStore.setPanY(options.pan_y);
-    gameStore.setZoomDisplay(zoomDisplay(options.zoom_factor));
+    gameStore.setZoomDisplay(options.zoom_factor);
 
     EventBus.$once("Board.Floor.Set", () => {
         if (options.active_layer) layerManager.selectLayer(options.active_layer, false);

--- a/client/src/game/ui/tools/map.vue
+++ b/client/src/game/ui/tools/map.vue
@@ -14,7 +14,7 @@ import { EventBus } from "@/game/event-bus";
 import { Shape } from "@/game/shapes/shape";
 import { ToolBasics } from "./ToolBasics";
 import { floorStore } from "@/game/layers/store";
-import { DEFAULT_GRID_SIZE, gameStore } from "../../store";
+import { DEFAULT_GRID_SIZE } from "../../store";
 import { sendShapePositionUpdate, sendShapeSizeUpdate } from "@/game/api/emits/shape/core";
 
 @Component
@@ -121,8 +121,8 @@ export default class MapTool extends Tool implements ToolBasics {
         }
 
         if (this.rect !== undefined) {
-            const xFactor = (this.gridX * gameStore.gridSize) / this.rect.w;
-            const yFactor = (this.gridY * gameStore.gridSize) / this.rect.h;
+            const xFactor = (this.gridX * DEFAULT_GRID_SIZE) / this.rect.w;
+            const yFactor = (this.gridY * DEFAULT_GRID_SIZE) / this.rect.h;
 
             this.shape.w *= xFactor;
             this.shape.h *= yFactor;
@@ -229,9 +229,9 @@ export default class MapTool extends Tool implements ToolBasics {
             } else {
                 this.gridY = this.gridX / this.aspectRatio;
             }
-            this.sizeY = this.gridY * gameStore.gridSize;
+            this.sizeY = this.gridY * DEFAULT_GRID_SIZE;
         }
-        this.sizeX = this.gridX * gameStore.gridSize;
+        this.sizeX = this.gridX * DEFAULT_GRID_SIZE;
         if (!this.manualDrag && this.gridX > 0) this.preview(true);
     }
 
@@ -242,27 +242,27 @@ export default class MapTool extends Tool implements ToolBasics {
             } else {
                 this.gridX = this.gridY * this.aspectRatio;
             }
-            this.sizeX = this.gridX * gameStore.gridSize;
+            this.sizeX = this.gridX * DEFAULT_GRID_SIZE;
         }
-        this.sizeY = this.gridY * gameStore.gridSize;
+        this.sizeY = this.gridY * DEFAULT_GRID_SIZE;
         if (!this.manualDrag && this.gridY > 0) this.preview(true);
     }
 
     updateSizeX(): void {
         if (this.lock) {
             this.sizeY = this.sizeX / this.aspectRatio;
-            this.gridY = this.sizeY / gameStore.gridSize;
+            this.gridY = this.sizeY / DEFAULT_GRID_SIZE;
         }
-        this.gridX = this.sizeX / gameStore.gridSize;
+        this.gridX = this.sizeX / DEFAULT_GRID_SIZE;
         if (this.sizeX > 0) this.preview(true);
     }
 
     updateSizeY(): void {
         if (this.lock) {
             this.sizeX = this.sizeY * this.aspectRatio;
-            this.gridX = this.sizeX / gameStore.gridSize;
+            this.gridX = this.sizeX / DEFAULT_GRID_SIZE;
         }
-        this.gridY = this.sizeY / gameStore.gridSize;
+        this.gridY = this.sizeY / DEFAULT_GRID_SIZE;
         if (this.sizeY > 0) this.preview(true);
     }
 }

--- a/client/src/game/units.ts
+++ b/client/src/game/units.ts
@@ -22,7 +22,7 @@ export function g2lz(z: number): number {
 }
 
 export function getUnitDistance(r: number): number {
-    return (r / gameSettingsStore.unitSize) * gameStore.gridSize;
+    return (r / gameSettingsStore.unitSize) * DEFAULT_GRID_SIZE;
 }
 
 export function g2lr(r: number): number {

--- a/client/src/game/utils.ts
+++ b/client/src/game/utils.ts
@@ -32,16 +32,6 @@ export function getFogColour(opposite = false): string {
     return tc.toRgbString();
 }
 
-export function zoomValue(display: number): number {
-    // Powercurve 0.2/3/10
-    // Based on https://stackoverflow.com/a/17102320
-    return 1 / (-5 / 3 + (28 / 15) * Math.exp(1.83 * display));
-}
-
-export function zoomDisplay(value: number): number {
-    return Math.log((1 / value + 5 / 3) * (15 / 28)) / 1.83;
-}
-
 export function equalPoint(a: number, b: number, delta = 0.0001): boolean {
     return a - delta < b && a + delta > b;
 }


### PR DESCRIPTION
As reported in #621 there is an issue with the size of auras when using a modified gridsize.

While fixing this I did some more thorough checks and encountered a couple of other places that were not using the correct math to handle modified gridsizes. In particular the map tool would also wrongly scale items and the zoom function would be off when loading a map resulting in a wrong location being shown.

This fixes #621 