### PR TITLE
feat(Undo): Add undo and redo support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These usually have no immediately visible impact on regular users
     -   shape movement
     -   shape rotation
     -   shape resize
+    -   floor movement
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ These usually have no immediately visible impact on regular users
 ### Added
 
 -   Is public toggle for annotations
--   Undo/Redo
+-   Undo/Redo (50 action memory)
     -   shape movement
     -   shape rotation
     -   shape resize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ These usually have no immediately visible impact on regular users
 ### Added
 
 -   Is public toggle for annotations
+-   Undo/Redo
+    -   shape movement
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ These usually have no immediately visible impact on regular users
 -   Undo/Redo
     -   shape movement
     -   shape rotation
+    -   shape resize
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ These usually have no immediately visible impact on regular users
     -   shape resize
     -   floor change
     -   layer change
+    -   shape creation/removal
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These usually have no immediately visible impact on regular users
 -   Is public toggle for annotations
 -   Undo/Redo
     -   shape movement
+    -   shape rotation
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ These usually have no immediately visible impact on regular users
     -   shape movement
     -   shape rotation
     -   shape resize
-    -   floor movement
+    -   floor change
+    -   layer change
 
 ### Fixes
 

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -18,6 +18,7 @@ import { dropAsset } from "./layers/utils";
 import { coreStore } from "@/core/store";
 import { mapGetters } from "vuex";
 import { Watch } from "vue-property-decorator";
+import { clearUndoStacks } from "./operations/undo";
 
 @Component({
     components: {
@@ -63,6 +64,7 @@ export default class Game extends Vue {
             this.$refs.ui.$refs.tools.keyup(event);
         });
         window.addEventListener("keydown", onKeyDown);
+        clearUndoStacks();
         this.ready.manager = true;
     }
 

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -16,17 +16,17 @@ socket.on("Shape.Set", async (data: ServerShape) => {
     // hard reset a shape
     const old = layerManager.UUIDMap.get(data.uuid);
     if (old) old.layer.removeShape(old, SyncMode.NO_SYNC, true);
-    const shape = await gameManager.addShape(data);
+    const shape = await gameManager.addShape(data, SyncMode.NO_SYNC);
     if (shape) EventBus.$emit("Shape.Set", shape);
 });
 
 socket.on("Shape.Add", async (shape: ServerShape) => {
-    await gameManager.addShape(shape);
+    await gameManager.addShape(shape, SyncMode.NO_SYNC);
 });
 
 socket.on("Shapes.Add", async (shapes: ServerShape[]) => {
     for (const shape of shapes) {
-        await gameManager.addShape(shape);
+        await gameManager.addShape(shape, SyncMode.NO_SYNC);
     }
 });
 

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -167,11 +167,11 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
             // Ctrl-v - Paste
             await pasteShapes();
         } else if (event.key === "z" && event.ctrlKey) {
-            undoOperation();
+            await undoOperation();
             event.preventDefault();
             event.stopPropagation();
         } else if (event.key === "Z" && event.ctrlKey) {
-            redoOperation();
+            await redoOperation();
             event.preventDefault();
             event.stopPropagation();
         } else if (event.key === "PageUp" && floorStore.currentFloorindex < floorStore.floors.length - 1) {

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -170,7 +170,7 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
             undoOperation();
             event.preventDefault();
             event.stopPropagation();
-        } else if (event.key === "r" && event.ctrlKey) {
+        } else if (event.key === "Z") {
             redoOperation();
             event.preventDefault();
             event.stopPropagation();

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -10,7 +10,7 @@ import { floorStore } from "../layers/store";
 import { moveFloor } from "../layers/utils";
 import { gameManager } from "../manager";
 import { moveShapes } from "../operations/movement";
-import { redoOperation, undoOperation } from "../operations/operations";
+import { redoOperation, undoOperation } from "../operations/undo";
 import { gameSettingsStore } from "../settings";
 import { activeShapeStore } from "../ui/ActiveShapeStore";
 

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -170,7 +170,7 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
             undoOperation();
             event.preventDefault();
             event.stopPropagation();
-        } else if (event.key === "Z") {
+        } else if (event.key === "Z" && event.ctrlKey) {
             redoOperation();
             event.preventDefault();
             event.stopPropagation();

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -3,15 +3,13 @@ import { layerManager } from "@/game/layers/manager";
 import { copyShapes, deleteShapes, pasteShapes } from "@/game/shapes/utils";
 import { DEFAULT_GRID_SIZE, gameStore } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
-import { visibilityStore } from "@/game/visibility/store";
-import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { SyncMode, SyncTo } from "../../core/comm/types";
 import { sendClientLocationOptions } from "../api/emits/client";
-import { sendShapePositionUpdate } from "../api/emits/shape/core";
 import { EventBus } from "../event-bus";
 import { floorStore } from "../layers/store";
 import { moveFloor } from "../layers/utils";
 import { gameManager } from "../manager";
+import { moveShapes } from "../operations/movement";
 import { gameSettingsStore } from "../settings";
 import { activeShapeStore } from "../ui/ActiveShapeStore";
 
@@ -110,40 +108,8 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
                     }
                 }
                 if (delta.length() === 0) return;
