### PR TITLE
feat(Grid): Define grid in physical terms (mini size + PPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ These usually have no immediately visible impact on regular users
 
 -   HiDPI/retina support
     -   window.devicePixelRatio is now taken into account for rendering
+    -   Can be disabled from ClientSettings->Display
+-   Physical (mini) grid size
+    -   Indicate grid size in function of mini dimensions and PPI
+    -   Disables zoom tool when enabled
 -   [tech] API Server is now disabled by default and can be enabled through the server_config
 -   [DM] Added ability to copy a location into another game session.
 -   [DM] The asset menu bar in-game now automatically live updates when changes are done in the asset manager

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -10,9 +10,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
 
     clientStore.setDefaultClientOptions(userOptionsToClient(options.default_user_options));
 
-    if (options.room_user_options?.grid_size !== undefined)
-        clientStore.setGridSize(options.room_user_options.grid_size, false);
-    else clientStore.setGridSize(options.default_user_options.grid_size, false);
+    // Appearance
     if (options.room_user_options?.grid_colour !== undefined)
         clientStore.setGridColour(options.room_user_options.grid_colour, false);
     else clientStore.setGridColour(options.default_user_options.grid_colour, false);
@@ -22,12 +20,32 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     if (options.room_user_options?.ruler_colour !== undefined)
         clientStore.setRulerColour(options.room_user_options.ruler_colour, false);
     else clientStore.setRulerColour(options.default_user_options.ruler_colour, false);
+
+    // Behaviour
     if (options.room_user_options?.invert_alt !== undefined)
         clientStore.setInvertAlt(options.room_user_options.invert_alt, false);
     else clientStore.setInvertAlt(options.default_user_options.invert_alt, false);
     if (options.room_user_options?.disable_scroll_to_zoom !== undefined)
         clientStore.setDisableScrollToZoom(options.room_user_options.disable_scroll_to_zoom, false);
     else clientStore.setDisableScrollToZoom(options.default_user_options.disable_scroll_to_zoom, false);
+
+    // Display
+    if (options.room_user_options?.use_high_dpi !== undefined)
+        clientStore.setUseHighDpi(options.room_user_options.use_high_dpi, false);
+    else clientStore.setUseHighDpi(options.default_user_options.use_high_dpi, false);
+    if (options.room_user_options?.grid_size !== undefined)
+        clientStore.setGridSize(options.room_user_options.grid_size, false);
+    else clientStore.setGridSize(options.default_user_options.grid_size, false);
+    if (options.room_user_options?.use_as_physical_board !== undefined)
+        clientStore.setUseAsPhysicalBoard(options.room_user_options.use_as_physical_board, false);
+    else clientStore.setUseAsPhysicalBoard(options.default_user_options.use_as_physical_board, false);
+    if (options.room_user_options?.mini_size !== undefined)
+        clientStore.setMiniSize(options.room_user_options.mini_size, false);
+    else clientStore.setMiniSize(options.default_user_options.mini_size, false);
+    if (options.room_user_options?.ppi !== undefined) clientStore.setPpi(options.room_user_options.ppi, false);
+    else clientStore.setPpi(options.default_user_options.ppi, false);
+
+    // Initiative
     if (options.room_user_options?.initiative_camera_lock !== undefined)
         clientStore.setInitiativeCameraLock(options.room_user_options.initiative_camera_lock, false);
     else clientStore.setInitiativeCameraLock(options.default_user_options.initiative_camera_lock, false);

--- a/client/src/game/layers/canvas.ts
+++ b/client/src/game/layers/canvas.ts
@@ -1,3 +1,5 @@
+import { clientStore } from "../../store/client";
+
 export function createCanvas(): HTMLCanvasElement {
     // Create canvas element
     const canvas = document.createElement("canvas");
@@ -6,12 +8,13 @@ export function createCanvas(): HTMLCanvasElement {
 }
 
 export function setCanvasDimensions(canvas: HTMLCanvasElement, width: number, height: number): void {
+    const pixelRatio = clientStore.devicePixelRatio.value;
     // Set display size in css pixels
     canvas.style.width = `${width}px`;
     canvas.style.height = `${height}px`;
     // Set actual size in memory
-    canvas.width = Math.floor(window.devicePixelRatio * width);
-    canvas.height = Math.floor(window.devicePixelRatio * height);
+    canvas.width = Math.floor(pixelRatio * width);
+    canvas.height = Math.floor(pixelRatio * height);
     // Normalize coordinate system to use css pixels
-    canvas.getContext("2d")?.scale(window.devicePixelRatio, window.devicePixelRatio);
+    canvas.getContext("2d")?.scale(pixelRatio, pixelRatio);
 }

--- a/client/src/game/models/settings.ts
+++ b/client/src/game/models/settings.ts
@@ -55,9 +55,15 @@ export interface ServerUserOptions {
     grid_colour: string;
     fow_colour: string;
     ruler_colour: string;
+
     invert_alt: boolean;
-    grid_size: number;
     disable_scroll_to_zoom: boolean;
+
+    use_high_dpi: boolean;
+    grid_size: number;
+    use_as_physical_board: boolean;
+    mini_size: number;
+    ppi: number;
 
     initiative_camera_lock: boolean;
     initiative_vision_lock: boolean;
@@ -65,13 +71,23 @@ export interface ServerUserOptions {
 }
 
 export interface UserOptions {
+    // Appearance
     gridColour: string;
     fowColour: string;
     rulerColour: string;
+
+    // Behaviour
     invertAlt: boolean;
-    gridSize: number;
     disableScrollToZoom: boolean;
 
+    // Display
+    useHighDpi: boolean;
+    useAsPhysicalBoard: boolean;
+    gridSize: number;
+    miniSize: number;
+    ppi: number;
+
+    // Initiative
     initiativeCameraLock: boolean;
     initiativeVisionLock: boolean;
     initiativeEffectVisibility: InitiativeEffectMode;
@@ -95,10 +111,16 @@ export const optionsToClient = (options: ServerLocationOptions): LocationOptions
 export const userOptionsToClient = (options: ServerUserOptions): UserOptions => ({
     fowColour: options.fow_colour,
     gridColour: options.grid_colour,
-    gridSize: options.grid_size,
-    invertAlt: options.invert_alt,
     rulerColour: options.ruler_colour,
+
+    invertAlt: options.invert_alt,
     disableScrollToZoom: options.disable_scroll_to_zoom,
+
+    useHighDpi: options.use_high_dpi,
+    gridSize: options.grid_size,
+    useAsPhysicalBoard: options.use_as_physical_board,
+    miniSize: options.mini_size,
+    ppi: options.ppi,
 
     initiativeCameraLock: options.initiative_camera_lock,
     initiativeVisionLock: options.initiative_vision_lock,

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -249,20 +249,15 @@ export abstract class Shape {
         else ctx.globalCompositeOperation = "source-over";
 
         const center = g2l(this.center());
+        const pixelRatio = clientStore.devicePixelRatio.value;
 
-        ctx.setTransform(
-            devicePixelRatio,
-            0,
-            0,
-            devicePixelRatio,
-            center.x * devicePixelRatio,
-            center.y * devicePixelRatio,
-        );
+        ctx.setTransform(pixelRatio, 0, 0, pixelRatio, center.x * pixelRatio, center.y * pixelRatio);
         ctx.rotate(this.angle);
     }
 
     drawPost(ctx: CanvasRenderingContext2D): void {
-        ctx.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+        const pixelRatio = clientStore.devicePixelRatio.value;
+        ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
 
         let bbox: BoundingRect | undefined;
         if (this.showBadge) {

--- a/client/src/game/shapes/variants/circularToken.ts
+++ b/client/src/game/shapes/variants/circularToken.ts
@@ -3,6 +3,7 @@ import * as tinycolor from "tinycolor2";
 import { g2l, g2lz } from "../../../core/conversions";
 import { GlobalPoint } from "../../../core/geometry";
 import { calcFontScale } from "../../../core/utils";
+import { clientStore } from "../../../store/client";
 import { ServerCircularToken } from "../../models/shapes";
 import { SHAPE_TYPE } from "../types";
 
@@ -53,7 +54,8 @@ export class CircularToken extends Circle {
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         const fontScale = calcFontScale(ctx, this.text, g2lz(this.r - 5));
-        ctx.setTransform(fontScale, 0, 0, fontScale, center.x * devicePixelRatio, center.y * devicePixelRatio);
+        const pixelRatio = clientStore.devicePixelRatio.value;
+        ctx.setTransform(fontScale, 0, 0, fontScale, center.x * pixelRatio, center.y * pixelRatio);
         ctx.rotate(this.angle);
         ctx.fillStyle = tinycolor.mostReadable(this.fillColour, ["#000", "#fff"]).toHexString();
         ctx.fillText(this.text, 0, 0);

--- a/client/src/game/ui/settings/client/AppearanceSettings.vue
+++ b/client/src/game/ui/settings/client/AppearanceSettings.vue
@@ -41,22 +41,11 @@ export default defineComponent({
             },
         });
 
-        const gridSize = computed({
-            get() {
-                return clientStore.state.gridSize;
-            },
-            set(gridSize: number) {
-                if (gridSize >= 1) {
-                    clientStore.setGridSize(gridSize, true);
-                }
-            },
-        });
-
         function setDefault(key: keyof UserOptions): void {
             clientStore.setDefaultClientOption(key, clientStore.state[key], true);
         }
 
-        return { t, defaultOptions, setDefault, fowColour, gridColour, rulerColour, gridSize };
+        return { t, defaultOptions, setDefault, fowColour, gridColour, rulerColour };
     },
 });
 </script>
@@ -83,20 +72,6 @@ export default defineComponent({
                     <font-awesome-icon icon="times-circle" />
                 </div>
                 <div :title="t('game.ui.settings.common.sync_default')" @click="setDefault('gridColour')">
-                    <font-awesome-icon icon="sync-alt" />
-                </div>
-            </template>
-        </div>
-        <div class="row">
-            <label for="gridSize" v-t="'game.ui.settings.client.AppearanceSettings.grid_size_in_pixels'"></label>
-            <div>
-                <input id="gridSize" type="number" v-model="gridSize" />
-            </div>
-            <template v-if="gridSize !== defaultOptions.gridSize">
-                <div :title="t('game.ui.settings.common.reset_default')" @click="gridSize = defaultOptions.gridSize">
-                    <font-awesome-icon icon="times-circle" />
-                </div>
-                <div :title="t('game.ui.settings.common.sync_default')" @click="setDefault('gridSize')">
                     <font-awesome-icon icon="sync-alt" />
                 </div>
             </template>

--- a/client/src/game/ui/settings/client/ClientSettings.vue
+++ b/client/src/game/ui/settings/client/ClientSettings.vue
@@ -8,10 +8,11 @@ import { uiStore } from "../../../../store/ui";
 import AppearanceSettings from "./AppearanceSettings.vue";
 import BehaviourSettings from "./BehaviourSettings.vue";
 import { ClientSettingCategory } from "./categories";
+import DisplaySettings from "./DisplaySettings.vue";
 import InitiativeSettings from "./InitiativeSettings.vue";
 
 export default defineComponent({
-    components: { AppearanceSettings, BehaviourSettings, InitiativeSettings, PanelModal },
+    components: { AppearanceSettings, BehaviourSettings, DisplaySettings, InitiativeSettings, PanelModal },
     setup() {
         const { t } = useI18n();
 
@@ -27,6 +28,7 @@ export default defineComponent({
         const categoryNames = [
             ClientSettingCategory.Appearance,
             ClientSettingCategory.Behaviour,
+            ClientSettingCategory.Display,
             ClientSettingCategory.Initiative,
         ];
 
@@ -46,6 +48,7 @@ export default defineComponent({
         <template v-slot:title>{{ t("game.ui.settings.client.ClientSettings.client_settings") }}</template>
         <template v-slot:default="{ selection }">
             <AppearanceSettings v-show="selection === ClientSettingCategory.Appearance" />
+            <DisplaySettings v-show="selection === ClientSettingCategory.Display" />
             <BehaviourSettings v-show="selection === ClientSettingCategory.Behaviour" />
             <InitiativeSettings v-show="selection === ClientSettingCategory.Initiative" />
         </template>

--- a/client/src/game/ui/settings/client/DisplaySettings.vue
+++ b/client/src/game/ui/settings/client/DisplaySettings.vue
@@ -1,0 +1,183 @@
+<script lang="ts">
+import { computed, defineComponent, toRef } from "vue";
+import { useI18n } from "vue-i18n";
+
+import { clientStore } from "../../../../store/client";
+import { UserOptions } from "../../../models/settings";
+
+export default defineComponent({
+    setup() {
+        const { t } = useI18n();
+
+        const defaultOptions = toRef(clientStore.state, "defaultClientOptions");
+
+        const useHighDpi = computed({
+            get() {
+                return clientStore.state.useHighDpi;
+            },
+            set(useHighDpi: boolean) {
+                clientStore.setUseHighDpi(useHighDpi, true);
+            },
+        });
+
+        const gridSize = computed({
+            get() {
+                return clientStore.state.gridSize;
+            },
+            set(gridSize: number) {
+                if (gridSize >= 1) {
+                    clientStore.setGridSize(gridSize, true);
+                }
+            },
+        });
+
+        const useAsPhysicalBoard = computed({
+            get() {
+                return clientStore.state.useAsPhysicalBoard;
+            },
+            set(useAsPhysicalBoard: boolean) {
+                clientStore.setUseAsPhysicalBoard(useAsPhysicalBoard, true);
+            },
+        });
+
+        const miniSize = computed({
+            get() {
+                return clientStore.state.miniSize;
+            },
+            set(miniSize: number) {
+                if (miniSize >= 1) {
+                    clientStore.setMiniSize(miniSize, true);
+                }
+            },
+        });
+
+        const ppi = computed({
+            get() {
+                return clientStore.state.ppi;
+            },
+            set(ppi: number) {
+                if (ppi >= 1) {
+                    clientStore.setPpi(ppi, true);
+                }
+            },
+        });
+
+        function setDefault(key: keyof UserOptions): void {
+            clientStore.setDefaultClientOption(key, clientStore.state[key], true);
+        }
+
+        return { t, defaultOptions, setDefault, gridSize, miniSize, ppi, useAsPhysicalBoard, useHighDpi };
+    },
+});
+</script>
+
+<template>
+    <div class="panel restore-panel">
+        <div class="row">
+            <label for="useHighDpi" v-t="'game.ui.settings.client.DisplaySettings.use_high_dpi'"></label>
+            <div><input id="useHighDpi" type="checkbox" v-model="useHighDpi" /></div>
+            <template v-if="useHighDpi !== defaultOptions.useHighDpi">
+                <div
+                    :title="t('game.ui.settings.common.reset_default')"
+                    @click="useHighDpi = defaultOptions.useHighDpi"
+                >
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div :title="t('game.ui.settings.common.sync_default')" @click="setDefault('useHighDpi')">
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+        <div class="spanrow header">Gameboard</div>
+        <div class="row">
+            <label
+                for="useAsPhysicalBoard"
+                v-t="'game.ui.settings.client.DisplaySettings.use_as_physical_gameboard'"
+            ></label>
+            <div><input id="useAsPhysicalBoard" type="checkbox" v-model="useAsPhysicalBoard" /></div>
+            <template v-if="useAsPhysicalBoard !== defaultOptions.useAsPhysicalBoard">
+                <div
+                    :title="t('game.ui.settings.common.reset_default')"
+                    @click="useAsPhysicalBoard = defaultOptions.useAsPhysicalBoard"
+                >
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div :title="t('game.ui.settings.common.sync_default')" @click="setDefault('useAsPhysicalBoard')">
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+        <div class="row" :class="{ 'row-disabled': !useAsPhysicalBoard }">
+            <label for="miniSize" v-t="'game.ui.settings.client.DisplaySettings.mini_size_in_inches'"></label>
+            <div>
+                <input id="miniSize" type="number" v-model="miniSize" :disabled="!useAsPhysicalBoard" />
+            </div>
+            <template v-if="miniSize !== defaultOptions.miniSize">
+                <div :title="t('game.ui.settings.common.reset_default')" @click="miniSize = defaultOptions.miniSize">
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div :title="t('game.ui.settings.common.sync_default')" @click="setDefault('miniSize')">
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+        <div class="row" :class="{ 'row-disabled': !useAsPhysicalBoard }">
+            <label for="ppi" v-t="'game.ui.settings.client.DisplaySettings.ppi'"></label>
+            <div>
+                <input id="ppi" type="number" v-model="ppi" :disabled="!useAsPhysicalBoard" />
+            </div>
+            <template v-if="ppi !== defaultOptions.ppi">
+                <div :title="t('game.ui.settings.common.reset_default')" @click="ppi = defaultOptions.ppi">
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div :title="t('game.ui.settings.common.sync_default')" @click="setDefault('ppi')">
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+        <div class="spanrow header">Grid</div>
+        <div class="row" :class="{ 'row-disabled': useAsPhysicalBoard }">
+            <label for="gridSize" v-t="'game.ui.settings.client.DisplaySettings.grid_size_in_pixels'"></label>
+            <div>
+                <input id="gridSize" type="number" v-model="gridSize" :disabled="useAsPhysicalBoard" />
+            </div>
+            <template v-if="gridSize !== defaultOptions.gridSize">
+                <div :title="t('game.ui.settings.common.reset_default')" @click="gridSize = defaultOptions.gridSize">
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div :title="t('game.ui.settings.common.sync_default')" @click="setDefault('gridSize')">
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+/* Force higher specificity without !important abuse */
+.panel.restore-panel {
+    min-width: 20vw;
+    column-gap: 15px;
+    grid-template-columns: [setting] 1fr [value] auto [restore] 30px [sync] 30px [end];
+}
+
+label {
+    grid-column-start: setting;
+}
+
+.overwritten,
+.restore-panel .row.overwritten * {
+    color: #7c253e;
+    font-weight: bold;
+}
+
+.panel input[type="number"] {
+    width: 50px;
+}
+
+.row-disabled > *,
+.row-disabled:hover > * {
+    cursor: not-allowed;
+    color: grey;
+}
+</style>

--- a/client/src/game/ui/settings/client/categories.ts
+++ b/client/src/game/ui/settings/client/categories.ts
@@ -1,5 +1,6 @@
 export enum ClientSettingCategory {
     Appearance = "Appearance",
     Behaviour = "Behaviour",
+    Display = "Display",
     Initiative = "Initiative",
 }

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -220,7 +220,7 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
+                    "DisplaySettings": {
                         "grid_size_in_pixels": "Gittergröße (in Pixel):"
                     },
                     "BehaviourSettings": {

--- a/client/src/locales/dk.json
+++ b/client/src/locales/dk.json
@@ -197,7 +197,7 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
+                    "DisplaySettings": {
                         "grid_size_in_pixels": "Gitterstørrelse (i pixels):"
                     },
                     "BehaviourSettings": {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -223,8 +223,12 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
-                        "grid_size_in_pixels": "Size (in pixels):"
+                    "DisplaySettings": {
+                        "use_high_dpi": "Use HiDPI/retina if applicable",
+                        "grid_size_in_pixels": "Size (in pixels):",
+                        "use_as_physical_gameboard": "Use as physical gameboard",
+                        "mini_size_in_inches": "Mini size (in inches)",
+                        "ppi": "Pixel density (PPI)"
                     },
                     "BehaviourSettings": {
                         "invert_alt_set": "Invert ALT behaviour",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -215,7 +215,7 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
+                    "DisplaySettings": {
                         "grid_size_in_pixels": "Tamaño de la Grilla (en pixeles):"
                     },
                     "BehaviourSettings": {

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -214,7 +214,7 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
+                    "DisplaySettings": {
                         "grid_size_in_pixels": "Dimensioni della griglia (in pixel):"
                     },
                     "BehaviourSettings": {

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -197,7 +197,7 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
+                    "DisplaySettings": {
                         "grid_size_in_pixels": "Размер сетки (в пикселях):"
                     },
                     "BehaviourSettings": {

--- a/client/src/locales/tw.json
+++ b/client/src/locales/tw.json
@@ -206,7 +206,7 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
+                    "DisplaySettings": {
                         "grid_size_in_pixels": "網格尺寸（像素）："
                     },
                     "BehaviourSettings": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -215,7 +215,7 @@
                     "ClientSettings": {
                         "client_settings": "Client Settings"
                     },
-                    "AppearanceSettings": {
+                    "DisplaySettings": {
                         "grid_size_in_pixels": "网格尺寸（像素）："
                     },
                     "BehaviourSettings": {

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -37,9 +37,15 @@ class ClientOptions(TypedDict, total=False):
     grid_colour: str
     fow_colour: str
     ruler_colour: str
+
     invert_alt: bool
-    grid_size: int
     disable_scroll_to_zoom: bool
+
+    use_high_dpi: bool
+    grid_size: int
+    use_as_physical_board: bool
+    mini_size: int
+    ppi: int
 
     initiative_camera_lock: bool
     initiative_vision_lock: bool

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -1,6 +1,13 @@
 from logging import disable
 import bcrypt
-from peewee import ForeignKeyField, fn, BooleanField, IntegerField, TextField
+from peewee import (
+    FloatField,
+    ForeignKeyField,
+    fn,
+    BooleanField,
+    IntegerField,
+    TextField,
+)
 from playhouse.shortcuts import model_to_dict
 
 from .base import BaseModel
@@ -13,9 +20,15 @@ class UserOptions(BaseModel):
     fow_colour = TextField(default="#000", null=True)
     grid_colour = TextField(default="#000", null=True)
     ruler_colour = TextField(default="#F00", null=True)
+
     invert_alt = BooleanField(default=False, null=True)
-    grid_size = IntegerField(default=50, null=True)
     disable_scroll_to_zoom = BooleanField(default=False, null=True)
+
+    use_high_dpi = BooleanField(default=True, null=True)
+    grid_size = IntegerField(default=50, null=True)
+    use_as_physical_board = BooleanField(default=False, null=True)
+    mini_size = FloatField(default=1, null=True)
+    ppi = IntegerField(default=96, null=True)
 
     initiative_camera_lock = BooleanField(default=False, null=True)
     initiative_vision_lock = BooleanField(default=False, null=True)
@@ -28,8 +41,13 @@ class UserOptions(BaseModel):
             grid_colour=None,
             ruler_colour=None,
             invert_alt=None,
-            grid_size=None,
             disable_scroll_to_zoom=None,
+            use_high_dpi=None,
+            grid_size=None,
+            use_as_physical_board=None,
+            initiative_camera_lock=None,
+            initiative_vision_lock=None,
+            initiative_effect_visibility=None,
         )
 
     def as_dict(self):

--- a/server/save.py
+++ b/server/save.py
@@ -13,7 +13,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 62
+SAVE_VERSION = 63
 
 import json
 import logging
@@ -1009,6 +1009,31 @@ def upgrade(version):
             db.execute_sql("DROP TABLE initiative_effect")
             db.execute_sql("DROP TABLE _initiative_61")
             db.execute_sql("DROP TABLE initiative_location_data")
+    elif version == 62:
+        # Add UserOptions.use_as_physical_board .ppi and .mini_size
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE user_options ADD COLUMN use_as_physical_board INTEGER DEFAULT 0"
+            )
+            db.execute_sql(
+                "ALTER TABLE user_options ADD COLUMN mini_size REAL DEFAULT 1"
+            )
+            db.execute_sql("ALTER TABLE user_options ADD COLUMN ppi INTEGER DEFAULT 96")
+            db.execute_sql(
+                "ALTER TABLE user_options ADD COLUMN use_high_dpi INTEGER DEFAULT 1"
+            )
+            data = db.execute_sql(
+                "UPDATE user_options SET use_as_physical_board = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
+            )
+            data = db.execute_sql(
+                "UPDATE user_options SET mini_size = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
+            )
+            data = db.execute_sql(
+                "UPDATE user_options SET ppi = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
+            )
+            data = db.execute_sql(
+                "UPDATE user_options SET use_high_dpi = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
+            )
 
     else:
         raise UnknownVersionException(


### PR DESCRIPTION
This PR adds an optional feature to define the grid size in terms of mini dimensions and pixel density (PPI).
This is interesting for those players that would like to use real minis on top of a tablet running PlanarAlly.

When enabled, this will disable the zoom tool (i.e. changing zoom does nothing).