### PR TITLE
bug(Initiative): Fix global group initiative removal popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ These usually have no immediately visible impact on regular users
 -   Shapes with a variant always appearing to other players
 -   Context menus going offscreen
 -   Navigating backwards (by mouse or with browser controls) not working
+-   Global initiative remove popup when deleting group shape
 
 ## [0.25.0] - 2021-02-07
 

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -105,15 +105,20 @@ export default class Initiative extends Vue {
         const d = initiativeStore.data.findIndex((a) => a.uuid === uuid);
         if (d < 0) return;
         if (initiativeStore.data[d].group) {
-            const continueRemoval = await this.$refs.confirmDialog.open(
-                "Removing initiative",
-                "Are you sure you wish to remove this group from the initiative order?",
-            );
-            if (!continueRemoval) {
-                return;
+            if (sync) {
+                const continueRemoval = await this.$refs.confirmDialog.open(
+                    "Removing initiative",
+                    "Are you sure you wish to remove this group from the initiative order?",
+                );
+                if (!continueRemoval) {
+                    return;
+                }
+                // Only remove from initiative if explicitly done
+                initiativeStore.data.splice(d, 1);
             }
+        } else {
+            initiativeStore.data.splice(d, 1);
         }
-        initiativeStore.data.splice(d, 1);
         if (sync) sendInitiativeRemove(uuid);
         // Remove highlight
         const shape = layerManager.UUIDMap.get(uuid);


### PR DESCRIPTION
This PR fixes a bug where a modal would appear for all players when a group initiative token is deleted.

This modal now only appears when initiated from the initiative UI itself