### PR TITLE
bug(Vision): Fixes private auras of non-active shapes no longer showing up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These usually have no immediately visible impact on regular users
 ### Fixes
 
 -   Shape name not immediately syncing on visibility toggle
+-   Vision tool disabled tokens private auras no longer being visible
 
 ## [0.24.1] - 2021-01-17
 

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -71,7 +71,7 @@ socket.on("Shapes.Floor.Change", (data: { uuids: string[]; floor: string }) => {
         .filter(s => s !== undefined) as Shape[];
     if (shapes.length === 0) return;
     moveFloor(shapes, layerManager.getFloor(getFloorId(data.floor))!, false);
-    if (shapes.some(s => s.ownedBy({ editAccess: true })))
+    if (shapes.some(s => s.ownedBy(false, { editAccess: true })))
         floorStore.selectFloor({ targetFloor: data.floor, sync: false });
 });
 

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -114,7 +114,7 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
                 let recalculateMovement = false;
                 const updateList = [];
                 for (const sel of selection) {
-                    if (!sel.ownedBy({ movementAccess: true })) continue;
+                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
                     if (sel.movementObstruction) {
                         recalculateMovement = true;
                         visibilityStore.deleteFromTriag({

--- a/client/src/game/layers/fowlighting.ts
+++ b/client/src/game/layers/fowlighting.ts
@@ -71,7 +71,7 @@ export class FowLightingLayer extends FowLayer {
                 const aura = shape.getAuras(true).find(a => a.uuid === light.aura);
                 if (aura === undefined) continue;
 
-                if (!shape.ownedBy({ visionAccess: true }) && !aura.visible) continue;
+                if (!shape.ownedBy(true, { visionAccess: true }) && !aura.visible) continue;
 
                 const auraLength = getUnitDistance(aura.value + aura.dim);
                 const center = shape.center();

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -139,7 +139,7 @@ export class Layer {
                 this.points.set(strp, (this.points.get(strp) || new Set()).add(shape.uuid));
             }
         }
-        if (shape.ownedBy({ visionAccess: true }) && shape.isToken) gameStore.addOwnedToken(shape.uuid);
+        if (shape.ownedBy(false, { visionAccess: true }) && shape.isToken) gameStore.addOwnedToken(shape.uuid);
         if (shape.annotation.length) gameStore.annotations.push(shape.uuid);
         if (sync !== SyncMode.NO_SYNC && !shape.preventSync)
             sendShapeAdd({ shape: shape.asDict(), temporary: sync === SyncMode.TEMP_SYNC });
@@ -268,7 +268,7 @@ export class Layer {
                 visibleShapes.push(shape);
             }
             for (const shape of visibleShapes) {
-                if (shape.isInvisible && !shape.ownedBy({ visionAccess: true })) continue;
+                if (shape.isInvisible && !shape.ownedBy(true, { visionAccess: true })) continue;
                 if (shape.labels.length === 0 && gameStore.filterNoLabel) continue;
                 if (
                     shape.labels.length &&

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -126,7 +126,7 @@ export function copyShapes(): void {
     if (!layer.hasSelection({ includeComposites: false })) return;
     const clipboard: ServerShape[] = [];
     for (const shape of layer.getSelection({ includeComposites: true })) {
-        if (!shape.ownedBy({ editAccess: true })) continue;
+        if (!shape.ownedBy(false, { editAccess: true })) continue;
         if (!shape.groupId) {
             createNewGroupForShapes([shape.uuid]);
         }
@@ -227,7 +227,7 @@ export function deleteShapes(shapes: readonly Shape[], sync: SyncMode): void {
     let recalculateMovement = false;
     for (let i = shapes.length - 1; i >= 0; i--) {
         const sel = shapes[i];
-        if (sync !== SyncMode.NO_SYNC && !sel.ownedBy({ editAccess: true })) continue;
+        if (sync !== SyncMode.NO_SYNC && !sel.ownedBy(false, { editAccess: true })) continue;
         removed.push(sel.uuid);
         if (sel.visionObstruction) recalculateVision = true;
         if (sel.movementObstruction) recalculateMovement = true;

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -88,7 +88,7 @@ export default class Initiative extends Vue {
         const shape = layerManager.UUIDMap.get(actor.uuid);
         // Shapes that are unknown to this client are hidden from this client but owned by other clients
         if (shape === undefined) return false;
-        return shape.ownedBy({ editAccess: true });
+        return shape.ownedBy(false, { editAccess: true });
     }
     getDefaultEffect(): { uuid: string; name: string; turns: number } {
         return { uuid: uuidv4(), name: this.$t("game.ui.initiative.initiative.new_effect").toString(), turns: 10 };
@@ -146,7 +146,7 @@ export default class Initiative extends Vue {
         if (this.cameraLock) {
             if (actorId !== null) {
                 const shape = layerManager.UUIDMap.get(actorId);
-                if (shape?.ownedBy({ visionAccess: true })) {
+                if (shape?.ownedBy(false, { visionAccess: true })) {
                     gameManager.setCenterPosition(shape.center());
                 }
             }
@@ -230,7 +230,7 @@ export default class Initiative extends Vue {
         const shape = layerManager.UUIDMap.get(actor.uuid);
         if (shape !== undefined) {
             if (shape.nameVisible) return shape.name;
-            if (shape.ownedBy({ editAccess: true })) return shape.name;
+            if (shape.ownedBy(false, { editAccess: true })) return shape.name;
         }
         return actor.source;
     }

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -66,7 +66,7 @@ export default class ShapeContext extends Vue {
     }
 
     isOwned(): boolean {
-        return this.getSelection(false).every(s => s.ownedBy({ editAccess: true }));
+        return this.getSelection(false).every(s => s.ownedBy(false, { editAccess: true }));
     }
 
     isActiveLayer(layer: string): boolean {

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -160,7 +160,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             if (!shape.options.has("preFogShape") && (shape.options.get("skipDraw") ?? false)) continue;
             if ([this.rotationAnchor?.uuid, this.rotationBox?.uuid, this.rotationEnd?.uuid].includes(shape.uuid))
                 continue;
-            if (shape.isInvisible && !shape.ownedBy({ movementAccess: true })) continue;
+            if (shape.isInvisible && !shape.ownedBy(false, { movementAccess: true })) continue;
 
             if (this.rotationUiActive && this.hasFeature(SelectFeatures.Rotate, features)) {
                 const anchor = this.rotationAnchor!.points[1];
@@ -289,7 +289,7 @@ export default class SelectTool extends Tool implements ToolBasics {
                 // If we are on the tokens layer do a movement block check.
                 if (layer.name === "tokens" && !(event.shiftKey && gameStore.IS_DM)) {
                     for (const sel of layerSelection) {
-                        if (!sel.ownedBy({ movementAccess: true })) continue;
+                        if (!sel.ownedBy(false, { movementAccess: true })) continue;
                         delta = calculateDelta(delta, sel, true);
                         if (delta !== ogDelta) this.deltaChanged = true;
                     }
@@ -298,7 +298,7 @@ export default class SelectTool extends Tool implements ToolBasics {
                 const updateList = [];
                 // Actually apply the delta on all shapes
                 for (const sel of layerSelection) {
-                    if (!sel.ownedBy({ movementAccess: true })) continue;
+                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
                     if (sel.visionObstruction)
                         visibilityStore.deleteFromTriag({
                             target: TriangulationTarget.VISION,
@@ -324,7 +324,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             } else if (this.mode === SelectOperations.Resize) {
                 let recalc = false;
                 for (const sel of layerSelection) {
-                    if (!sel.ownedBy({ movementAccess: true })) continue;
+                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
                     if (sel.visionObstruction)
                         visibilityStore.deleteFromTriag({
                             target: TriangulationTarget.VISION,
@@ -391,7 +391,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             const cbbox = this.selectionHelper!.getBoundingBox();
             for (const shape of layer.getShapes({ includeComposites: false })) {
                 if (!shape.options.has("preFogShape") && (shape.options.get("skipDraw") ?? false)) continue;
-                if (!shape.ownedBy({ movementAccess: true })) continue;
+                if (!shape.ownedBy(false, { movementAccess: true })) continue;
                 if (!shape.visibleInCanvas(layer.canvas, { includeAuras: false })) continue;
                 if (layerSelection.some(s => s.uuid === shape.uuid)) continue;
 
@@ -436,7 +436,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             if (this.mode === SelectOperations.Drag) {
                 const updateList = [];
                 for (const sel of layerSelection) {
-                    if (!sel.ownedBy({ movementAccess: true })) continue;
+                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
 
                     if (
                         this.dragRay.origin!.x === g2lx(sel.refPoint.x) &&
@@ -480,7 +480,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             }
             if (this.mode === SelectOperations.Resize) {
                 for (const sel of layerSelection) {
-                    if (!sel.ownedBy({ movementAccess: true })) continue;
+                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
                     if (
                         gameSettingsStore.useGrid &&
                         useSnapping(event) &&
@@ -514,7 +514,7 @@ export default class SelectTool extends Tool implements ToolBasics {
             }
             if (this.mode === SelectOperations.Rotate) {
                 for (const sel of layerSelection) {
-                    if (!sel.ownedBy({ movementAccess: true })) continue;
+                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
 
                     const newAngle = Math.round(this.angle / ANGLE_SNAP) * ANGLE_SNAP;
                     if (


### PR DESCRIPTION
When you control multiple shapes and use the vision tool or initiative vision lock, private auras of non-active shapes would still be visible. This is now resolved.

This closes #625 