### PR TITLE
feat(UI): Improve active tool mode clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ These usually have no immediately visible impact on regular users
 
 -   Draw helper now has a contrast border
 -   Initiative can now be advanced by the active player
+-   Toolbar mode is now more clearly shown
 -   [tech] Moved from vue-cli to vite
     -   this greatly improves dev and build speed
     -   main dev script is now `npm run dev`

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -1,5 +1,6 @@
-<script lang="ts">
-import { computed, defineComponent } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
+import type { CSSProperties } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { gameStore } from "../../../store/game";
@@ -14,44 +15,47 @@ import SelectTool from "./SelectTool.vue";
 import SpellTool from "./SpellTool.vue";
 import VisionTool from "./VisionTool.vue";
 
-export default defineComponent({
-    components: { DrawTool, FilterTool, MapTool, RulerTool, SelectTool, SpellTool, VisionTool },
-    setup() {
-        const { t } = useI18n();
+const { t } = useI18n();
 
-        function isToolVisible(tool: ToolName): boolean {
-            if (tool === ToolName.Filter) {
-                return gameStore.state.labels.size > 0;
-            } else if (tool === ToolName.Vision) {
-                return gameStore.state.ownedTokens.size > 1;
-            }
-            return true;
+function isToolVisible(tool: ToolName): boolean {
+    if (tool === ToolName.Filter) {
+        return gameStore.state.labels.size > 0;
+    } else if (tool === ToolName.Vision) {
+        return gameStore.state.ownedTokens.size > 1;
+    }
+    return true;
+}
+
+const visibleTools = computed(() => {
+    {
+        const tools = [];
+        for (const [toolName] of activeModeTools.value) {
+            if (dmTools.includes(toolName) && !gameStore.state.isDm) continue;
+            if (!isToolVisible(toolName)) continue;
+
+            const tool = toolMap[toolName];
+            tools.push({
+                name: toolName,
+                translation: tool.toolTranslation,
+                alert: tool.alert.value,
+            });
         }
+        return tools;
+    }
+});
 
-        const visibleTools = computed(() => {
-            {
-                const tools = [];
-                for (const [toolName] of activeModeTools.value) {
-                    if (dmTools.includes(toolName) && !gameStore.state.isDm) continue;
-                    if (!isToolVisible(toolName)) continue;
+function getStyle(tool: ToolMode): CSSProperties {
+    if (tool === activeToolMode.value) {
+        return { fontWeight: "bold" };
+    }
+    return {};
+}
 
-                    const tool = toolMap[toolName];
-                    tools.push({
-                        name: toolName,
-                        translation: tool.toolTranslation,
-                        alert: tool.alert.value,
-                    });
-                }
-                return tools;
-            }
-        });
-
-        const modeTranslation = computed(() =>
-            activeToolMode.value === ToolMode.Build ? t("tool.Build") : t("tool.Play"),
-        );
-
-        return { activeTool, modeTranslation, t, toggleActiveMode, ToolName, visibleTools };
-    },
+const toolModes = computed(() => {
+    return [
+        { name: t("tool.Build"), style: getStyle(ToolMode.Build) },
+        { name: t("tool.Play"), style: getStyle(ToolMode.Play) },
+    ];
 });
 </script>
 
@@ -69,10 +73,11 @@ export default defineComponent({
                 >
                     <a href="#">{{ tool.translation }}</a>
                 </li>
-                <li id="tool-mode" @click="toggleActiveMode" :title="t('game.ui.tools.tools.change_mode')">
-                    {{ modeTranslation }}
-                </li>
+                <li id="tool-mode"></li>
             </ul>
+            <div id="tool-mode-full" @click="toggleActiveMode" :title="t('game.ui.tools.tools.change_mode')">
+                <span v-for="mode of toolModes" :style="mode.style" :key="mode.name">{{ mode.name }}</span>
+            </div>
         </div>
         <div>
             <SelectTool v-if="activeTool === ToolName.Select" />
@@ -98,7 +103,8 @@ export default defineComponent({
     bottom: 25px;
     right: 25px;
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-end;
 
     * {
         user-select: none !important;
@@ -118,9 +124,9 @@ export default defineComponent({
         list-style: none;
         padding: 0;
         margin: 0;
-        border: solid 1px #82c8a0;
+        border: solid 1px cadetblue;
         background-color: cadetblue;
-        border-radius: 10px;
+        border-radius: 10px 10px 0 10px;
 
         > li {
             &:first-child {
@@ -133,22 +139,20 @@ export default defineComponent({
                 border-radius: 0px 10px 10px 0px; /* Border radius needs to be two less than the actual border, otherwise there will be a gap */
             }
         }
-    }
-}
 
-#tool-mode {
-    align-self: center;
-    border-right: 0;
-    padding: 5px;
-    font-size: 0;
-
-    &::first-letter {
-        font-size: 1rem;
+        #tool-mode {
+            padding: 5px;
+        }
     }
 
-    &:hover {
-        cursor: pointer;
-        font-size: 1em;
+    #tool-mode-full {
+        background-color: cadetblue;
+        padding: 0.3em 0.75em;
+        border-radius: 0 0 10px 10px;
+
+        span + span {
+            padding-left: 10px;
+        }
     }
 }
 


### PR DESCRIPTION
This PR changes the toolbar UI slightly to more prominently show the active toolmode as well as all other modes available.

![image](https://user-images.githubusercontent.com/1814713/126460393-c69df41f-426c-4543-8ff6-f4fb8ec9efd0.png)
