### PR TITLE
bug(Toolbar): Make active tool-mode more distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ These usually have no immediately visible impact on regular users
 
 ### Changed
 
--   Active tool is now more distinct
+-   Active tool-mode is now more distinct
 
 ## [0.28.0] - 2021-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Changed
+
+-   Active tool is now more distinct
+
 ## [0.28.0] - 2021-07-21
 
 ### Added

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -47,9 +47,15 @@ const visibleTools = computed(() => {
 
 function getStyle(tool: ToolMode): CSSProperties {
     if (tool === activeToolMode.value) {
-        return { fontWeight: "bold" };
+        return {
+            fontWeight: "bold",
+            fontSize: "larger",
+            textDecoration: "underline",
+            textUnderlineOffset: "5px",
+            textDecorationThickness: "3px",
+        };
     }
-    return {};
+    return { fontStyle: "italic" };
 }
 
 const toolModes = computed(() => {


### PR DESCRIPTION
This PR tries to address some of the feedback on the recent toolbar change.
In particular the issue described in #807 that it is difficult to discern the active tool-mode on some screens.

The active tool-mode will now be a larger font size and have an underline, whereas all non active modes will be italic

![image](https://user-images.githubusercontent.com/1814713/128178120-d670954c-a0a3-4f6c-a60f-f1e7706a04f3.png)
