### PR TITLE
Docker image building on ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These usually have no immediately visible impact on regular users
 -   [DM] Co-DM not seeing private initiatives
 -   [DM] Removing last floor giving a blank screen
 -   [DM] Removing floors below the active floor giving a blank screen
+-   [tech] Building docker image on ARM
 
 ## [0.26.1] - 2021-03-15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@
 FROM node:12-alpine as BUILDER
 
 WORKDIR /usr/src/client
+
+# Install additional dependencies
+RUN apk add --no-cache python3 make g++
+
 # Copy first package.json so changes in code dont require to reinstall all npm modules
 COPY client/package.json client/package-lock.json ./
 RUN npm i


### PR DESCRIPTION
This PR should make possible to build docker image on ARM machine. Changes are only in BUILDER, so final image size is the same as before.
I tested it on Raspberry PI 4B running Raspbian buster.