### PR TITLE
bug(UI): Firefox styling some elements undesireable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ These usually have no immediately visible impact on regular users
 -   Locked shapes being able to change floors
 -   vision min range equal to max range bug
 -   Angled auras not rotating with general shape rotation
+-   Multiple styling issues in firefox
+    -   annotations no longer fill entire screen width
 
 ## [0.28.0] - 2021-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ These usually have no immediately visible impact on regular users
 -   vision min range equal to max range bug
 -   Angled auras not rotating with general shape rotation
 -   Multiple styling issues in firefox
-    -   annotations no longer fill entire screen width
+    -   Annotations no longer fill entire screen width
+    -   Aura UI being way to wide
 
 ## [0.28.0] - 2021-07-21
 

--- a/client/src/game/ui/Annotation.vue
+++ b/client/src/game/ui/Annotation.vue
@@ -24,7 +24,9 @@ export default defineComponent({
     right: 0;
     margin: auto;
     z-index: 10;
+    width: -moz-fit-content;
     width: fit-content;
+    height: -moz-fit-content;
     height: fit-content;
 
     border: solid 1px #9c455e;

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -466,6 +466,7 @@ export default defineComponent({
 <style scoped lang="scss">
 .ContextMenu ul {
     border: 1px solid #82c8a0;
+    width: -moz-fit-content;
     width: fit-content;
 
     li {

--- a/client/src/game/ui/settings/shape/TrackerSettings.vue
+++ b/client/src/game/ui/settings/shape/TrackerSettings.vue
@@ -313,6 +313,10 @@ input[type="text"] {
     padding: 2px;
 }
 
+input[type="number"] {
+    width: 65px;
+}
+
 .aura {
     display: flex;
     flex-direction: column;
@@ -393,7 +397,7 @@ input[type="text"] {
 
     input:checked + .details {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 1fr minmax(180px, 1fr);
         align-items: center;
         row-gap: 0.5em;
     }

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -51,7 +51,7 @@ function getStyle(tool: ToolMode): CSSProperties {
             fontWeight: "bold",
             fontSize: "larger",
             textDecoration: "underline",
-            textUnderlineOffset: "5px",
+            textUnderlineOffset: "6px",
             textDecorationThickness: "3px",
         };
     }


### PR DESCRIPTION
This PR fixes 2 places where FF styles differently compared to chromium.

- Annotation bar was always full width on ff
- Aura UI Was way to wide