### PR TITLE
bug(Notes): Fix notes disappearing on location change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ These usually have no immediately visible impact on regular users
 -   Co-DMs can no longer strip DM status of the campaign creator
 -   Co-DMs can no longer kick the campaign creator
 -   Assets' block properties no longer working
+-   Notes disappearing when changing locations
 
 ## [0.27.0] - 2021-06-02
 

--- a/server/api/socket/location.py
+++ b/server/api/socket/location.py
@@ -202,18 +202,17 @@ async def load_location(sid: str, location: Location, *, complete=False):
 
     # 8. Load Notes
 
-    if complete:
-        await sio.emit(
-            "Notes.Set",
-            [
-                note.as_dict()
-                for note in Note.select().where(
-                    (Note.user == pr.player) & (Note.room == pr.room)
-                )
-            ],
-            room=sid,
-            namespace=GAME_NS,
-        )
+    await sio.emit(
+        "Notes.Set",
+        [
+            note.as_dict()
+            for note in Note.select().where(
+                (Note.user == pr.player) & (Note.room == pr.room)
+            )
+        ],
+        room=sid,
+        namespace=GAME_NS,
+    )
 
     # 9. Load Markers
 


### PR DESCRIPTION
This PR fixes a bug with the notes section in-game disappearing when changing locations