### PR TITLE
feat(Floor): Tileable floor backgrounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ server/oldsaves
 .venv
 venv/
 env/
+server/.python-version
 
 # PyInstaller
 server/dist/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ These usually have no immediately visible impact on regular users
 
 ### Added
 
--   Configure background colors for floors (map layer)
+-   Configure background for floors (map layer)
     -   Can be configured on a campaign/location or individual floor level
+    -   Can be set to "empty", "simple colour" or a repeated asset
 
 ### Changed
 

--- a/client/src/game/layers/floor.ts
+++ b/client/src/game/layers/floor.ts
@@ -1,4 +1,5 @@
 import { floorStore } from "../../store/floor";
+import { BackgroundPattern } from "../models/floor";
 
 export function recalculateZIndices(): void {
     let i = 0;
@@ -8,4 +9,23 @@ export function recalculateZIndices(): void {
             i += 1;
         }
     }
+}
+
+export function getPattern(pattern: string): BackgroundPattern | undefined {
+    const regex = /pattern\(([a-zA-Z0-9-_]+),([\d.]+),([\d.]+).([\d.]+).([\d.]+)\)/;
+    const output = pattern.match(regex);
+    if (output === null || output[0] === "") {
+        return undefined;
+    }
+    return {
+        hash: output[1],
+        offsetX: Number.parseFloat(output[2]),
+        offsetY: Number.parseFloat(output[3]),
+        scaleX: Number.parseFloat(output[4]),
+        scaleY: Number.parseFloat(output[5]),
+    };
+}
+
+export function patternToString(pattern: BackgroundPattern): string {
+    return `pattern(${pattern.hash},${pattern.offsetX},${pattern.offsetY},${pattern.scaleX},${pattern.scaleY})`;
 }

--- a/client/src/game/layers/variants/map.ts
+++ b/client/src/game/layers/variants/map.ts
@@ -1,8 +1,13 @@
+import { baseAdjust } from "../../../core/utils";
+import { clientStore } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
 import { settingsStore } from "../../../store/settings";
 import { FloorType } from "../../models/floor";
+import { getPattern } from "../floor";
 
 import { Layer } from "./layer";
