### PR TITLE
Add defeated indicator to tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These usually have no immediately visible impact on regular users
     "general -> public_name".  If the public_name is empty or does not exists it falls back to normal operation.
 -   Added code to planarally.py to display the warning about the template directory if not running in 
     dev mode.
+-   Added ability to put a cross through tokens to mark them as defeated using a toggle in the token properties or by selecting them and pressing 'x'
 
 ### Changed
 

--- a/client/src/game/api/emits/shape/options.ts
+++ b/client/src/game/api/emits/shape/options.ts
@@ -11,6 +11,7 @@ function sendSimpleShapeOption<T>(event: string): (data: { shape: string; value:
 }
 
 export const sendShapeSetInvisible = sendSimpleShapeOption<boolean>("Shape.Options.Invisible.Set");
+export const sendShapeSetDefeated = sendSimpleShapeOption<boolean>("Shape.Options.Defeated.Set");
 export const sendShapeSetLocked = sendSimpleShapeOption<boolean>("Shape.Options.Locked.Set");
 export const sendShapeSetIsToken = sendSimpleShapeOption<boolean>("Shape.Options.Token.Set");
 export const sendShapeSetBlocksMovement = sendSimpleShapeOption<boolean>("Shape.Options.MovementBlock.Set");

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -25,8 +25,6 @@ socket.on("Shape.Options.VisionBlock.Set", wrapCall(Shape.prototype.setVisionBlo
 socket.on("Shape.Options.MovementBlock.Set", wrapCall(Shape.prototype.setMovementBlock));
 socket.on("Shape.Options.Locked.Set", wrapCall(Shape.prototype.setLocked));
 socket.on("Shape.Options.ShowBadge.Set", wrapCall(Shape.prototype.setShowBadge));
-socket.on("Shape.Options.Invisible.Set", wrapCall(Shape.prototype.setInvisible));
-socket.on("Shape.Options.Defeated.Set", wrapCall(Shape.prototype.setDefeated));
 
 socket.on("Shape.Options.Annotation.Set", wrapCall(Shape.prototype.setAnnotation));
 socket.on("Shape.Options.Label.Add", wrapCall(Shape.prototype.addLabel));

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -18,6 +18,7 @@ socket.on("Shape.Options.Name.Set", wrapCall(Shape.prototype.setName));
 socket.on("Shape.Options.NameVisible.Set", wrapCall(Shape.prototype.setNameVisible));
 socket.on("Shape.Options.Token.Set", wrapCall(Shape.prototype.setIsToken));
 socket.on("Shape.Options.Invisible.Set", wrapCall(Shape.prototype.setInvisible));
+socket.on("Shape.Options.Defeated.Set", wrapCall(Shape.prototype.setDefeated));
 socket.on("Shape.Options.StrokeColour.Set", wrapCall(Shape.prototype.setStrokeColour));
 socket.on("Shape.Options.FillColour.Set", wrapCall(Shape.prototype.setFillColour));
 socket.on("Shape.Options.VisionBlock.Set", wrapCall(Shape.prototype.setVisionBlock));
@@ -25,6 +26,7 @@ socket.on("Shape.Options.MovementBlock.Set", wrapCall(Shape.prototype.setMovemen
 socket.on("Shape.Options.Locked.Set", wrapCall(Shape.prototype.setLocked));
 socket.on("Shape.Options.ShowBadge.Set", wrapCall(Shape.prototype.setShowBadge));
 socket.on("Shape.Options.Invisible.Set", wrapCall(Shape.prototype.setInvisible));
+socket.on("Shape.Options.Defeated.Set", wrapCall(Shape.prototype.setDefeated));
 
 socket.on("Shape.Options.Annotation.Set", wrapCall(Shape.prototype.setAnnotation));
 socket.on("Shape.Options.Label.Add", wrapCall(Shape.prototype.addLabel));
@@ -83,4 +85,10 @@ socket.on("Shape.Options.Invisible.Set", (data: { shape: string; value: boolean 
     const shape = layerManager.UUIDMap.get(data.shape);
     if (shape === undefined) return;
     shape.setInvisible(data.value, SyncTo.UI);
+});
+
+socket.on("Shape.Options.Defeated.Set", (data: { shape: string; value: boolean }) => {
+    const shape = layerManager.UUIDMap.get(data.shape);
+    if (shape === undefined) return;
+    shape.setDefeated(data.value, SyncTo.UI);
 });

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -122,6 +122,18 @@ export function onKeyDown(event: KeyboardEvent): void {
         } else if (event.key === "d") {
             // d - Deselect all
             layerManager.clearSelection();
+        } else if (event.key === "x") {
+            // x - Mark Defeated
+            const selection = layerManager.getSelection({ includeComposites: true });
+            for (const shape of selection) {
+                const isDefeated = !shape.isDefeated;
+                shape.setDefeated(isDefeated, SyncTo.SERVER);
+                if (activeShapeStore.uuid === shape.uuid) {
+                    activeShapeStore.setIsDefeated({ isDefeated, syncTo: SyncTo.UI });
+                }
+            }
+            event.preventDefault();
+            event.stopPropagation();
         } else if (event.key === "l" && ctrlOrCmdPressed(event)) {
             const selection = layerManager.getSelection({ includeComposites: true });
             for (const shape of selection) {

--- a/client/src/game/models/shapes.ts
+++ b/client/src/game/models/shapes.ts
@@ -26,6 +26,7 @@ export interface ServerShape {
     annotation_visible: boolean;
     is_token: boolean;
     is_invisible: boolean;
+    is_defeated: boolean;
     options?: string;
     badge: number;
     show_badge: boolean;

--- a/client/src/game/models/templates.ts
+++ b/client/src/game/models/templates.ts
@@ -16,6 +16,7 @@ export const BaseTemplateStrings = [
     "annotation",
     "is_token",
     "is_invisible",
+    "is_defeated",
     "show_badge",
     "is_locked",
     "default_edit_access",

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -42,6 +42,7 @@ import {
     sendShapeSetBlocksVision,
     sendShapeSetFillColour,
     sendShapeSetInvisible,
+    sendShapeSetDefeated,
     sendShapeSetIsToken,
     sendShapeSetLocked,
     sendShapeSetName,
@@ -107,6 +108,7 @@ export abstract class Shape {
     // Does this shape represent a playable token
     isToken = false;
     isInvisible = false;
+    isDefeated = false;
     // Show a highlight box
     showHighlight = false;
 
@@ -331,6 +333,7 @@ export abstract class Shape {
             annotation_visible: this.annotationVisible,
             is_token: this.isToken,
             is_invisible: this.isInvisible,
+            is_defeated: this.isDefeated,
             options: JSON.stringify([...this.options]),
             badge: this.badge,
             show_badge: this.showBadge,
@@ -358,6 +361,7 @@ export abstract class Shape {
         this.strokeColour = data.stroke_colour;
         this.isToken = data.is_token;
         this.isInvisible = data.is_invisible;
+        this.isDefeated = data.is_defeated;
         this.nameVisible = data.name_visible;
         this.badge = data.badge;
         this.showBadge = data.show_badge;
@@ -432,6 +436,21 @@ export abstract class Shape {
             if (bbox === undefined) bbox = this.getBoundingBox();
             ctx.strokeStyle = "red";
             ctx.strokeRect(g2lx(bbox.topLeft.x) - 5, g2ly(bbox.topLeft.y) - 5, g2lz(bbox.w) + 10, g2lz(bbox.h) + 10);
+        }
+        if (this.isDefeated) {
+            bbox = this.getBoundingBox();
+            const crossTL = g2l(bbox.topLeft);
+            const crossBR = g2l(bbox.botRight);
+            const r = g2lz(10);
+            ctx.strokeStyle = "red";
+            ctx.fillStyle = this.strokeColour;
+            ctx.lineWidth = g2lz(2);
+            ctx.beginPath();
+            ctx.moveTo(crossTL.x + r, crossTL.y + r);
+            ctx.lineTo(crossBR.x - r, crossBR.y - r);
+            ctx.moveTo(crossTL.x + r, crossBR.y - r);
+            ctx.lineTo(crossBR.x - r, crossTL.y + r);
+            ctx.stroke();
         }
     }
 
@@ -558,6 +577,14 @@ export abstract class Shape {
         if (syncTo === SyncTo.UI) this._(activeShapeStore.setIsInvisible, { isInvisible, syncTo });
 
         this.isInvisible = isInvisible;
+        this.invalidate(!this.triggersVisionRecalc);
+    }
+
+    setDefeated(isDefeated: boolean, syncTo: SyncTo): void {
+        if (syncTo === SyncTo.SERVER) sendShapeSetDefeated({ shape: this.uuid, value: isDefeated });
+        if (syncTo === SyncTo.UI) this._(activeShapeStore.setIsDefeated, { isDefeated, syncTo });
+
+        this.isDefeated = isDefeated;
         this.invalidate(!this.triggersVisionRecalc);
     }
 

--- a/client/src/game/ui/ActiveShapeStore.ts
+++ b/client/src/game/ui/ActiveShapeStore.ts
@@ -44,7 +44,9 @@ export interface ActiveShapeState {
     isToken: boolean;
     setIsToken(data: { isToken: boolean; syncTo: SyncTo }): void;
     isInvisible: boolean;
+    isDefeated: boolean;
     setIsInvisible(data: { isInvisible: boolean; syncTo: SyncTo }): void;
+    setIsDefeated(data: { isDefeated: boolean; syncTo: SyncTo }): void;
     strokeColour: string | undefined;
     setStrokeColour(data: { colour: string; syncTo: SyncTo }): void;
     fillColour: string | undefined;
@@ -126,6 +128,7 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
     private _nameVisible = false;
     private _isToken = false;
     private _isInvisible = false;
+    private _isDefeated = false;
     private _strokeColour: string | null = null;
     private _fillColour: string | null = null;
     private _visionObstruction = false;
@@ -257,6 +260,10 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
         return this._isInvisible;
     }
 
+    get isDefeated(): boolean {
+        return this._isDefeated;
+    }
+
     @Mutation
     setIsInvisible(data: { isInvisible: boolean; syncTo: SyncTo }): void {
         if (this._uuid === null) return;
@@ -266,6 +273,18 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
         if (data.syncTo !== SyncTo.UI) {
             const shape = layerManager.UUIDMap.get(this._uuid)!;
             shape.setInvisible(data.isInvisible, data.syncTo);
+        }
+    }
+
+    @Mutation
+    setIsDefeated(data: { isDefeated: boolean; syncTo: SyncTo }): void {
+        if (this._uuid === null) return;
+
+        this._isDefeated = data.isDefeated;
+
+        if (data.syncTo !== SyncTo.UI) {
+            const shape = layerManager.UUIDMap.get(this._uuid)!;
+            shape.setDefeated(data.isDefeated, data.syncTo);
         }
     }
 
@@ -745,6 +764,7 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
         this._nameVisible = shape.nameVisible;
         this._isToken = shape.isToken;
         this._isInvisible = shape.isInvisible;
+        this._isDefeated = shape.isDefeated;
         this._strokeColour = shape.strokeColour;
         this._fillColour = shape.fillColour;
         this._visionObstruction = shape.visionObstruction;
@@ -795,6 +815,7 @@ class ActiveShapeStore extends VuexModule implements ActiveShapeState {
         this._nameVisible = false;
         this._isToken = false;
         this._isInvisible = false;
+        this._isDefeated = false;
         this._strokeColour = null;
         this._fillColour = null;
         this._visionObstruction = false;

--- a/client/src/game/ui/selection/edit_dialog/PropertySettings.vue
+++ b/client/src/game/ui/selection/edit_dialog/PropertySettings.vue
@@ -37,6 +37,11 @@ export default class PropertySettings extends Vue {
         this.shape.setIsInvisible({ isInvisible: event.target.checked, syncTo: SyncTo.SERVER });
     }
 
+    setDefeated(event: { target: HTMLInputElement }): void {
+        if (!this.owned) return;
+        this.shape.setIsDefeated({ isDefeated: event.target.checked, syncTo: SyncTo.SERVER });
+    }
+
     setLocked(event: { target: HTMLInputElement }): void {
         if (!this.owned) return;
         this.shape.setLocked({ isLocked: event.target.checked, syncTo: SyncTo.SERVER });
@@ -112,6 +117,21 @@ export default class PropertySettings extends Vue {
                 id="shapeselectiondialog-is-invisible"
                 :checked="shape.isInvisible"
                 @click="setInvisible"
+                style="grid-column-start: toggle"
+                class="styled-checkbox"
+                :disabled="!owned"
+            />
+        </div>
+        <div class="row">
+            <label
+                for="shapeselectiondialog-is-defeated"
+                v-t="'game.ui.selection.edit_dialog.dialog.is_defeated'"
+            ></label>
+            <input
+                type="checkbox"
+                id="shapeselectiondialog-is-defeated"
+                :checked="shape.isDefeated"
+                @click="setDefeated"
                 style="grid-column-start: toggle"
                 class="styled-checkbox"
                 :disabled="!owned"

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -184,6 +184,7 @@
                         "edit_asset": "Edit asset",
                         "is_a_token": "Is a token",
                         "is_invisible": "Is invisible",
+                        "is_defeated": "Is defeated",
                         "is_locked": "Is locked",
                         "show_badge": "Show badge",
                         "show_annotation": "Is public",

--- a/server/api/socket/shape/data_models.py
+++ b/server/api/socket/shape/data_models.py
@@ -78,6 +78,7 @@ class ShapeKeys(TypedDict):
     annotation: str
     is_token: bool
     is_invisible: bool
+    is_defeated: bool
     options: Optional[str]
     badge: int
     show_badge: bool

--- a/server/api/socket/shape/options.py
+++ b/server/api/socket/shape/options.py
@@ -85,6 +85,26 @@ async def set_invisible(sid: str, data: ShapeSetBooleanValue):
         namespace=GAME_NS,
     )
 
+@sio.on("Shape.Options.Defeated.Set", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def set_defeated(sid: str, data: ShapeSetBooleanValue):
+    pr: PlayerRoom = game_state.get(sid)
+
+    shape = get_shape_or_none(pr, data["shape"], "Defeated.Set")
+    if shape is None:
+        return
+
+    shape.is_defeated = data["value"]
+    shape.save()
+
+    await sio.emit(
+        "Shape.Options.Defeated.Set",
+        data,
+        skip_sid=sid,
+        room=pr.active_location.get_path(),
+        namespace=GAME_NS,
+    )
+
 
 @sio.on("Shape.Options.Locked.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -51,6 +51,7 @@ class Shape(BaseModel):
     default_edit_access = BooleanField(default=False)
     default_vision_access = BooleanField(default=False)
     is_invisible = BooleanField(default=False)
+    is_defeated = BooleanField(default=False)
     default_movement_access = BooleanField(default=False)
     is_locked = BooleanField(default=False)
     angle = FloatField(default=0)

--- a/server/save.py
+++ b/server/save.py
@@ -13,7 +13,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 56
+SAVE_VERSION = 57
 
 import json
 import logging
@@ -862,6 +862,13 @@ def upgrade(version):
             )
             db.execute_sql(
                 "INSERT INTO text (shape_id, text, font_size) SELECT shape_id, text, 20 FROM _text_55"
+            )
+
+    elif version == 56:
+        # Add defeated toggle to shapes
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE shape ADD COLUMN is_defeated INTEGER NOT NULL DEFAULT 0"
             )
     else:
         raise UnknownVersionException(


### PR DESCRIPTION
This commit allows you to mark assets as defeated which draws a red cross through them.
This state can be toggled using the 'is defeated' checkbox in the object properties or by selecting the asset and pressing 'x'.

Make sure to do your PR on the `dev` branch and NOT on the `master` branch.  This repo uses gitflow which only uses the master branch as a release branch.

Make sure to update the `CHANGELOG`.