### PR TITLE
feat(PlayerViewport): Add player viewport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ These usually have no immediately visible impact on regular users
 -   Physical (mini) grid size
     -   Indicate grid size in function of mini dimensions and PPI
     -   Disables zoom tool when enabled
--   [tech] API Server is now disabled by default and can be enabled through the server_config
 -   [DM] Added ability to copy a location into another game session.
 -   [DM] The asset menu bar in-game now automatically live updates when changes are done in the asset manager
+-   [DM] Player viewport info
+    -   Show a rectangle on the DM layer representing the player current viewport
+    -   Moving this rectangle will live update the related player's view (only pan for now)
+    -   Can be toggled on from the DM settings
+-   [tech] API Server is now disabled by default and can be enabled through the server_config
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ These usually have no immediately visible impact on regular users
     -   Option to change the sorting behaviour
     -   Blur effect to make it clear that initiative is not yet synced
     -   Enter can now be used to submit a new initiative value
+-   [DM] kicking a player now first prompts for confirmation
 -   [tech] server_config variable `public_name` is now commented by default
 -   [tech] removed dependencies from Dockefile, that were no longer needed
 -   [tech] A big rewrite/refactor of the client has been done.

--- a/client/src/game/api/emits/client.ts
+++ b/client/src/game/api/emits/client.ts
@@ -5,7 +5,14 @@ import { socket } from "../socket";
 
 export function sendClientLocationOptions(): void {
     const state = clientStore.state;
-    _sendClientLocationOptions({ pan_x: state.panX, pan_y: state.panY, zoom_factor: state.zoomDisplay });
+    _sendClientLocationOptions({
+        pan_x: state.panX,
+        pan_y: state.panY,
+        zoom_display: state.zoomDisplay,
+        zoom_factor: clientStore.zoomFactor.value,
+        client_h: window.innerHeight,
+        client_w: window.innerWidth,
+    });
 }
 
 function _sendClientLocationOptions(locationOptions: ServerUserLocationOptions): void {

--- a/client/src/game/api/emits/client.ts
+++ b/client/src/game/api/emits/client.ts
@@ -21,3 +21,5 @@ function _sendClientLocationOptions(locationOptions: ServerUserLocationOptions):
 
 export const sendRoomClientOptions = wrapSocket<Partial<ServerUserOptions>>("Client.Options.Room.Set");
 export const sendDefaultClientOptions = wrapSocket<Partial<ServerUserOptions>>("Client.Options.Default.Set");
+
+export const sendMoveClient = wrapSocket<{ player: number; data: ServerUserLocationOptions }>("Client.Move");

--- a/client/src/game/api/emits/shape/core.ts
+++ b/client/src/game/api/emits/shape/core.ts
@@ -21,7 +21,7 @@ export const sendTextUpdate = wrapSocket<{ uuid: string; text: string; temporary
 export function sendShapeOptionsUpdate(shapes: readonly Shape[], temporary: boolean): void {
     const options = shapes
         .filter((s) => !s.preventSync)
-        .map((s) => ({ uuid: s.uuid, option: JSON.stringify([...s.options]) }));
+        .map((s) => ({ uuid: s.uuid, option: JSON.stringify(Object.entries(s.options)) }));
     if (options.length > 0) {
         socket.emit("Shapes.Options.Update", {
             options,

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -1,9 +1,24 @@
 import { clientStore } from "../../../store/client";
-import { ServerClient, userOptionsToClient } from "../../models/settings";
+import { floorStore } from "../../../store/floor";
+import { gameStore } from "../../../store/game";
+import { moveClientRect } from "../../client";
+import { ServerClient, ServerUserLocationOptions, userOptionsToClient } from "../../models/settings";
 import { socket } from "../socket";
 
 // eslint-disable-next-line import/no-unused-modules
 export let activeLayerToselect: string | undefined;
+
+socket.on("Client.Move", (data: { player: number } & ServerUserLocationOptions) => {
+    const { player, ...locationData } = data;
+    if (gameStore.state.isDm) {
+        moveClientRect(player, locationData);
+    } else {
+        clientStore.setPanX(data.pan_x);
+        clientStore.setPanY(data.pan_y);
+        clientStore.setZoomDisplay(data.zoom_display);
+        floorStore.invalidateAllFloors();
+    }
+});
 
 socket.on("Client.Options.Set", (options: ServerClient) => {
     clientStore.setUsername(options.name);

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -58,7 +58,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
 
     clientStore.setPanX(options.location_user_options.pan_x);
     clientStore.setPanY(options.location_user_options.pan_y);
-    clientStore.setZoomDisplay(options.location_user_options.zoom_factor);
+    clientStore.setZoomDisplay(options.location_user_options.zoom_display);
 
     activeLayerToselect = options.location_user_options.active_layer;
 });

--- a/client/src/game/api/events/player.ts
+++ b/client/src/game/api/events/player.ts
@@ -1,39 +1,6 @@
-import { toGP } from "../../../core/geometry";
-import { InvalidationMode, SyncMode } from "../../../core/models/types";
-import { uuidv4 } from "../../../core/utils";
-import { floorStore } from "../../../store/floor";
 import { gameStore } from "../../../store/game";
-import { UuidMap } from "../../../store/shapeMap";
-import { LayerName } from "../../models/floor";
-import { ServerUserLocationOptions } from "../../models/settings";
-import { Rect } from "../../shapes/variants/rect";
 import { socket } from "../socket";
-
-const playerRectUuids: Map<number, string> = new Map();
 
 socket.on("Player.Role.Set", (data: { player: number; role: number }) => {
     gameStore.setPlayerRole(data.player, data.role, false);
-});
-
-socket.on("Player.Move", (data: { player: number } & ServerUserLocationOptions) => {
-    if (!playerRectUuids.has(data.player)) {
-        playerRectUuids.set(data.player, uuidv4());
-    }
-    const uuid = playerRectUuids.get(data.player)!;
-    const layer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Draw)!;
-    if (!UuidMap.has(uuid)) {
-        const rect = new Rect(toGP(0, 0), 100, 100, {
-            fillColour: "rgba(0, 0, 0, 0)",
-            strokeColour: "rgba(0, 0, 0, 1)",
-            uuid,
-        });
-        layer.addShape(rect, SyncMode.NO_SYNC, InvalidationMode.NO, false);
-    }
-    const rect = UuidMap.get(uuid)! as Rect;
-    const h = data.client_h / data.zoom_factor;
-    const w = data.client_w / data.zoom_factor;
-    rect.h = h;
-    rect.w = w;
-    rect.center(toGP(w / 2 - data.pan_x, h / 2 - data.pan_y));
-    layer.invalidate(true);
 });

--- a/client/src/game/api/events/player.ts
+++ b/client/src/game/api/events/player.ts
@@ -1,6 +1,39 @@
+import { toGP } from "../../../core/geometry";
+import { InvalidationMode, SyncMode } from "../../../core/models/types";
+import { uuidv4 } from "../../../core/utils";
+import { floorStore } from "../../../store/floor";
 import { gameStore } from "../../../store/game";
+import { UuidMap } from "../../../store/shapeMap";
+import { LayerName } from "../../models/floor";
+import { ServerUserLocationOptions } from "../../models/settings";
+import { Rect } from "../../shapes/variants/rect";
 import { socket } from "../socket";
+
+const playerRectUuids: Map<number, string> = new Map();
 
 socket.on("Player.Role.Set", (data: { player: number; role: number }) => {
     gameStore.setPlayerRole(data.player, data.role, false);
+});
+
+socket.on("Player.Move", (data: { player: number } & ServerUserLocationOptions) => {
+    if (!playerRectUuids.has(data.player)) {
+        playerRectUuids.set(data.player, uuidv4());
+    }
+    const uuid = playerRectUuids.get(data.player)!;
+    const layer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Draw)!;
+    if (!UuidMap.has(uuid)) {
+        const rect = new Rect(toGP(0, 0), 100, 100, {
+            fillColour: "rgba(0, 0, 0, 0)",
+            strokeColour: "rgba(0, 0, 0, 1)",
+            uuid,
+        });
+        layer.addShape(rect, SyncMode.NO_SYNC, InvalidationMode.NO, false);
+    }
+    const rect = UuidMap.get(uuid)! as Rect;
+    const h = data.client_h / data.zoom_factor;
+    const w = data.client_w / data.zoom_factor;
+    rect.h = h;
+    rect.w = w;
+    rect.center(toGP(w / 2 - data.pan_x, h / 2 - data.pan_y));
+    layer.invalidate(true);
 });

--- a/client/src/game/api/events/room.ts
+++ b/client/src/game/api/events/room.ts
@@ -34,7 +34,7 @@ socket.on(
         gameStore.setRoomCreator(data.creator);
         gameStore.setInvitationCode(data.invitationCode);
         gameStore.setIsLocked(data.isLocked, false);
-        gameStore.setPlayers(data.players);
+        gameStore.setPlayers(data.players.map((p) => ({ ...p, showRect: false })));
         gameStore.setPublicName(data.publicName);
         settingsStore.setDefaultLocationOptions(optionsToClient(data.default_options));
         setLocationOptions(undefined, data.default_options);
@@ -46,5 +46,5 @@ socket.on("Room.Info.InvitationCode.Set", (invitationCode: string) => {
 });
 
 socket.on("Room.Info.Players.Add", (data: { id: number; name: string; location: number; role: number }) => {
-    gameStore.addPlayer(data);
+    gameStore.addPlayer({ ...data, showRect: false });
 });

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -52,7 +52,7 @@ socket.on("Shapes.Options.Update", (data: { uuid: string; option: string }[]) =>
         if (shape === undefined) {
             continue;
         }
-        shape.setOptions(new Map(JSON.parse(sh.option)), SyncTo.UI);
+        shape.setOptions(Object.fromEntries(JSON.parse(sh.option)), SyncTo.UI);
     }
 });
 

--- a/client/src/game/client.ts
+++ b/client/src/game/client.ts
@@ -1,0 +1,55 @@
+import { toGP } from "../core/geometry";
+import { InvalidationMode, SyncMode } from "../core/models/types";
+import { uuidv4 } from "../core/utils";
+import { floorStore } from "../store/floor";
+import { UuidMap } from "../store/shapeMap";
+
+import { sendMoveClient } from "./api/emits/client";
+import { LayerName } from "./models/floor";
+import { ServerUserLocationOptions } from "./models/settings";
+import { Rect } from "./shapes/variants/rect";
+
+const playerRectUuids: Map<number, string> = new Map();
+const playerLocationData: Map<number, ServerUserLocationOptions> = new Map();
+
+export function moveClientRect(player: number, data: ServerUserLocationOptions): void {
+    if (!playerRectUuids.has(player)) {
+        playerRectUuids.set(player, uuidv4());
+    }
+    playerLocationData.set(player, data);
+    const uuid = playerRectUuids.get(player)!;
+    const layer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Dm)!;
+    if (!UuidMap.has(uuid)) {
+        const rect = new Rect(toGP(0, 0), 100, 100, {
+            fillColour: "rgba(0, 0, 0, 0)",
+            strokeColour: "rgba(0, 0, 0, 1)",
+            uuid,
+        });
+        rect.options.isPlayerRect = true;
+        rect.preventSync = true;
+        layer.addShape(rect, SyncMode.NO_SYNC, InvalidationMode.NO, false);
+    }
+    const rect = UuidMap.get(uuid)! as Rect;
+    const h = data.client_h / data.zoom_factor;
+    const w = data.client_w / data.zoom_factor;
+    rect.h = h;
+    rect.w = w;
+    rect.center(toGP(w / 2 - data.pan_x, h / 2 - data.pan_y));
+    layer.invalidate(true);
+}
+
+export function moveClient(rectUuid: string): void {
+    const player = [...playerRectUuids.entries()].find(([_, uuid]) => uuid === rectUuid)?.[0] ?? -1;
+    if (player < 0) return;
+    const rect = UuidMap.get(rectUuid)!;
+    if (rect === undefined) return;
+    const playerData = playerLocationData.get(player);
+    if (playerData === undefined) return;
+
+    const h = playerData.client_h / playerData.zoom_factor;
+    const w = playerData.client_w / playerData.zoom_factor;
+
+    const center = rect.center();
+
+    sendMoveClient({ player, data: { ...playerData, pan_x: w / 2 - center.x, pan_y: h / 2 - center.y } });
+}

--- a/client/src/game/client.ts
+++ b/client/src/game/client.ts
@@ -26,6 +26,7 @@ export function moveClientRect(player: number, data: ServerUserLocationOptions):
             uuid,
         });
         rect.options.isPlayerRect = true;
