### PR TITLE
i18n: client/dm options to settings

### DIFF
--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -126,7 +126,7 @@ export default class MenuBar extends Vue {
                         <div v-if="!notes.length" v-t="'game.ui.menu.MenuBar.no_notes'"></div>
                     </div>
                 </div>
-                <!-- DM OPTIONS -->
+                <!-- DM SETTINGS -->
                 <button
                     class="menu-accordion"
                     @click="openDmSettings"

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -127,7 +127,11 @@ export default class MenuBar extends Vue {
                     </div>
                 </div>
                 <!-- DM OPTIONS -->
-                <button class="menu-accordion" @click="openDmSettings" v-t="'game.ui.menu.MenuBar.dm_settings'"></button>
+                <button
+                    class="menu-accordion"
+                    @click="openDmSettings"
+                    v-t="'game.ui.menu.MenuBar.dm_settings'"
+                ></button>
             </template>
             <!-- MARKERS -->
             <button class="menu-accordion" v-t="'common.markers'"></button>

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -127,7 +127,7 @@ export default class MenuBar extends Vue {
                     </div>
                 </div>
                 <!-- DM OPTIONS -->
-                <button class="menu-accordion" @click="openDmSettings" v-t="'game.ui.menu.MenuBar.dm_options'"></button>
+                <button class="menu-accordion" @click="openDmSettings" v-t="'game.ui.menu.MenuBar.dm_settings'"></button>
             </template>
             <!-- MARKERS -->
             <button class="menu-accordion" v-t="'common.markers'"></button>
@@ -144,11 +144,11 @@ export default class MenuBar extends Vue {
                     <div v-if="!markers.length" v-t="'game.ui.menu.MenuBar.no_markers'"></div>
                 </div>
             </div>
-            <!-- CLIENT OPTIONS -->
+            <!-- CLIENT SETTINGS -->
             <button
                 class="menu-accordion"
                 @click="openUserSettings"
-                v-t="'game.ui.menu.MenuBar.client_options'"
+                v-t="'game.ui.menu.MenuBar.client_settings'"
             ></button>
         </div>
         <router-link

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -155,9 +155,9 @@
                     "create_note": "Notiz erstellen",
                     "delete_marker": "Markierung löschen",
                     "no_notes": "Keine Notizen",
-                    "dm_options": "SL Optionen",
+                    "dm_settings": "SL Einstellungen",
                     "no_markers": "Keine Markierungen",
-                    "client_options": "Client Optionen"
+                    "client_settings": "Einstellungen"
                 }
             },
             "NoteDialog": {

--- a/client/src/locales/dk.json
+++ b/client/src/locales/dk.json
@@ -139,9 +139,9 @@
                     "create_note": "Lav note",
                     "delete_marker": "Slet markør",
                     "no_notes": "Ingen noter",
-                    "dm_options": "DM Instillinger",
+                    "dm_settings": "DM Instillinger",
                     "no_markers": "Ingen markører",
-                    "client_options": "Klient instillinger"
+                    "client_settings": "Klient instillinger"
                 }
             },
             "NoteDialog": {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -155,9 +155,9 @@
                     "create_note": "Create note",
                     "delete_marker": "Delete marker",
                     "no_notes": "No notes",
-                    "dm_options": "DM Options",
+                    "dm_settings": "DM Options",
                     "no_markers": "No markers",
-                    "client_options": "Client Options"
+                    "client_settings": "Client Settings"
                 }
             },
             "NoteDialog": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -152,9 +152,9 @@
                     "create_note": "Crear nota",
                     "delete_marker": "Borrar etiqueta",
                     "no_notes": "No hay notas",
-                    "dm_options": "Opciones de DM",
+                    "dm_settings": "Opciones de DM",
                     "no_markers": "No hay etiquetas",
-                    "client_options": "Opciones de cliente"
+                    "client_settings": "Opciones de cliente"
                 }
             },
             "NoteDialog": {

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -151,9 +151,9 @@
                     "create_note": "Crea nota",
                     "delete_marker": "Elimina indicatore",
                     "no_notes": "Nessuna nota",
-                    "dm_options": "Opzioni DM",
+                    "dm_settings": "Opzioni DM",
                     "no_markers": "Nessun indicatore",
-                    "client_options": "Opzioni client"
+                    "client_settings": "Opzioni client"
                 }
             },
             "NoteDialog": {

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -139,9 +139,9 @@
                     "create_note": "Создать заметку",
                     "delete_marker": "Удалить маркер",
                     "no_notes": "Нет заметок",
-                    "dm_options": "Опции для мастера",
+                    "dm_settings": "Опции для мастера",
                     "no_markers": "Нет маркеров",
-                    "client_options": "Опции клиента"
+                    "client_settings": "Опции клиента"
                 }
             },
             "NoteDialog": {

--- a/client/src/locales/tw.json
+++ b/client/src/locales/tw.json
@@ -145,9 +145,9 @@
                     "create_note": "新增筆記",
                     "delete_marker": "刪除記號",
                     "no_notes": "暫無筆記",
-                    "dm_options": "DM選項",
+                    "dm_settings": "DM選項",
                     "no_markers": "暫無記號",
-                    "client_options": "客戶端選項"
+                    "client_settings": "客戶端選項"
                 }
             },
             "NoteDialog": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -152,9 +152,9 @@
                     "create_note": "创建便签",
                     "delete_marker": "删除记号",
                     "no_notes": "暂无便签",
-                    "dm_options": "DM选项",
+                    "dm_settings": "DM选项",
                     "no_markers": "暂无记号",
-                    "client_options": "客户端选项"
+                    "client_settings": "客户端选项"
                 }
             },
             "NoteDialog": {


### PR DESCRIPTION
This closes #714
I changed DM 'options' to 'settings' as well to add to conformity. Changes were not only to the i18n strings but also to source to be consistent.

Not sure whether this is important enough to be mentioned within the changelog. Only pro I'd see for this would be to have an alert for translators, but translations themselves do not necessarily follow the conflict in English. So it might also be simply changed and that's it. There's still `git blame`. :)