### PR TITLE
bug(Vision): Fix minimal vision being applied to all floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,15 @@ These usually have no immediately visible impact on regular users
     -   layer change
     -   shape creation/removal
 
-### Fixes
+### Fixed
 
 -   Shape name not immediately syncing on visibility toggle
 -   Vision tool disabled tokens private auras no longer being visible
+-   Tokens giving minimal vision on other floors
 
 ## [0.24.1] - 2021-01-17
 
-### Fixes
+### Fixed
 
 -   minimal token vision being broken
 -   pasting polygons would change the angle on the first segment

--- a/client/src/game/layers/fowlighting.ts
+++ b/client/src/game/layers/fowlighting.ts
@@ -41,11 +41,12 @@ export class FowLightingLayer extends FowLayer {
             if (
                 gameSettingsStore.fullFow &&
                 layerManager.hasLayer(floorStore.currentFloor, "tokens") &&
-                floorStore.currentFloor === floorStore.floors[floorStore.currentFloorindex]
+                floorStore.currentFloor.id === this.floor
             ) {
                 for (const sh of gameStore.activeTokens) {
                     const shape = layerManager.UUIDMap.get(sh)!;
                     if ((shape.options.get("skipDraw") ?? false) === true) continue;
+                    if (shape.floor.id !== floorStore.currentFloor.id) continue;
                     const bb = shape.getBoundingBox();
                     const lcenter = g2l(shape.center());
                     const alm = 0.8 * g2lz(bb.w);


### PR DESCRIPTION
This fixes a bug where the minimal vision for tokens would be visible on all floors.