### PR TITLE
bug(Load): Fix location user options not being set correctly on load

### DIFF
--- a/client/src/game/api/emits/client.ts
+++ b/client/src/game/api/emits/client.ts
@@ -8,7 +8,7 @@ export function sendClientLocationOptions(): void {
 }
 
 function _sendClientLocationOptions(locationOptions: ServerUserLocationOptions): void {
-    socket.emit("Client.Options.Location.Set", { location_options: locationOptions });
+    socket.emit("Client.Options.Location.Set", locationOptions);
 }
 
 export const sendRoomClientOptions = wrapSocket<Partial<ServerUserOptions>>("Client.Options.Room.Set");

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -42,6 +42,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     gameStore.setZoomDisplay(options.location_user_options.zoom_factor);
 
     EventBus.$once("Board.Floor.Set", () => {
-        if (options.active_layer) layerManager.selectLayer(options.active_layer, false);
+        if (options.location_user_options.active_layer)
+            layerManager.selectLayer(options.location_user_options.active_layer, false);
     });
 });

--- a/client/src/game/comm/types/settings.ts
+++ b/client/src/game/comm/types/settings.ts
@@ -36,8 +36,6 @@ export interface LocationOptions {
 
 export interface ServerClient {
     name: string;
-    active_floor?: string;
-    active_layer?: string;
     location_user_options: ServerUserLocationOptions;
     default_user_options: ServerUserOptions;
     room_user_options?: ServerUserOptions;
@@ -47,6 +45,8 @@ export interface ServerUserLocationOptions {
     pan_x: number;
     pan_y: number;
     zoom_factor: number;
+    active_floor?: string;
+    active_layer?: string;
 }
 
 export interface ServerUserOptions {

--- a/server/api/socket/location.py
+++ b/server/api/socket/location.py
@@ -143,9 +143,11 @@ async def load_location(sid: str, location: Location, *, complete=False):
 
     floors = [floor for floor in location.floors.order_by(Floor.index)]
 
-    if "active_floor" in client_options:
+    if "active_floor" in client_options["location_user_options"]:
         index = next(
-            i for i, f in enumerate(floors) if f.name == client_options["active_floor"]
+            i
+            for i, f in enumerate(floors)
+            if f.name == client_options["location_user_options"]["active_floor"]
         )
         lower_floors = floors[index - 1 :: -1] if index > 0 else []
         higher_floors = floors[index + 1 :] if index < len(floors) else []


### PR DESCRIPTION
During load the location user options (last pan location + layer/floor info) was not loaded correctly due to the change in client settings types recently introduced