### PR TITLE
bug(UI): Fix shape name not syncing immediately on visibility toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ These usually have no immediately visible impact on regular users
 
 -   Is public toggle for annotations
 
+### Fixes
+
+-   Shape name not immediately syncing on visibility toggle
+
 ## [0.24.1] - 2021-01-17
 
 ### Fixes

--- a/server/api/socket/shape/options.py
+++ b/server/api/socket/shape/options.py
@@ -351,6 +351,8 @@ async def set_name_visible(sid: str, data: ShapeSetBooleanValue):
     shape.name_visible = data["value"]
     shape.save()
 
+    owners = [*get_owner_sids(pr, shape, skip_sid=sid)]
+
     await sio.emit(
         "Shape.Options.NameVisible.Set",
         data,
@@ -358,6 +360,16 @@ async def set_name_visible(sid: str, data: ShapeSetBooleanValue):
         room=pr.active_location.get_path(),
         namespace=GAME_NS,
     )
+
+    for psid in game_state.get_sids(active_location=pr.active_location, skip_sid=sid):
+        if psid in owners:
+            continue
+        await sio.emit(
+            "Shape.Options.Name.Set",
+            {"shape": shape.uuid, "value": shape.name if data["value"] else "?"},
+            room=psid,
+            namespace=GAME_NS,
+        )
 
 
 @sio.on("Shape.Options.ShowBadge.Set", namespace=GAME_NS)


### PR DESCRIPTION
This closes #636. When toggling the name visibility it would not immediately sync the active name value or "?" to other clients.