### PR TITLE
Docker image cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These usually have no immediately visible impact on regular users
 ### Changed
 
 -   [tech] server_config variable `public_name` is now commented by default
+-   [tech] removed dependencies from Dockefile, that were no longer needed
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ VOLUME /planarally/static/assets
 
 ENV PA_GIT_INFO docker:${DOCKER_TAG}-${SOURCE_COMMIT}
 
-RUN apt-get update && apt-get install dumb-init curl build-essential libffi-dev libssl-dev -y && \
+# Dependencies for building requirements
+RUN apt-get update && apt-get install dumb-init libffi-dev libssl-dev gcc -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy first requirements.txt so changes in code dont require to reinstall python requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ VOLUME /planarally/static/assets
 ENV PA_GIT_INFO docker:${DOCKER_TAG}-${SOURCE_COMMIT}
 
 # Dependencies for building requirements
-RUN apt-get update && apt-get install dumb-init libffi-dev libssl-dev gcc -y && \
+RUN apt-get update && apt-get install dumb-init libffi-dev libssl-dev gcc curl -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy first requirements.txt so changes in code dont require to reinstall python requirements


### PR DESCRIPTION
Removed unused packages used for building server on ARM, that are no longer needed.
This cleans around 100MB in uncompressed image.