### PR TITLE
bug(Selection): Changing selection directly from one shape to another not working properly

### DIFF
--- a/client/src/store/activeShape.ts
+++ b/client/src/store/activeShape.ts
@@ -144,18 +144,21 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
             const selection = selectionState.state.selection;
             if (selection.size === 0) {
                 this.clear();
-            } else if (this._state.uuid === undefined && selection.size > 0) {
+            } else if (this._state.uuid === undefined) {
                 this.setActiveShape(UuidMap.get([...selection][0])!);
             } else {
-                let found = false;
+                let sameMainShape = false;
                 for (const sel of selection) {
                     if ([this._state.uuid, this._state.parentUuid].includes(sel)) {
-                        found = true;
+                        sameMainShape = true;
                         break;
                     }
                 }
-                if (!found) {
+                if (!sameMainShape) {
+                    const showEditDialog = this._state.showEditDialog;
                     activeShapeStore.clear();
+                    activeShapeStore.setActiveShape(UuidMap.get([...selection][0])!);
+                    if (showEditDialog) this._state.showEditDialog = showEditDialog;
                 }
             }
         });


### PR DESCRIPTION
This PR fixes a bug where it was always required to first fully deselect a shape and then select a new shape.