### PR TITLE
Fix upload bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ These usually have no immediately visible impact on regular users
 -   Shapes with a variant always appearing to other players
 -   Context menus going offscreen
 -   Navigating backwards (by mouse or with browser controls) not working
+-   Large uploads using the asset manager no longer fail part way through
 
 ## [0.25.0] - 2021-02-07
 

--- a/client/src/assetManager/AssetManager.vue
+++ b/client/src/assetManager/AssetManager.vue
@@ -152,7 +152,10 @@ export default class AssetManager extends Vue {
                 await new Promise((resolve) => {
                     const fr = new FileReader();
                     fr.readAsArrayBuffer(
-                        file.slice(slice * CHUNK_SIZE, slice * CHUNK_SIZE + Math.min(CHUNK_SIZE, file.size - slice * CHUNK_SIZE)),
+                        file.slice(
+                            slice * CHUNK_SIZE,
+                            slice * CHUNK_SIZE + Math.min(CHUNK_SIZE, file.size - slice * CHUNK_SIZE),
+                        ),
                     );
                     fr.onload = (_e) => {
                         socket.emit(

--- a/client/src/assetManager/AssetManager.vue
+++ b/client/src/assetManager/AssetManager.vue
@@ -135,7 +135,7 @@ export default class AssetManager extends Vue {
     prepareUpload(): void {
         document.getElementById("files")!.click();
     }
-    upload(fls?: FileList, target?: number): void {
+    async upload(fls?: FileList, target?: number): Promise<void> {
         const files = (document.getElementById("files")! as HTMLInputElement).files;
         if (fls === undefined) {
             if (files) fls = files;
@@ -149,23 +149,26 @@ export default class AssetManager extends Vue {
             const slices = Math.ceil(file.size / CHUNK_SIZE);
             assetStore._pendingUploads.push(file.name);
             for (let slice = 0; slice < slices; slice++) {
-                const fr = new FileReader();
-                fr.readAsArrayBuffer(
-                    file.slice(
-                        slice * CHUNK_SIZE,
-                        slice * CHUNK_SIZE + Math.min(CHUNK_SIZE, file.size - slice * CHUNK_SIZE),
-                    ),
-                );
-                fr.onload = (_e) => {
-                    socket.emit("Asset.Upload", {
-                        name: file.name,
-                        directory: target,
-                        data: fr.result,
-                        slice,
-                        totalSlices: slices,
-                        uuid,
-                    });
-                };
+                await new Promise((resolve) => {
+                    const fr = new FileReader();
+                    fr.readAsArrayBuffer(
+                        file.slice(slice * CHUNK_SIZE, slice * CHUNK_SIZE + Math.min(CHUNK_SIZE, file.size - slice * CHUNK_SIZE)),
+                    );
+                    fr.onload = (_e) => {
+                        socket.emit(
+                            "Asset.Upload",
+                            {
+                                name: file.name,
+                                directory: target,
+                                data: fr.result,
+                                slice,
+                                totalSlices: slices,
+                                uuid,
+                            },
+                            resolve,
+                        );
+                    };
+                });
             }
         }
     }


### PR DESCRIPTION
This change causes the websocket used to upload files to wait for an ack before sending the next slice of the file.

I've tested with large sets of tokens known to cause the upload to fail previously as well as large files and with this change they are uploaded with no issues. Uploads are slightly slower now but not significantly so.