### PR TITLE
bug(Initiative): Fix type error when a unknown shape is in the list

### DIFF
--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -86,7 +86,7 @@ export default defineComponent({
         }
 
         function hasImage(actor: InitiativeData): boolean {
-            return UuidMap.get(actor.shape)!.type === "assetrect";
+            return UuidMap.get(actor.shape)?.type === "assetrect" ?? false;
         }
 
         function getImage(actor: InitiativeData): string {


### PR DESCRIPTION
This PR fixes the initiative window showing a type error if any of the shapes in the list is unknown to the viewer.

This can occur because
- The shape actually no longer exists (e.g. it was removed)
- The shape is moved to the DM Layer

In the first case everyone sees the error, in the latter only the players