### PR TITLE
feat(Shape): Add editable text value for circulartoken and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These usually have no immediately visible impact on regular users
 -   Physical (mini) grid size
     -   Indicate grid size in function of mini dimensions and PPI
     -   Disables zoom tool when enabled
+-   Ability to edit the text value for CircularTokens and Text objects from the property settings
 -   [DM] Added ability to copy a location into another game session.
 -   [DM] The asset menu bar in-game now automatically live updates when changes are done in the asset manager
 -   [DM] Player viewport info

--- a/client/src/game/api/emits/shape/circularToken.ts
+++ b/client/src/game/api/emits/shape/circularToken.ts
@@ -1,0 +1,5 @@
+import { wrapSocket } from "../../helpers";
+
+export const sendCircularTokenUpdate = wrapSocket<{ uuid: string; text: string; temporary: boolean }>(
+    "Shape.CircularToken.Value.Set",
+);

--- a/client/src/game/api/emits/shape/core.ts
+++ b/client/src/game/api/emits/shape/core.ts
@@ -17,7 +17,6 @@ export const sendShapesMove =
         shapes: string[];
         target: { location: number; floor: string; x: number; y: number };
     }>("Shapes.Location.Move");
-export const sendTextUpdate = wrapSocket<{ uuid: string; text: string; temporary: boolean }>("Shape.Text.Value.Set");
 
 export function sendShapeOptionsUpdate(shapes: readonly Shape[], temporary: boolean): void {
     const options = shapes

--- a/client/src/game/api/emits/shape/text.ts
+++ b/client/src/game/api/emits/shape/text.ts
@@ -1,0 +1,3 @@
+import { wrapSocket } from "../../helpers";
+
+export const sendTextUpdate = wrapSocket<{ uuid: string; text: string; temporary: boolean }>("Shape.Text.Value.Set");

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -7,8 +7,10 @@ import "./events/location";
 import "./events/notification";
 import "./events/player";
 import "./events/room";
+import "./events/shape/circularToken";
 import "./events/shape/core";
 import "./events/shape/options";
+import "./events/shape/text";
 import "./events/shape/togglecomposite";
 
 import { toGP } from "../../core/geometry";

--- a/client/src/game/api/events/shape/circularToken.ts
+++ b/client/src/game/api/events/shape/circularToken.ts
@@ -1,0 +1,11 @@
+import { UuidMap } from "../../../../store/shapeMap";
+import { CircularToken } from "../../../shapes/variants/circularToken";
+import { socket } from "../../socket";
+
+socket.on("Shape.CircularToken.Value.Set", (data: { uuid: string; text: string }) => {
+    const shape = UuidMap.get(data.uuid) as CircularToken | undefined;
+    if (shape === undefined) return;
+
+    shape.text = data.text;
+    shape.layer.invalidate(true);
+});

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -7,7 +7,6 @@ import { Shape } from "../../../shapes/shape";
 import { deleteShapes } from "../../../shapes/utils";
 import { Circle } from "../../../shapes/variants/circle";
 import { Rect } from "../../../shapes/variants/rect";
-import { Text } from "../../../shapes/variants/text";
 import { addShape, moveFloor, moveLayer } from "../../../temp";
 import { socket } from "../../socket";
 
@@ -76,14 +75,6 @@ socket.on("Shapes.Layer.Change", (data: { uuids: string[]; floor: string; layer:
     const shapes = data.uuids.map((u) => UuidMap.get(u) ?? undefined).filter((s) => s !== undefined) as Shape[];
     if (shapes.length === 0) return;
     moveLayer(shapes, floorStore.getLayer(floorStore.getFloor({ name: data.floor })!, data.layer)!, false);
-});
-
-socket.on("Shape.Text.Value.Set", (data: { uuid: string; text: string }) => {
-    const shape = UuidMap.get(data.uuid) as Text | undefined;
-    if (shape === undefined) return;
-
-    shape.text = data.text;
-    shape.layer.invalidate(true);
 });
 
 socket.on("Shape.Rect.Size.Update", (data: { uuid: string; w: number; h: number }) => {

--- a/client/src/game/api/events/shape/text.ts
+++ b/client/src/game/api/events/shape/text.ts
@@ -1,0 +1,11 @@
+import { UuidMap } from "../../../../store/shapeMap";
+import { Text } from "../../../shapes/variants/text";
+import { socket } from "../../socket";
+
+socket.on("Shape.Text.Value.Set", (data: { uuid: string; text: string }) => {
+    const shape = UuidMap.get(data.uuid) as Text | undefined;
+    if (shape === undefined) return;
+
+    shape.text = data.text;
+    shape.layer.invalidate(true);
+});

--- a/client/src/game/shapes/variants/circularToken.ts
+++ b/client/src/game/shapes/variants/circularToken.ts
@@ -2,8 +2,10 @@ import * as tinycolor from "tinycolor2";
 
 import { g2l, g2lz } from "../../../core/conversions";
 import { GlobalPoint } from "../../../core/geometry";
+import { SyncMode } from "../../../core/models/types";
 import { calcFontScale } from "../../../core/utils";
 import { clientStore } from "../../../store/client";
+import { sendCircularTokenUpdate } from "../../api/emits/shape/circularToken";
 import { ServerCircularToken } from "../../models/shapes";
 import { SHAPE_TYPE } from "../types";
 
@@ -29,6 +31,7 @@ export class CircularToken extends Circle {
         this.font = font;
         this.name = this.text;
     }
+
     asDict(): ServerCircularToken {
         return Object.assign(this.getBaseDict(), {
             radius: this.r,
@@ -37,6 +40,7 @@ export class CircularToken extends Circle {
             font: this.font,
         });
     }
+
     fromDict(data: ServerCircularToken): void {
         super.fromDict(data);
         this.r = data.radius;
@@ -44,6 +48,7 @@ export class CircularToken extends Circle {
         this.text = data.text;
         this.font = data.font;
     }
+
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
 
@@ -61,5 +66,12 @@ export class CircularToken extends Circle {
         ctx.fillText(this.text, 0, 0);
 
         super.drawPost(ctx);
+    }
+
+    setText(text: string, sync: SyncMode): void {
+        this.text = text;
+        if (sync !== SyncMode.NO_SYNC) {
+            sendCircularTokenUpdate({ uuid: this.uuid, text, temporary: sync === SyncMode.TEMP_SYNC });
+        }
     }
 }

--- a/client/src/game/shapes/variants/text.ts
+++ b/client/src/game/shapes/variants/text.ts
@@ -1,6 +1,8 @@
 import { g2lz, l2gz } from "../../../core/conversions";
 import { addP, GlobalPoint, toGP, Vector } from "../../../core/geometry";
 import { rotateAroundPoint } from "../../../core/math";
+import { SyncMode } from "../../../core/models/types";
+import { sendTextUpdate } from "../../api/emits/shape/text";
 import { ServerText } from "../../models/shapes";
 import { Shape } from "../shape";
 import { SHAPE_TYPE } from "../types";
@@ -177,5 +179,12 @@ export class Text extends Shape {
             y += lineHeight;
         }
         return allLines;
+    }
+
+    setText(text: string, sync: SyncMode): void {
+        this.text = text;
+        if (sync !== SyncMode.NO_SYNC) {
+            sendTextUpdate({ uuid: this.uuid, text, temporary: sync === SyncMode.TEMP_SYNC });
+        }
     }
 }

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -8,7 +8,7 @@ import { i18n } from "../../../i18n";
 import { clientStore, DEFAULT_GRID_SIZE } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
 import { settingsStore } from "../../../store/settings";
-import { sendShapePositionUpdate, sendTextUpdate } from "../../api/emits/shape/core";
+import { sendShapePositionUpdate } from "../../api/emits/shape/core";
 import { LayerName } from "../../models/floor";
 import { ToolFeatures, ToolName, ToolPermission } from "../../models/tools";
 import { Line } from "../../shapes/variants/line";
@@ -122,9 +122,8 @@ class RulerTool extends Tool {
         const xmid = Math.min(start.x, end.x) + xdiff / 2;
         const ymid = Math.min(start.y, end.y) + ydiff / 2;
         this.text.refPoint = toGP(xmid, ymid);
-        this.text.text = label;
+        this.text.setText(label, SyncMode.TEMP_SYNC);
         this.text.angle = angle;
-        sendTextUpdate({ uuid: this.text.uuid, text: this.text.text, temporary: true });
         sendShapePositionUpdate([this.text], true);
         layer.invalidate(true);
     }

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -203,9 +203,6 @@ class InitiativeStore extends Store<InitiativeState> {
         if (effect === undefined) effect = getDefaultEffect();
         actor.effects.push(effect);
 
-        console.log(this._state.locationData[0].effects);
-        console.log(this._state.newData[0].effects);
-        console.log(this._state.locationData[0].effects === this._state.newData[0].effects);
         if (sync) sendInitiativeNewEffect({ actor: actor.shape, effect });
     }
 

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -375,6 +375,25 @@ async def move_shapes(sid: str, data: ServerShapeLocationMove):
         )
 
 
+@sio.on("Shape.CircularToken.Value.Set", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def set_circular_token_value(sid: str, data: TextUpdateData):
+    pr: PlayerRoom = game_state.get(sid)
+
+    if not data["temporary"]:
+        shape: CircularToken = CircularToken.get_by_id(data["uuid"])
+        shape.text = data["text"]
+        shape.save()
+
+    await sio.emit(
+        "Shape.CircularToken.Value.Set",
+        data,
+        room=pr.active_location.get_path(),
+        skip_sid=sid,
+        namespace=GAME_NS,
+    )
+
+
 @sio.on("Shape.Text.Value.Set", namespace=GAME_NS)
 @auth.login_required(app, sio)
 async def set_text_value(sid: str, data: TextUpdateData):


### PR DESCRIPTION
The Circular token (basic token) and text objects their text value cannot be changed after creation. This PR changes this and adds an extra "value" field to the property settings of these shapes.

This fixes #715 