### PR TITLE
bug(Variant): Fix minimal vision over non-owned variant shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These usually have no immediately visible impact on regular users
 -   Big red border when disconnected
 -   Option to make other players (co-)DM
 -   Show a small info popup when trying to join a locked session
+-   Option to load wall info from an accompanying svg file
 -   Support for dungeondraft dd2vtt files
     -   When placed on the board, a special 'apply ddraft' button is available in the extra settings to load the walls/portals/lights
 
@@ -36,6 +37,7 @@ These usually have no immediately visible impact on regular users
 -   Some cases where a disconnect would happen without reconnect attempts
 -   Cause of slow session loading times
     -   shape group info is now sent along during initial load
+-   Shapes with a variant always appearing to other players
 
 ## [0.25.0] - 2021-02-07
 

--- a/client/src/game/shapes/variants/togglecomposite.ts
+++ b/client/src/game/shapes/variants/togglecomposite.ts
@@ -94,7 +94,8 @@ export class ToggleComposite extends Shape {
         this.active_variant = variant;
         const newVariant = layerManager.UUIDMap.get(this.active_variant)!;
 
-        if (newVariant.isToken) gameStore.addOwnedToken(newVariant.uuid);
+        if (newVariant.isToken && newVariant.ownedBy(false, { visionAccess: true }))
+            gameStore.addOwnedToken(newVariant.uuid);
         if (newVariant.movementObstruction)
             addBlocker(TriangulationTarget.MOVEMENT, newVariant.uuid, newVariant.floor.id, true);
         if (newVariant.visionObstruction)


### PR DESCRIPTION
Due to a bug there was always a minimal area visible for tokens that have variant information even though the player did not own the shape.