### PR TITLE
bug(Template): Fix template drops not rescaling to grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ These usually have no immediately visible impact on regular users
 
 -   It's no longer possible to create a floor with a name that is already in use
 -   Token properly snaps to mouse when leaving wall
+-   Template drops on non-default grid scales where not resized accordingly
 
 ## [0.25.0] - 2021-02-07
 

--- a/client/src/game/shapes/template.ts
+++ b/client/src/game/shapes/template.ts
@@ -1,5 +1,5 @@
 import { aurasToServer } from "../comm/conversion/aura";
-import { ServerShape } from "../comm/types/shapes";
+import { ServerRect, ServerShape } from "../comm/types/shapes";
 import {
     BaseAuraStrings,
     BaseAuraTemplate,
@@ -9,6 +9,7 @@ import {
     BaseTrackerTemplate,
     getTemplateKeys,
 } from "../comm/types/templates";
+import { gameSettingsStore } from "../settings";
 
 import { createEmptyAura, createEmptyTracker } from "./trackers/empty";
 
@@ -28,9 +29,22 @@ export function applyTemplate<T extends ServerShape>(shape: T, template: BaseTem
         shape.auras.push({ ...defaultAura, ...auraTemplate });
     }
 
+    const gridRescale = 5 / gameSettingsStore.unitSize;
+
     // Shape specific keys
     for (const key of getTemplateKeys(shape.type_)) {
-        if (key in template) (shape as any)[key] = (template as any)[key];
+        if (["assetrect", "rect"].includes(shape.type_)) {
+            const rect = (shape as any) as ServerRect;
+            const rectTemplate = (template as any) as ServerRect;
+
+            if (key === "width") {
+                rect.width = rectTemplate.width * gridRescale;
+            } else if (key === "height") {
+                rect.height = rectTemplate.height * gridRescale;
+            }
+        } else {
+            if (key in template) (shape as any)[key] = (template as any)[key];
+        }
     }
 
     return shape;


### PR DESCRIPTION
When dropping an asset with template info for width and/or height, they would not be rescaled when dealing with a non-default grid scale (e.g. 10ft per square)

This closes #629 