+
+const patternImages: Record<string, HTMLImageElement> = {};
 
 export class MapLayer extends Layer {
     draw(_doClear?: boolean): void {
@@ -11,7 +16,7 @@ export class MapLayer extends Layer {
 
             const floor = floorStore.getFloor({ id: this.floor });
 
-            let background: string | null = null;
+            let background: string | CanvasPattern | null = null;
 
             if (floor?.backgroundValue === undefined) {
                 if (floor?.type === FloorType.Air) {
@@ -21,8 +26,31 @@ export class MapLayer extends Layer {
                 } else {
                     background = settingsStore.undergroundMapBackground.value;
                 }
-            } else {
+            } else if (floor?.backgroundValue.startsWith("rgb")) {
                 background = floor.backgroundValue;
+            } else if (floor?.backgroundValue.startsWith("pattern")) {
+                const patternData = getPattern(floor?.backgroundValue);
+                if (patternData !== undefined) {
+                    const hash = patternData.hash;
+                    const patternImage = patternImages[hash];
+                    if (patternImage === undefined) {
+                        const img = new Image();
+                        patternImages[hash] = img;
+                        img.src = baseAdjust("/static/assets/" + hash);
+                        img.onload = () => {
+                            this.invalidate(true);
+                        };
+                    } else if (patternImage.loading) {
+                        const pattern = this.ctx.createPattern(patternImage, "repeat");
+                        const panX = (patternData.offsetX + clientStore.state.panX) * clientStore.zoomFactor.value;
+                        const panY = (patternData.offsetY + clientStore.state.panY) * clientStore.zoomFactor.value;
+                        const scaleX = patternData.scaleX * clientStore.zoomFactor.value;
+                        const scaleY = patternData.scaleY * clientStore.zoomFactor.value;
+
+                        pattern?.setTransform(new DOMMatrix([scaleX, 0, 0, scaleY, panX, panY]));
+                        background = pattern;
+                    }
+                }
             }
 
             if (background !== null && background !== "none") {

--- a/client/src/game/layers/variants/map.ts
+++ b/client/src/game/layers/variants/map.ts
@@ -16,25 +16,30 @@ export class MapLayer extends Layer {
 
             const floor = floorStore.getFloor({ id: this.floor });
 
-            let background: string | CanvasPattern | null = null;
-
-            if (floor?.backgroundValue === undefined) {
+            let floorBackground = floor?.backgroundValue;
+            if (floorBackground === undefined) {
                 if (floor?.type === FloorType.Air) {
-                    background = settingsStore.airMapBackground.value;
+                    floorBackground = settingsStore.airMapBackground.value ?? undefined;
                 } else if (floor?.type === FloorType.Ground) {
-                    background = settingsStore.groundMapBackground.value;
+                    floorBackground = settingsStore.groundMapBackground.value ?? undefined;
                 } else {
-                    background = settingsStore.undergroundMapBackground.value;
+                    floorBackground = settingsStore.undergroundMapBackground.value ?? undefined;
                 }
-            } else if (floor?.backgroundValue.startsWith("rgb")) {
-                background = floor.backgroundValue;
-            } else if (floor?.backgroundValue.startsWith("pattern")) {
-                background = this.getPatternBackground(floor.backgroundValue);
             }
 
-            if (background !== null && background !== "none") {
-                this.ctx.fillStyle = background;
-                this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+            if (floorBackground !== undefined && floorBackground !== "none") {
+                let background: string | CanvasPattern | null = null;
+
+                if (floorBackground.startsWith("rgb")) {
+                    background = floorBackground;
+                } else if (floorBackground.startsWith("pattern")) {
+                    background = this.getPatternBackground(floorBackground);
+                }
+
+                if (background !== null) {
+                    this.ctx.fillStyle = background;
+                    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+                }
             }
 
             super.draw(false);

--- a/client/src/game/models/floor.ts
+++ b/client/src/game/models/floor.ts
@@ -29,16 +29,30 @@ export function getFloorTypes(): string[] {
 export enum BackgroundType {
     None,
     Simple,
+    Pattern,
 }
 
 export function getBackgroundTypes(): string[] {
-    return ["None", "Simple"];
+    return ["None", "Simple", "Pattern"];
 }
 
 export function getBackgroundTypeFromString(background: string | null): BackgroundType {
     if (background === null || background === "none") {
         return BackgroundType.None;
-    } else {
+    } else if (background.startsWith("rgb")) {
         return BackgroundType.Simple;
+    } else if (background.startsWith("pattern")) {
+        return BackgroundType.Pattern;
+    } else {
+        console.warn("Unknown background type ", background);
+        return BackgroundType.None;
     }
+}
+
+export interface BackgroundPattern {
+    hash: string;
+    offsetX: number;
+    offsetY: number;
+    scaleX: number;
+    scaleY: number;
 }

--- a/client/src/game/ui/settings/FloorSettings.vue
+++ b/client/src/game/ui/settings/FloorSettings.vue
@@ -18,6 +18,8 @@ import {
     getFloorTypes,
 } from "../../models/floor";
 
+import PatternSettings from "./floor/PatternSettings.vue";
+
 const { t } = useI18n();
 const modals = useModal();
 
@@ -98,41 +100,9 @@ function resetBackground(): void {
     floorStore.setFloorBackground({ id: floor.value.id }, undefined, true);
 }
 
-async function setPattern(): Promise<void> {
+function setPatternData(data: string): void {
     if (floor.value === undefined) return;
-
-    const data = await modals.assetPicker();
-    if (data === undefined || data.file_hash === undefined) return;
-
-    floorStore.setFloorBackground({ id: floor.value.id }, `pattern(${data.file_hash},0,0,1,1)`, true);
-}
-
-const backgroundPattern = computed(() => {
-    const background = floor.value?.backgroundValue ?? defaultBackground.value;
-    const defaultPattern = {
-        hash: "",
-        offsetX: 0,
-        offsetY: 0,
-        scaleX: 0,
-        scaleY: 0,
-    };
-    if (background === null) return defaultPattern;
-
-    return getPattern(background) ?? defaultPattern;
-});
-
-function setPatternData(data: { offsetX?: Event; offsetY?: Event; scaleX?: Event; scaleY?: Event }): void {
-    if (floor.value === undefined) return;
-
-    const pattern = backgroundPattern.value;
-    const offsetX = data.offsetX ? Number.parseInt(getValue(data.offsetX)) : pattern.offsetX;
-    const offsetY = data.offsetY ? Number.parseInt(getValue(data.offsetY)) : pattern.offsetY;
-    const scaleX = data.scaleX ? Number.parseInt(getValue(data.scaleX)) / 100 : pattern.scaleX;
-    const scaleY = data.scaleY ? Number.parseInt(getValue(data.scaleY)) / 100 : pattern.scaleY;
-
-    const newPattern = { ...pattern, offsetX, offsetY, scaleX, scaleY };
-
-    floorStore.setFloorBackground({ id: floor.value.id }, patternToString(newPattern), true);
+    floorStore.setFloorBackground({ id: floor.value.id }, data, true);
 }
 </script>
 
@@ -194,48 +164,10 @@ function setPatternData(data: { offsetX?: Event; offsetY?: Event; scaleX?: Event
             </template>
 
             <template v-if="backgroundType === BackgroundType.Pattern">
-                <div>Pattern</div>
-                <div>
-                    <img
-                        alt="Pattern image preview"
-                        :src="baseAdjust('/static/assets/' + backgroundPattern.hash)"
-                        class="pattern-preview"
-                    />
-                    <font-awesome-icon id="set-pattern" icon="plus-square" title="Set a pattern" @click="setPattern" />
-                </div>
-                <div></div>
-
-                <div>Offset</div>
-                <div>
-                    <input
-                        type="number"
-                        :value="backgroundPattern.offsetX"
-                        @change="setPatternData({ offsetX: $event })"
-                    />
-                    <input
-                        type="number"
-                        :value="backgroundPattern.offsetY"
-                        @change="setPatternData({ offsetY: $event })"
-                    />
-                </div>
-                <div></div>
-
-                <div>Scale</div>
-                <div>
-                    <input
-                        type="number"
-                        min="1"
-                        :value="100 * backgroundPattern.scaleX"
-                        @change="setPatternData({ scaleX: $event })"
-                    />
-                    <input
-                        type="number"
-                        min="1"
-                        :value="100 * backgroundPattern.scaleY"
-                        @change="setPatternData({ scaleY: $event })"
-                    />
-                </div>
-                <div></div>
+                <PatternSettings
+                    :pattern="floor?.backgroundValue ?? defaultBackground ?? ''"
+                    @update:pattern="setPatternData"
+                />
             </template>
 
             <div></div>
@@ -279,10 +211,5 @@ function setPatternData(data: { offsetX?: Event; offsetY?: Event; scaleX?: Event
 .modal-body .row.overwritten * {
     color: #7c253e;
     font-weight: bold;
-}
-
-.pattern-preview {
-    max-width: 100px;
-    max-height: 100px;
 }
 </style>

--- a/client/src/game/ui/settings/FloorSettings.vue
+++ b/client/src/game/ui/settings/FloorSettings.vue
@@ -77,7 +77,7 @@ function setBackgroundType(event: Event): void {
     const type = Number.parseInt((event.target as HTMLSelectElement).value);
     let value: string | undefined;
     if (type === 0) {
-        value = "rgba(0, 0, 0, 0)";
+        value = "none";
     } else {
         value = "rgba(255, 255, 255, 1)";
     }

--- a/client/src/game/ui/settings/FloorSettings.vue
+++ b/client/src/game/ui/settings/FloorSettings.vue
@@ -196,7 +196,11 @@ function setPatternData(data: { offsetX?: Event; offsetY?: Event; scaleX?: Event
             <template v-if="backgroundType === BackgroundType.Pattern">
                 <div>Pattern</div>
                 <div>
-                    <img :src="baseAdjust('/static/assets/' + backgroundPattern.hash)" class="pattern-preview" />
+                    <img
+                        alt="Pattern image preview"
+                        :src="baseAdjust('/static/assets/' + backgroundPattern.hash)"
+                        class="pattern-preview"
+                    />
                     <font-awesome-icon id="set-pattern" icon="plus-square" title="Set a pattern" @click="setPattern" />
                 </div>
                 <div></div>

--- a/client/src/game/ui/settings/FloorSettings.vue
+++ b/client/src/game/ui/settings/FloorSettings.vue
@@ -5,11 +5,9 @@ import { useI18n } from "vue-i18n";
 import ColourPicker from "../../../core/components/ColourPicker.vue";
 import Modal from "../../../core/components/modals/Modal.vue";
 import { useModal } from "../../../core/plugins/modals/plugin";
-import { baseAdjust, getValue } from "../../../core/utils";
 import { floorStore } from "../../../store/floor";
 import { settingsStore } from "../../../store/settings";
 import { uiStore } from "../../../store/ui";
-import { getPattern, patternToString } from "../../layers/floor";
 import {
     BackgroundType,
     FloorType,

--- a/client/src/game/ui/settings/floor/PatternSettings.vue
+++ b/client/src/game/ui/settings/floor/PatternSettings.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { computed, defineEmit, defineProps } from "vue";
+
+import { useModal } from "../../../../core/plugins/modals/plugin";
+import { baseAdjust, getValue } from "../../../../core/utils";
+import { getPattern, patternToString } from "../../../layers/floor";
+import type { BackgroundPattern } from "../../../models/floor";
+
+const props = defineProps({ pattern: { type: String, required: true } });
+const emit = defineEmit({ "update:pattern": (_: string) => true });
+
+const modals = useModal();
+
+const defaultPattern: BackgroundPattern = {
+    hash: "",
+    offsetX: 0,
+    offsetY: 0,
+    scaleX: 1,
+    scaleY: 1,
+};
+
+const backgroundPattern = computed(() => getPattern(props.pattern) ?? defaultPattern);
+
+async function setPatternImage(): Promise<void> {
+    const data = await modals.assetPicker();
+    if (data === undefined || data.file_hash === undefined) return;
+
+    emit("update:pattern", patternToString({ ...backgroundPattern.value, hash: data.file_hash }));
+}
+
+function setPatternData(data: { offsetX?: Event; offsetY?: Event; scaleX?: Event; scaleY?: Event }): void {
+    const pattern = backgroundPattern.value;
+    const offsetX = data.offsetX ? Number.parseInt(getValue(data.offsetX)) : pattern.offsetX;
+    const offsetY = data.offsetY ? Number.parseInt(getValue(data.offsetY)) : pattern.offsetY;
+    const scaleX = data.scaleX ? Number.parseInt(getValue(data.scaleX)) / 100 : pattern.scaleX;
+    const scaleY = data.scaleY ? Number.parseInt(getValue(data.scaleY)) / 100 : pattern.scaleY;
+
+    const newPattern = { ...pattern, offsetX, offsetY, scaleX, scaleY };
+
+    emit("update:pattern", patternToString(newPattern));
+}
+</script>
+
+<template>
+    <div>Pattern</div>
+    <div>
+        <img
+            v-if="backgroundPattern.hash !== ''"
+            alt="Pattern image preview"
+            :src="baseAdjust('/static/assets/' + backgroundPattern.hash)"
+            class="pattern-preview"
+        />
+        <font-awesome-icon id="set-pattern" icon="plus-square" title="Set a pattern" @click="setPatternImage" />
+    </div>
+    <div></div>
+
+    <div>Offset</div>
+    <div>
+        <input type="number" :value="backgroundPattern.offsetX" @change="setPatternData({ offsetX: $event })" />
+        <input type="number" :value="backgroundPattern.offsetY" @change="setPatternData({ offsetY: $event })" />
+    </div>
+    <div></div>
+
+    <div>Scale</div>
+    <div>
+        <input
+            type="number"
+            min="1"
+            :value="100 * backgroundPattern.scaleX"
+            @change="setPatternData({ scaleX: $event })"
+        />
+        <input
+            type="number"
+            min="1"
+            :value="100 * backgroundPattern.scaleY"
+            @change="setPatternData({ scaleY: $event })"
+        />
+    </div>
+    <div></div>
+</template>
+
+<style scoped lang="scss">
+.pattern-preview {
+    max-width: 100px;
+    max-height: 100px;
+}
+</style>

--- a/client/src/game/ui/settings/location/FloorSettings.vue
+++ b/client/src/game/ui/settings/location/FloorSettings.vue
@@ -3,9 +3,10 @@ import { computed, defineProps, ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../../core/components/ColourPicker.vue";
-import { BackgroundType, getBackgroundTypes } from "../../../../game/models/floor";
+import { BackgroundType, getBackgroundTypeFromString, getBackgroundTypes } from "../../../../game/models/floor";
 import { settingsStore } from "../../../../store/settings";
 import type { LocationOptions } from "../../../models/settings";
+import PatternSettings from "../floor/PatternSettings.vue";
 
 const { t } = useI18n();
 
@@ -23,8 +24,15 @@ const options = computed(() => {
 
 const location = computed(() => (isGlobal.value ? undefined : props.location));
 
-function getBackgroundValueFromType(type: BackgroundType, val: string | null | undefined): string | null {
-    return type === BackgroundType.None ? "none" : val ?? "rgba(255, 255, 255, 1)";
+function getBackgroundValueFromType(type: BackgroundType): string | null {
+    switch (type) {
+        case BackgroundType.Simple:
+            return "rgba(255, 255, 255, 1)";
+        case BackgroundType.Pattern:
+            return "pattern:empty";
+        default:
+            return "none";
+    }
 }
 
 // TODO: Clean up this hack around settingsstore not being reactive when setting things
@@ -42,11 +50,7 @@ const airBackground = computed({
     },
 });
 const airBackgroundType = computed(() => {
-    if (airBackground.value === null || airBackground.value === "none") {
-        return BackgroundType.None;
-    } else {
-        return BackgroundType.Simple;
-    }
+    return getBackgroundTypeFromString(airBackground.value);
 });
 
 function setAirBackground(background: string): void {
@@ -55,7 +59,7 @@ function setAirBackground(background: string): void {
 
 function setAirBackgroundFromEvent(event: Event): void {
     const type = Number.parseInt((event.target as HTMLSelectElement).value);
-    airBackground.value = getBackgroundValueFromType(type, options.value.airMapBackground);
+    airBackground.value = getBackgroundValueFromType(type);
     invalidateHack.value++;
 }
 
@@ -71,11 +75,7 @@ const groundBackground = computed({
     },
 });
 const groundBackgroundType = computed(() => {
-    if (groundBackground.value === null || groundBackground.value === "none") {
-        return BackgroundType.None;
-    } else {
-        return BackgroundType.Simple;
-    }
+    return getBackgroundTypeFromString(groundBackground.value);
 });
 
 function setGroundBackground(background: string): void {
@@ -84,7 +84,7 @@ function setGroundBackground(background: string): void {
 
 function setGroundBackgroundFromEvent(event: Event): void {
     const type = Number.parseInt((event.target as HTMLSelectElement).value);
-    groundBackground.value = getBackgroundValueFromType(type, options.value.groundMapBackground);
+    groundBackground.value = getBackgroundValueFromType(type);
     invalidateHack.value++;
 }
 
@@ -100,11 +100,7 @@ const undergroundBackground = computed({
     },
 });
 const undergroundBackgroundType = computed(() => {
-    if (undergroundBackground.value === null || undergroundBackground.value === "none") {
-        return BackgroundType.None;
-    } else {
-        return BackgroundType.Simple;
-    }
+    return getBackgroundTypeFromString(undergroundBackground.value);
 });
 
 function setUndergroundBackground(background: string): void {
@@ -113,7 +109,7 @@ function setUndergroundBackground(background: string): void {
 
 function setUndergroundBackgroundFromEvent(event: Event): void {
     const type = Number.parseInt((event.target as HTMLSelectElement).value);
-    undergroundBackground.value = getBackgroundValueFromType(type, options.value.undergroundMapBackground);
+    undergroundBackground.value = getBackgroundValueFromType(type);
     invalidateHack.value++;
 }
 
@@ -169,6 +165,9 @@ function e(k: any): boolean {
             <div><ColourPicker :colour="airBackground ?? undefined" @update:colour="setAirBackground($event)" /></div>
             <div></div>
         </div>
+        <div class="row" v-show="airBackgroundType === BackgroundType.Pattern">
+            <PatternSettings :pattern="airBackground ?? ''" @update:pattern="setAirBackground" />
+        </div>
 
         <div class="row" :class="{ overwritten: !isGlobal && e(options.groundMapBackground) }">
             <label :for="'groundBackground-' + location">
@@ -196,6 +195,9 @@ function e(k: any): boolean {
                 <ColourPicker :colour="groundBackground ?? undefined" @update:colour="setGroundBackground($event)" />
             </div>
             <div></div>
+        </div>
+        <div class="row" v-show="groundBackgroundType === BackgroundType.Pattern">
+            <PatternSettings :pattern="groundBackground ?? ''" @update:pattern="setGroundBackground" />
         </div>
 
         <div class="row" :class="{ overwritten: !isGlobal && e(options.undergroundMapBackground) }">
@@ -231,6 +233,9 @@ function e(k: any): boolean {
                 />
             </div>
             <div></div>
+        </div>
+        <div class="row" v-show="undergroundBackgroundType === BackgroundType.Pattern">
+            <PatternSettings :pattern="undergroundBackground ?? ''" @update:pattern="setUndergroundBackground" />
         </div>
     </div>
 </template>

--- a/client/src/store/floor.ts
+++ b/client/src/store/floor.ts
@@ -210,6 +210,7 @@ class FloorStore extends Store<FloorState> {
         if (floor === undefined) return;
 
         floor.backgroundValue = backgroundValue;
+        this.invalidate(floor);
         if (sync) sendFloorSetBackground({ name: floor.name, background: backgroundValue });
     }
 

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -128,7 +128,18 @@ class SettingsStore extends Store<SettingsState> {
                 location: location,
             });
 
-            if (["fowLos", "spawnLocations", "unitSize", "visionMinRange", "visionMaxRange"].includes(key)) {
+            if (
+                [
+                    "fowLos",
+                    "spawnLocations",
+                    "unitSize",
+                    "visionMinRange",
+                    "visionMaxRange",
+                    "airMapBackground",
+                    "groundMapBackground",
+                    "undergroundMapBackground",
+                ].includes(key)
+            ) {
                 floorStore.invalidateAllFloors();
             } else if (["fullFow", "fowOpacity"].includes(key)) {
                 floorStore.invalidateLightAllFloors();
@@ -271,6 +282,7 @@ class SettingsStore extends Store<SettingsState> {
 
     setAirMapBackground(airMapBackground: string | null, location: number | undefined, sync: boolean): void {
         if (this.mutate("airMapBackground", airMapBackground, location)) {
+            floorStore.invalidateAllFloors();
             if (sync)
                 sendLocationOptions({
                     options: { air_map_background: airMapBackground },
@@ -281,6 +293,7 @@ class SettingsStore extends Store<SettingsState> {
 
     setGroundMapBackground(groundMapBackground: string | null, location: number | undefined, sync: boolean): void {
         if (this.mutate("groundMapBackground", groundMapBackground, location)) {
+            floorStore.invalidateAllFloors();
             if (sync)
                 sendLocationOptions({
                     options: { ground_map_background: groundMapBackground },
@@ -295,6 +308,7 @@ class SettingsStore extends Store<SettingsState> {
         sync: boolean,
     ): void {
         if (this.mutate("undergroundMapBackground", undergroundMapBackground, location)) {
+            floorStore.invalidateAllFloors();
             if (sync)
                 sendLocationOptions({
                     options: { underground_map_background: undergroundMapBackground },

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -292,7 +292,9 @@ class SettingsStore extends Store<SettingsState> {
     }
 
     setGroundMapBackground(groundMapBackground: string | null, location: number | undefined, sync: boolean): void {
+        console.log(groundMapBackground);
         if (this.mutate("groundMapBackground", groundMapBackground, location)) {
+            console.log(11);
             floorStore.invalidateAllFloors();
             if (sync)
                 sendLocationOptions({


### PR DESCRIPTION
This PR goes further upon the recent background color feature for floors and adds support for repeating background tiles.

An image can be selected from the assets and an offset/scale can be provided to adjust the exact positioning.

Most things have been done, it's just a matter of adding the floor pattern UI to the location settings.

Additionally this PR also fixes a couple of small things:
- Don't apply a mask so that you can pan around during the location settings
- Immediately trigger a rerender when changing background settings
- Fix inconsistency in displayed background type in the floor details

(This closes #522)