### PR TITLE
bug(Floor): Fix reorder wrong render until refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These usually have no immediately visible impact on regular users
 ### Fixed
 
 -   A bug related to floors and lighting on higher up floors not updating
+-   Reordering floors being rendered wrong until a refresh
 
 ## [0.26.1] - 2021-03-15
 

--- a/client/src/assetManager/AssetManager.vue
+++ b/client/src/assetManager/AssetManager.vue
@@ -9,9 +9,7 @@ import { socket } from "@/assetManager/socket";
 import { assetStore } from "@/assetManager/store";
 import Prompt from "@/core/components/modals/prompt.vue";
 import { Asset } from "@/core/models/types";
-import { baseAdjust, uuidv4 } from "@/core/utils";
-
-import { ctrlOrCmdPressed } from "../game/input/keyboard";
+import { baseAdjust, ctrlOrCmdPressed, uuidv4 } from "@/core/utils";
 
 Component.registerHooks(["beforeRouteEnter"]);
 

--- a/client/src/core/utils.ts
+++ b/client/src/core/utils.ts
@@ -76,3 +76,8 @@ export async function getErrorReason(response: Response): Promise<string> {
     }
     return responseText;
 }
+
+export function ctrlOrCmdPressed(event: KeyboardEvent | MouseEvent | TouchEvent): boolean {
+    if (navigator.platform.includes("Mac")) return event.metaKey;
+    return event.ctrlKey;
+}

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -17,7 +17,6 @@ import { EventBus } from "@/game/event-bus";
 import { GlobalPoint } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { addFloor } from "@/game/layers/utils";
-import { gameManager } from "@/game/manager";
 import { Note, ServerFloor } from "@/game/models/general";
 import { gameStore } from "@/game/store";
 import { router } from "@/router";
@@ -26,6 +25,7 @@ import { coreStore } from "../../core/store";
 import { floorStore } from "../layers/store";
 import { Location } from "../models/settings";
 import { deleteShapes } from "../shapes/utils";
+import { setCenterPosition } from "../utils";
 import { visibilityStore } from "../visibility/store";
 
 // Core WS events
