### PR TITLE
bug(Vision) Fix vision range setting conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These usually have no immediately visible impact on regular users
 
 -   Locked shapes being able to move locations
 -   Locked shapes being able to change floors
+-   vision min range equal to max range bug
 
 ## [0.28.0] - 2021-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These usually have no immediately visible impact on regular users
 ### Changed
 
 -   Active tool-mode is now more distinct
+-   Prevent setting visionMinRange > visionMaxRange using settings UI
 
 ### Fixed
 

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -26,6 +26,13 @@ export class FowVisionLayer extends FowLayer {
             // This was done in commit be1e65cff1e7369375fe11cfa1643fab1d11beab.
             if (!gameStore.state.isDm) super.draw(false);
 
+            const visionMin = g2lr(settingsStore.visionMinRange.value);
+            let visionMax = g2lr(settingsStore.visionMaxRange.value);
+            // The radial-gradient doesn't handle equal radii properly.
+            if (visionMax === visionMin) {
+                visionMax += 0.01;
+            }
+
             for (const tokenId of gameStore.activeTokens.value) {
                 const token = UuidMap.get(tokenId);
                 if (token === undefined || token.floor.id !== this.floor) continue;
@@ -36,10 +43,10 @@ export class FowVisionLayer extends FowLayer {
                 const gradient = this.ctx.createRadialGradient(
                     lcenter.x,
                     lcenter.y,
-                    g2lr(settingsStore.visionMinRange.value),
+                    visionMin,
                     lcenter.x,
                     lcenter.y,
-                    g2lr(settingsStore.visionMaxRange.value),
+                    visionMax,
                 );
                 gradient.addColorStop(0, "rgba(0, 0, 0, 1)");
                 gradient.addColorStop(1, "rgba(0, 0, 0, 0)");

--- a/client/src/game/ui/settings/location/VisionSettings.vue
+++ b/client/src/game/ui/settings/location/VisionSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineProps, toRef } from "vue";
+import { computed, defineProps, ref, toRef } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { getValue } from "../../../../core/utils";
@@ -14,6 +14,9 @@ const { t } = useI18n();
 const visionMode = toRef(visionState.state, "mode");
 
 const isGlobal = computed(() => props.location < 0);
+
+// TODO: Clean up this hack around settingsstore not being reactive when setting things
+const invalidateHack = ref(0);
 
 const options = computed(() => {
     if (isGlobal.value) {
@@ -72,19 +75,29 @@ const unitSizeUnit = computed({
 
 const visionMinRange = computed({
     get() {
+        invalidateHack.value;
         return settingsStore.getLocationOptions("visionMinRange", location.value);
     },
-    set(visionMinRange: number) {
-        settingsStore.setVisionRangeMin(visionMinRange, location.value, true);
+    set(newMin: number) {
+        if (newMin > visionMaxRange.value) {
+            newMin = visionMaxRange.value;
+            invalidateHack.value++;
+        }
+        settingsStore.setVisionRangeMin(newMin, location.value, true);
     },
 });
 
 const visionMaxRange = computed({
     get() {
+        invalidateHack.value;
         return settingsStore.getLocationOptions("visionMaxRange", location.value);
     },
-    set(visionMaxRange: number) {
-        settingsStore.setVisionRangeMax(visionMaxRange, location.value, true);
+    set(newMax: number) {
+        if (newMax < visionMinRange.value) {
+            newMax = visionMinRange.value;
+            invalidateHack.value++;
+        }
+        settingsStore.setVisionRangeMax(newMax, location.value, true);
     },
 });
 
@@ -192,7 +205,13 @@ function changeVisionMode(event: Event): void {
                 {{ t("game.ui.settings.VisionSettings.min_full_vision_UNIT", { unit: unitSizeUnit }) }}
             </label>
             <div>
-                <input :id="'vmininp-' + location" type="number" min="0" v-model.lazy.number="visionMinRange" />
+                <input
+                    :id="'vmininp-' + location"
+                    type="number"
+                    min="0"
+                    :max="options.visionMaxRange ?? 0"
+                    v-model.lazy.number="visionMinRange"
+                />
             </div>
             <div
                 v-if="!isGlobal && options.visionMinRange !== undefined"
@@ -208,7 +227,12 @@ function changeVisionMode(event: Event): void {
                 {{ t("game.ui.settings.VisionSettings.max_vision_UNIT", { unit: unitSizeUnit }) }}
             </label>
             <div>
-                <input :id="'vmaxinp-' + location" type="number" min="0" v-model.lazy.number="visionMaxRange" />
+                <input
+                    :id="'vmaxinp-' + location"
+                    type="number"
+                    :min="Math.max(0, options.visionMinRange ?? 0)"
+                    v-model.lazy.number="visionMaxRange"
+                />
             </div>
             <div
                 v-if="!isGlobal && options.visionMaxRange !== undefined"


### PR DESCRIPTION
This addresses the two problems mentioned in #797.

- Fix vision when min range == max range
- Prevent setting the min range > max range through the UI