### PR TITLE
feat(Vision): Use svg mask to draw vision lines

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13213,6 +13213,11 @@
             "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
             "dev": true
         },
+        "path-data-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/path-data-polyfill/-/path-data-polyfill-1.0.3.tgz",
+            "integrity": "sha512-zZMXB709yzMu7y+2FkKDn4Ctp+uEbufmCkO1w90itOTGH99Dq6N8jXmX7bcxrUT/dMw2jnmKN8ucfw9LI/XToQ=="
+        },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "core-js": "^3.8.3",
+        "path-data-polyfill": "^1.0.3",
         "socket.io-client": "^3.1.1",
         "swiper": "^5.4.5",
         "tinycolor2": "^1.4.2",

--- a/client/src/game/api/emits/shape/core.ts
+++ b/client/src/game/api/emits/shape/core.ts
@@ -18,7 +18,9 @@ export const sendShapesMove = wrapSocket<{
 export const sendTextUpdate = wrapSocket<{ uuid: string; text: string; temporary: boolean }>("Shape.Text.Value.Set");
 
 export function sendShapeOptionsUpdate(shapes: readonly Shape[], temporary: boolean): void {
-    const options = shapes.filter((s) => !s.preventSync).map((s) => ({ uuid: s.uuid, option: s.getOptions() }));
+    const options = shapes
+        .filter((s) => !s.preventSync)
+        .map((s) => ({ uuid: s.uuid, option: JSON.stringify([...s.options]) }));
     if (options.length > 0) {
         socket.emit("Shapes.Options.Update", {
             options,

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -1,4 +1,4 @@
-import { SyncMode } from "../../../../core/models/types";
+import { SyncMode, SyncTo } from "../../../../core/models/types";
 import { EventBus } from "../../../event-bus";
 import { layerManager } from "../../../layers/manager";
 import { floorStore, getFloorId } from "../../../layers/store";
@@ -52,7 +52,7 @@ socket.on("Shapes.Options.Update", (data: { uuid: string; option: string }[]) =>
         if (shape === undefined) {
             continue;
         }
-        shape.setOptions(sh.option);
+        shape.setOptions(new Map(JSON.parse(sh.option)), SyncTo.UI);
     }
 });
 

--- a/client/src/game/svg.ts
+++ b/client/src/game/svg.ts
@@ -1,0 +1,88 @@
+import "path-data-polyfill";
+
+import { GlobalPoint, Vector } from "./geom";
+import { Asset } from "./shapes/variants/asset";
+
+export function pathToArray(shape: Asset, path: SVGPathElement): number[][][] {
+    const paths: number[][][] = [];
+
+    let currentLocation = new GlobalPoint(0, 0);
+    const pathData = (path as any).getPathData();
+
+    let points: number[][] = [];
+
+    const targetRP = shape.refPoint;
+    const w = shape.w;
+    const h = shape.h;
+
+    const dW = w / shape.options.get("svgWidth");
+    const dH = h / shape.options.get("svgHeight");
+
+    for (const seg of pathData) {
+        switch (seg.type) {
+            case "Z": {
+                //ClosePath
+                currentLocation = GlobalPoint.fromArray(points[0]);
+                break;
+            }
+            case "M": {
+                //MoveToAbs
+                currentLocation = new GlobalPoint(targetRP.x + seg.values[0] * dW, targetRP.y + seg.values[1] * dH);
+                break;
+            }
+            case "m": {
+                //MoveToRel
+                points.push(points[0]);
+                paths.push(points);
+                points = [];
+                currentLocation = currentLocation.add(new Vector(dW * seg.values[0], dH * seg.values[1]));
+                break;
+            }
+            case "L": {
+                //LineToAbs
+                currentLocation = new GlobalPoint(seg.values[0], seg.values[1]);
+                break;
+            }
+            case "l": {
+                //LineToRel
+                currentLocation = currentLocation.add(new Vector(dW * seg.values[0], dH * seg.values[1]));
+                break;
+            }
+            case "H": {
+                //LineToHorizontalAbs
+                currentLocation = new GlobalPoint(seg.values[0], currentLocation.y);
+                break;
+            }
+            case "h": {
+                // LineToHorizontalRel
+                currentLocation = currentLocation.add(new Vector(seg.values[0], 0));
+                break;
+            }
+            case "V": {
+                // LineToVerticalAbs
+                currentLocation = new GlobalPoint(currentLocation.x, seg.values[0]);
+                break;
+            }
+            case "v": {
+                // LineToVerticalRel
+                currentLocation = currentLocation.add(new Vector(0, seg.values[0]));
+                break;
+            }
+            case "c": {
+                // bezier curve
+                currentLocation = currentLocation.add(new Vector(dW * seg.values[4], dH * seg.values[5]));
+                break;
+            }
+            default: {
+                //throw error;
+                console.warn("Path contains unsupported segment: " + seg.type);
+                break;
+            }
+        }
+        points.push(currentLocation.asArray());
+    }
+
+    paths.push(points);
+
+    return paths;
+}

--- a/client/src/game/ui/ActiveShapeStore.ts
+++ b/client/src/game/ui/ActiveShapeStore.ts
@@ -18,6 +18,7 @@ import { Aura, Label, Tracker } from "../shapes/interfaces";
 import { ShapeAccess, ShapeOwner } from "../shapes/owners";
 import { Shape } from "../shapes/shape";
 import { createEmptyUiAura, createEmptyUiTracker } from "../shapes/trackers/empty";
+import { SHAPE_TYPE } from "../shapes/types";
 import { ToggleComposite } from "../shapes/variants/togglecomposite";
 import { gameStore } from "../store";
 
@@ -30,6 +31,9 @@ export interface ActiveShapeState {
     parentUuid: string | undefined;
     isComposite: boolean;
     showEditDialog: boolean;
+    type: SHAPE_TYPE | undefined;
+
+    floor: number | undefined;
     options: Record<string, any> | undefined;
     setOptions(data: { options: Record<string, any>; syncTo: SyncTo }): void;
 
@@ -114,6 +118,7 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
     // The last Uuid is used to make sure that the UI remains open when a shape is removed and re-added
     private _lastUuid: string | null = null;
     private _showEditDialog = false;
+    private _type: SHAPE_TYPE | null = null;
 
     private _options: Record<string, any> | null = null;
 
@@ -170,6 +175,16 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
     @Mutation
     setShowEditDialog(visible: boolean): void {
         this._showEditDialog = visible;
+    }
+
+    get type(): SHAPE_TYPE | undefined {
+        return this._type ?? undefined;
+    }
+
+    // OPTIONS
+
+    get floor(): number | undefined {
+        return this._uuid ? layerManager.UUIDMap.get(this._uuid)?.floor.id : undefined;
     }
 
     get options(): Record<string, any> | undefined {
@@ -722,6 +737,7 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
         this._uuid = shape.uuid;
         const parent = layerManager.getCompositeParent(shape.uuid);
         this._parentUuid = parent?.uuid ?? null;
+        this._type = shape.type;
 
         this._options = Object.fromEntries(shape.options);
 
@@ -771,6 +787,7 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
 
         this._uuid = null;
         this._parentUuid = null;
+        this._type = null;
 
         this._options = null;
 

--- a/client/tests/unit/game/visibility/te/pa.test.ts
+++ b/client/tests/unit/game/visibility/te/pa.test.ts
@@ -17,6 +17,7 @@ jest.mock("@/game/api/socket", () => ({
 jest.mock("@/i18n.ts", () => ({
     t: jest.fn(),
 }));
+jest.mock("path-data-polyfill", () => {});
 
 let cdt: CDT;
 


### PR DESCRIPTION
Setting up all the walls etc can be an arduous task.  To alleviate that work significantly there now is an option to upload an svg to use as a reference for the walls.

This can be accessed from the Extra settings panel when you've selected an asset.

Some considerations:
- The svg is expected to be somewhat simple, as in just a collection of `<path>` elements. Any styling/scripting/other stuff is not supported and the behaviour of such an svg is undefined when used. (the svg is just scraped for its path info and not used otherwise)
- For obvious reasons, how smaller the svg, the better the performance will be in PA.
- Remove everything that should not be a wall (room numbers, doors, stairs, other furnishing, text etc) This is just meant as a wall mask on top of your regular asset.

It's important to remove doors and windows etc, if you want to make them useable/interactive during gameplay. It's not possible to modify the svg/fow path in planarally as you can when you draw it manually! So it is strongly advised to draw the doors/windows manually so that you can toggle their properties and/or open them.

I've personally been using this [online vector tool](https://www.vectorizer.io) to great success. For best results I think you want to set 'roundness' to none, and if there are multiple colours in the image, try to minimize them as this usualy gives the compacter path, but play with this however you want.

Just realize that everything in the svg that is a path will be used for the visibility triangulation.

Thi is the resulting visibility grid in planar ally when using a simple svg based on the pngs in [this issue](https://github.com/Kruptein/PlanarAlly/issues/641):

![image](https://user-images.githubusercontent.com/1814713/107873718-b54fb300-6eb4-11eb-8a18-84a2c78d65f7.png)
