### PR TITLE
feat(Rendering): Add support for HiDPI/retina screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ These usually have no immediately visible impact on regular users
 
 ### Added
 
+-   HiDPI/retina support
+    -   window.devicePixelRatio is now taken into account for rendering
 -   [tech] API Server is now disabled by default and can be enabled through the server_config
 -   [DM] Added ability to copy a location into another game session.
 -   [DM] The asset menu bar in-game now automatically live updates when changes are done in the asset manager

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -77,9 +77,7 @@ export default defineComponent({
         }
 
         function resizeWindow(): void {
-            floorStore.setWidth(window.innerWidth);
-            floorStore.setHeight(window.innerHeight);
-            floorStore.invalidateAllFloors();
+            floorStore.resize(window.innerWidth, window.innerHeight);
         }
 
         // Touch events

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -45,6 +45,7 @@ export default defineComponent({
 
         const gameState = gameStore.state;
 
+        const mediaQuery = matchMedia(`(resolution: ${devicePixelRatio}dppx)`);
         let throttledMoveSet = false;
         let throttledMove: (event: MouseEvent) => void = (_event: MouseEvent) => {};
         let throttledTouchMoveSet = false;
@@ -62,12 +63,14 @@ export default defineComponent({
             window.addEventListener("keydown", onKeyDown);
             window.addEventListener("resize", resizeWindow);
             clearUndoStacks();
+            mediaQuery.addEventListener("change", resizeWindow);
         });
 
         onUnmounted(() => {
             window.removeEventListener("keyup", keyUp);
             window.removeEventListener("keydown", onKeyDown);
             window.removeEventListener("resize", resizeWindow);
+            mediaQuery.removeEventListener("change", resizeWindow);
         });
 
         // Window events

--- a/client/src/game/layers/canvas.ts
+++ b/client/src/game/layers/canvas.ts
@@ -1,14 +1,17 @@
 export function createCanvas(): HTMLCanvasElement {
     // Create canvas element
     const canvas = document.createElement("canvas");
+    setCanvasDimensions(canvas, window.innerWidth, window.innerHeight);
+    return canvas;
+}
+
+export function setCanvasDimensions(canvas: HTMLCanvasElement, width: number, height: number): void {
     // Set display size in css pixels
-    canvas.style.width = `${window.innerWidth}px`;
-    canvas.style.height = `${window.innerHeight}px`;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
     // Set actual size in memory
-    canvas.width = Math.floor(window.devicePixelRatio * window.innerWidth);
-    canvas.height = Math.floor(window.devicePixelRatio * window.innerHeight);
+    canvas.width = Math.floor(window.devicePixelRatio * width);
+    canvas.height = Math.floor(window.devicePixelRatio * height);
     // Normalize coordinate system to use css pixels
     canvas.getContext("2d")?.scale(window.devicePixelRatio, window.devicePixelRatio);
-
-    return canvas;
 }

--- a/client/src/game/layers/canvas.ts
+++ b/client/src/game/layers/canvas.ts
@@ -1,0 +1,14 @@
+export function createCanvas(): HTMLCanvasElement {
+    // Create canvas element
+    const canvas = document.createElement("canvas");
+    // Set display size in css pixels
+    canvas.style.width = `${window.innerWidth}px`;
+    canvas.style.height = `${window.innerHeight}px`;
+    // Set actual size in memory
+    canvas.width = Math.floor(window.devicePixelRatio * window.innerWidth);
+    canvas.height = Math.floor(window.devicePixelRatio * window.innerHeight);
+    // Normalize coordinate system to use css pixels
+    canvas.getContext("2d")?.scale(window.devicePixelRatio, window.devicePixelRatio);
+
+    return canvas;
+}

--- a/client/src/game/layers/variants/fow.ts
+++ b/client/src/game/layers/variants/fow.ts
@@ -1,7 +1,7 @@
 import { floorStore } from "../../../store/floor";
 import { LayerName } from "../../models/floor";
 import { Shape } from "../../shapes/shape";
-import { createCanvas } from "../canvas";
+import { createCanvas, setCanvasDimensions } from "../canvas";
 
 import { Layer } from "./layer";
 
@@ -17,14 +17,9 @@ export class FowLayer extends Layer {
         this.vCtx = this.virtualCanvas.getContext("2d")!;
     }
 
-    set width(width: number) {
-        super.width = width;
-        this.virtualCanvas.width = width;
-    }
-
-    set height(height: number) {
-        super.height = height;
-        this.virtualCanvas.height = height;
+    resize(width: number, height: number): void {
+        super.resize(width, height);
+        setCanvasDimensions(this.virtualCanvas, width, height);
     }
 
     _draw(): void {

--- a/client/src/game/layers/variants/fow.ts
+++ b/client/src/game/layers/variants/fow.ts
@@ -1,6 +1,7 @@
 import { floorStore } from "../../../store/floor";
 import { LayerName } from "../../models/floor";
 import { Shape } from "../../shapes/shape";
+import { createCanvas } from "../canvas";
 
 import { Layer } from "./layer";
 
@@ -12,9 +13,7 @@ export class FowLayer extends Layer {
 
     constructor(canvas: HTMLCanvasElement, public name: LayerName, public floor: number, protected index: number) {
         super(canvas, name, floor, index);
-        this.virtualCanvas = document.createElement("canvas");
-        this.virtualCanvas.width = window.innerWidth;
-        this.virtualCanvas.height = window.innerHeight;
+        this.virtualCanvas = createCanvas();
         this.vCtx = this.virtualCanvas.getContext("2d")!;
     }
 
@@ -46,13 +45,13 @@ export class FowLayer extends Layer {
                     const mapl = floorStore.getLayer(floor, LayerName.Map);
                     if (mapl === undefined) continue;
                     this.ctx.globalCompositeOperation = "destination-out";
-                    this.ctx.drawImage(mapl.canvas, 0, 0);
+                    this.ctx.drawImage(mapl.canvas, 0, 0, window.innerWidth, window.innerHeight);
                 }
                 if (floor.id !== activeFloor) {
                     const fowl = floorStore.getLayer(floor, this.name);
                     if (fowl === undefined) continue;
                     this.ctx.globalCompositeOperation = "source-over";
-                    this.ctx.drawImage(fowl.canvas, 0, 0);
+                    this.ctx.drawImage(fowl.canvas, 0, 0, window.innerWidth, window.innerHeight);
                 }
                 if (floor.id === activeFloor) break;
             }

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -129,13 +129,19 @@ export class FowLightingLayer extends FowLayer {
                 }
 
                 this.vCtx.fill();
-                this.ctx.drawImage(this.virtualCanvas, 0, 0);
+                this.ctx.drawImage(this.virtualCanvas, 0, 0, window.innerWidth, window.innerHeight);
             }
 
             const activeFloor = floorStore.currentFloor.value!.id;
             if (settingsStore.fowLos.value && this.floor === activeFloor) {
                 this.ctx.globalCompositeOperation = "source-in";
-                this.ctx.drawImage(floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Vision)!.canvas, 0, 0);
+                this.ctx.drawImage(
+                    floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Vision)!.canvas,
+                    0,
+                    0,
+                    window.innerWidth,
+                    window.innerHeight,
+                );
             }
 
             for (const preShape of this.preFogShapes) {

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -65,14 +65,14 @@ export class FowVisionLayer extends FowLayer {
                     const fowl = floorStore.getLayer(floor, this.name);
                     if (fowl === undefined) continue;
                     this.vCtx.globalCompositeOperation = "destination-over";
-                    this.vCtx.drawImage(fowl.canvas, 0, 0);
+                    this.vCtx.drawImage(fowl.canvas, 0, 0, window.innerWidth, window.innerHeight);
                     const mapl = floorStore.getLayer(floor, LayerName.Map);
                     if (mapl === undefined) continue;
                     this.vCtx.globalCompositeOperation = "destination-out";
-                    this.vCtx.drawImage(mapl.canvas, 0, 0);
+                    this.vCtx.drawImage(mapl.canvas, 0, 0, window.innerWidth, window.innerHeight);
                 }
                 this.ctx.globalCompositeOperation = "source-over";
-                this.ctx.drawImage(this.virtualCanvas, 0, 0);
+                this.ctx.drawImage(this.virtualCanvas, 0, 0, window.innerWidth, window.innerHeight);
             }
 
             // For the players this is done at the beginning of this function.  TODO: why the split up ???

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -14,6 +14,7 @@ import { Shape } from "../../shapes/shape";
 import { createShapeFromDict } from "../../shapes/utils";
 import { initiativeStore } from "../../ui/initiative/state";
 import { TriangulationTarget, visionState } from "../../vision/state";
+import { setCanvasDimensions } from "../canvas";
 import { selectionState } from "../selection";
 import { compositeState } from "../state";
 
@@ -64,16 +65,12 @@ export class Layer {
         return this.canvas.width;
     }
 
-    set width(width: number) {
-        this.canvas.width = width;
-    }
-
     get height(): number {
         return this.canvas.height;
     }
 
-    set height(height: number) {
-        this.canvas.height = height;
+    resize(width: number, height: number): void {
+        setCanvasDimensions(this.canvas, width, height);
     }
 
     // SHAPES

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -250,12 +250,19 @@ export abstract class Shape {
 
         const center = g2l(this.center());
 
-        ctx.setTransform(1, 0, 0, 1, center.x, center.y);
+        ctx.setTransform(
+            devicePixelRatio,
+            0,
+            0,
+            devicePixelRatio,
+            center.x * devicePixelRatio,
+            center.y * devicePixelRatio,
+        );
         ctx.rotate(this.angle);
     }
 
     drawPost(ctx: CanvasRenderingContext2D): void {
-        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
 
         let bbox: BoundingRect | undefined;
         if (this.showBadge) {

--- a/client/src/store/floor.ts
+++ b/client/src/store/floor.ts
@@ -313,16 +313,11 @@ class FloorStore extends Store<FloorState> {
 
     // WINDOW
 
-    setHeight(height: number): void {
+    resize(width: number, height: number): void {
         for (const layer of [...this.layerMap.values()].flat()) {
-            layer.height = height;
+            layer.resize(width, height);
         }
-    }
-
-    setWidth(width: number): void {
-        for (const layer of [...this.layerMap.values()].flat()) {
-            layer.width = width;
-        }
+        floorStore.invalidateAllFloors();
     }
 }
 

--- a/client/src/store/floor.ts
+++ b/client/src/store/floor.ts
@@ -9,6 +9,7 @@ import {
     sendRenameFloor,
 } from "../game/api/emits/floor";
 import { addNewGroup, hasGroup } from "../game/groups";
+import { createCanvas } from "../game/layers/canvas";
 import { recalculateZIndices } from "../game/layers/floor";
 import { selectionState } from "../game/layers/selection";
 import { FowLightingLayer } from "../game/layers/variants/fowLighting";
@@ -182,16 +183,7 @@ class FloorStore extends Store<FloorState> {
     // LAYERS
 
     addServerLayer(layerInfo: ServerLayer, floor: Floor): void {
-        // Create canvas element
-        const canvas = document.createElement("canvas");
-        // Set display size in css pixels
-        canvas.style.width = `${window.innerWidth}px`;
-        canvas.style.height = `${window.innerHeight}px`;
-        // Set actual size in memory
-        canvas.width = Math.floor(window.devicePixelRatio * window.innerWidth);
-        canvas.height = Math.floor(window.devicePixelRatio * window.innerHeight);
-        // Normalize coordinate system to use css pixels
-        canvas.getContext("2d")?.scale(window.devicePixelRatio, window.devicePixelRatio);
+        const canvas = createCanvas();
 
         const layerName = layerInfo.name as LayerName;
 

--- a/client/src/store/floor.ts
+++ b/client/src/store/floor.ts
@@ -184,8 +184,14 @@ class FloorStore extends Store<FloorState> {
     addServerLayer(layerInfo: ServerLayer, floor: Floor): void {
         // Create canvas element
         const canvas = document.createElement("canvas");
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
+        // Set display size in css pixels
+        canvas.style.width = `${window.innerWidth}px`;
+        canvas.style.height = `${window.innerHeight}px`;
+        // Set actual size in memory
+        canvas.width = Math.floor(window.devicePixelRatio * window.innerWidth);
+        canvas.height = Math.floor(window.devicePixelRatio * window.innerHeight);
+        // Normalize coordinate system to use css pixels
+        canvas.getContext("2d")?.scale(window.devicePixelRatio, window.devicePixelRatio);
 
         const layerName = layerInfo.name as LayerName;
 


### PR DESCRIPTION
This PR adds proper support for devices with a `window.devicePixelRatio` that differs from the default 1.

This should render sharper images on those devices.