### PR TITLE
bug(DM-Settings): Prevent Co-DM removing main DM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These usually have no immediately visible impact on regular users
 
 -   Draw helper now has a contrast border
 -   Initiative can now be advanced by the active player
+-   Co-DMs can no longer strip DM status of the campaign creator
 -   [tech] Moved from vue-cli to vite
     -   this greatly improves dev and build speed
     -   main dev script is now `npm run dev`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ These usually have no immediately visible impact on regular users
 
 -   Draw helper now has a contrast border
 -   Initiative can now be advanced by the active player
--   Co-DMs can no longer strip DM status of the campaign creator
 -   [tech] Moved from vue-cli to vite
     -   this greatly improves dev and build speed
     -   main dev script is now `npm run dev`
@@ -28,6 +27,8 @@ These usually have no immediately visible impact on regular users
     -   Show cursor:pointer on slider hover
 -   Draw tool cursor not immediately changing on colour change
 -   Initiative reordering with unset values would throw error
+-   Co-DMs can no longer strip DM status of the campaign creator
+-   Co-DMs can no longer kick the campaign creator
 
 ## [0.27.0] - 2021-06-02
 

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -1,10 +1,11 @@
 <script lang="ts">
 import { computed, defineComponent, ref, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 
 import InputCopyElement from "../../../../core/components/InputCopyElement.vue";
 import { useModal } from "../../../../core/plugins/modals/plugin";
+import { coreStore } from "../../../../store/core";
 import { gameStore } from "../../../../store/game";
 import { sendDeleteRoom, sendRefreshInviteCode } from "../../../api/emits/room";
 import { getRoles } from "../../../models/role";
@@ -14,6 +15,7 @@ export default defineComponent({
     setup() {
         const { t } = useI18n();
         const modals = useModal();
+        const route = useRoute();
         const router = useRouter();
 
         const gameState = gameStore.state;
@@ -30,6 +32,9 @@ export default defineComponent({
         const invitationUrl = computed(
             () => `${window.location.protocol}//${gameState.publicName}/invite/${gameState.invitationCode}`,
         );
+
+        const creator = computed(() => route.params.creator);
+        const username = toRef(coreStore.state, "username");
 
         function refreshInviteCode(): void {
             sendRefreshInviteCode();
@@ -74,6 +79,8 @@ export default defineComponent({
             t,
 
             players: toRef(gameState, "players"),
+            creator,
+            username,
             kickPlayer,
             changePlayerRole,
             togglePlayerRect,
@@ -99,7 +106,10 @@ export default defineComponent({
         <div class="row smallrow" v-for="player of players" :key="player.id">
             <div>{{ player.name }}</div>
             <div class="player-actions">
-                <select @change="changePlayerRole($event, player.id)">
+                <select
+                    @change="changePlayerRole($event, player.id)"
+                    :disabled="username !== creator && player.name === creator"
+                >
                     <option
                         v-for="[i, role] of roles.entries()"
                         :key="'role-' + i + '-' + player.id"

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -126,7 +126,11 @@ export default defineComponent({
                 >
                     <font-awesome-icon icon="eye" />
                 </div>
-                <div @click="kickPlayer(player.id)" v-t="'game.ui.settings.dm.AdminSettings.kick'"></div>
+                <div
+                    @click="kickPlayer(player.id)"
+                    v-t="'game.ui.settings.dm.AdminSettings.kick'"
+                    :style="{ opacity: username !== creator && player.name === creator ? 0.3 : 1.0 }"
+                ></div>
             </div>
         </div>
         <div class="row smallrow" v-if="players.length === 0">

--- a/client/src/store/game.ts
+++ b/client/src/store/game.ts
@@ -164,6 +164,13 @@ class GameStore extends Store<GameState> {
     }
 
     kickPlayer(playerId: number): void {
+        const player = this._state.players.find((p) => p.id === playerId);
+        if (player === undefined) return;
+
+        if (player.name === router.currentRoute.value.params.creator && coreStore.state.username !== player.name) {
+            return;
+        }
+
         sendRoomKickPlayer(playerId);
         this._state.players = this._state.players.filter((p) => p.id !== playerId);
     }

--- a/client/src/store/game.ts
+++ b/client/src/store/game.ts
@@ -17,7 +17,9 @@ import { Player } from "../game/models/player";
 import { ServerShape } from "../game/models/shapes";
 import { setCenterPosition } from "../game/position";
 import { Label } from "../game/shapes/interfaces";
+import { router } from "../router";
 
+import { coreStore } from "./core";
 import { floorStore } from "./floor";
 import { UuidMap } from "./shapeMap";
 
@@ -169,6 +171,10 @@ class GameStore extends Store<GameState> {
     setPlayerRole(playerId: number, role: number, sync: boolean): void {
         const player = this._state.players.find((p) => p.id === playerId);
         if (player === undefined) return;
+
+        if (player.name === router.currentRoute.value.params.creator && coreStore.state.username !== player.name) {
+            return;
+        }
 
         player.role = role;
         if (sync) sendChangePlayerRole({ player: playerId, role });

--- a/server/api/socket/player.py
+++ b/server/api/socket/player.py
@@ -5,6 +5,7 @@ from api.socket.constants import GAME_NS
 from app import app, sio
 from models import PlayerRoom
 from models.role import Role
+from models.user import User
 from state.game import game_state
 from utils import logger
 
@@ -51,6 +52,14 @@ async def set_player_role(sid: str, data: PlayerRoleChange):
     new_role = Role(data["role"])
 
     player_pr: PlayerRoom = PlayerRoom.get(player=data["player"], room=pr.room)
+    creator: User = player_pr.room.creator
+
+    if pr.player != creator and creator == player_pr.player:
+        logger.warning(
+            f"{pr.player.name} attempted to change the role of the campaign creator"
+        )
+        return
+
     player_pr.role = new_role
     player_pr.save()
 


### PR DESCRIPTION
This PR fixes #712, and prevents Co-DMs from downgrading the DM's role or kicking them.