### PR TITLE
bug(Aura): Fix angled auras not rotating with shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ These usually have no immediately visible impact on regular users
 -   Locked shapes being able to move locations
 -   Locked shapes being able to change floors
 -   vision min range equal to max range bug
+-   Angled auras not rotating with general shape rotation
 
 ## [0.28.0] - 2021-07-21
 

--- a/client/src/game/draw.ts
+++ b/client/src/game/draw.ts
@@ -89,8 +89,8 @@ export function drawAuras(shape: Shape, ctx: CanvasRenderingContext2D): void {
             gradient.addColorStop(1, tc.setAlpha(0).toRgbString());
         }
 
-        const angleA = aura.angle === 360 ? 0 : toRadians(aura.direction - aura.angle / 2);
-        const angleB = aura.angle === 360 ? Math.PI * 2 : toRadians(aura.direction + aura.angle / 2);
+        const angleA = aura.angle === 360 ? 0 : shape.angle + toRadians(aura.direction - aura.angle / 2);
+        const angleB = aura.angle === 360 ? Math.PI * 2 : shape.angle + toRadians(aura.direction + aura.angle / 2);
 
         // Set visibility polygon as clipping path
         if (aura.visionSource) {

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -113,8 +113,8 @@ export class FowLightingLayer extends FowLayer {
                 this.vCtx.globalCompositeOperation = "source-in";
                 this.vCtx.beginPath();
 
-                const angleA = toRadians(aura.direction - aura.angle / 2);
-                const angleB = toRadians(aura.direction + aura.angle / 2);
+                const angleA = shape.angle + toRadians(aura.direction - aura.angle / 2);
+                const angleB = shape.angle + toRadians(aura.direction + aura.angle / 2);
 
                 if (aura.angle < 360) {
                     this.vCtx.moveTo(lcenter.x, lcenter.y);


### PR DESCRIPTION
This PR fixes #795, when using an aura that only covers a specific angle, it would not rotate along with the shape