### PR TITLE
Updated self hosting tutorial URL

### DIFF
--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -10,7 +10,7 @@ from utils import FILE_DIR
 
 if (not (FILE_DIR / "templates").exists()) and ("dev" not in sys.argv):
     print(
-        "You must gather your par— you must build the client, before starting the server.\nSee https://www.planarally.io/tutorial/setup/self-hosting/ on how to build the client or import a pre-built client."
+        "You must gather your par— you must build the client, before starting the server.\nSee https://www.planarally.io/server/setup/self-hosting/ on how to build the client or import a pre-built client."
     )
     sys.exit(1)
 


### PR DESCRIPTION
I noticed the url to the self hosting tutorial wasn't working when I was setting up my development environment. I've updated it to point to the correct page.