### PR TITLE
bug(Vision): Fix vision tool private auras with default permissions

### DIFF
--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -646,8 +646,7 @@ export abstract class Shape {
         if (limitToActiveTokens && !isActiveToken) return false;
 
         return (
-            gameStore.IS_DM ||
-            (gameStore.FAKE_PLAYER && isActiveToken) ||
+            gameStore.FAKE_PLAYER ||
             (options.editAccess && this.defaultAccess.edit) ||
             (options.movementAccess && this.defaultAccess.movement) ||
             (options.visionAccess && this.defaultAccess.vision) ||

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -639,21 +639,25 @@ export abstract class Shape {
         limitToActiveTokens: boolean,
         options: Partial<{ editAccess: boolean; visionAccess: boolean; movementAccess: boolean }>,
     ): boolean {
+        if (gameStore.IS_DM) return true;
+
         const isActiveToken = gameStore.activeTokens.includes(this.uuid);
+
+        if (limitToActiveTokens && !isActiveToken) return false;
+
         return (
             gameStore.IS_DM ||
             (gameStore.FAKE_PLAYER && isActiveToken) ||
             (options.editAccess && this.defaultAccess.edit) ||
             (options.movementAccess && this.defaultAccess.movement) ||
             (options.visionAccess && this.defaultAccess.vision) ||
-            ((!limitToActiveTokens || isActiveToken) &&
-                this._owners.some(
-                    (u) =>
-                        u.user === gameStore.username &&
-                        (options.editAccess ? u.access.edit === true : true) &&
-                        (options.movementAccess ? u.access.movement === true : true) &&
-                        (options.visionAccess ? u.access.vision === true : true),
-                ))
+            this._owners.some(
+                (u) =>
+                    u.user === gameStore.username &&
+                    (options.editAccess ? u.access.edit === true : true) &&
+                    (options.movementAccess ? u.access.movement === true : true) &&
+                    (options.visionAccess ? u.access.vision === true : true),
+            )
         );
     }
 


### PR DESCRIPTION
This is a follow-up of an earlier PR #639 that addresses the same issue but also for default access permissions.

This closes #625