### PR TITLE
bug(Startup): Fix long loading times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ These usually have no immediately visible impact on regular users
 -   Token properly snaps to mouse when leaving wall
 -   Template drops on non-default grid scales where not resized accordingly
 -   Some cases where a disconnect would happen without reconnect attempts
+-   Cause of slow session loading times
+    -   shape group info is now sent along during initial load
 
 ## [0.25.0] - 2021-02-07
 

--- a/client/src/game/api/emits/groups.ts
+++ b/client/src/game/api/emits/groups.ts
@@ -1,18 +1,6 @@
 import { GroupJoinPayload, ServerGroup } from "../../models/groups";
 import { wrapSocket } from "../helpers";
-import { socket } from "../socket";
 
-export async function requestGroupInfo(groupId: string): Promise<ServerGroup> {
-    socket.emit("Group.Info.Get", groupId);
-    return await new Promise((resolve: (value: ServerGroup) => void) =>
-        socket.on("Group.Info", (value: ServerGroup) => {
-            if (value.uuid === groupId) {
-                socket.off("Group.Id");
-                resolve(value);
-            }
-        }),
-    );
-}
 export const sendGroupUpdate = wrapSocket<ServerGroup>("Group.Update");
 export const sendMemberBadgeUpdate = wrapSocket<{ uuid: string; badge: number }[]>("Group.Members.Update");
 export const sendCreateGroup = wrapSocket<ServerGroup>("Group.Create");

--- a/client/src/game/groups.ts
+++ b/client/src/game/groups.ts
@@ -29,6 +29,10 @@ export function addNewGroup(group: Group, sync: boolean): void {
     }
 }
 
+export function hasGroup(groupId: string): boolean {
+    return groupMap.has(groupId);
+}
+
 export function removeGroup(groupId: string, sync: boolean): void {
     const members = getGroupMembers(groupId);
     for (const member of members) {

--- a/client/src/game/groups.ts
+++ b/client/src/game/groups.ts
@@ -2,7 +2,6 @@ import { SyncTo } from "../core/models/types";
 import { uuidv4 } from "../core/utils";
 
 import {
-    requestGroupInfo,
     sendCreateGroup,
     sendGroupJoin,
     sendGroupLeave,
@@ -64,12 +63,6 @@ export function updateGroupFromServer(serverGroup: ServerGroup): void {
     for (const layer of new Set(getGroupMembers(group.uuid).map((s) => s.layer))) {
         layer.invalidate(true);
     }
-}
-
-export async function fetchGroup(groupId: string): Promise<Group> {
-    const groupInfo = groupToClient(await requestGroupInfo(groupId));
-    addNewGroup(groupInfo, false);
-    return groupInfo;
 }
 
 export function getGroupSize(groupId: string): number {

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -15,6 +15,8 @@ import { baseAdjust, uuidv4 } from "../../core/utils";
 import i18n from "../../i18n";
 import { requestAssetOptions } from "../api/emits/asset";
 import { sendFloorChange, sendLayerChange } from "../api/emits/shape/core";
+import { addNewGroup, hasGroup } from "../groups";
+import { groupToClient } from "../models/groups";
 import { BaseTemplate } from "../models/templates";
 import { addOperation } from "../operations/undo";
 import { gameSettingsStore } from "../settings";
@@ -93,6 +95,16 @@ async function createLayer(layerInfo: ServerLayer, floor: Floor): Promise<void> 
         return;
     }
     if (layerInfo.name !== "fow-players") layers.appendChild(canvas);
+
+    // Load layer groups
+
+    for (const serverGroup of layerInfo.groups) {
+        const group = groupToClient(serverGroup);
+        if (!hasGroup(group.uuid)) {
+            addNewGroup(group, false);
+        }
+    }
+
     // Load layer shapes
     await layer.setServerShapes(layerInfo.shapes);
 }

--- a/client/src/game/models/general.ts
+++ b/client/src/game/models/general.ts
@@ -1,5 +1,6 @@
 import { ServerShape } from "@/game/models/shapes";
 
+import { ServerGroup } from "./groups";
 import { ServerLocationOptions } from "./settings";
 
 export interface ServerLocation {
@@ -37,6 +38,7 @@ export interface ServerLayer {
     index: number;
     name: string;
     layer: string;
+    groups: ServerGroup[];
     shapes: ServerShape[];
     selectable: boolean;
     player_editable: boolean;

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -24,7 +24,7 @@ import { Text } from "@/game/shapes/variants/text";
 
 import { sendRemoveShapes } from "../api/emits/shape/core";
 import { EventBus } from "../event-bus";
-import { addGroupMembers, createNewGroupForShapes, fetchGroup, generateNewBadge, getGroup } from "../groups";
+import { addGroupMembers, createNewGroupForShapes, generateNewBadge, getGroup } from "../groups";
 import { floorStore, getFloorId } from "../layers/store";
 import { addOperation } from "../operations/undo";
 import { gameStore } from "../store";
@@ -35,18 +35,19 @@ import { Tracker } from "./interfaces";
 import { Polygon } from "./variants/polygon";
 import { ToggleComposite } from "./variants/togglecomposite";
 
+// eslint-disable-next-line
 export async function createShapeFromDict(shape: ServerShape): Promise<Shape | undefined> {
     let sh: Shape;
 
     // A fromJSON and toJSON on Shape would be cleaner but ts does not allow for static abstracts so yeah.
 
-    // Fetch group info if required
     if (shape.group) {
-        let group = getGroup(shape.group);
+        const group = getGroup(shape.group);
         if (group === undefined) {
-            group = await fetchGroup(shape.group);
+            console.log("Missing group info detected");
+        } else {
+            addGroupMembers(group.uuid, [{ uuid: shape.uuid, badge: shape.badge }], false);
         }
-        addGroupMembers(group.uuid, [{ uuid: shape.uuid, badge: shape.badge }], false);
     }
 
     // Shape Type specifics

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -8,8 +8,10 @@ from peewee import (
     TextField,
 )
 from playhouse.shortcuts import model_to_dict
+from typing import Set
 
 from .base import BaseModel
+from .groups import Group
 from .user import User, UserOptions
 
 __all__ = [
@@ -236,9 +238,13 @@ class Layer(BaseModel):
             backrefs=False,
             exclude=[Layer.id, Layer.player_visible],
         )
-        data["shapes"] = [
-            shape.as_dict(user, dm) for shape in self.shapes.order_by(Shape.index)
-        ]
+        groups_added: Set[Group] = set()
+        data["groups"] = []
+        data["shapes"] = []
+        for shape in self.shapes.order_by(Shape.index):
+            data["shapes"].append(shape.as_dict(user, dm))
+            if shape.group and not shape.group.uuid in groups_added:
+                data["groups"].append(model_to_dict(shape.group))
         return data
 
     class Meta:


### PR DESCRIPTION
This fixes a bug where sessions would be slow to load.

This was caused due to a regression introduced with the more complex grouping logic, that did an async callback to the server during the initial load. This in turn caused the normal layer loading to be halted until all grouping info was retrieved.