### PR TITLE
bug(UI): Update location bar user position when moving shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ These usually have no immediately visible impact on regular users
 -   Tokens giving minimal vision on other floors
 -   Floor creation not triangulating
     -   This fixes newly created floors being broken in regards to vision until a refresh
+-   Update location bar user position when moving shape
 
 ## [0.24.1] - 2021-01-17
 

--- a/client/src/game/ui/selection/shapecontext.vue
+++ b/client/src/game/ui/selection/shapecontext.vue
@@ -171,7 +171,7 @@ export default class ShapeContext extends Vue {
             }
         }
 
-        const targetLocation = {
+        const targetPosition = {
             floor: spawnLocation.floor,
             x: spawnLocation.x + spawnLocation.width / 2,
             y: spawnLocation.y + spawnLocation.height / 2,
@@ -179,14 +179,19 @@ export default class ShapeContext extends Vue {
 
         sendShapesMove({
             shapes: selection.map((s) => s.uuid),
-            target: { location: newLocation, ...targetLocation },
+            target: { location: newLocation, ...targetPosition },
         });
         if (gameSettingsStore.movePlayerOnTokenChange) {
             const users: Set<string> = new Set();
             for (const shape of selection) {
                 for (const owner of shape.owners) users.add(owner.user);
             }
-            sendLocationChange({ location: newLocation, users: [...users], position: { ...targetLocation } });
+            sendLocationChange({ location: newLocation, users: [...users], position: { ...targetPosition } });
+            for (const player of gameStore.players) {
+                if (users.has(player.name)) {
+                    player.location = newLocation;
+                }
+            }
         }
 
         this.close();


### PR DESCRIPTION
When moving a shape to another location, all related users are moved with it.
This change was not reflected in the locations bar until a refresh.