### PR TITLE
bug(Floor): Fix floor creation duplicate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Fixed
+
+-   It's no longer possible to create a floor with a name that is already in use
+
 ## [0.25.0] - 2021-02-07
 
 ### Added

--- a/client/src/game/ui/floors.vue
+++ b/client/src/game/ui/floors.vue
@@ -71,8 +71,14 @@ export default class FloorSelect extends Vue {
         const value = await this.$refs.prompt.prompt(
             this.$t("game.ui.floors.new_name").toString(),
             this.$t("game.ui.floors.creation").toString(),
+            (value) => {
+                if (floorStore.floors.some((f) => f.name === value)) {
+                    return { valid: false, reason: "This name is already in use!" };
+                }
+                return { valid: true };
+            },
         );
-        if (value === undefined) return;
+        if (value === undefined || getFloorId(value) !== -1) return;
         sendCreateFloor(value);
     }
 


### PR DESCRIPTION
This PR closes #653 which showed that it's possible to create a floor with a name already in use, which would result in errors when interacting with this new floor.