### PR TITLE
feat(Draw): Erase mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ These usually have no immediately visible impact on regular users
 ### Added
 
 -   Client setting to disable zoom behaviour on scroll
+-   Erase option to draw tool
+    -   This makes anything from the current floor below it in the draw stack in its region transparent
 
 ### Changed
 

--- a/client/src/game/layers/layer.ts
+++ b/client/src/game/layers/layer.ts
@@ -269,6 +269,7 @@ export class Layer {
             // To optimize things slightly, we keep track of the shapes that passed the first round
             const visibleShapes: Shape[] = [];
 
+            // Aura draw loop
             for (const shape of this.shapes) {
                 if (shape.options.has("skipDraw") && shape.options.get("skipDraw")) continue;
                 if (!shape.visibleInCanvas(this.canvas, { includeAuras: true })) continue;
@@ -276,6 +277,7 @@ export class Layer {
                 drawAuras(shape, ctx);
                 visibleShapes.push(shape);
             }
+            // Normal shape draw loop
             for (const shape of visibleShapes) {
                 if (shape.isInvisible && !shape.ownedBy(true, { visionAccess: true })) continue;
                 if (shape.labels.length === 0 && gameStore.filterNoLabel) continue;

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -644,6 +644,7 @@ export default class DrawTool extends Tool implements ToolBasics {
 .option-selected,
 .option:hover {
     background-color: #82c8a0;
+    cursor: pointer;
 }
 
 .selectgroup {

--- a/client/src/game/ui/tools/draw.vue
+++ b/client/src/game/ui/tools/draw.vue
@@ -57,7 +57,7 @@ export default class DrawTool extends Tool implements ToolBasics {
     shapeSelect = "square";
     shapes = ["square", "circle", "draw-polygon", "paint-brush"];
     modeSelect = "normal";
-    modes = ["normal", "reveal", "hide"];
+    modes = ["normal", "reveal", "hide", "erase"];
 
     brushSize = 5;
     closedPolygon = false;
@@ -170,21 +170,37 @@ export default class DrawTool extends Tool implements ToolBasics {
 
         const fowLayer = layerManager.getLayer(floorStore.currentFloor, "fow");
         const normalLayer = floorStore.currentLayer;
+        const mapLayer = layerManager.getLayer(floorStore.currentFloor, "map")!;
         if (fowLayer === undefined || normalLayer === undefined) return;
 
         this.setupBrush();
 
-        if (newValue !== "normal" && oldValue === "normal") {
+        // Removal
+
+        if (oldValue === "normal") {
             normalLayer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
-            fowLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
-        } else if (newValue === "normal" && oldValue !== "normal") {
-            normalLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+        } else if (oldValue === "erase") {
+            mapLayer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
+        } else {
             fowLayer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
+        }
+
+        // Adding
+
+        if (newValue === "normal") {
+            normalLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+        } else if (newValue === "erase") {
+            mapLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+        } else {
+            fowLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
         }
     }
     getLayer(data?: { floor?: Floor; layer?: string }): Layer | undefined {
         if (this.modeSelect === "normal")
             return layerManager.getLayer(data?.floor ?? floorStore.currentFloor, data?.layer);
+        else if (this.modeSelect === "erase") {
+            return layerManager.getLayer(floorStore.currentFloor, "map");
+        }
         return layerManager.getLayer(floorStore.currentFloor, "fow");
     }
 
@@ -244,13 +260,17 @@ export default class DrawTool extends Tool implements ToolBasics {
                     return;
             }
 
-            if (this.modeSelect !== "normal") {
+            if (this.modeSelect === "erase") {
+                this.shape.fillColour = "rgba(0, 0, 0, 1)";
+            }
+            if (this.modeSelect === "hide" || this.modeSelect === "reveal") {
                 this.shape.options.set("preFogShape", true);
                 this.shape.options.set("skipDraw", true);
                 this.shape.fillColour = "rgba(0, 0, 0, 1)";
             }
             if (this.modeSelect === "reveal") this.shape.globalCompositeOperation = "source-over";
             else if (this.modeSelect === "hide") this.shape.globalCompositeOperation = "destination-out";
+            else if (this.modeSelect === "erase") this.shape.globalCompositeOperation = "destination-out";
 
             this.shape.addOwner({ user: gameStore.username, access: { edit: true } }, SyncTo.UI);
             if (layer.name === "fow" && this.modeSelect === "normal") {
@@ -562,6 +582,9 @@ export default class DrawTool extends Tool implements ToolBasics {
 
             case "hide":
                 return this.$t("draw.hide").toString();
+
+            case "erase":
+                return this.$t("draw.erase").toString();
 
             default:
                 return "";

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -374,7 +374,8 @@
         "paint-brush": "paint-brush",
         "normal": "normal",
         "reveal": "reveal",
-        "hide": "hide"
+        "hide": "hide",
+        "erase": "erase"
     },
     "tool": {
         "Build": "Build",


### PR DESCRIPTION
This adds a new mode to the draw tool for DMs.

When operating in erase mode you can draw shapes as usual which will make everything below them on their floor transparent. 

Just as shapes drawn in reveal or hide mode appear automatically on the 'fow' layer, shapes drawn with this tool will appear automatically on the 'map' layer, although nothing prevents you from moving it to another layer.

These shapes are selectable and actually follow the draw stack. So if you move a particular map asset to the top it will appear over the erased area, great for things like a wooden log that lays over a gaping hole for example!

Potential usecases:
- an explosion destroys a part of the floor and you want to show things on the floor below
- you forgot to remove some part of an asset you uploaded and want to patch it in PA itself

Example image:

the black and red shapes are part of the upper floor map layer, whereas the light blue shape is part of the lower floor map.
The polygon is drawn with the erase tool, but the red shape has been moved to the front.
If I were to remove the light blue shape, the polygon would show the white background of the lower floor instead.

![image](https://user-images.githubusercontent.com/1814713/107423598-cdbe7700-6b1c-11eb-8eaf-ae52d443714c.png)


This closes #619