-                let recalculateVision = false;
-                let recalculateMovement = false;
-                const updateList = [];
-                for (const sel of selection) {
-                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
-                    if (sel.movementObstruction) {
-                        recalculateMovement = true;
-                        visibilityStore.deleteFromTriag({
-                            target: TriangulationTarget.MOVEMENT,
-                            shape: sel.uuid,
-                        });
-                    }
-                    if (sel.visionObstruction) {
-                        recalculateVision = true;
-                        visibilityStore.deleteFromTriag({
-                            target: TriangulationTarget.VISION,
-                            shape: sel.uuid,
-                        });
-                    }
-                    sel.refPoint = sel.refPoint.add(delta);
-                    if (sel.movementObstruction)
-                        visibilityStore.addToTriag({ target: TriangulationTarget.MOVEMENT, shape: sel.uuid });
-                    if (sel.visionObstruction)
-                        visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: sel.uuid });
-                    // todo: Fix again
-                    // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();
-                    if (!sel.preventSync) updateList.push(sel);
-                }
-                sendShapePositionUpdate(updateList, false);
 
-                const floorId = floorStore.currentFloor.id;
-                if (recalculateVision) visibilityStore.recalculateVision(floorId);
-                if (recalculateMovement) visibilityStore.recalculateMovement(floorId);
-                floorStore.currentLayer!.invalidate(false);
+                moveShapes(selection, delta, false);
             } else {
                 // The pan offsets should be in the opposite direction to give the correct feel.
                 gameStore.increasePanX(offsetX * -1);

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -10,6 +10,7 @@ import { floorStore } from "../layers/store";
 import { moveFloor } from "../layers/utils";
 import { gameManager } from "../manager";
 import { moveShapes } from "../operations/movement";
+import { redoOperation, undoOperation } from "../operations/operations";
 import { gameSettingsStore } from "../settings";
 import { activeShapeStore } from "../ui/ActiveShapeStore";
 
@@ -165,6 +166,14 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
         } else if (event.key === "v" && event.ctrlKey) {
             // Ctrl-v - Paste
             await pasteShapes();
+        } else if (event.key === "z" && event.ctrlKey) {
+            undoOperation();
+            event.preventDefault();
+            event.stopPropagation();
+        } else if (event.key === "r" && event.ctrlKey) {
+            redoOperation();
+            event.preventDefault();
+            event.stopPropagation();
         } else if (event.key === "PageUp" && floorStore.currentFloorindex < floorStore.floors.length - 1) {
             // Page Up - Move floor up
             // Alt + Page Up - Move selected shapes floor up

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -9,6 +9,7 @@ import { TriangulationTarget } from "@/game/visibility/te/pa";
 import { removeBlocker, removeVisionSources } from "@/game/visibility/utils";
 import { sendRemoveShapes, sendShapeAdd, sendShapeOrder } from "../api/emits/shape/core";
 import { removeGroupMember } from "../groups";
+import { addOperation } from "../operations/undo";
 import { gameSettingsStore } from "../settings";
 import { drawAuras } from "../shapes/trackers/draw";
 import { activeShapeStore } from "../ui/ActiveShapeStore";
@@ -148,6 +149,10 @@ export class Layer {
         if (activeShapeStore.uuid === undefined && activeShapeStore.lastUuid === shape.uuid) {
             const selection = this.getSelection({ skipUiHelpers: false, includeComposites: false });
             this.setSelection(shape, ...selection);
+        }
+
+        if (sync === SyncMode.FULL_SYNC) {
+            addOperation({ type: "shapeadd", shapes: [shape.asDict()] });
         }
     }
 

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -22,6 +22,7 @@ import { applyTemplate } from "../shapes/template";
 import { DEFAULT_GRID_SIZE } from "../store";
 import { Floor } from "./floor";
 import { floorStore, getFloorId, newFloorId } from "./store";
+import { addOperation } from "../operations/undo";
 
 export async function addFloor(serverFloor: ServerFloor): Promise<void> {
     const floor: Floor = {
@@ -208,7 +209,11 @@ export function moveFloor(shapes: Shape[], newFloor: Floor, sync: boolean): void
     newLayer.pushShapes(...shapes);
     oldLayer.invalidate(false);
     newLayer.invalidate(false);
-    if (sync) sendFloorChange({ uuids: shapes.map((s) => s.uuid), floor: newFloor.name });
+    if (sync) {
+        const uuids = shapes.map((s) => s.uuid);
+        sendFloorChange({ uuids, floor: newFloor.name });
+        addOperation({ type: "floormovement", shapes: uuids, from: oldFloor.id, to: newFloor.id });
+    }
 }
 
 export function moveLayer(shapes: readonly Shape[], newLayer: Layer, sync: boolean): void {

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -232,12 +232,15 @@ export function moveLayer(shapes: readonly Shape[], newLayer: Layer, sync: boole
     oldLayer.invalidate(true);
     newLayer.invalidate(false);
     // Sync!
-    if (sync)
+    if (sync) {
+        const uuids = shapes.map((s) => s.uuid);
         sendLayerChange({
-            uuids: shapes.map((s) => s.uuid),
+            uuids,
             layer: newLayer.name,
             floor: layerManager.getFloor(newLayer.floor)!.name,
         });
+        addOperation({ type: "layermovement", shapes: uuids, from: oldLayer.name, to: newLayer.name });
+    }
 }
 
 export function addAllCompositeShapes(shapes: readonly Shape[]): readonly Shape[] {

--- a/client/src/game/manager.ts
+++ b/client/src/game/manager.ts
@@ -10,7 +10,7 @@ import { getFloorId } from "./layers/store";
 import { Shape } from "./shapes/shape";
 
 export class GameManager {
-    async addShape(shape: ServerShape): Promise<Shape | undefined> {
+    async addShape(shape: ServerShape, sync: SyncMode): Promise<Shape | undefined> {
         if (!layerManager.hasLayer(layerManager.getFloor(getFloorId(shape.floor))!, shape.layer)) {
             console.log(`Shape with unknown layer ${shape.layer} could not be added`);
             return;
@@ -21,7 +21,7 @@ export class GameManager {
             console.log(`Shape with unknown type ${shape.type_} could not be added`);
             return;
         }
-        layer.addShape(sh, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+        layer.addShape(sh, sync, InvalidationMode.NORMAL);
         layer.invalidate(false);
         return sh;
     }

--- a/client/src/game/operations/model.ts
+++ b/client/src/game/operations/model.ts
@@ -1,15 +1,12 @@
 import { GlobalPoint } from "../geom";
 
+export type Operation = MovementOperation | ResizeOperation | RotationOperation;
+
+// MOVEMENT
 export interface ShapeMovementOperation {
     uuid: string;
     from: number[];
     to: number[];
-}
-
-export interface ShapeRotationOperation {
-    uuid: string;
-    from: number;
-    to: number;
 }
 
 export interface MovementOperation {
@@ -17,10 +14,27 @@ export interface MovementOperation {
     shapes: ShapeMovementOperation[];
 }
 
+// RESIZE
+export interface ResizeOperation {
+    type: "resize";
+    // shapes: (RectResizeOperation | CircleResizeOperation | PolygonResizeOperation)[];
+    uuid: string;
+    fromPoint: number[];
+    toPoint: number[];
+    resizePoint: number;
+    retainAspectRatio: boolean;
+}
+
+// ROTATION
+
+export interface ShapeRotationOperation {
+    uuid: string;
+    from: number;
+    to: number;
+}
+
 export interface RotationOperation {
     type: "rotation";
     shapes: ShapeRotationOperation[];
     center: GlobalPoint;
 }
-
-export type Operation = MovementOperation | RotationOperation;

--- a/client/src/game/operations/model.ts
+++ b/client/src/game/operations/model.ts
@@ -1,6 +1,6 @@
 import { GlobalPoint } from "../geom";
 
-export type Operation = MovementOperation | ResizeOperation | RotationOperation;
+export type Operation = FloorMoveOperation | MovementOperation | ResizeOperation | RotationOperation;
 
 // MOVEMENT
 export interface ShapeMovementOperation {
@@ -37,4 +37,13 @@ export interface RotationOperation {
     type: "rotation";
     shapes: ShapeRotationOperation[];
     center: GlobalPoint;
+}
+
+// FLOOR CHANGE
+
+export interface FloorMoveOperation {
+    type: "floormovement";
+    from: number;
+    to: number;
+    shapes: string[];
 }

--- a/client/src/game/operations/model.ts
+++ b/client/src/game/operations/model.ts
@@ -1,6 +1,11 @@
 import { GlobalPoint } from "../geom";
 
-export type Operation = FloorMoveOperation | MovementOperation | ResizeOperation | RotationOperation;
+export type Operation =
+    | FloorMoveOperation
+    | LayerMoveOperation
+    | MovementOperation
+    | ResizeOperation
+    | RotationOperation;
 
 // MOVEMENT
 export interface ShapeMovementOperation {
@@ -45,5 +50,14 @@ export interface FloorMoveOperation {
     type: "floormovement";
     from: number;
     to: number;
+    shapes: string[];
+}
+
+// LAYER CHANGE
+
+export interface LayerMoveOperation {
+    type: "layermovement";
+    from: string;
+    to: string;
     shapes: string[];
 }

--- a/client/src/game/operations/model.ts
+++ b/client/src/game/operations/model.ts
@@ -1,7 +1,15 @@
+import { GlobalPoint } from "../geom";
+
 export interface ShapeMovementOperation {
     uuid: string;
     from: number[];
     to: number[];
+}
+
+export interface ShapeRotationOperation {
+    uuid: string;
+    from: number;
+    to: number;
 }
 
 export interface MovementOperation {
@@ -9,4 +17,10 @@ export interface MovementOperation {
     shapes: ShapeMovementOperation[];
 }
 
-export type Operation = MovementOperation;
+export interface RotationOperation {
+    type: "rotation";
+    shapes: ShapeRotationOperation[];
+    center: GlobalPoint;
+}
+
+export type Operation = MovementOperation | RotationOperation;

--- a/client/src/game/operations/model.ts
+++ b/client/src/game/operations/model.ts
@@ -1,0 +1,12 @@
+export interface ShapeMovementOperation {
+    uuid: string;
+    from: number[];
+    to: number[];
+}
+
+export interface MovementOperation {
+    type: "movement";
+    shapes: ShapeMovementOperation[];
+}
+
+export type Operation = MovementOperation;

--- a/client/src/game/operations/model.ts
+++ b/client/src/game/operations/model.ts
@@ -1,3 +1,4 @@
+import { ServerShape } from "../comm/types/shapes";
 import { GlobalPoint } from "../geom";
 
 export type Operation =
@@ -5,7 +6,9 @@ export type Operation =
     | LayerMoveOperation
     | MovementOperation
     | ResizeOperation
-    | RotationOperation;
+    | RotationOperation
+    | ShapeAddOperation
+    | ShapeRemoveOperation;
 
 // MOVEMENT
 export interface ShapeMovementOperation {
@@ -60,4 +63,18 @@ export interface LayerMoveOperation {
     from: string;
     to: string;
     shapes: string[];
+}
+
+// SHAPE REMOVE
+
+export interface ShapeRemoveOperation {
+    type: "shaperemove";
+    shapes: ServerShape[];
+}
+
+// SHAPE ADD
+
+export interface ShapeAddOperation {
+    type: "shapeadd";
+    shapes: ServerShape[];
 }

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -1,0 +1,44 @@
+import { sendShapePositionUpdate } from "../api/emits/shape/core";
+import { Vector } from "../geom";
+import { Shape } from "../shapes/shape";
+import { visibilityStore } from "../visibility/store";
+import { TriangulationTarget } from "../visibility/te/pa";
+export function moveShapes(shapes: readonly Shape[], delta: Vector, temporary: boolean): void {
+    let recalculateMovement = false;
+    let recalculateVision = false;
+
+
+    for (const shape of shapes) {
+        if (!shape.ownedBy(false, { movementAccess: true })) continue;
+
+        if (shape.movementObstruction && !temporary) {
+            recalculateMovement = true;
+            visibilityStore.deleteFromTriag({
+                target: TriangulationTarget.MOVEMENT,
+                shape: shape.uuid,
+            });
+        }
+        if (shape.visionObstruction) {
+            recalculateVision = true;
+            visibilityStore.deleteFromTriag({
+                target: TriangulationTarget.VISION,
+                shape: shape.uuid,
+            });
+        }
+
+        shape.refPoint = shape.refPoint.add(delta);
+
+        if (shape.movementObstruction && !temporary)
+            visibilityStore.addToTriag({ target: TriangulationTarget.MOVEMENT, shape: shape.uuid });
+        if (shape.visionObstruction)
+            visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: shape.uuid });
+        // todo: Fix again
+        // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();
+        if (!shape.preventSync) updateList.push(shape);
+    }
+    sendShapePositionUpdate(updateList, temporary);
+
+    const floorId = shapes[0].floor.id;
+    if (recalculateVision) visibilityStore.recalculateVision(floorId);
+    if (recalculateMovement) visibilityStore.recalculateMovement(floorId);
+    shapes[0].layer.invalidate(false);

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -3,7 +3,8 @@ import { Vector } from "../geom";
 import { Shape } from "../shapes/shape";
 import { visibilityStore } from "../visibility/store";
 import { TriangulationTarget } from "../visibility/te/pa";
-import { addOperation, MovementOperation, ShapeMovementOperation } from "./operations";
+import { MovementOperation, ShapeMovementOperation } from "./model";
+import { addOperation } from "./undo";
 
 export function moveShapes(shapes: readonly Shape[], delta: Vector, temporary: boolean): void {
     let recalculateMovement = false;

--- a/client/src/game/operations/operations.ts
+++ b/client/src/game/operations/operations.ts
@@ -1,0 +1,56 @@
+import { GlobalPoint, Vector } from "../geom";
+import { layerManager } from "../layers/manager";
+import { moveShapes } from "./movement";
+
+export interface ShapeMovementOperation {
+    uuid: string;
+    from: number[];
+    to: number[];
+}
+
+export interface MovementOperation {
+    type: "movement";
+    shapes: ShapeMovementOperation[];
+}
+
+export type Operation = MovementOperation;
+
+const undoStack: Operation[] = [];
+let redoStack: Operation[] = [];
+let operationInProgress = false;
+
+export function addOperation(operation: Operation): void {
+    console.log(operationInProgress, operation.type, operation);
+    if (operationInProgress) return;
+    undoStack.push(operation);
+    redoStack = [];
+}
+
+export function undoOperation(): void {
+    handleOperation("undo");
+}
+
+export function redoOperation(): void {
+    handleOperation("redo");
+}
+
+function handleOperation(direction: "undo" | "redo"): void {
+    operationInProgress = true;
+    const op = direction === "undo" ? undoStack.pop() : redoStack.pop();
+    if (op !== undefined) {
+        if (direction === "undo") redoStack.push(op);
+        else undoStack.push(op);
+
+        if (op.type === "movement") {
+            handleMovement(op.shapes, direction);
+        }
+    }
+    operationInProgress = false;
+}
+
+function handleMovement(shapes: ShapeMovementOperation[], direction: "undo" | "redo"): void {
+    const fullShapes = shapes.map((s) => layerManager.UUIDMap.get(s.uuid)!);
+    let delta = Vector.fromPoints(GlobalPoint.fromArray(shapes[0].to), GlobalPoint.fromArray(shapes[0].from));
+    if (direction === "redo") delta = delta.reverse();
+    moveShapes(fullShapes, delta, true);
+}

--- a/client/src/game/operations/resize.ts
+++ b/client/src/game/operations/resize.ts
@@ -1,0 +1,35 @@
+import { sendShapeSizeUpdate } from "../api/emits/shape/core";
+import { GlobalPoint } from "../geom";
+import { Shape } from "../shapes/shape";
+import { visibilityStore } from "../visibility/store";
+import { TriangulationTarget } from "../visibility/te/pa";
+
+export function resizeShape(
+    shape: Shape,
+    targetPoint: GlobalPoint,
+    resizePoint: number,
+    retainAspectRatio: boolean,
+    temporary: boolean,
+): number {
+    if (!temporary) console.log(targetPoint, resizePoint);
+    let recalculateVision = false;
+
+    if (shape.visionObstruction)
+        visibilityStore.deleteFromTriag({
+            target: TriangulationTarget.VISION,
+            shape: shape.uuid,
+        });
+
+    const newResizePoint = shape.resize(resizePoint, targetPoint, retainAspectRatio);
+    // todo: think about calling deleteIntersectVertex directly on the corner point
+    if (shape.visionObstruction) {
+        visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: shape.uuid });
+        recalculateVision = true;
+    }
+    if (!shape.preventSync) sendShapeSizeUpdate({ shape, temporary });
+
+    if (recalculateVision) visibilityStore.recalculateVision(shape.floor.id);
+    shape.layer.invalidate(false);
+
+    return newResizePoint;
+}

--- a/client/src/game/operations/rotation.ts
+++ b/client/src/game/operations/rotation.ts
@@ -27,6 +27,7 @@ export function rotateShapes(
         }
         if (!shape.preventSync) sendShapePositionUpdate([shape], temporary);
     }
+
     if (recalculateVision) visibilityStore.recalculateVision(shapes[0].floor.id);
     shapes[0].layer.invalidate(false);
 }

--- a/client/src/game/operations/rotation.ts
+++ b/client/src/game/operations/rotation.ts
@@ -1,0 +1,32 @@
+import { sendShapePositionUpdate } from "../api/emits/shape/core";
+import { GlobalPoint } from "../geom";
+import { Shape } from "../shapes/shape";
+import { visibilityStore } from "../visibility/store";
+import { TriangulationTarget } from "../visibility/te/pa";
+
+export function rotateShapes(
+    shapes: readonly Shape[],
+    deltaAngle: number,
+    center: GlobalPoint,
+    temporary: boolean,
+): void {
+    let recalculateVision = false;
+
+    for (const shape of shapes) {
+        if (shape.visionObstruction)
+            visibilityStore.deleteFromTriag({
+                target: TriangulationTarget.VISION,
+                shape: shape.uuid,
+            });
+
+        shape.rotateAround(center, deltaAngle);
+
+        if (shape.visionObstruction) {
+            visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: shape.uuid });
+            recalculateVision = true;
+        }
+        if (!shape.preventSync) sendShapePositionUpdate([shape], temporary);
+    }
+    if (recalculateVision) visibilityStore.recalculateVision(shapes[0].floor.id);
+    shapes[0].layer.invalidate(false);
+}

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -1,14 +1,16 @@
+import { EventBus } from "../event-bus";
 import { GlobalPoint, Vector } from "../geom";
 import { layerManager } from "../layers/manager";
-import { Operation, ShapeMovementOperation } from "./model";
+import { Operation, ShapeMovementOperation, ShapeRotationOperation } from "./model";
 import { moveShapes } from "./movement";
+import { rotateShapes } from "./rotation";
 
 const undoStack: Operation[] = [];
 let redoStack: Operation[] = [];
 let operationInProgress = false;
 
 export function addOperation(operation: Operation): void {
-    console.log(operationInProgress, operation.type, operation);
+    console.log(operationInProgress, operation);
     if (operationInProgress) return;
     undoStack.push(operation);
     redoStack = [];
@@ -31,6 +33,8 @@ function handleOperation(direction: "undo" | "redo"): void {
 
         if (op.type === "movement") {
             handleMovement(op.shapes, direction);
+        } else if (op.type === "rotation") {
+            handleRotation(op.shapes, op.center, direction);
         }
     }
     operationInProgress = false;
@@ -41,4 +45,12 @@ function handleMovement(shapes: ShapeMovementOperation[], direction: "undo" | "r
     let delta = Vector.fromPoints(GlobalPoint.fromArray(shapes[0].to), GlobalPoint.fromArray(shapes[0].from));
     if (direction === "redo") delta = delta.reverse();
     moveShapes(fullShapes, delta, true);
+}
+
+function handleRotation(shapes: ShapeRotationOperation[], center: GlobalPoint, direction: "undo" | "redo"): void {
+    const fullShapes = shapes.map((s) => layerManager.UUIDMap.get(s.uuid)!);
+    let angle = shapes[0].from - shapes[0].to;
+    if (direction === "redo") angle *= -1;
+    rotateShapes(fullShapes, angle, center, true);
+    EventBus.$emit("Select.RotationHelper.Reset");
 }

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -2,7 +2,7 @@ import { EventBus } from "../event-bus";
 import { GlobalPoint, Vector } from "../geom";
 import { layerManager } from "../layers/manager";
 import { floorStore } from "../layers/store";
-import { moveFloor } from "../layers/utils";
+import { moveFloor, moveLayer } from "../layers/utils";
 import { Operation, ShapeMovementOperation, ShapeRotationOperation } from "./model";
 import { moveShapes } from "./movement";
 import { resizeShape } from "./resize";
@@ -42,6 +42,8 @@ function handleOperation(direction: "undo" | "redo"): void {
             handleResize(op.uuid, op.fromPoint, op.toPoint, op.resizePoint, op.retainAspectRatio, direction);
         } else if (op.type === "floormovement") {
             handleFloorMove(op.shapes, op.from, op.to, direction);
+        } else if (op.type === "layermovement") {
+            handleLayerMove(op.shapes, op.from, op.to, direction);
         }
     }
     operationInProgress = false;
@@ -79,6 +81,15 @@ function handleFloorMove(shapes: string[], from: number, to: number, direction: 
     const fullShapes = shapes.map((s) => layerManager.UUIDMap.get(s)!);
     let floorId = from;
     if (direction === "redo") floorId = to;
-    const floor = floorStore.floors.find((f) => f.id === floorId)!;
+    const floor = layerManager.getFloor(floorId)!;
     moveFloor(fullShapes, floor, true);
+}
+
+function handleLayerMove(shapes: string[], from: string, to: string, direction: "undo" | "redo"): void {
+    const fullShapes = shapes.map((s) => layerManager.UUIDMap.get(s)!);
+    let layerName = from;
+    if (direction === "redo") layerName = to;
+    const floor = layerManager.getFloor(fullShapes[0].floor.id)!;
+    const layer = layerManager.getLayer(floor, layerName)!;
+    moveLayer(fullShapes, layer, true);
 }

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -1,7 +1,6 @@
 import { EventBus } from "../event-bus";
 import { GlobalPoint, Vector } from "../geom";
 import { layerManager } from "../layers/manager";
-import { floorStore } from "../layers/store";
 import { moveFloor, moveLayer } from "../layers/utils";
 import { Operation, ShapeMovementOperation, ShapeRotationOperation } from "./model";
 import { moveShapes } from "./movement";

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -11,7 +11,7 @@ import { moveShapes } from "./movement";
 import { resizeShape } from "./resize";
 import { rotateShapes } from "./rotation";
 
-const undoStack: Operation[] = [];
+let undoStack: Operation[] = [];
 let redoStack: Operation[] = [];
 let operationInProgress = false;
 
@@ -36,6 +36,14 @@ export function overrideLastOperation(operation: Operation): void {
     if (lastOp === undefined || lastOp.type !== operation.type)
         throw new Error("Wrong usage of overrideLastOperation.");
     undoStack.push(operation);
+}
+
+/**
+ * Clear the undo and redo stacks.
+ */
+export function clearUndoStacks(): void {
+    undoStack = [];
+    redoStack = [];
 }
 
 export async function undoOperation(): Promise<void> {

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -19,10 +19,10 @@ let operationInProgress = false;
  * Add a new operation to the undo stack.
  */
 export function addOperation(operation: Operation): void {
-    console.log(operationInProgress, operation);
     if (operationInProgress) return;
     undoStack.push(operation);
     redoStack = [];
+    if (undoStack.length > 50) undoStack.shift();
 }
 
 /**

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -61,6 +61,7 @@ function handleMovement(shapes: ShapeMovementOperation[], direction: "undo" | "r
     let delta = Vector.fromPoints(GlobalPoint.fromArray(shapes[0].to), GlobalPoint.fromArray(shapes[0].from));
     if (direction === "redo") delta = delta.reverse();
     moveShapes(fullShapes, delta, true);
+    EventBus.$emit("Select.RotationHelper.Reset");
 }
 
 function handleRotation(shapes: ShapeRotationOperation[], center: GlobalPoint, direction: "undo" | "redo"): void {

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -1,6 +1,8 @@
 import { EventBus } from "../event-bus";
 import { GlobalPoint, Vector } from "../geom";
 import { layerManager } from "../layers/manager";
+import { floorStore } from "../layers/store";
+import { moveFloor } from "../layers/utils";
 import { Operation, ShapeMovementOperation, ShapeRotationOperation } from "./model";
 import { moveShapes } from "./movement";
 import { resizeShape } from "./resize";
@@ -38,6 +40,8 @@ function handleOperation(direction: "undo" | "redo"): void {
             handleRotation(op.shapes, op.center, direction);
         } else if (op.type === "resize") {
             handleResize(op.uuid, op.fromPoint, op.toPoint, op.resizePoint, op.retainAspectRatio, direction);
+        } else if (op.type === "floormovement") {
+            handleFloorMove(op.shapes, op.from, op.to, direction);
         }
     }
     operationInProgress = false;
@@ -69,4 +73,12 @@ function handleResize(
     const shape = layerManager.UUIDMap.get(uuid)!;
     const targetPoint = direction === "undo" ? fromPoint : toPoint;
     resizeShape(shape, GlobalPoint.fromArray(targetPoint), resizePoint, retainAspectRatio, false);
+}
+
+function handleFloorMove(shapes: string[], from: number, to: number, direction: "undo" | "redo"): void {
+    const fullShapes = shapes.map((s) => layerManager.UUIDMap.get(s)!);
+    let floorId = from;
+    if (direction === "redo") floorId = to;
+    const floor = floorStore.floors.find((f) => f.id === floorId)!;
+    moveFloor(fullShapes, floor, true);
 }

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -1,19 +1,7 @@
 import { GlobalPoint, Vector } from "../geom";
 import { layerManager } from "../layers/manager";
+import { Operation, ShapeMovementOperation } from "./model";
 import { moveShapes } from "./movement";
-
-export interface ShapeMovementOperation {
-    uuid: string;
-    from: number[];
-    to: number[];
-}
-
-export interface MovementOperation {
-    type: "movement";
-    shapes: ShapeMovementOperation[];
-}
-
-export type Operation = MovementOperation;
 
 const undoStack: Operation[] = [];
 let redoStack: Operation[] = [];

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -3,6 +3,7 @@ import { GlobalPoint, Vector } from "../geom";
 import { layerManager } from "../layers/manager";
 import { Operation, ShapeMovementOperation, ShapeRotationOperation } from "./model";
 import { moveShapes } from "./movement";
+import { resizeShape } from "./resize";
 import { rotateShapes } from "./rotation";
 
 const undoStack: Operation[] = [];
@@ -35,6 +36,8 @@ function handleOperation(direction: "undo" | "redo"): void {
             handleMovement(op.shapes, direction);
         } else if (op.type === "rotation") {
             handleRotation(op.shapes, op.center, direction);
+        } else if (op.type === "resize") {
+            handleResize(op.uuid, op.fromPoint, op.toPoint, op.resizePoint, op.retainAspectRatio, direction);
         }
     }
     operationInProgress = false;
@@ -53,4 +56,17 @@ function handleRotation(shapes: ShapeRotationOperation[], center: GlobalPoint, d
     if (direction === "redo") angle *= -1;
     rotateShapes(fullShapes, angle, center, true);
     EventBus.$emit("Select.RotationHelper.Reset");
+}
+
+function handleResize(
+    uuid: string,
+    fromPoint: number[],
+    toPoint: number[],
+    resizePoint: number,
+    retainAspectRatio: boolean,
+    direction: "undo" | "redo",
+): void {
+    const shape = layerManager.UUIDMap.get(uuid)!;
+    const targetPoint = direction === "undo" ? fromPoint : toPoint;
+    resizeShape(shape, GlobalPoint.fromArray(targetPoint), resizePoint, retainAspectRatio, false);
 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -384,7 +384,7 @@ export abstract class Shape {
     }
 
     setPositionRepresentation(position: { angle: number; points: number[][] }): void {
-        this.refPoint = GlobalPoint.fromArray(position.points[0]);
+        this._refPoint = GlobalPoint.fromArray(position.points[0]);
         this.angle = position.angle;
         this.updateShapeVision(false, false);
     }

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -25,6 +25,7 @@ import { sendRemoveShapes } from "../api/emits/shape/core";
 import { EventBus } from "../event-bus";
 import { addGroupMembers, createNewGroupForShapes, fetchGroup, generateNewBadge, getGroup } from "../groups";
 import { floorStore, getFloorId } from "../layers/store";
+import { addOperation } from "../operations/undo";
 import { gameStore } from "../store";
 import { VisibilityMode, visibilityStore } from "../visibility/store";
 import { TriangulationTarget } from "../visibility/te/pa";
@@ -241,6 +242,10 @@ export function deleteShapes(shapes: readonly Shape[], sync: SyncMode): void {
         if (recalculateVision)
             visibilityStore.recalculate({ target: TriangulationTarget.VISION, floor: floorStore.currentFloorindex });
         layerManager.invalidateVisibleFloors();
+    }
+
+    if (sync === SyncMode.FULL_SYNC) {
+        addOperation({ type: "shaperemove", shapes: shapes.map((s) => s.asDict()) });
     }
 }
 

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -30,6 +30,7 @@ import { ToolBasics } from "./ToolBasics";
 import { floorStore } from "@/game/layers/store";
 import { Floor } from "@/game/layers/floor";
 import { sendShapeSizeUpdate } from "@/game/api/emits/shape/core";
+import { overrideLastOperation } from "../../operations/undo";
 
 @Component({
     components: {
@@ -460,6 +461,8 @@ export default class DrawTool extends Tool implements ToolBasics {
         if (layer !== undefined) {
             layer.invalidate(false);
         }
+
+        overrideLastOperation({ type: "shapeadd", shapes: [this.shape.asDict()] });
     }
 
     onSelect(mouse?: { x: number; y: number }): void {

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -25,6 +25,7 @@ import { sendShapePositionUpdate, sendShapeSizeUpdate } from "../../api/emits/sh
 import { Shape } from "@/game/shapes/shape";
 import Tools from "./tools.vue";
 import { RulerFeatures } from "./ruler.vue";
+import { moveShapes } from "../../operations/movement";
 
 enum SelectOperations {
     Noop,
@@ -294,25 +295,9 @@ export default class SelectTool extends Tool implements ToolBasics {
                         if (delta !== ogDelta) this.deltaChanged = true;
                     }
                 }
-                let recalc = false;
-                const updateList = [];
-                // Actually apply the delta on all shapes
-                for (const sel of layerSelection) {
-                    if (!sel.ownedBy(false, { movementAccess: true })) continue;
-                    if (sel.visionObstruction)
-                        visibilityStore.deleteFromTriag({
-                            target: TriangulationTarget.VISION,
-                            shape: sel.uuid,
-                        });
-                    sel.refPoint = sel.refPoint.add(delta);
-                    if (sel.visionObstruction) {
-                        visibilityStore.addToTriag({ target: TriangulationTarget.VISION, shape: sel.uuid });
-                        recalc = true;
-                    }
-                    if (!sel.preventSync) updateList.push(sel);
-                }
-                sendShapePositionUpdate(updateList, true);
-                if (recalc) visibilityStore.recalculateVision(layerSelection[0].floor.id);
+
+                moveShapes(layerSelection, delta, true);
+
                 this.dragRay = Ray.fromPoints(this.dragRay.origin, lp);
 
                 if (this.rotationUiActive) {

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -26,7 +26,8 @@ import { Shape } from "@/game/shapes/shape";
 import Tools from "./tools.vue";
 import { RulerFeatures } from "./ruler.vue";
 import { moveShapes } from "../../operations/movement";
-import { addOperation, Operation } from "../../operations/operations";
+import { Operation } from "../../operations/model";
+import { addOperation } from "../../operations/undo";
 
 enum SelectOperations {
     Noop,

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -205,6 +205,16 @@ export default class SelectTool extends Tool implements ToolBasics {
                     this.mode = SelectOperations.Resize;
                     layer.invalidate(true);
                     hit = true;
+
+                    this.operationList = {
+                        type: "resize",
+                        uuid: shape.uuid,
+                        fromPoint: shape.points[this.resizePoint],
+                        toPoint: [],
+                        resizePoint: this.resizePoint,
+                        retainAspectRatio: false,
+                    };
+
                     break;
                 }
             }
@@ -472,8 +482,10 @@ export default class SelectTool extends Tool implements ToolBasics {
                             recalcMovement = true;
                         }
                     }
-                    this.operationList!.shapes[s].to = sel.refPoint.asArray();
-                    this.operationReady = true;
+                    if (this.operationList?.type === "movement") {
+                        this.operationList.shapes[s].to = sel.refPoint.asArray();
+                        this.operationReady = true;
+                    }
 
                     if (sel.visionObstruction) recalcVision = true;
                     if (sel.movementObstruction) recalcMovement = true;
@@ -513,6 +525,14 @@ export default class SelectTool extends Tool implements ToolBasics {
                     if (!sel.preventSync) {
                         sendShapeSizeUpdate({ shape: sel, temporary: false });
                     }
+
+                    if (this.operationList?.type === "resize") {
+                        this.operationList.toPoint = l2g(lp).asArray();
+                        this.operationList.resizePoint = this.resizePoint;
+                        this.operationList.retainAspectRatio = event.ctrlKey;
+                        this.operationReady = true;
+                    }
+
                     sel.updatePoints();
                 }
             }
@@ -531,8 +551,10 @@ export default class SelectTool extends Tool implements ToolBasics {
                         this.rotateSelection(newAngle, rotationCenter, false);
                     } else if (!sel.preventSync) sendShapePositionUpdate([sel], false);
 
-                    this.operationList!.shapes[s].to = sel.angle;
-                    this.operationReady = true;
+                    if (this.operationList?.type === "rotation") {
+                        this.operationList.shapes[s].to = sel.angle;
+                        this.operationReady = true;
+                    }
 
                     sel.updatePoints();
                 }

--- a/client/tests/unit/game/visibility/te/pa.test.ts
+++ b/client/tests/unit/game/visibility/te/pa.test.ts
@@ -13,6 +13,9 @@ jest.mock("@/game/api/socket", () => ({
         on: jest.fn(),
     },
 }));
+jest.mock("@/i18n.ts", () => ({
+    t: jest.fn(),
+}));
 
 let cdt: CDT;
 


### PR DESCRIPTION
This PR adds undo and redo support. (ctrl+z and shift+z).

Currently the number of remembered operations is hardcoded to 50.
This value might change or become configurable in the future.

To-do list:
- [x] movement
- [x] rotation
- [x] resizing
- [x] layer movement
- [x] floor movement
- [x] creation/deletion

This closese #66 