### PR TITLE
bug(Select): Fix shape mouse snap desync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These usually have no immediately visible impact on regular users
 ### Fixed
 
 -   It's no longer possible to create a floor with a name that is already in use
+-   Token properly snaps to mouse when leaving wall
 
 ## [0.25.0] - 2021-02-07
 

--- a/client/src/game/ui/tools/select.vue
+++ b/client/src/game/ui/tools/select.vue
@@ -335,7 +335,9 @@ export default class SelectTool extends Tool implements ToolBasics {
 
                 moveShapes(layerSelection, delta, true);
 
-                this.dragRay = Ray.fromPoints(this.dragRay.origin, lp);
+                if (!this.deltaChanged) {
+                    this.dragRay = Ray.fromPoints(this.dragRay.origin, lp);
+                }
 
                 if (this.rotationUiActive) {
                     this.removeRotationUi();


### PR DESCRIPTION
When moving a shape into a wall, the shape and the mouse will no longer be in sync, which can give some unpleasant behaviour.

This closes #648 