### PR TITLE
feat(Assets): Support dd2vtt assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ These usually have no immediately visible impact on regular users
 -   Big red border when disconnected
 -   Option to make other players (co-)DM
 -   Show a small info popup when trying to join a locked session
+-   Support for dungeondraft dd2vtt files
+    -   When placed on the board, a special 'apply ddraft' button is available in the extra settings to load the walls/portals/lights
 
 ### Changed
 

--- a/client/src/game/models/ddraft.ts
+++ b/client/src/game/models/ddraft.ts
@@ -1,0 +1,34 @@
+interface DDraftCoord {
+    x: number;
+    y: number;
+}
+
+interface DDraftPortal {
+    position: DDraftCoord;
+    bounds: DDraftCoord[];
+    rotation: number;
+    closed: boolean;
+    freestanding: boolean;
+}
+
+interface DDraftResolution {
+    map_origin: DDraftCoord;
+    map_size: DDraftCoord;
+    pixels_per_grid: number;
+}
+
+interface DDraftLight {
+    position: DDraftCoord;
+    range: number;
+    intensity: number;
+    color: string;
+    shadows: boolean;
+}
+
+export interface DDraftData {
+    ddraft_format: string;
+    ddraft_resolution: DDraftResolution;
+    ddraft_lights: DDraftLight[];
+    ddraft_line_of_sight: DDraftCoord[][];
+    ddraft_portals: DDraftPortal[];
+}

--- a/client/src/game/shapes/template.ts
+++ b/client/src/game/shapes/template.ts
@@ -13,11 +13,15 @@ import { gameSettingsStore } from "../settings";
 
 import { createEmptyAura, createEmptyTracker } from "./trackers/empty";
 
