### PR TITLE
bug(Vision): Fix multi-floor static vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Fixed
+
+-   A bug related to floors and lighting on higher up floors not updating
+
 ## [0.26.1] - 2021-03-15
 
 ### Fixed

--- a/client/src/game/layers/manager.ts
+++ b/client/src/game/layers/manager.ts
@@ -193,9 +193,11 @@ class LayerManager {
 
     invalidateVisibleFloors(): void {
         const current = floorStore.currentFloor;
+        let floorFound = false;
         for (const floor of floorStore.floors) {
-            this.invalidate(floor);
-            if (floor === current) break;
+            if (floorFound) this.invalidateLight(floor);
+            else this.invalidate(floor);
+            if (floor === current) floorFound = true;
         }
     }
 
@@ -204,7 +206,8 @@ class LayerManager {
     // as you typically require the allFloor variant
     invalidateLight(floor: Floor): void {
         const layers = this.getLayers(floor);
-        for (let i = layers.length - 1; i >= 0; i--) if (layers[i].isVisionLayer) layers[i].invalidate(true);
+        for (let i = layers.length - 1; i >= 0; i--)
+            if (layers[i].isVisionLayer || layers[i].name === "map") layers[i].invalidate(true);
     }
 
     invalidateLightAllFloors(): void {


### PR DESCRIPTION
When using floors, light/vision sources on higher floors would not be updated when panning (and other operations). This could be abused to see into rooms not intended and just gives an odd vibe.

This does sadly remove part of an optimisation that was in place with multi floor rendering, but this can't be helped.