### PR TITLE
feat(UI): Show a small info popup when trying to join a locked session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These usually have no immediately visible impact on regular users
     -   This makes anything from the current floor below it in the draw stack in its region transparent
 -   Big red border when disconnected
 -   Option to make other players (co-)DM
+-   Show a small info popup when trying to join a locked session
 
 ### Changed
 

--- a/client/src/dashboard/main.vue
+++ b/client/src/dashboard/main.vue
@@ -3,14 +3,19 @@ import Vue from "vue";
 import Component from "vue-class-component";
 import { Route, NavigationGuard } from "vue-router";
 
+import ConfirmDialog from "@/core/components/modals/confirm.vue";
 import { coreStore } from "@/core/store";
 
 import { baseAdjustedFetch, getErrorReason, postFetch } from "../core/utils";
 
 Component.registerHooks(["beforeRouteEnter"]);
 
-@Component
+@Component({ components: { ConfirmDialog } })
 export default class Dashboard extends Vue {
+    $refs!: {
+        confirm: ConfirmDialog;
+    };
+
     owned = [];
     joined = [];
     error = "";
@@ -28,6 +33,16 @@ export default class Dashboard extends Vue {
                 (vm as this).error = await getErrorReason(response);
             }
         });
+    }
+
+    async mounted(): Promise<void> {
+        if (this.$route.params?.error === "join_game") {
+            await this.$refs.confirm.open(
+                "Failed to join session",
+                "It was not possible to join the game session. This might be because the DM has locked the session.",
+                { showNo: false, yes: "Ok" },
+            );
+        }
     }
 
     async createRoom(_event: Event): Promise<void> {
@@ -60,6 +75,7 @@ export default class Dashboard extends Vue {
 
 <template>
     <div style="display: contents">
+        <ConfirmDialog ref="confirm"></ConfirmDialog>
         <div id="formcontainer">
             <form>
                 <fieldset>

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -43,12 +43,12 @@ socket.on("disconnect", (reason: string) => {
 socket.on("connect_error", (error: any) => {
     console.error("Could not connect to game session.");
     if (error.message === "Connection rejected by server") {
-        router.push("/dashboard");
+        router.push({ name: "dashboard", params: { error: "join_game" } });
     }
 });
 socket.on("error", (_error: any) => {
     console.error("Game session does not exist.");
-    router.push("/dashboard");
+    router.push({ name: "dashboard", params: { error: "join_game" } });
 });
 socket.on("redirect", (destination: string) => {
     console.log("redirecting");

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -54,6 +54,7 @@ export const router = new Router({
         },
         {
             path: "/dashboard",
+            name: "dashboard",
             component: Dashboard,
             meta: {
                 auth: true,


### PR DESCRIPTION
Right now when a session is locked and you try to join as a player you just get redirected to the dashboard without much info.