### PR TITLE
bug(Floor/Vision) Fix floor triangulation not called for newly created floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ These usually have no immediately visible impact on regular users
 -   Shape name not immediately syncing on visibility toggle
 -   Vision tool disabled tokens private auras no longer being visible
 -   Tokens giving minimal vision on other floors
+-   Floor creation not triangulating
+    -   This fixes newly created floors being broken in regards to vision until a refresh
 
 ## [0.24.1] - 2021-01-17
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -66,8 +66,6 @@ socket.on("Board.Floor.Set", async (floor: ServerFloor) => {
     // When this condition is evaluated after the await, we are at the mercy of the async scheduler
     const selectFloor = floorStore.floors.length === 0;
     await addFloor(floor);
-    visibilityStore.recalculateVision(getFloorId(floor.name));
-    visibilityStore.recalculateMovement(getFloorId(floor.name));
 
     if (selectFloor) {
         floorStore.selectFloor({ targetFloor: floor.name, sync: false });

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -22,7 +22,7 @@ import { gameStore } from "@/game/store";
 import { router } from "@/router";
 
 import { coreStore } from "../../core/store";
-import { floorStore, getFloorId } from "../layers/store";
+import { floorStore } from "../layers/store";
 import { deleteShapes } from "../shapes/utils";
 import { visibilityStore } from "../visibility/store";
 

--- a/client/src/game/visibility/te/pa.ts
+++ b/client/src/game/visibility/te/pa.ts
@@ -27,6 +27,8 @@ export function addCDT(floor: number): void {
     visibilityStore.movementBlockers.push({ floor, blockers: [] });
     visibilityStore.visionBlockers.push({ floor, blockers: [] });
     visibilityStore.visionSources.push({ floor, sources: [] });
+    triangulate(TriangulationTarget.VISION, floor);
+    triangulate(TriangulationTarget.MOVEMENT, floor);
 }
 
 export function removeCDT(floor: number): void {


### PR DESCRIPTION
When creating a new floor, the initial triangulation was not called which caused any lighting related shape to break the floor until a refresh.