@@ -89,7 +89,7 @@ socket.on("Board.Floor.Set", (floor: ServerFloor) => {
 socket.on("Position.Set", (data: { floor?: string; x: number; y: number; zoom?: number }) => {
     if (data.floor) floorStore.selectFloor({ targetFloor: data.floor, sync: false });
     if (data.zoom) gameStore.setZoomDisplay(data.zoom);
-    gameManager.setCenterPosition(new GlobalPoint(data.x, data.y));
+    setCenterPosition(new GlobalPoint(data.x, data.y));
 });
 
 socket.on("Notes.Set", (notes: Note[]) => {

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -5,11 +5,11 @@ import { DEFAULT_GRID_SIZE, gameStore } from "@/game/store";
 import { calculateDelta } from "@/game/ui/tools/utils";
 
 import { SyncMode, SyncTo } from "../../core/models/types";
+import { ctrlOrCmdPressed } from "../../core/utils";
 import { sendClientLocationOptions } from "../api/emits/client";
 import { EventBus } from "../event-bus";
 import { floorStore } from "../layers/store";
 import { moveFloor } from "../layers/utils";
-import { gameManager } from "../manager";
 import { moveShapes } from "../operations/movement";
 import { redoOperation, undoOperation } from "../operations/undo";
 import { gameSettingsStore } from "../settings";
@@ -234,9 +234,4 @@ function changeFloor(event: KeyboardEvent, targetFloor: number): void {
         floorStore.selectFloor({ targetFloor, sync: true });
     }
     if (event.shiftKey) for (const shape of selection) newLayer.pushSelection(shape);
-}
-
-export function ctrlOrCmdPressed(event: KeyboardEvent | MouseEvent | TouchEvent): boolean {
-    if (navigator.platform.includes("Mac")) return event.metaKey;
-    return event.ctrlKey;
 }

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -14,6 +14,7 @@ import { moveShapes } from "../operations/movement";
 import { redoOperation, undoOperation } from "../operations/undo";
 import { gameSettingsStore } from "../settings";
 import { activeShapeStore } from "../ui/ActiveShapeStore";
+import { setCenterPosition } from "../utils";
 
 export function onKeyUp(event: KeyboardEvent): void {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
@@ -31,7 +32,7 @@ export function onKeyUp(event: KeyboardEvent): void {
             if (tokens.length === 0) return;
             const i = tokens.findIndex((o) => o.center().equals(gameStore.screenCenter));
             const token = tokens[(i + 1) % tokens.length];
-            gameManager.setCenterPosition(token.center());
+            setCenterPosition(token.center());
             floorStore.selectFloor({ targetFloor: token.floor.name, sync: true });
         }
         if (event.key === "Enter") {
@@ -154,7 +155,7 @@ export function onKeyDown(event: KeyboardEvent): void {
             gameStore.toggleUI();
         } else if (event.key === "0" && ctrlOrCmdPressed(event)) {
             // Ctrl-0 or numpad 0 - Re-center/reset the viewport
-            gameManager.setCenterPosition(new GlobalPoint(0, 0));
+            setCenterPosition(new GlobalPoint(0, 0));
             sendClientLocationOptions();
             layerManager.invalidateAllFloors();
         } else if (event.code === "Numpad5") {
@@ -170,7 +171,7 @@ export function onKeyDown(event: KeyboardEvent): void {
                 targetX /= selection.length;
                 targetY /= selection.length;
             }
-            gameManager.setCenterPosition(new GlobalPoint(targetX, targetY));
+            setCenterPosition(new GlobalPoint(targetX, targetY));
             sendClientLocationOptions();
             layerManager.invalidateAllFloors();
         } else if (event.key === "c" && ctrlOrCmdPressed(event)) {

--- a/client/src/game/layers/store.ts
+++ b/client/src/game/layers/store.ts
@@ -6,6 +6,7 @@ import { sendFloorReorder, sendRenameFloor } from "../api/emits/floor";
 import { Floor } from "./floor";
 import { Layer } from "./layer";
 import { layerManager } from "./manager";
+import { recalculateZIndices } from "./utils";
 
 let FLOOR_ID = 0;
 
@@ -123,6 +124,7 @@ class FloorStore extends VuexModule implements FloorState {
         const activeFloorName = this._floors[this.floorIndex].name;
         this._floors = data.floors.map((name) => this._floors.find((f) => f.name === name)!);
         this.floorIndex = this._floors.findIndex((f) => f.name === activeFloorName);
+        recalculateZIndices();
         if (data.sync) sendFloorReorder(data.floors);
     }
 }

--- a/client/src/game/layers/utils.ts
+++ b/client/src/game/layers/utils.ts
@@ -42,7 +42,7 @@ export function addFloor(serverFloor: ServerFloor): void {
     recalculateZIndices();
 }
 
-function recalculateZIndices(): void {
+export function recalculateZIndices(): void {
     let i = 0;
     for (const floor of floorStore.floors) {
         for (const layer of layerManager.getLayers(floor)) {

--- a/client/src/game/manager.ts
+++ b/client/src/game/manager.ts
@@ -1,12 +1,8 @@
 import { InvalidationMode, SyncMode } from "@/core/models/types";
-import { GlobalPoint } from "@/game/geom";
 import { layerManager } from "@/game/layers/manager";
 import { ServerShape } from "@/game/models/shapes";
 import { createShapeFromDict } from "@/game/shapes/utils";
-import { gameStore } from "@/game/store";
-import { g2l } from "@/game/units";
 
-import { sendClientLocationOptions } from "./api/emits/client";
 import { getFloorId } from "./layers/store";
 import { Shape } from "./shapes/shape";
 
@@ -25,14 +21,6 @@ class GameManager {
         layer.addShape(sh, sync, InvalidationMode.NORMAL);
         layer.invalidate(false);
         return sh;
-    }
-
-    setCenterPosition(position: GlobalPoint): void {
-        const localPos = g2l(position);
-        gameStore.increasePanX((window.innerWidth / 2 - localPos.x) / gameStore.zoomFactor);
-        gameStore.increasePanY((window.innerHeight / 2 - localPos.y) / gameStore.zoomFactor);
-        layerManager.invalidateAllFloors();
-        sendClientLocationOptions();
     }
 }
 

--- a/client/src/game/store.ts
+++ b/client/src/game/store.ts
@@ -23,10 +23,10 @@ import {
 import { sendChangePlayerRole } from "./api/emits/players";
 import { sendRoomKickPlayer, sendRoomLock } from "./api/emits/room";
 import { floorStore } from "./layers/store";
-import { gameManager } from "./manager";
 import { UserOptions, Location } from "./models/settings";
 import { gameSettingsStore } from "./settings";
 import { Label } from "./shapes/interfaces";
+import { setCenterPosition } from "./utils";
 
 export const DEFAULT_GRID_SIZE = 50;
 
@@ -280,7 +280,7 @@ class GameStore extends VuexModule implements GameState {
     jumpToMarker(marker: string): void {
         const shape = layerManager.UUIDMap.get(marker);
         if (shape == undefined) return;
-        gameManager.setCenterPosition(shape.center());
+        setCenterPosition(shape.center());
         sendClientLocationOptions();
         layerManager.invalidateAllFloors();
     }

--- a/client/src/game/ui/initiative/initiative.vue
+++ b/client/src/game/ui/initiative/initiative.vue
@@ -24,8 +24,8 @@ import { InitiativeData, InitiativeEffect } from "@/game/models/general";
 import { gameStore } from "@/game/store";
 
 import { getGroupMembers } from "../../groups";
-import { gameManager } from "../../manager";
 import { Shape } from "../../shapes/shape";
+import { setCenterPosition } from "../../utils";
 
 import { initiativeStore } from "./store";
 
@@ -153,7 +153,7 @@ export default class Initiative extends Vue {
             if (actorId !== null) {
                 const shape = layerManager.UUIDMap.get(actorId);
                 if (shape?.ownedBy(false, { visionAccess: true })) {
-                    gameManager.setCenterPosition(shape.center());
+                    setCenterPosition(shape.center());
                 }
             }
         }

--- a/client/src/game/ui/selection/edit_dialog/GroupSettings.vue
+++ b/client/src/game/ui/selection/edit_dialog/GroupSettings.vue
@@ -19,8 +19,8 @@ import {
     setCreationOrder,
 } from "../../../groups";
 import { layerManager } from "../../../layers/manager";
-import { gameManager } from "../../../manager";
 import { CREATION_ORDER_OPTIONS, CREATION_ORDER_TYPES, Group } from "../../../models/groups";
+import { setCenterPosition } from "../../../utils";
 import { ActiveShapeState, activeShapeStore } from "../../ActiveShapeStore";
 
 @Component({ components: { ConfirmDialog } })
@@ -176,7 +176,7 @@ export default class GroupSettings extends Vue {
 
     centerMember(member: Shape): void {
         if (!this.owned) return;
-        gameManager.setCenterPosition(member.center());
+        setCenterPosition(member.center());
     }
 
     toggleHighlight(member: Shape, show: boolean): void {

--- a/client/src/game/ui/tools/DrawTool.vue
+++ b/client/src/game/ui/tools/DrawTool.vue
@@ -24,8 +24,8 @@ import { equalPoints, useSnapping } from "@/game/utils";
 import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget, insertConstraint, getCDT } from "@/game/visibility/te/pa";
 
+import { ctrlOrCmdPressed } from "../../../core/utils";
 import { EventBus } from "../../event-bus";
-import { ctrlOrCmdPressed } from "../../input/keyboard";
 import { overrideLastOperation } from "../../operations/undo";
 import { gameSettingsStore } from "../../settings";
 import { Text } from "../../shapes/variants/text";

--- a/client/src/game/ui/tools/SelectTool.vue
+++ b/client/src/game/ui/tools/SelectTool.vue
@@ -17,8 +17,8 @@ import { visibilityStore } from "@/game/visibility/store";
 import { TriangulationTarget } from "@/game/visibility/te/pa";
 
 import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { ctrlOrCmdPressed } from "../../../core/utils";
 import { sendShapePositionUpdate, sendShapeSizeUpdate } from "../../api/emits/shape/core";
-import { ctrlOrCmdPressed } from "../../input/keyboard";
 import { Operation } from "../../operations/model";
 import { moveShapes } from "../../operations/movement";
 import { resizeShape } from "../../operations/resize";

--- a/client/src/game/utils.ts
+++ b/client/src/game/utils.ts
@@ -2,8 +2,11 @@ import tinycolor from "tinycolor2";
 
 import { GlobalPoint, LocalPoint, Vector } from "@/game/geom";
 
+import { sendClientLocationOptions } from "./api/emits/client";
+import { layerManager } from "./layers/manager";
 import { gameSettingsStore } from "./settings";
 import { gameStore } from "./store";
+import { g2l } from "./units";
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getLocalPointFromEvent(e: any): LocalPoint {
@@ -67,4 +70,12 @@ export function getPointsCenter(points: GlobalPoint[]): GlobalPoint {
         .reduce((acc: Vector, val: GlobalPoint) => acc.add(new Vector(val.x, val.y)), new Vector(0, 0))
         .multiply(1 / points.length);
     return GlobalPoint.fromArray([...vertexAvg]);
+}
+
+export function setCenterPosition(position: GlobalPoint): void {
+    const localPos = g2l(position);
+    gameStore.increasePanX((window.innerWidth / 2 - localPos.x) / gameStore.zoomFactor);
+    gameStore.increasePanY((window.innerHeight / 2 - localPos.y) / gameStore.zoomFactor);
+    layerManager.invalidateAllFloors();
+    sendClientLocationOptions();
 }


### PR DESCRIPTION
When reordering floors, they would not be rendered correctly until a refresh.