### PR TITLE
feature(Ping): Make size constant irregardless of zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ These usually have no immediately visible impact on regular users
     -   When placed on the board, a special 'apply ddraft' button is available in the extra settings to load the walls/portals/lights
 -   Text shape to the draw tool
     -   When you click somewhere, a modal will appear to ask for the text
--   Code to set a public hostname to be used when updating the invitation url by reading from server_config.cfg 
-    "general -> public_name".  If the public_name is empty or does not exists it falls back to normal operation.
--   Added code to planarally.py to display the warning about the template directory if not running in 
+-   Code to set a public hostname to be used when updating the invitation url by reading from server_config.cfg
+    "general -> public_name". If the public_name is empty or does not exists it falls back to normal operation.
+-   Added code to planarally.py to display the warning about the template directory if not running in
     dev mode.
 -   Added ability to put a cross through tokens to mark them as defeated using a toggle in the token properties or by selecting them and pressing 'x'
 
@@ -35,7 +35,8 @@ These usually have no immediately visible impact on regular users
 -   Spell cone icon is now filled
 -   Ctrl keybindings now use Cmd on mac
 -   OpenSans font is now loaded from the server itself instead of google fonts
--   Ruler size is now always fixed in regards to the zoom scale
+-   Ruler size is now always the same size on your screen irregardles of zoom
+-   Ping size is now always the same size on your screen irregardles of zoom
 
 ### Fixed
 

--- a/client/src/game/shapes/variants/circle.ts
+++ b/client/src/game/shapes/variants/circle.ts
@@ -56,16 +56,17 @@ export class Circle extends Shape {
         if (this.fillColour === "fog") ctx.fillStyle = getFogColour();
         else ctx.fillStyle = this.fillColour;
 
-        this.drawArc(ctx, g2lz(this.r));
+        this.drawArc(ctx, this.ignoreZoomSize ? this.r : g2lz(this.r));
         ctx.fill();
 
         if (this.strokeColour !== "rgba(0, 0, 0, 0)") {
             const borderWidth = 5;
             ctx.beginPath();
-            ctx.lineWidth = g2lz(borderWidth);
+            ctx.lineWidth = this.ignoreZoomSize ? borderWidth : g2lz(borderWidth);
             ctx.strokeStyle = this.strokeColour;
             // Inset the border with - borderWidth / 2
-            this.drawArc(ctx, Math.max(borderWidth / 2, g2lz(this.r - borderWidth / 2)));
+            const r = this.r - borderWidth / 2;
+            this.drawArc(ctx, Math.max(borderWidth / 2, this.ignoreZoomSize ? r : g2lz(r)));
             ctx.stroke();
         }
         super.drawPost(ctx);

--- a/client/src/game/ui/tools/ping.vue
+++ b/client/src/game/ui/tools/ping.vue
@@ -62,6 +62,8 @@ export default class PingTool extends Tool implements ToolBasics {
         this.active = true;
         this.ping = new Circle(this.startPoint, 20, { fillColour: gameStore.rulerColour });
         this.border = new Circle(this.startPoint, 40, { fillColour: "#0000", strokeColour: gameStore.rulerColour });
+        this.ping.ignoreZoomSize = true;
+        this.border.ignoreZoomSize = true;
         this.ping.addOwner({ user: gameStore.username, access: { edit: true } }, SyncTo.SHAPE);
         this.border.addOwner({ user: gameStore.username, access: { edit: true } }, SyncTo.SHAPE);
         layer.addShape(this.ping, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);


### PR DESCRIPTION
Just like the ruler received changes, the ping tool now also has a fixed size that is decoupled from the zoom scale.

This greatly increases clarity when certain players are zoomed out, where the ping tool would appear very small.