### PR TITLE
feat(Dice): Share results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Added
+
+-   Dice rolling tool
+
 ### Changed
 
 -   Active tool-mode is now more distinct

--- a/client/src/game/api/emits/dice.ts
+++ b/client/src/game/api/emits/dice.ts
@@ -1,0 +1,4 @@
+import { DiceResult } from "../../models/dice";
+import { wrapSocket } from "../helpers";
+
+export const sendDiceRollResult = wrapSocket<DiceResult>("Dice.Roll.Result");

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -1,4 +1,5 @@
 import "./events/access";
+import "./events/dice";
 import "./events/floor";
 import "./events/groups";
 import "./events/initiative";

--- a/client/src/game/api/events/dice.ts
+++ b/client/src/game/api/events/dice.ts
@@ -1,0 +1,14 @@
+import { POSITION, useToast } from "vue-toastification";
+
+import { DiceResult } from "../../models/dice";
+import { diceTool } from "../../tools/variants/dice";
+import { socket } from "../socket";
+
+const toast = useToast();
+
+socket.on("Dice.Roll.Result", (data: DiceResult) => {
+    toast.info(`${data.player} threw a ${data.result}`, {
+        position: POSITION.TOP_RIGHT,
+    });
+    diceTool.state.history.push(data);
+});

--- a/client/src/game/models/dice.ts
+++ b/client/src/game/models/dice.ts
@@ -1,0 +1,6 @@
+export interface DiceResult {
+    player: string;
+    roll: string;
+    result: number;
+    shareWithAll: boolean;
+}

--- a/client/src/game/tools/variants/dice.ts
+++ b/client/src/game/tools/variants/dice.ts
@@ -4,6 +4,7 @@ import type { Mesh } from "@babylonjs/core/Meshes/mesh";
 import type { Dice, DiceThrower, DieOptions, DndParser } from "@planarally/dice";
 import { watch } from "@vue/runtime-core";
 import tinycolor from "tinycolor2";
+import { reactive } from "vue";
 
 import { randomInterval } from "../../../core/utils";
 import { i18n } from "../../../i18n";
@@ -32,6 +33,16 @@ class DiceTool extends Tool {
     diceThrower!: DiceThrower;
     dndParser!: DndParser;
     vector3!: typeof Vector3;
+
+    state = reactive<{
+        shareWithAll: boolean;
+        autoRoll: boolean;
+        history: { roll: string; result: number; player: string }[];
+    }>({
+        shareWithAll: false,
+        autoRoll: true,
+        history: [],
+    });
 
     constructor() {
         super();
@@ -89,8 +100,6 @@ class DiceTool extends Tool {
             angular: new this.vector3(linear.x / 2, 0, 0),
             color,
         };
-
-        console.log(options);
 
         const results = await diceTool.dndParser.fromString(inp, options, (die, mesh) => this.addShadow(die, mesh));
         diceStore.setResults(results);

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -459,9 +459,10 @@ export default defineComponent({
     font: inherit;
     line-height: inherit;
     text-align: left;
-    padding: 0.4em 0 0.4em 4em;
     position: relative;
     outline: none;
+    width: 2.6em;
+    padding: 0.4em 0 0.4em 0.4em;
 
     &:hover {
         cursor: pointer;

--- a/server/api/socket/__init__.py
+++ b/server/api/socket/__init__.py
@@ -3,6 +3,7 @@ from . import (
     asset_manager,
     client,
     connection,
+    dice,
     floor,
     groups,
     initiative,

--- a/server/api/socket/dice.py
+++ b/server/api/socket/dice.py
@@ -1,0 +1,26 @@
+from typing_extensions import TypedDict
+
+import auth
+from api.socket.constants import GAME_NS
+from app import app, sio
+from models import PlayerRoom
+from models.role import Role
+from state.game import game_state
+
+
+class RollInfo(TypedDict):
+    player: str
+    roll: str
+    result: int
+    shareWithAll: bool
+
+
+@sio.on("Dice.Roll.Result", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def on_dice_roll(sid: str, roll_info: RollInfo):
+    pr: PlayerRoom = game_state.get(sid)
+    for p_sid, p_pr in game_state.get_t(room=pr.room):
+        if p_sid != sid and (roll_info["shareWithAll"] or p_pr.role == Role.DM):
+            await sio.emit(
+                "Dice.Roll.Result", data=roll_info, room=p_sid, namespace=GAME_NS
+            )


### PR DESCRIPTION
This PR adds a couple of things:

- Adds a toggle to disable auto-rolling
- Adds a toggle to share results with all players (otherwise only with DMs)

When dice are rolled the result is shared to either all players or only dms and they will receive a notification in the top right corner, informing them who rolled and what the result was.

These rolls are also added to the dice history in the dice tool and on hover shows which player a certain roll belongs to.

_I want to re-iterate that the dice tool UI is not final, and more a rough proof of concept atm._