### PR TITLE
bug(Initiative): Fix initiative sometimes not working on location change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ If you still have issues contact me and I can give you some console code.
     -   auras/zoom/map would all use wrong math(s)
 -   Teleporting to a spawn location, only changing location not setting the position
 -   Synchronization of Label visibility
+-   Initiative possibly not working when changing locations
 -   [DM] Floor rename always setting a blank name
 
 ## [0.23.1] - 2020-10-25

--- a/server/api/socket/initiative.py
+++ b/server/api/socket/initiative.py
@@ -126,6 +126,10 @@ async def update_initiative(sid: str, data: ServerInitiativeData):
                     )
                     update.execute()
                 data["index"] = new_index
+            elif data.get("index", None) is None:
+                data["index"] = 0
+            if initiative.location_data != location_data:
+                initiative.location_data = location_data
             # Update model instance
             update_model_from_dict(initiative, reduce_data_to_model(Initiative, data))
             initiative.save()


### PR DESCRIPTION
Under certain conditions, tokens that changed location would not be able to get any initiative assigned to them