+        rect.options.skipDraw = true;
         rect.preventSync = true;
         layer.addShape(rect, SyncMode.NO_SYNC, InvalidationMode.NO, false);
     }
@@ -52,4 +53,14 @@ export function moveClient(rectUuid: string): void {
     const center = rect.center();
 
     sendMoveClient({ player, data: { ...playerData, pan_x: w / 2 - center.x, pan_y: h / 2 - center.y } });
+}
+
+export function showClientRect(player: number, show: boolean): void {
+    const rectUuid = playerRectUuids.get(player);
+    if (rectUuid === undefined) return;
+    const rect = UuidMap.get(rectUuid)!;
+    if (rect === undefined) return;
+
+    rect.options.skipDraw = !show;
+    rect.layer.invalidate(true);
 }

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -16,14 +16,14 @@ import { FowLayer } from "./fow";
 export class FowLightingLayer extends FowLayer {
     addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, snappable = true): void {
         super.addShape(shape, sync, invalidate, snappable);
-        if (shape.options.has("preFogShape") && (shape.options.get("preFogShape") as boolean)) {
+        if (shape.options.preFogShape ?? false) {
             this.preFogShapes.push(shape);
         }
     }
 
     removeShape(shape: Shape, sync: SyncMode, recalculate: boolean): boolean {
         let idx = -1;
-        if (shape.options.has("preFogShape") && (shape.options.get("preFogShape") as boolean)) {
+        if (shape.options.preFogShape ?? false) {
             idx = this.preFogShapes.findIndex((s) => s.uuid === shape.uuid);
         }
         const remove = super.removeShape(shape, sync, recalculate);
@@ -44,7 +44,7 @@ export class FowLightingLayer extends FowLayer {
             ) {
                 for (const sh of gameStore.activeTokens.value) {
                     const shape = UuidMap.get(sh)!;
-                    if ((shape.options.get("skipDraw") ?? false) === true) continue;
+                    if (shape.options.skipDraw ?? false) continue;
                     if (shape.floor.id !== floorStore.currentFloor.value!.id) continue;
                     const bb = shape.getBoundingBox();
                     const lcenter = g2l(shape.center());

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -118,7 +118,7 @@ export class Layer {
     getShapes(options: { skipUiHelpers?: boolean; includeComposites: boolean }): readonly Shape[] {
         const skipUiHelpers = options.skipUiHelpers ?? true;
         let shapes: readonly Shape[] = skipUiHelpers
-            ? this.shapes.filter((s) => !s.options.has("UiHelper"))
+            ? this.shapes.filter((s) => !(s.options.UiHelper ?? false))
             : this.shapes;
         if (options.includeComposites) {
             shapes = compositeState.addAllCompositeShapes(shapes);
@@ -249,7 +249,7 @@ export class Layer {
 
             // Aura draw loop
             for (const shape of this.shapes) {
-                if (shape.options.has("skipDraw") && (shape.options.get("skipDraw") as boolean)) continue;
+                if (shape.options.skipDraw ?? false) continue;
                 if (!shape.visibleInCanvas(this.canvas, { includeAuras: true })) continue;
                 if (this.name === LayerName.Lighting && currentLayer !== this) continue;
                 drawAuras(shape, ctx);

--- a/client/src/game/models/player.ts
+++ b/client/src/game/models/player.ts
@@ -3,4 +3,5 @@ export interface Player {
     name: string;
     location: number;
     role: number;
+    showRect: boolean;
 }

--- a/client/src/game/models/settings.ts
+++ b/client/src/game/models/settings.ts
@@ -46,6 +46,9 @@ export interface ServerClient {
 export interface ServerUserLocationOptions {
     pan_x: number;
     pan_y: number;
+    client_w: number;
+    client_h: number;
+    zoom_display: number;
     zoom_factor: number;
     active_floor?: string;
     active_layer?: string;

--- a/client/src/game/models/shapes.ts
+++ b/client/src/game/models/shapes.ts
@@ -140,3 +140,16 @@ export const ownerToClient = (owner: ServerShapeOwner): ShapeOwner => ({
     shape: owner.shape,
     access: accessToClient(owner),
 });
+
+export interface ShapeOptions {
+    isPlayerRect: boolean;
+
+    preFogShape: boolean;
+    skipDraw: boolean;
+
+    svgHeight: number;
+    svgPaths: string[];
+    svgWidth: number;
+
+    UiHelper: boolean;
+}

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -49,7 +49,11 @@ export function moveShapes(shapes: readonly Shape[], delta: Vector, temporary: b
         // todo: Fix again
         // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();
         if (!shape.preventSync) updateList.push(shape);
+        if (shape.options.isPlayerRect ?? false) {
+            const x = 2;
+        }
     }
+
     sendShapePositionUpdate(updateList, temporary);
     if (!temporary) addOperation(operationList);
 

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -1,5 +1,6 @@
 import { addP, toArrayP, Vector } from "../../core/geometry";
 import { sendShapePositionUpdate } from "../api/emits/shape/core";
+import { moveClient } from "../client";
 import { Shape } from "../shapes/shape";
 import { TriangulationTarget, visionState } from "../vision/state";
 
@@ -50,7 +51,7 @@ export function moveShapes(shapes: readonly Shape[], delta: Vector, temporary: b
         // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();
         if (!shape.preventSync) updateList.push(shape);
         if (shape.options.isPlayerRect ?? false) {
-            const x = 2;
+            moveClient(shape.uuid);
         }
     }
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -47,7 +47,7 @@ import { Layer } from "../layers/variants/layer";
 import { aurasFromServer, aurasToServer, partialAuraToServer } from "../models/conversion/aura";
 import { partialTrackerToServer, trackersFromServer, trackersToServer } from "../models/conversion/tracker";
 import { Floor, LayerName } from "../models/floor";
-import { accessToServer, ownerToClient, ownerToServer, ServerShape } from "../models/shapes";
+import { accessToServer, ownerToClient, ownerToServer, ServerShape, ShapeOptions } from "../models/shapes";
 import { initiativeStore } from "../ui/initiative/state";
 import { TriangulationTarget, visionState } from "../vision/state";
 
@@ -128,7 +128,7 @@ export abstract class Shape {
     preventSync = false;
 
     // Additional options for specialized uses
-    options: Map<string, any> = new Map();
+    options: Partial<ShapeOptions> = {};
 
     constructor(
         refPoint: GlobalPoint,
@@ -426,7 +426,7 @@ export abstract class Shape {
             is_token: this.isToken,
             is_invisible: this.isInvisible,
             is_defeated: this.isDefeated,
-            options: JSON.stringify([...this.options]),
+            options: JSON.stringify(Object.entries(this.options)),
             badge: this.badge,
             show_badge: this.showBadge,
             is_locked: this.isLocked,
@@ -466,7 +466,7 @@ export abstract class Shape {
             this.annotation = data.annotation;
         }
         this.name = data.name;
-        if (data.options !== undefined) this.options = new Map(JSON.parse(data.options));
+        if (data.options !== undefined) this.options = Object.fromEntries(JSON.parse(data.options));
         if (data.asset !== undefined) this.assetId = data.asset;
         if (data.group !== undefined) this.groupId = data.group;
         // retain reactivity
@@ -642,11 +642,11 @@ export abstract class Shape {
 
     // OPTIONS
 
-    setOptions(options: Map<string, any>, syncTo: SyncTo): void {
+    setOptions(options: Partial<ShapeOptions>, syncTo: SyncTo): void {
         this.options = options;
 
         if (syncTo === SyncTo.SERVER) sendShapeOptionsUpdate([this], false);
-        if (syncTo === SyncTo.UI) this._("setOptions")(Object.fromEntries(this.options), syncTo);
+        if (syncTo === SyncTo.UI) this._("setOptions")(this.options, syncTo);
     }
 
     // ACCESS

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -214,7 +214,7 @@ export function pasteShapes(targetLayer?: LayerName): readonly Shape[] {
         if (shape === undefined) continue;
 
         layer.addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);
-        if (!shape.options.has("skipDraw")) selectionState.push(shape);
+        if (!(shape.options.skipDraw ?? false)) selectionState.push(shape);
     }
 
     layer.invalidate(false);

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -31,7 +31,7 @@ export class ToggleComposite extends Shape {
         },
     ) {
         super(position, options);
-        this.options.set("skipDraw", true);
+        this.options.skipDraw = true;
         for (const variant of _variants) {
             compositeState.addComposite(this.uuid, variant, false);
         }
@@ -113,9 +113,9 @@ export class ToggleComposite extends Shape {
         }
 
         if (sync) {
-            oldVariant.options.set("skipDraw", true);
+            oldVariant.options.skipDraw = true;
             const oldCenter = oldVariant.center();
-            newVariant.options.delete("skipDraw");
+            delete newVariant.options.skipDraw;
             newVariant.center(oldCenter);
 
             sendShapePositionUpdate([newVariant], false);

--- a/client/src/game/svg.ts
+++ b/client/src/game/svg.ts
@@ -15,8 +15,8 @@ export function pathToArray(shape: Asset, path: SVGPathElement): number[][][] {
     const w = shape.w;
     const h = shape.h;
 
-    const dW = w / shape.options.get("svgWidth");
-    const dH = h / shape.options.get("svgHeight");
+    const dW = w / (shape.options.svgWidth ?? 1);
+    const dH = h / (shape.options.svgHeight ?? 1);
 
     for (const seg of pathData) {
         switch (seg.type) {

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -313,8 +313,8 @@ class DrawTool extends Tool {
                 this.shape.fillColour = "rgba(0, 0, 0, 1)";
             }
             if (this.state.selectedMode === DrawMode.Hide || this.state.selectedMode === DrawMode.Reveal) {
-                this.shape.options.set("preFogShape", true);
-                this.shape.options.set("skipDraw", true);
+                this.shape.options.preFogShape = true;
+                this.shape.options.skipDraw = true;
                 this.shape.fillColour = "rgba(0, 0, 0, 1)";
             }
             if (this.state.selectedMode === DrawMode.Reveal) this.shape.globalCompositeOperation = "source-over";
@@ -549,16 +549,16 @@ class DrawTool extends Tool {
     private setupBrush(): void {
         if (this.brushHelper === undefined) return;
         if (this.state.selectedMode === DrawMode.Reveal || this.state.selectedMode === DrawMode.Hide) {
-            this.brushHelper.options.set("preFogShape", true);
-            this.brushHelper.options.set("skipDraw", true);
+            this.brushHelper.options.preFogShape = true;
+            this.brushHelper.options.skipDraw = true;
             this.brushHelper.fillColour = "rgba(0, 0, 0, 1)";
 
             if (this.state.selectedMode === DrawMode.Reveal) this.brushHelper.globalCompositeOperation = "source-over";
             else if (this.state.selectedMode === DrawMode.Hide)
                 this.brushHelper.globalCompositeOperation = "destination-out";
         } else {
-            this.brushHelper.options.delete("preFogShape");
-            this.brushHelper.options.delete("skipDraw");
+            delete this.brushHelper.options.preFogShape;
+            delete this.brushHelper.options.skipDraw;
             this.brushHelper.globalCompositeOperation = "source-over";
             this.brushHelper.fillColour = this.state.fillColour;
         }

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -153,8 +153,7 @@ class SelectTool extends Tool implements ISelectTool {
 
         for (let i = selectionStack.length - 1; i >= 0; i--) {
             const shape = selectionStack[i];
-            if (!shape.options.has("preFogShape") && ((shape.options.get("skipDraw") as boolean | undefined) ?? false))
-                continue;
+            if (!(shape.options.preFogShape ?? false) && (shape.options.skipDraw ?? false)) continue;
             if ([this.rotationAnchor?.uuid, this.rotationBox?.uuid, this.rotationEnd?.uuid].includes(shape.uuid))
                 continue;
             if (shape.isInvisible && !shape.ownedBy(false, { movementAccess: true })) continue;
@@ -244,7 +243,7 @@ class SelectTool extends Tool implements ISelectTool {
                     strokeColour: "#7c253e",
                 });
                 this.selectionHelper.strokeWidth = 2;
-                this.selectionHelper.options.set("UiHelper", "true");
+                this.selectionHelper.options.UiHelper = true;
                 this.selectionHelper.addOwner(
                     { user: clientStore.state.username, access: { edit: true } },
                     SyncTo.SHAPE,
@@ -388,11 +387,7 @@ class SelectTool extends Tool implements ISelectTool {
             }
             const cbbox = this.selectionHelper!.getBoundingBox();
             for (const shape of layer.getShapes({ includeComposites: false })) {
-                if (
-                    !shape.options.has("preFogShape") &&
-                    ((shape.options.get("skipDraw") as boolean | undefined) ?? false)
-                )
-                    continue;
+                if (!(shape.options.preFogShape ?? false) && (shape.options.skipDraw ?? false)) continue;
                 if (!shape.ownedBy(false, { movementAccess: true })) continue;
                 if (!shape.visibleInCanvas(layer.canvas, { includeAuras: false })) continue;
                 if (layerSelection.some((s) => s.uuid === shape.uuid)) continue;

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -37,6 +37,11 @@ export default defineComponent({
             showRefreshState.value = true;
         }
 
+        async function kickPlayer(playerId: number): Promise<void> {
+            const value = await modals.confirm("Kicking player", "Are you sure you wish to kick this player?");
+            if (value === true) gameStore.kickPlayer(playerId);
+        }
+
         function changePlayerRole(event: { target: HTMLSelectElement }, player: number): void {
             const value = event.target.value;
             const role = parseInt(value);
@@ -62,7 +67,7 @@ export default defineComponent({
             t,
 
             players: toRef(gameState, "players"),
-            kickPlayer: (playerId: number) => gameStore.kickPlayer(playerId),
+            kickPlayer,
             changePlayerRole,
             roles,
 

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -50,6 +50,13 @@ export default defineComponent({
             gameStore.setPlayerRole(player, role, true);
         }
 
+        function togglePlayerRect(player: number): void {
+            const p = gameStore.state.players.find((p) => p.id === player)?.showRect;
+            if (p === undefined) return;
+
+            gameStore.setShowPlayerRect(player, !p);
+        }
+
         async function deleteSession(): Promise<void> {
             const value = await modals.prompt(
                 t("game.ui.settings.dm.AdminSettings.delete_session_msg_CREATOR_ROOM", {
@@ -69,6 +76,7 @@ export default defineComponent({
             players: toRef(gameState, "players"),
             kickPlayer,
             changePlayerRole,
+            togglePlayerRect,
             roles,
 
             invitationUrl,
@@ -101,6 +109,13 @@ export default defineComponent({
                         {{ role }}
                     </option>
                 </select>
+                <div
+                    title="Show player viewport"
+                    :style="{ opacity: player.showRect ? 1 : 0.3 }"
+                    @click="togglePlayerRect(player.id)"
+                >
+                    <font-awesome-icon icon="eye" />
+                </div>
                 <div @click="kickPlayer(player.id)" v-t="'game.ui.settings.dm.AdminSettings.kick'"></div>
             </div>
         </div>
@@ -155,6 +170,10 @@ export default defineComponent({
 <style lang="scss" scoped>
 .player-actions {
     display: flex;
+
+    * {
+        margin: 0 10px;
+    }
 
     select {
         margin-right: 20%;

--- a/client/src/game/ui/settings/shape/ExtraSettings.vue
+++ b/client/src/game/ui/settings/shape/ExtraSettings.vue
@@ -14,6 +14,7 @@ import { settingsStore } from "../../../../store/settings";
 import { UuidMap } from "../../../../store/shapeMap";
 import { DDraftData } from "../../../models/ddraft";
 import { LayerName } from "../../../models/floor";
+import { ShapeOptions } from "../../../models/shapes";
 import { Aura } from "../../../shapes/interfaces";
 import { Asset } from "../../../shapes/variants/asset";
 import { Circle } from "../../../shapes/variants/circle";
@@ -87,10 +88,12 @@ export default defineComponent({
                 const path = pathChild.getAttribute("d");
                 if (path !== null) paths.push(path);
             }
-            const options = { ...activeShapeStore.state.options! };
-            options.svgPaths = paths;
-            options.svgWidth = w;
-            options.svgHeight = h;
+            const options: Partial<ShapeOptions> = {
+                ...activeShapeStore.state.options!,
+                svgPaths: paths,
+                svgHeight: h,
+                svgWidth: w,
+            };
             activeShapeStore.setOptions(options, SyncTo.SERVER);
             visionState.recalculateVision(activeShapeStore.floor.value!);
             hasPath.value = true;
@@ -101,7 +104,7 @@ export default defineComponent({
             delete options.svgPaths;
             delete options.svgWidth;
             delete options.svgHeight;
-            activeShapeStore.setOptions(options, SyncTo.SERVER);
+            activeShapeStore.setOptions(options as Omit<ShapeOptions, "svgPaths">, SyncTo.SERVER);
             visionState.recalculateVision(activeShapeStore.floor.value!);
             hasPath.value = false;
         }

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -105,8 +105,8 @@ class VisionState extends Store<State> {
             const shape = UuidMap.get(sh)!;
             if (shape.floor.id !== floor) continue;
 
-            if (shape.type === "assetrect" && shape.options.has("svgPaths")) {
-                for (const pathString of shape.options.get("svgPaths") as string[]) {
+            if (shape.type === "assetrect") {
+                for (const pathString of shape.options.svgPaths ?? []) {
                     const pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
                     pathElement.setAttribute("d", pathString);
                     const paths = pathToArray(shape as Asset, pathElement);

--- a/client/src/store/activeShape.ts
+++ b/client/src/store/activeShape.ts
@@ -4,6 +4,7 @@ import { SyncTo } from "../core/models/types";
 import { Store } from "../core/store";
 import { selectionState } from "../game/layers/selection";
 import { compositeState } from "../game/layers/state";
+import { ShapeOptions } from "../game/models/shapes";
 import { Aura, Label, Tracker } from "../game/shapes/interfaces";
 import { ShapeAccess, ShapeOwner } from "../game/shapes/owners";
 import { Shape } from "../game/shapes/shape";
@@ -41,7 +42,7 @@ interface ActiveShapeState {
     showEditDialog: boolean;
     type: SHAPE_TYPE | undefined;
 
-    options: Record<string, any> | undefined;
+    options: Partial<ShapeOptions> | undefined;
 
     groupId: string | undefined;
 
@@ -172,14 +173,14 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
     // OPTIONS
 
-    setOptions(options: Record<string, any>, syncTo: SyncTo): void {
+    setOptions(options: Partial<ShapeOptions>, syncTo: SyncTo): void {
         if (this._state.uuid === undefined) return;
 
         this._state.options = options;
 
         if (syncTo !== SyncTo.UI) {
             const shape = UuidMap.get(this._state.uuid)!;
-            shape.setOptions(new Map(Object.entries(this._state.options)), SyncTo.SERVER);
+            shape.setOptions(this._state.options, SyncTo.SERVER);
         }
     }
 
@@ -628,7 +629,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
         this._state.parentUuid = parent?.uuid;
         this._state.type = shape.type;
 
-        this._state.options = Object.fromEntries(shape.options);
+        this._state.options = { ...shape.options };
 
         this._state.groupId = shape.groupId;
 

--- a/client/src/store/game.ts
+++ b/client/src/store/game.ts
@@ -11,6 +11,7 @@ import { sendMarkerCreate, sendMarkerRemove } from "../game/api/emits/marker";
 import { sendNewNote, sendRemoveNote, sendUpdateNote } from "../game/api/emits/note";
 import { sendChangePlayerRole } from "../game/api/emits/players";
 import { sendRoomKickPlayer, sendRoomLock } from "../game/api/emits/room";
+import { showClientRect } from "../game/client";
 import { Note } from "../game/models/general";
 import { Player } from "../game/models/player";
 import { ServerShape } from "../game/models/shapes";
@@ -168,8 +169,17 @@ class GameStore extends Store<GameState> {
     setPlayerRole(playerId: number, role: number, sync: boolean): void {
         const player = this._state.players.find((p) => p.id === playerId);
         if (player === undefined) return;
+
         player.role = role;
         if (sync) sendChangePlayerRole({ player: playerId, role });
+    }
+
+    setShowPlayerRect(playerId: number, showPlayerRect: boolean): void {
+        const player = this._state.players.find((p) => p.id === playerId);
+        if (player === undefined) return;
+
+        player.showRect = showPlayerRect;
+        showClientRect(playerId, showPlayerRect);
     }
 
     // ROOM

--- a/client/src/store/shapeMap.ts
+++ b/client/src/store/shapeMap.ts
@@ -1,3 +1,4 @@
 import { Shape } from "../game/shapes/shape";
 
 export const UuidMap: Map<string, Shape> = new Map();
+(window as any).UuidMap = UuidMap;

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -1,19 +1,7 @@
-from typing import Any, Dict
-
-from typing_extensions import TypedDict
-
-import auth
-from api.socket.constants import GAME_NS
-from app import app, sio
-from models import Floor, Layer, LocationUserOption, PlayerRoom
-from models.db import db
-from models.role import Role
-from models.user import UserOptions
-from state.game import game_state
-
 from . import (
     asset,
     asset_manager,
+    client,
     connection,
     floor,
     groups,
@@ -26,95 +14,3 @@ from . import (
     room,
     shape,
 )
-
-# DATA CLASSES FOR TYPE CHECKING
-class LocationOptions(TypedDict):
-    pan_x: int
-    pan_y: int
-    zoom_display: int
-    zoom_factor: int
-    client_w: int
-    client_h: int
-
-
-class ClientOptions(TypedDict, total=False):
-    grid_colour: str
-    fow_colour: str
-    ruler_colour: str
-
-    invert_alt: bool
-    disable_scroll_to_zoom: bool
-
-    use_high_dpi: bool
-    grid_size: int
-    use_as_physical_board: bool
-    mini_size: int
-    ppi: int
-
-    initiative_camera_lock: bool
-    initiative_vision_lock: bool
-    initiative_effect_visibility: int
-
-
-@sio.on("Client.Options.Default.Set", namespace=GAME_NS)
-@auth.login_required(app, sio)
-async def set_client_default_options(sid: str, data: ClientOptions):
-    pr: PlayerRoom = game_state.get(sid)
-
-    UserOptions.update(**data).where(
-        UserOptions.id == pr.player.default_options
-    ).execute()
-
-
-@sio.on("Client.Options.Room.Set", namespace=GAME_NS)
-@auth.login_required(app, sio)
-async def set_client_room_options(sid: str, data: ClientOptions):
-    pr: PlayerRoom = game_state.get(sid)
-
-    with db.atomic():
-        if pr.user_options is None:
-            pr.user_options = UserOptions.create_empty()
-            pr.save()
-
-        UserOptions.update(**data).where(UserOptions.id == pr.user_options).execute()
-
-
-@sio.on("Client.Options.Location.Set", namespace=GAME_NS)
-@auth.login_required(app, sio)
-async def set_client_location_options(sid: str, data: LocationOptions):
-    pr: PlayerRoom = game_state.get(sid)
-
-    LocationUserOption.update(
-        pan_x=data["pan_x"],
-        pan_y=data["pan_y"],
-        zoom_display=data["zoom_display"],
-    ).where(
-        (LocationUserOption.location == pr.active_location)
-        & (LocationUserOption.user == pr.player)
-    ).execute()
-
-    if pr.role != Role.DM:
-        for sid, player in game_state.get_t(skip_sid=sid):
-            if player.role == Role.DM:
-                await sio.emit(
-                    "Player.Move",
-                    {"player": pr.player.id, **data},
-                    room=sid,
-                    namespace=GAME_NS,
-                )
-
-
-@sio.on("Client.ActiveLayer.Set", namespace=GAME_NS)
-@auth.login_required(app, sio)
-async def set_layer(sid: str, data: Dict[str, Any]):
-    pr: PlayerRoom = game_state.get(sid)
-
-    try:
-        floor = pr.active_location.floors.select().where(Floor.name == data["floor"])[0]
-        layer = floor.layers.select().where(Layer.name == data["layer"])[0]
-    except IndexError:
-        pass
-    else:
-        luo = LocationUserOption.get(user=pr.player, location=pr.active_location)
-        luo.active_layer = layer
-        luo.save()

--- a/server/api/socket/client.py
+++ b/server/api/socket/client.py
@@ -1,0 +1,127 @@
+from typing import Any, Dict
+
+from typing_extensions import TypedDict
+
+import auth
+
+from api.socket.constants import GAME_NS
+from app import app, sio
+from models import Floor, Layer, LocationUserOption, PlayerRoom
+from models.db import db
+from models.role import Role
+from models.user import UserOptions
+from state.game import game_state
+
+
+# DATA CLASSES FOR TYPE CHECKING
+class LocationOptions(TypedDict):
+    pan_x: int
+    pan_y: int
+    zoom_display: int
+    zoom_factor: int
+    client_w: int
+    client_h: int
+
+
+class MoveClientData(TypedDict):
+    player: int
+    data: LocationOptions
+
+
+class ClientOptions(TypedDict, total=False):
+    grid_colour: str
+    fow_colour: str
+    ruler_colour: str
+
+    invert_alt: bool
+    disable_scroll_to_zoom: bool
+
+    use_high_dpi: bool
+    grid_size: int
+    use_as_physical_board: bool
+    mini_size: int
+    ppi: int
+
+    initiative_camera_lock: bool
+    initiative_vision_lock: bool
+    initiative_effect_visibility: int
+
+
+@sio.on("Client.Options.Default.Set", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def set_client_default_options(sid: str, data: ClientOptions):
+    pr: PlayerRoom = game_state.get(sid)
+
+    UserOptions.update(**data).where(
+        UserOptions.id == pr.player.default_options
+    ).execute()
+
+
+@sio.on("Client.Options.Room.Set", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def set_client_room_options(sid: str, data: ClientOptions):
+    pr: PlayerRoom = game_state.get(sid)
+
+    with db.atomic():
+        if pr.user_options is None:
+            pr.user_options = UserOptions.create_empty()
+            pr.save()
+
+        UserOptions.update(**data).where(UserOptions.id == pr.user_options).execute()
+
+
+async def update_client_location(
+    player: int, room: int, sid: str, data: LocationOptions
+):
+    pr = PlayerRoom.get(player=player, room=room)
+
+    LocationUserOption.update(
+        pan_x=data["pan_x"],
+        pan_y=data["pan_y"],
+        zoom_display=data["zoom_display"],
+    ).where(
+        (LocationUserOption.location == pr.active_location)
+        & (LocationUserOption.user == pr.player)
+    ).execute()
+
+    if pr.role != Role.DM:
+        for p_sid, p_player in game_state.get_t(skip_sid=sid):
+            if p_player.role == Role.DM or p_player.player.id == player:
+                await sio.emit(
+                    "Client.Move",
+                    {"player": pr.player.id, **data},
+                    room=p_sid,
+                    namespace=GAME_NS,
+                )
+
+
+@sio.on("Client.Options.Location.Set", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def set_client_location_options(sid: str, data: LocationOptions):
+    pr: PlayerRoom = game_state.get(sid)
+
+    await update_client_location(pr.player.id, pr.room.id, sid, data)
+
+
+@sio.on("Client.Move", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def move_client(sid: str, data: MoveClientData):
+    pr: PlayerRoom = game_state.get(sid)
+
+    await update_client_location(data["player"], pr.room.id, sid, data["data"])
+
+
+@sio.on("Client.ActiveLayer.Set", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def set_layer(sid: str, data: Dict[str, Any]):
+    pr: PlayerRoom = game_state.get(sid)
+
+    try:
+        floor = pr.active_location.floors.select().where(Floor.name == data["floor"])[0]
+        layer = floor.layers.select().where(Layer.name == data["layer"])[0]
+    except IndexError:
+        pass
+    else:
+        luo = LocationUserOption.get(user=pr.player, location=pr.active_location)
+        luo.active_layer = layer
+        luo.save()

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -272,7 +272,7 @@ class LocationUserOption(BaseModel):
     user = ForeignKeyField(User, backref="location_options", on_delete="CASCADE")
     pan_x = IntegerField(default=0)
     pan_y = IntegerField(default=0)
-    zoom_factor = FloatField(default=1.0)
+    zoom_display = FloatField(default=1.0)
     active_layer = ForeignKeyField(Layer, backref="active_users", null=True)
 
     def __repr__(self):

--- a/server/state/__init__.py
+++ b/server/state/__init__.py
@@ -38,6 +38,10 @@ class State(ABC, Generic[T]):
             ):
                 yield sid
 
+    def get_t(self, **options) -> Generator[Tuple[str, T], None, None]:
+        for sid in self.get_sids(**options):
+            yield sid, self.get(sid)
+
     def get_users(self, **options) -> Generator[Tuple[str, User], None, None]:
         for sid in self.get_sids(**options):
             yield sid, self.get_user(sid)


### PR DESCRIPTION
This PR adds a new toggle in the DM/Admin settings to show player viewports.

When toggled on for a player, a new rectangle will appear on the DM layer that reflects the current viewport that player has.
You are able to move this rectangle and thus update the user's viewport as a DM.

This is especially useful for cases where you use a second monitor to show player-view.