-export function applyTemplate<T extends ServerShape>(shape: T, template: BaseTemplate): T {
+export function applyTemplate<T extends ServerShape>(shape: T, template: BaseTemplate & { options?: string }): T {
     // should be shape[key], but this is something that TS cannot correctly infer (issue #31445)
     for (const key of BaseTemplateStrings) {
         if (key in template) (shape as any)[key] = template[key];
     }
+
+    // Options are not to be copied to a template by default, which is why they're not part of BaseTemplate
+    // Some custom things do add options to a template and they should be set accordingly
+    if ("options" in template) shape.options = template.options;
 
     for (const trackerTemplate of template.trackers ?? []) {
         const defaultTracker = createEmptyTracker();

--- a/client/src/game/ui/selection/edit_dialog/ExtraSettings.vue
+++ b/client/src/game/ui/selection/edit_dialog/ExtraSettings.vue
@@ -12,11 +12,12 @@ import { GlobalPoint } from "../../../geom";
 import { layerManager } from "../../../layers/manager";
 import { floorStore } from "../../../layers/store";
 import { DDraftData } from "../../../models/ddraft";
+import { gameSettingsStore } from "../../../settings";
 import { Aura } from "../../../shapes/interfaces";
 import { Asset } from "../../../shapes/variants/asset";
 import { Circle } from "../../../shapes/variants/circle";
 import { Polygon } from "../../../shapes/variants/polygon";
-import { gameStore } from "../../../store";
+import { DEFAULT_GRID_SIZE, gameStore } from "../../../store";
 import { l2gz } from "../../../units";
 import { visibilityStore } from "../../../visibility/store";
 import { ActiveShapeState, activeShapeStore } from "../../ActiveShapeStore";
@@ -180,9 +181,9 @@ export default class AccessSettings extends Vue {
                 visionSource: true,
                 visible: true,
                 name: "ddraft light source",
-                value: size * light.range,
+                value: light.range * gameSettingsStore.unitSize * (DEFAULT_GRID_SIZE / size),
                 dim: 0,
-                colour: light.color,
+                colour: `#${light.color}`,
                 borderColour: "rgba(0, 0, 0, 0)",
                 angle: 360,
                 direction: 0,

--- a/client/src/game/ui/selection/edit_dialog/ExtraSettings.vue
+++ b/client/src/game/ui/selection/edit_dialog/ExtraSettings.vue
@@ -131,14 +131,9 @@ export default class AccessSettings extends Vue {
         const realShape = layerManager.UUIDMap.get(this.shape.uuid!)! as Asset;
 
         const targetRP = realShape.refPoint;
-        const w = realShape.w;
-        const h = realShape.h;
 
-        const dW = w / (dDraftData.ddraft_resolution.map_size.x * size);
-        const dH = h / (dDraftData.ddraft_resolution.map_size.y * size);
-
-        console.log(dW, dH);
-        console.log(w, h, dDraftData.ddraft_resolution.map_size.x * size);
+        const dW = realShape.w / (dDraftData.ddraft_resolution.map_size.x * size);
+        const dH = realShape.h / (dDraftData.ddraft_resolution.map_size.y * size);
 
         const fowLayer = layerManager.getLayer(floorStore.currentFloor, "fow")!;
 

--- a/server/api/socket/asset_manager/common.py
+++ b/server/api/socket/asset_manager/common.py
@@ -1,0 +1,17 @@
+from typing_extensions import TypedDict
+
+from utils import FILE_DIR
+
+
+class UploadData(TypedDict):
+    uuid: str
+    name: str
+    directory: int
+    slice: int
+    totalSlices: int
+    data: bytes
+
+
+ASSETS_DIR = FILE_DIR / "static" / "assets"
+if not ASSETS_DIR.exists():
+    ASSETS_DIR.mkdir()

--- a/server/api/socket/asset_manager/ddraft.py
+++ b/server/api/socket/asset_manager/ddraft.py
@@ -1,0 +1,75 @@
+import base64
+import json
+import hashlib
+from typing import List
+from typing_extensions import TypedDict
+
+from app import sio
+from models import Asset
+from state.asset import asset_state
+from ..constants import ASSET_NS
+from .common import ASSETS_DIR, UploadData
+
+
+class Coord(TypedDict):
+    x: int
+    y: int
+
+
+class DDraftPortal(TypedDict):
+    position: Coord
+    bounds: List[Coord]
+    rotation: int
+    closed: bool
+    freestanding: bool
+
+
+class DDraftResolution(TypedDict):
+    map_origin: Coord
+    map_size: Coord
+    pixels_per_grid: int
+
+
+class DDraftData(TypedDict):
+    format: str
+    resolution: DDraftResolution
+    line_of_sight: List[Coord]
+    portals: List[DDraftPortal]
+    image: str
+
+
+async def handle_ddraft_file(upload_data: UploadData, data: bytes, sid: str):
+    ddraft_file: DDraftData = json.loads(data)
+
+    image = base64.b64decode(ddraft_file["image"])
+
+    sh = hashlib.sha1(image)
+    hashname = sh.hexdigest()
+
+    if not (ASSETS_DIR / hashname).exists():
+        with open(ASSETS_DIR / hashname, "wb") as f:
+            f.write(image)
+
+    template = {
+        "version": "0",
+        "shape": "assetrect",
+        "templates": {
+            "default": {
+                "options": json.dumps(
+                    [[f"ddraft_{k}", v] for k, v in ddraft_file.items() if k != "image"]
+                )
+            }
+        },
+    }
+
+    user = asset_state.get_user(sid)
+
+    asset = Asset.create(
+        name=upload_data["name"],
+        file_hash=hashname,
+        owner=user,
+        parent=upload_data["directory"],
+        options=json.dumps(template),
+    )
+
+    await sio.emit("Asset.Upload.Finish", asset.as_dict(), room=sid, namespace=ASSET_NS)


### PR DESCRIPTION
This PR adds support for dungeondraft's dd2vtt format.

When dropping such an asset on the board, an extra option will appear in the asset's extra settings to 'apply' the ddraft features.
It's done in this way for now, as there is no current concept of shapes belonging to eachother, so when you resize/refit your asset to the map, the walls would not follow if they were applied immediately. (expect changes here in the future).

This closes #677 