### PR TITLE
feat(Menu): Live update asset menu on asset-manager changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ These usually have no immediately visible impact on regular users
 
 -   [tech] API Server is now disabled by default and can be enabled through the server_config
 -   [DM] Added ability to copy a location into another game session.
+-   [DM] The asset menu bar in-game now automatically live updates when changes are done in the asset manager
 
 ### Changed
 
 -   [tech] server_config variable `public_name` is now commented by default
 -   [tech] removed dependencies from Dockefile, that were no longer needed
+-   [tech] A big rewrite/refactor of the client has been done.
 
 ### Fixed
 

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -100,10 +100,11 @@ export default defineComponent({
             <!-- ASSETS -->
             <template v-if="isDm">
                 <button class="menu-accordion" v-t="'common.assets'"></button>
-                <div id="menu-assets" class="menu-accordion-panel">
+                <div id="menu-assets" class="menu-accordion-panel" style="position: relative">
                     <input id="asset-search" v-model="assetSearch" :placeholder="t('common.search')" />
                     <a
                         class="actionButton"
+                        style="top: 25px"
                         :href="baseAdjust('/assets')"
                         target="blank"
                         :title="t('game.ui.menu.MenuBar.open_asset_manager')"

--- a/server/api/socket/asset_manager/__init__.py
+++ b/server/api/socket/asset_manager/__init__.py
@@ -18,9 +18,11 @@ from uuid import uuid4
 import auth
 from app import app, sio
 from models import Asset
+from models.user import User
 from state.asset import asset_state
+from state.game import game_state
 from utils import logger
-from ..constants import ASSET_NS
+from ..constants import ASSET_NS, GAME_NS
 from .common import UploadData
 from .ddraft import ASSETS_DIR, handle_ddraft_file
 
@@ -36,6 +38,17 @@ class AssetDict(TypedDict):
 class AssetExport(TypedDict):
     file_hashes: List[str]
     data: List[AssetDict]
+
+
+async def update_live_game(user: User):
+    for sid, pr in game_state._sid_map.items():
+        if pr.player == user:
+            await sio.emit(
+                "Asset.List.Set",
+                Asset.get_user_structure(user),
+                room=sid,
+                namespace=GAME_NS,
+            )
 
 
 @sio.on("connect", namespace=ASSET_NS)
@@ -105,6 +118,7 @@ async def create_folder(sid: str, data):
         parent = Asset.get_root_folder(user)
     asset = Asset.create(name=data["name"], owner=user, parent=parent)
     await sio.emit("Folder.Create", asset.as_dict(), room=sid, namespace=ASSET_NS)
+    await update_live_game(user)
 
 
 @sio.on("Inode.Move", namespace=ASSET_NS)
@@ -121,6 +135,7 @@ async def move_inode(sid: str, data):
         return
     asset.parent = target
     asset.save()
+    await update_live_game(user)
 
 
 @sio.on("Asset.Rename", namespace=ASSET_NS)
@@ -133,6 +148,7 @@ async def assetmgmt_rename(sid: str, data):
         return
     asset.name = data["name"]
     asset.save()
+    await update_live_game(user)
 
 
 @sio.on("Asset.Remove", namespace=ASSET_NS)
@@ -144,6 +160,8 @@ async def assetmgmt_rm(sid: str, data):
         logger.warning(f"{user.name} attempted to remove a file it doesn't own.")
         return
     asset.delete_instance(recursive=True, delete_nullable=True)
+
+    await update_live_game(user)
 
     if asset.file_hash is not None and (ASSETS_DIR / asset.file_hash).exists():
         if Asset.select().where(Asset.file_hash == asset.file_hash).count() == 0:
@@ -252,6 +270,9 @@ async def assetmgmt_upload(sid: str, upload_data: UploadData):
         await handle_ddraft_file(upload_data, data, sid)
     else:
         await handle_regular_file(upload_data, data, sid)
+    
+    user = asset_state.get_user(sid)
+    await update_live_game(user)
 
 
 def export_asset(asset: Union[AssetDict, List[AssetDict]], parent=-1) -> AssetExport:


### PR DESCRIPTION
This PR finally changes the asset-menubar behaviour in-game to be updated when a change is done to the asset manager, so you no longer have to refresh the page!