### PR TITLE
bug(Spawn): Set location x/y position on spawn teleport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,9 @@ If you still have issues contact me and I can give you some console code.
 -   Selection including shapes out of vision
 -   Adding/Removing labels no longer being synced by the server
 -   Current floor no longer being highlighted in context menu
--   Fix multiple issues when having a modified client gridsize
+-   Multiple issues when having a modified client gridsize
     -   auras/zoom/map would all use wrong math(s)
+-   Teleporting to a spawn location, only changing location not setting the position
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/client/src/game/api/emits/location.ts
+++ b/client/src/game/api/emits/location.ts
@@ -7,7 +7,11 @@ export const sendLocationOptions = wrapSocket<{ options: Partial<ServerLocationO
     "Location.Options.Set",
 );
 export const sendLocationOrder = wrapSocket<number[]>("Locations.Order.Set");
-export const sendLocationChange = wrapSocket<{ location: number; users: string[] }>("Location.Change");
+export const sendLocationChange = wrapSocket<{
+    location: number;
+    users: string[];
+    position?: { x: number; y: number };
+}>("Location.Change");
 export const sendNewLocation = wrapSocket<string>("Location.New");
 export const sendLocationRename = wrapSocket<{ location: number; name: string }>("Location.Rename");
 export const sendLocationRemove = wrapSocket<number>("Location.Delete");

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -78,9 +78,9 @@ socket.on("Board.Floor.Set", async (floor: ServerFloor) => {
 
 // Varia
 
-socket.on("Position.Set", (data: { floor: string; x: number; y: number; zoom: number }) => {
-    floorStore.selectFloor({ targetFloor: data.floor, sync: false });
-    gameStore.setZoomDisplay(data.zoom);
+socket.on("Position.Set", (data: { floor?: string; x: number; y: number; zoom?: number }) => {
+    if (data.floor) floorStore.selectFloor({ targetFloor: data.floor, sync: false });
+    if (data.zoom) gameStore.setZoomDisplay(data.zoom);
     gameManager.setCenterPosition(new GlobalPoint(data.x, data.y));
 });
 

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -179,7 +179,7 @@ export default class ShapeContext extends Vue {
             for (const shape of selection) {
                 for (const owner of shape.owners) users.add(owner.user);
             }
-            sendLocationChange({ location: newLocation, users: [...users] });
+            sendLocationChange({ location: newLocation, users: [...users], position: { ...targetLocation } });
         }
 
         this.close();


### PR DESCRIPTION
When the DM moves tokens to a spawn point, it will only change the location but not explicitly set the position to be centered on.

This is now fixed and more user friendly.