### PR TITLE
bug(Grid): Prevent unitSize < 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ These usually have no immediately visible impact on regular users
 -   [DM] Co-DM not seeing private initiatives
 -   [DM] Removing last floor giving a blank screen
 -   [DM] Removing floors below the active floor giving a blank screen
+-   [DM] Setting a value < 1 for unitSize was possible
 -   [tech] Building docker image on ARM
 
 ## [0.26.1] - 2021-03-15

--- a/client/src/game/ui/settings/location/GridSettings.vue
+++ b/client/src/game/ui/settings/location/GridSettings.vue
@@ -45,7 +45,7 @@ export default defineComponent({
                 return settingsStore.getLocationOptions("unitSize", location.value);
             },
             set(unitSize: number) {
-                settingsStore.setUnitSize(unitSize, location.value, true);
+                if (unitSize >= 1) settingsStore.setUnitSize(unitSize, location.value, true);
             },
         });
 


### PR DESCRIPTION
This prevents the possibility of setting the unit size of the grid to be smaller than 1, which causes multiple drawing errors.
This fixes #776 