### PR TITLE
by default, comment public_name config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ These usually have no immediately visible impact on regular users
 
 -   [tech] API Server is now disabled by default and can be enabled through the server_config
 
+### Changed
+
+-   [tech] server_config variable `public_name` is now commented by default
+
 ### Fixed
 
 -   A bug related to floors and lighting on higher up floors not updating

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -20,7 +20,7 @@ ssl_privkey = cert/privkey.pem
 
 [General]
 save_file = planar.sqlite
-public_name = 
+#public_name = 
 
 [APIserver]
 # The API server is an administration server on which some API calls can be made.


### PR DESCRIPTION
having an empty configuration value can be confusing, it's better to comment it to show it is optional