### PR TITLE
feat(ClientSetting): Add disable scroll to zoom setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Added
+
+-   Client setting to disable zoom behaviour on scroll
+
 ### Changed
 
 -   Client settings

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -18,6 +18,7 @@ import Initiative from "@/game/ui/initiative/initiative.vue";
 
 import { dropAsset } from "./layers/utils";
 import { clearUndoStacks } from "./operations/undo";
+import { gameStore } from "./store";
 import UI from "./ui/ui.vue";
 
 @Component({
@@ -86,6 +87,8 @@ export default class Game extends Vue {
     // Window events
 
     zoom(event: WheelEvent): void {
+        if (gameStore.disableScrollToZoom) return;
+
         throttle(scrollZoom)(event);
     }
 

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -26,6 +26,16 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     if (options.room_user_options?.invert_alt)
         gameStore.setInvertAlt({ invertAlt: options.room_user_options.invert_alt, sync: false });
     else gameStore.setInvertAlt({ invertAlt: options.default_user_options.invert_alt, sync: false });
+    if (options.room_user_options?.disable_scroll_to_zoom)
+        gameStore.setDisableScrollToZoom({
+            disableScrollToZoom: options.room_user_options.disable_scroll_to_zoom,
+            sync: false,
+        });
+    else
+        gameStore.setDisableScrollToZoom({
+            disableScrollToZoom: options.default_user_options.disable_scroll_to_zoom,
+            sync: false,
+        });
 
     gameStore.setPanX(options.location_user_options.pan_x);
     gameStore.setPanY(options.location_user_options.pan_y);

--- a/client/src/game/comm/types/settings.ts
+++ b/client/src/game/comm/types/settings.ts
@@ -55,6 +55,7 @@ export interface ServerUserOptions {
     ruler_colour: string;
     invert_alt: boolean;
     grid_size: number;
+    disable_scroll_to_zoom: boolean;
 }
 
 export interface UserOptions {
@@ -63,6 +64,7 @@ export interface UserOptions {
     rulerColour: string;
     invertAlt: boolean;
     gridSize: number;
+    disableScrollToZoom: boolean;
 }
 
 export const optionsToClient = (options: ServerLocationOptions): LocationOptions => ({
@@ -86,4 +88,5 @@ export const userOptionsToClient = (options: ServerUserOptions): UserOptions => 
     gridSize: options.grid_size,
     invertAlt: options.invert_alt,
     rulerColour: options.ruler_colour,
+    disableScrollToZoom: options.disable_scroll_to_zoom,
 });

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -67,6 +67,7 @@ class GameStore extends VuexModule implements GameState {
         rulerColour: "rgba(255, 0, 0, 1)",
         invertAlt: false,
         gridSize: DEFAULT_GRID_SIZE,
+        disableScrollToZoom: false,
     };
 
     gridColour = "rgba(0, 0, 0, 1)";
@@ -81,6 +82,7 @@ class GameStore extends VuexModule implements GameState {
      *  The zoom code will take care of proper conversions.
      */
     gridSize = DEFAULT_GRID_SIZE;
+    disableScrollToZoom = false;
 
     panX = 0;
     panY = 0;
@@ -479,6 +481,12 @@ class GameStore extends VuexModule implements GameState {
     setInvertAlt(data: { invertAlt: boolean; sync: boolean }): void {
         this.invertAlt = data.invertAlt;
         if (data.sync) sendRoomClientOptions({ invert_alt: data.invertAlt });
+    }
+
+    @Mutation
+    setDisableScrollToZoom(data: { disableScrollToZoom: boolean; sync: boolean }): void {
+        this.disableScrollToZoom = data.disableScrollToZoom;
+        if (data.sync) sendRoomClientOptions({ disable_scroll_to_zoom: data.disableScrollToZoom });
     }
 
     @Mutation

--- a/client/src/game/ui/settings/client/BehaviourSettings.vue
+++ b/client/src/game/ui/settings/client/BehaviourSettings.vue
@@ -19,6 +19,14 @@ export default class BehaviourSettings extends Vue {
         gameStore.setInvertAlt({ invertAlt: value, sync: true });
     }
 
+    get disableScrollToZoom(): boolean {
+        return gameStore.disableScrollToZoom;
+    }
+
+    set disableScrollToZoom(value: boolean) {
+        gameStore.setDisableScrollToZoom({ disableScrollToZoom: value, sync: true });
+    }
+
     setDefault(key: keyof UserOptions): void {
         gameStore.setDefaultClientOption({ key, value: gameStore[key], sync: true });
     }
@@ -27,7 +35,7 @@ export default class BehaviourSettings extends Vue {
 
 <template>
     <div class="panel restore-panel">
-        <div class="spanrow header">Grid</div>
+        <div class="spanrow header">Snapping</div>
         <div class="row">
             <label for="invertAlt" v-t="'game.ui.settings.client.BehaviourSettings.invert_alt_set'"></label>
             <div><input id="invertAlt" type="checkbox" v-model="invertAlt" /></div>
@@ -36,6 +44,25 @@ export default class BehaviourSettings extends Vue {
                     <font-awesome-icon icon="times-circle" />
                 </div>
                 <div :title="$t('game.ui.settings.common.sync_default')" @click="setDefault('invertAlt')">
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+        <div class="spanrow header">Mouse & Gestures</div>
+        <div class="row">
+            <label
+                for="disableScrollToZoom"
+                v-t="'game.ui.settings.client.BehaviourSettings.disable_scroll_to_zoom'"
+            ></label>
+            <div><input id="disableScrollToZoom" type="checkbox" v-model="disableScrollToZoom" /></div>
+            <template v-if="disableScrollToZoom !== defaultOptions.disableScrollToZoom">
+                <div
+                    :title="$t('game.ui.settings.common.reset_default')"
+                    @click="disableScrollToZoom = defaultOptions.disableScrollToZoom"
+                >
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div :title="$t('game.ui.settings.common.sync_default')" @click="setDefault('disableScrollToZoom')">
                     <font-awesome-icon icon="sync-alt" />
                 </div>
             </template>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -221,7 +221,8 @@
                         "grid_size_in_pixels": "Size (in pixels):"
                     },
                     "BehaviourSettings": {
-                        "invert_alt_set": "Invert ALT behaviour"
+                        "invert_alt_set": "Invert ALT behaviour",
+                        "disable_scroll_to_zoom": "Disable scroll to zoom"
                     }
                 },
                 "dm": {

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -38,6 +38,7 @@ class ClientOptions(TypedDict, total=False):
     ruler_colour: str
     invert_alt: bool
     grid_size: int
+    disable_scroll_to_zoom: bool
 
 
 class BringPlayersData(TypedDict):

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -1,3 +1,4 @@
+from logging import disable
 import bcrypt
 from peewee import ForeignKeyField, fn, BooleanField, IntegerField, TextField
 from playhouse.shortcuts import model_to_dict
@@ -14,6 +15,7 @@ class UserOptions(BaseModel):
     ruler_colour = TextField(default="#F00", null=True)
     invert_alt = BooleanField(default=False, null=True)
     grid_size = IntegerField(default=50, null=True)
+    disable_scroll_to_zoom = BooleanField(default=False, null=True)
 
     @classmethod
     def create_empty(cls):
@@ -23,6 +25,7 @@ class UserOptions(BaseModel):
             ruler_colour=None,
             invert_alt=None,
             grid_size=None,
+            disable_scroll_to_zoom=None,
         )
 
     def as_dict(self):

--- a/server/save.py
+++ b/server/save.py
@@ -13,7 +13,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 53
+SAVE_VERSION = 54
 
 import json
 import logging
@@ -837,6 +837,15 @@ def upgrade(version):
 
             db.execute_sql("DROP TABLE _player_room_52")
             db.execute_sql("DROP TABLE _user_52")
+    elif version == 53:
+        # Add UserOptions.disable_scroll_to_zoom
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE user_options ADD COLUMN disable_scroll_to_zoom INTEGER DEFAULT 0"
+            )
+            data = db.execute_sql(
+                "UPDATE user_options SET disable_scroll_to_zoom = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
+            )
     else:
         raise UnknownVersionException(
             f"No upgrade code for save format {version} was found."


### PR DESCRIPTION
This PR closes #578 and adds a new behavioural setting to the client settings to disable the ability to zoom when using the scroll wheel.