### PR TITLE
feat(SVG): Multiple improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ These usually have no immediately visible impact on regular users
 -   Added number input to the aura angle direction UI
 -   Select hit detection on borders is increased
 -   Variant-switcher re-enabled
+-   SVG-walls handling
+    -   stored metadata is different
+        -   old method is still supported but will be deprecated in the future
+        -   it is strongly advised to reapply your svg walls
+    -   now takes basic transforms into account (i.e. scale && translate)
 
 ### Fixed
 

--- a/client/src/core/geometry.ts
+++ b/client/src/core/geometry.ts
@@ -62,8 +62,13 @@ export class Vector {
         this.x = x;
         this.y = y;
     }
+
     static fromPoints(p1: Point, p2: Point): Vector {
         return new Vector(p2.x - p1.x, p2.y - p1.y);
+    }
+
+    static fromArray(a: [number, number]): Vector {
+        return new Vector(a[0], a[1]);
     }
 
     asArray(): [number, number] {
@@ -130,4 +135,8 @@ export class Ray<T extends Point> {
     getT(t1: number, distance: number): number {
         return t1 + Math.sqrt(Math.pow(distance, 2) / (Math.pow(this.direction.x, 2) + Math.pow(this.direction.y, 2)));
     }
+}
+
+export function getCenterLine(start: [number, number], end: [number, number]): [number, number] {
+    return [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2];
 }

--- a/client/src/game/client.ts
+++ b/client/src/game/client.ts
@@ -35,7 +35,7 @@ export function moveClientRect(player: number, data: ServerUserLocationOptions):
         polygon.options.isPlayerRect = true;
         polygon.options.skipDraw = !(gameStore.state.players.find((p) => p.id === player)?.showRect ?? false);
         polygon.preventSync = true;
-        layer.addShape(polygon, SyncMode.NO_SYNC, InvalidationMode.NO, false);
+        layer.addShape(polygon, SyncMode.NO_SYNC, InvalidationMode.NO, { snappable: false });
     }
     const polygon = UuidMap.get(uuid)! as Polygon;
     const h = data.client_h / data.zoom_factor;

--- a/client/src/game/draw.ts
+++ b/client/src/game/draw.ts
@@ -202,7 +202,7 @@ function y(yy: number, local: boolean): number {
 let I = 0;
 let J = 0;
 
-function drawLine(from: number[], to: number[], constrained: boolean, local: boolean): void {
+export function drawLine(from: number[], to: number[], constrained: boolean, local: boolean): void {
     // J++;
     // if (constrained) {
     //     I++;

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -14,8 +14,8 @@ import { computeVisibility } from "../../vision/te";
 import { FowLayer } from "./fow";
 
 export class FowLightingLayer extends FowLayer {
-    addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, snappable = true): void {
-        super.addShape(shape, sync, invalidate, snappable);
+    addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, options?: { snappable?: boolean }): void {
+        super.addShape(shape, sync, invalidate, options);
         if (shape.options.preFogShape ?? false) {
             this.preFogShapes.push(shape);
         }

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -83,13 +83,13 @@ export class Layer {
         return this.getShapes(options).length;
     }
 
-    addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, snappable = true): void {
+    addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, options?: { snappable?: boolean }): void {
         shape.setLayer(this.floor, this.name);
         this.shapes.push(shape);
         UuidMap.set(shape.uuid, shape);
         shape.setBlocksVision(shape.blocksVision, SyncTo.UI, invalidate !== InvalidationMode.NO);
         shape.setBlocksMovement(shape.blocksMovement, SyncTo.UI, invalidate !== InvalidationMode.NO);
-        if (snappable) {
+        if (options?.snappable ?? true) {
             for (const point of shape.points) {
                 const strp = JSON.stringify(point);
                 this.points.set(strp, (this.points.get(strp) || new Set()).add(shape.uuid));

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -85,7 +85,9 @@ export class Layer {
 
     addShape(shape: Shape, sync: SyncMode, invalidate: InvalidationMode, options?: { snappable?: boolean }): void {
         shape.setLayer(this.floor, this.name);
+
         this.shapes.push(shape);
+
         UuidMap.set(shape.uuid, shape);
         shape.setBlocksVision(shape.blocksVision, SyncTo.UI, invalidate !== InvalidationMode.NO);
         shape.setBlocksMovement(shape.blocksMovement, SyncTo.UI, invalidate !== InvalidationMode.NO);
@@ -97,8 +99,9 @@ export class Layer {
         }
         if (shape.ownedBy(false, { visionAccess: true }) && shape.isToken) gameStore.addOwnedToken(shape.uuid);
         if (shape.annotation.length) gameStore.addAnnotation(shape.uuid);
-        if (sync !== SyncMode.NO_SYNC && !shape.preventSync)
+        if (sync !== SyncMode.NO_SYNC && !shape.preventSync) {
             sendShapeAdd({ shape: shape.asDict(), temporary: sync === SyncMode.TEMP_SYNC });
+        }
         if (invalidate) this.invalidate(invalidate !== InvalidationMode.WITH_LIGHT);
 
         if (
@@ -112,6 +115,7 @@ export class Layer {
         if (sync === SyncMode.FULL_SYNC) {
             addOperation({ type: "shapeadd", shapes: [shape.asDict()] });
         }
+        shape.onLayerAdd();
     }
 
     // UI helpers are objects that are created for UI reaons but that are not pertinent to the actual state
@@ -210,6 +214,7 @@ export class Layer {
         return true;
     }
 
+    // TODO: This does not take into account shapes that the server does not know about
     moveShapeOrder(shape: Shape, destinationIndex: number, sync: SyncMode): void {
         const oldIdx = this.shapes.indexOf(shape);
         if (oldIdx === destinationIndex) return;

--- a/client/src/game/models/shapes.ts
+++ b/client/src/game/models/shapes.ts
@@ -148,9 +148,12 @@ export interface ShapeOptions {
     skipDraw: boolean;
     borderOperation: string;
 
+    // legacy svg stuff
     svgHeight: number;
     svgPaths: string[];
     svgWidth: number;
+    // new svg stuff
+    svgAsset: string;
 
     UiHelper: boolean;
 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -159,6 +159,8 @@ export abstract class Shape {
         return this.isToken || this.getAuras(true).some((a) => a.visionSource) || this.blocksMovement;
     }
 
+    onLayerAdd(): void {}
+
     // POSITION
 
     get floor(): Floor {

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -1,6 +1,8 @@
 import { g2l, g2lx, g2ly, g2lz } from "../../../core/conversions";
 import type { GlobalPoint } from "../../../core/geometry";
 import type { ServerAsset } from "../../models/shapes";
+import { loadSvgData } from "../../svg";
+import { visionState } from "../../vision/state";
 import type { SHAPE_TYPE } from "../types";
 
 import { BaseRect } from "./baseRect";
@@ -10,6 +12,8 @@ export class Asset extends BaseRect {
     img: HTMLImageElement;
     src = "";
     strokeColour = "white";
+
+    svgData?: { svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }[];
 
     constructor(
         img: HTMLImageElement,
@@ -35,6 +39,16 @@ export class Asset extends BaseRect {
     fromDict(data: ServerAsset): void {
         super.fromDict(data);
         this.src = data.src;
+        this.loadSvgs();
+    }
+
+    async loadSvgs(): Promise<void> {
+        if (this.options.svgAsset !== undefined) {
+            const svgs = await loadSvgData(`/static/assets/${this.options.svgAsset}`);
+            this.svgData = [...svgs.values()].map((svg) => ({ svg, rp: this.refPoint, paths: undefined }));
+            visionState.recalculateVision(this._floor!);
+            this.invalidate(false);
+        }
     }
 
     draw(ctx: CanvasRenderingContext2D): void {

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -2,7 +2,7 @@ import { g2l, g2lx, g2ly, g2lz } from "../../../core/conversions";
 import type { GlobalPoint } from "../../../core/geometry";
 import type { ServerAsset } from "../../models/shapes";
 import { loadSvgData } from "../../svg";
-import { visionState } from "../../vision/state";
+import { TriangulationTarget, visionState } from "../../vision/state";
 import type { SHAPE_TYPE } from "../types";
 
 import { BaseRect } from "./baseRect";
@@ -46,7 +46,14 @@ export class Asset extends BaseRect {
         if (this.options.svgAsset !== undefined) {
             const svgs = await loadSvgData(`/static/assets/${this.options.svgAsset}`);
             this.svgData = [...svgs.values()].map((svg) => ({ svg, rp: this.refPoint, paths: undefined }));
-            visionState.recalculateVision(this._floor!);
+            if (this.blocksVision) {
+                visionState.recalculateVision(this._floor!);
+                visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: this.uuid });
+            }
+            if (this.blocksMovement) {
+                visionState.recalculateMovement(this._floor!);
+                visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: this.uuid });
+            }
             this.invalidate(false);
         }
     }

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -1,11 +1,14 @@
 import { g2l, g2lx, g2ly, g2lz } from "../../../core/conversions";
+import { toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
+import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import type { ServerAsset } from "../../models/shapes";
 import { loadSvgData } from "../../svg";
 import { TriangulationTarget, visionState } from "../../vision/state";
 import type { SHAPE_TYPE } from "../types";
 
 import { BaseRect } from "./baseRect";
+import { Polygon } from "./polygon";
 
 export class Asset extends BaseRect {
     type: SHAPE_TYPE = "assetrect";
@@ -39,11 +42,24 @@ export class Asset extends BaseRect {
     fromDict(data: ServerAsset): void {
         super.fromDict(data);
         this.src = data.src;
-        this.loadSvgs();
+    }
+
+    onLayerAdd(): void {
+        if (this.options.svgAsset !== undefined && this.svgData === undefined) {
+            this.loadSvgs();
+        }
     }
 
     async loadSvgs(): Promise<void> {
         if (this.options.svgAsset !== undefined) {
+            const cover = new Polygon(
+                this.refPoint,
+                this.points.slice(1).map((p) => toGP(p)),
+                { openPolygon: false },
+            );
+            this.layer.addShape(cover, SyncMode.NO_SYNC, InvalidationMode.NORMAL, {
+                snappable: false,
+            });
             const svgs = await loadSvgData(`/static/assets/${this.options.svgAsset}`);
             this.svgData = [...svgs.values()].map((svg) => ({ svg, rp: this.refPoint, paths: undefined }));
             if (this.blocksVision) {
@@ -54,6 +70,7 @@ export class Asset extends BaseRect {
                 visionState.recalculateMovement(this._floor!);
                 visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: this.uuid });
             }
+            this.layer.removeShape(cover, SyncMode.NO_SYNC, false);
             this.invalidate(false);
         }
     }

--- a/client/src/game/svg.ts
+++ b/client/src/game/svg.ts
@@ -1,10 +1,97 @@
 import "path-data-polyfill";
-import { addP, toArrayP, toGP, Vector } from "../core/geometry";
+import { addP, getCenterLine, toArrayP, toGP, Vector } from "../core/geometry";
+import { baseAdjustedFetch } from "../core/utils";
+import { floorStore } from "../store/floor";
 
+import { drawLine } from "./draw";
 import type { Asset } from "./shapes/variants/asset";
 
-export function pathToArray(shape: Asset, path: SVGPathElement): number[][][] {
-    const paths: number[][][] = [];
+export async function loadSvgData(url: string): Promise<NodeList> {
+    const response = await baseAdjustedFetch(url);
+    const data = await response.text();
+
+    const template = document.createElement("template");
+    template.innerHTML = data;
+    return template.content.querySelectorAll("svg");
+}
+
+interface ScaleTransform {
+    type: "scale";
+    value: [number, number];
+}
+
+interface TranslateTransform {
+    type: "translate";
+    value: [number, number];
+}
+
+type Transform = (ScaleTransform | TranslateTransform)[];
+
+function copyTransform(transform: Transform | undefined): Transform {
+    if (transform === undefined) return [];
+    return transform.map((t) => ({ ...t, value: [...t.value] as [number, number] }));
+}
+
+function applyTransform(point: [number, number], transform?: Transform, scale = false): [number, number] {
+    if (transform === undefined) return point;
+    for (const t of transform.slice().reverse()) {
+        if (t.type === "scale") {
+            point = [point[0] * t.value[0], point[1] * t.value[1]];
+        } else if (t.type === "translate" && !scale) {
+            point = [point[0] + t.value[0], point[1] + t.value[1]];
+        }
+    }
+    return point;
+}
+
+export function* getPaths(
+    shape: Asset,
+    svgEl: SVGSVGElement,
+    dW: number,
+    dH: number,
+    transform?: Transform,
+): Generator<[number, number][][], void, void> {
+    for (const child of svgEl.children) {
+        if (child.tagName === "g") {
+            const newTransform = copyTransform(transform);
+            for (const t of (child as SVGSVGElement).transform.baseVal) {
+                if (t.type === 2) {
+                    newTransform.push({ type: "translate", value: [t.matrix.e, t.matrix.f] });
+                } else if (t.type === 3) {
+                    newTransform.push({ type: "scale", value: [t.matrix.a, t.matrix.d] });
+                } else {
+                    console.log("Unsupported svg transform type encountered, please bother Kruptein to fix this", t);
+                }
+            }
+            yield* getPaths(shape, child as SVGSVGElement, dW, dH, newTransform);
+        } else if (child.tagName === "path") {
+            const path = child.getAttribute("d");
+            if (path === null) continue;
+
+            const newTransform = copyTransform(transform);
+            for (const t of (child as SVGSVGElement).transform.baseVal) {
+                if (t.type === 2) {
+                    newTransform.push({ type: "translate", value: [t.matrix.e, t.matrix.f] });
+                } else if (t.type === 3) {
+                    newTransform.push({ type: "scale", value: [t.matrix.a, t.matrix.d] });
+                } else {
+                    console.log("Unsupported svg transform type encountered, please bother Kruptein to fix this", t);
+                }
+            }
+            yield pathToArray(shape, child as SVGPathElement, dW, dH, newTransform);
+        }
+    }
+}
+
+const DEBUG_SVG = false;
+export function pathToArray(
+    shape: Asset,
+    path: SVGPathElement,
+    dW: number,
+    dH: number,
+    transform?: Transform,
+): [number, number][][] {
+    const paths: [number, number][][] = [];
 
     let currentLocation = toGP(0, 0);
     const pathData = (path as any).getPathData();
@@ -12,13 +99,9 @@ export function pathToArray(shape: Asset, path: SVGPathElement): number[][][] {
     let points: [number, number][] = [];
 
     const targetRP = shape.refPoint;
-    const w = shape.w;
-    const h = shape.h;
-
-    const dW = w / (shape.options.svgWidth ?? 1);
-    const dH = h / (shape.options.svgHeight ?? 1);
 
     for (const seg of pathData) {
+        let point = applyTransform(seg.values, transform, true);
         switch (seg.type) {
             case "Z": {
                 //ClosePath
@@ -26,8 +109,9 @@ export function pathToArray(shape: Asset, path: SVGPathElement): number[][][] {
                 break;
             }
             case "M": {
+                point = applyTransform(seg.values, transform);
                 //MoveToAbs
-                currentLocation = toGP(targetRP.x + seg.values[0] * dW, targetRP.y + seg.values[1] * dH);
+                currentLocation = toGP(targetRP.x + point[0] * dW, targetRP.y + point[1] * dH);
                 break;
             }
             case "m": {
@@ -35,48 +119,66 @@ export function pathToArray(shape: Asset, path: SVGPathElement): number[][][] {
                 points.push(points[0]);
                 paths.push(points);
                 points = [];
-                currentLocation = addP(currentLocation, new Vector(dW * seg.values[0], dH * seg.values[1]));
+                currentLocation = addP(currentLocation, new Vector(dW * point[0], dH * point[1]));
                 break;
             }
             case "L": {
+                point = applyTransform(seg.values, transform);
                 //LineToAbs
-                currentLocation = toGP(targetRP.x + dW * seg.values[0], targetRP.y + dH * seg.values[1]);
+                currentLocation = toGP(targetRP.x + dW * point[0], targetRP.y + dH * point[1]);
                 break;
             }
             case "l": {
                 //LineToRel
-                currentLocation = addP(currentLocation, new Vector(dW * seg.values[0], dH * seg.values[1]));
+                currentLocation = addP(currentLocation, new Vector(dW * point[0], dH * point[1]));
                 break;
             }
             case "H": {
+                point = applyTransform(seg.values, transform);
                 //LineToHorizontalAbs
-                currentLocation = toGP(targetRP.x + dW * seg.values[0], targetRP.y + dH * currentLocation.y);
+                currentLocation = toGP(targetRP.x + dW * point[0], targetRP.y + dH * currentLocation.y);
                 break;
             }
             case "h": {
                 // LineToHorizontalRel
-                currentLocation = addP(currentLocation, new Vector(dW * seg.values[0], 0));
+                currentLocation = addP(currentLocation, new Vector(dW * point[0], 0));
                 break;
             }
             case "V": {
+                point = applyTransform(seg.values, transform);
                 // LineToVerticalAbs
-                currentLocation = toGP(targetRP.x + dW * currentLocation.x, targetRP.y + dH * seg.values[0]);
+                currentLocation = toGP(targetRP.x + dW * currentLocation.x, targetRP.y + dH * point[0]);
                 break;
             }
             case "v": {
                 // LineToVerticalRel
-                currentLocation = addP(currentLocation, new Vector(0, dH * seg.values[0]));
+                currentLocation = addP(currentLocation, new Vector(0, dH * point[0]));
                 break;
             }
             case "C": {
                 // bezier curve
-                currentLocation = toGP(targetRP.x + seg.values[0] * dW, targetRP.y + seg.values[1] * dH);
+                currentLocation = toGP(targetRP.x + point[0] * dW, targetRP.y + point[1] * dH);
                 break;
             }
             case "c": {
+                const cp1 = applyTransform(seg.values, transform, true);
+                const cp1g = addP(currentLocation, new Vector(dW * cp1[0], dH * cp1[1]));
+                const cp2 = applyTransform(seg.values.slice(2), transform, true);
+                const cp2g = addP(currentLocation, new Vector(dW * cp2[0], dH * cp2[1]));
+                const end = applyTransform(seg.values.slice(4), transform, true);
+                const endg = addP(currentLocation, new Vector(dW * end[0], dH * end[1]));
+                for (const l of splitBezier(
+                    [currentLocation.x, currentLocation.y],
+                    [endg.x, endg.y],
+                    [cp1g.x, cp1g.y],
+                    [cp2g.x, cp2g.y],
+                )) {
+                    points.push(l[1]);
+                    if (DEBUG_SVG) drawLine(points[points.length - 2], l[1], true, false);
+                }
                 // bezier curve
-                currentLocation = addP(currentLocation, new Vector(dW * seg.values[4], dH * seg.values[5]));
-                break;
+                currentLocation = endg; // addP(currentLocation, new Vector(dW * end[0], dH * end[1]));
+                continue;
             }
             default: {
                 //throw error;
@@ -85,9 +187,47 @@ export function pathToArray(shape: Asset, path: SVGPathElement): number[][][] {
             }
         }
         points.push(toArrayP(currentLocation));
+        if (DEBUG_SVG) {
+            const l = points.length;
+            if (floorStore.currentFloor.value !== undefined) {
+                if (l > 1) {
+                    drawLine(points[l - 2], points[l - 1], true, false);
+                }
+            }
+        }
     }
 
     paths.push(points);
 
     return paths;
+}
+
+// Recursive de Casteljau
+function* splitBezier(
+    start: [number, number],
+    end: [number, number],
+    cp1: [number, number],
+    cp2: [number, number],
+): Generator<[number, number][]> {
+    if (isFlatCurve(start, cp1, cp2)) {
+        yield [start, end];
+        return;
+    }
+    const p1 = getCenterLine(start, cp1);
+    const p2 = getCenterLine(cp1, cp2);
+    const p3 = getCenterLine(cp2, end);
+
+    const p12 = getCenterLine(p1, p2);
+    const p23 = getCenterLine(p2, p3);
+
+    const p1234 = getCenterLine(p12, p23);
+
+    yield* splitBezier(start, p1234, p1, p12);
+    yield* splitBezier(p1234, end, p23, p3);
+}
+
+function isFlatCurve(start: [number, number], cp1: [number, number], cp2: [number, number]): boolean {
+    const t1 = (cp1[1] - start[1]) * (cp2[0] - cp1[0]);
+    const t2 = (cp2[1] - cp1[1]) * (cp1[0] - start[0]);
+    return Math.abs(t1 - t2) < 5;
 }

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -191,11 +191,11 @@ class DrawTool extends Tool {
         // Adding
 
         if (newValue === DrawMode.Normal) {
-            normalLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+            normalLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
         } else if (newValue === DrawMode.Erase) {
-            mapLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+            mapLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
         } else {
-            fowLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+            fowLayer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
         }
     }
 
@@ -230,7 +230,7 @@ class DrawTool extends Tool {
         layer.canvas.parentElement!.style.cursor = "none";
         this.brushHelper = this.createBrush(toGP(mouse?.x ?? -1000, mouse?.y ?? -1000));
         this.setupBrush();
-        layer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false); // during mode change the shape is already added
+        layer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false }); // during mode change the shape is already added
         // if (gameStore.state.isDm) this.showLayerPoints();
     }
 
@@ -371,7 +371,7 @@ class DrawTool extends Tool {
                     lineWidth: this.state.brushSize,
                     strokeColour: this.state.fillColour,
                 });
-                layer.addShape(this.ruler, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+                layer.addShape(this.ruler, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
             } else {
                 this.ruler.refPoint = lastPoint;
                 this.ruler.endPoint = lastPoint;
@@ -603,7 +603,7 @@ class DrawTool extends Tool {
         if (this.brushHelper !== undefined) layer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
         this.brushHelper = this.createBrush(toGP(-1000, -1000), bs);
         this.setupBrush();
-        layer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false); // during mode change the shape is already added
+        layer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false }); // during mode change the shape is already added
         if (refPoint) this.brushHelper.refPoint = refPoint;
     }
 }

--- a/client/src/game/tools/variants/map.ts
+++ b/client/src/game/tools/variants/map.ts
@@ -106,7 +106,7 @@ class MapTool extends Tool {
         this.rect = new Rect(cloneP(this.startPoint), 0, 0, { fillColour: "rgba(0,0,0,0)", strokeColour: "black" });
         this.state.hasRect = true;
         this.rect.preventSync = true;
-        layer.addShape(this.rect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+        layer.addShape(this.rect, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
         selectionState.set(this.rect);
     }
 

--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -61,8 +61,8 @@ class PingTool extends Tool {
         this.border.ignoreZoomSize = true;
         this.ping.addOwner({ user: clientStore.state.username, access: { edit: true } }, SyncTo.SHAPE);
         this.border.addOwner({ user: clientStore.state.username, access: { edit: true } }, SyncTo.SHAPE);
-        layer.addShape(this.ping, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
-        layer.addShape(this.border, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
+        layer.addShape(this.ping, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL, { snappable: false });
+        layer.addShape(this.border, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL, { snappable: false });
     }
 
     onMove(lp: LocalPoint): void {

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -62,7 +62,7 @@ class RulerTool extends Tool {
         }
 
         ruler.addOwner({ user: clientStore.state.username, access: { edit: true } }, SyncTo.SHAPE);
-        layer.addShape(ruler, this.syncMode, InvalidationMode.NORMAL);
+        layer.addShape(ruler, this.syncMode, InvalidationMode.NORMAL, { snappable: false });
         this.rulers.push(ruler);
     }
 
@@ -88,7 +88,7 @@ class RulerTool extends Tool {
         });
         this.text.ignoreZoomSize = true;
         this.text.addOwner({ user: clientStore.state.username, access: { edit: true } }, SyncTo.SHAPE);
-        layer.addShape(this.text, this.syncMode, InvalidationMode.NORMAL);
+        layer.addShape(this.text, this.syncMode, InvalidationMode.NORMAL, { snappable: false });
     }
 
     onMove(lp: LocalPoint, event: MouseEvent | TouchEvent): void {

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -254,7 +254,7 @@ class SelectTool extends Tool implements ISelectTool {
                     { user: clientStore.state.username, access: { edit: true } },
                     SyncTo.SHAPE,
                 );
-                layer.addShape(this.selectionHelper, SyncMode.NO_SYNC, InvalidationMode.NO);
+                layer.addShape(this.selectionHelper, SyncMode.NO_SYNC, InvalidationMode.NO, { snappable: false });
             } else {
                 this.selectionHelper.refPoint = this.selectionStartPoint;
                 this.selectionHelper.w = 0;
@@ -656,7 +656,7 @@ class SelectTool extends Tool implements ISelectTool {
 
         for (const rotationShape of [this.rotationAnchor, this.rotationBox, this.rotationEnd]) {
             rotationShape.addOwner({ user: clientStore.state.username, access: { edit: true } }, SyncTo.SHAPE);
-            layer.addShape(rotationShape, SyncMode.NO_SYNC, InvalidationMode.NO);
+            layer.addShape(rotationShape, SyncMode.NO_SYNC, InvalidationMode.NO, { snappable: false });
         }
 
         if (layerSelection.length === 1) {

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -124,7 +124,7 @@ class SpellTool extends Tool {
             this.shape,
             this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC,
             InvalidationMode.NORMAL,
-            false,
+            { snappable: false },
         );
 
         this.drawRangeShape();
@@ -144,7 +144,7 @@ class SpellTool extends Tool {
             fillColour: "rgba(0,0,0,0)",
             strokeColour: "black",
         });
-        layer.addShape(this.rangeShape, SyncMode.NO_SYNC, InvalidationMode.NORMAL, false);
+        layer.addShape(this.rangeShape, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -175,7 +175,7 @@ class SpellTool extends Tool {
 
         layer.removeShape(this.shape, this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC, false);
         this.shape.isInvisible = !this.state.showPublic;
-        layer.addShape(this.shape, SyncMode.FULL_SYNC, InvalidationMode.NORMAL, false);
+        layer.addShape(this.shape, SyncMode.FULL_SYNC, InvalidationMode.NORMAL, { snappable: false });
         this.shape = undefined;
         activateTool(ToolName.Select);
     }

--- a/client/src/game/ui/contextmenu/DefaultContext.vue
+++ b/client/src/game/ui/contextmenu/DefaultContext.vue
@@ -74,7 +74,7 @@ async function createSpawnLocation(): Promise<void> {
 
     floorStore
         .getLayer(floorStore.currentFloor.value!, LayerName.Dm)!
-        .addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO, false);
+        .addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO, { snappable: false });
     img.onload = () => (gameState.boardInitialized ? shape.layer.invalidate(true) : undefined);
 
     settingsStore.setSpawnLocations([...spawnLocations, shape.uuid], settingsStore.state.activeLocation, true);

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -110,52 +110,56 @@ class VisionState extends Store<State> {
             const shape = UuidMap.get(sh)!;
             if (shape.floor.id !== floor) continue;
 
-            if (shape.type === "assetrect") {
-                const asset = shape as Asset;
-                if (shape.options.svgAsset !== undefined && asset.svgData !== undefined) {
-                    for (const svgData of asset.svgData) {
-                        if (!equalsP(shape.refPoint, svgData.rp) || svgData.paths === undefined) {
-                            const w = asset.w;
-                            const h = asset.h;
+            this.triangulateShape(target, shape);
+        }
+        this.addWalls(cdt);
+        (window as any).CDT = this.cdt;
+    }
 
-                            const svg = svgData.svg as SVGSVGElement;
-
-                            const dW = w / (svg.width.animVal.valueInSpecifiedUnits ?? 1);
-                            const dH = h / (svg.height.animVal.valueInSpecifiedUnits ?? 1);
-
-                            svgData.paths = [...getPaths(asset, svg as SVGSVGElement, dW, dH)];
-                        }
-                        for (const paths of svgData.paths) {
-                            for (const path of paths) {
-                                this.triangulatePath(target, shape, path, false);
-                            }
-                        }
-                    }
-                    continue;
-                } else if (shape.options.svgPaths !== undefined) {
-                    for (const pathString of shape.options.svgPaths ?? []) {
+    private triangulateShape(target: TriangulationTarget, shape: Shape): void {
+        if (shape.points.length === 0) return;
+        if (shape.type === "assetrect") {
+            const asset = shape as Asset;
+            if (shape.options.svgAsset !== undefined && asset.svgData !== undefined) {
+                for (const svgData of asset.svgData) {
+                    if (!equalsP(shape.refPoint, svgData.rp) || svgData.paths === undefined) {
                         const w = asset.w;
                         const h = asset.h;
 
-                        const dW = w / (shape.options.svgWidth ?? 1);
-                        const dH = h / (shape.options.svgHeight ?? 1);
+                        const svg = svgData.svg as SVGSVGElement;
 
-                        const pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
-                        pathElement.setAttribute("d", pathString);
-                        const paths = pathToArray(shape as Asset, pathElement, dW, dH);
+                        const dW = w / (svg.width.animVal.valueInSpecifiedUnits ?? 1);
+                        const dH = h / (svg.height.animVal.valueInSpecifiedUnits ?? 1);
+
+                        svgData.paths = [...getPaths(asset, svg as SVGSVGElement, dW, dH)];
+                    }
+                    for (const paths of svgData.paths) {
                         for (const path of paths) {
                             this.triangulatePath(target, shape, path, false);
-                            break;
                         }
                     }
-                    continue;
                 }
+                return;
+            } else if (shape.options.svgPaths !== undefined) {
+                for (const pathString of shape.options.svgPaths ?? []) {
+                    const w = asset.w;
+                    const h = asset.h;
+
+                    const dW = w / (shape.options.svgWidth ?? 1);
+                    const dH = h / (shape.options.svgHeight ?? 1);
+
+                    const pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
+                    pathElement.setAttribute("d", pathString);
+                    const paths = pathToArray(shape as Asset, pathElement, dW, dH);
+                    for (const path of paths) {
+                        this.triangulatePath(target, shape, path, false);
+                        break;
+                    }
+                }
+                return;
             }
-            this.triangulatePath(target, shape, shape.points, shape.isClosed);
         }
-        // // console.log(s);
-        this.addWalls(cdt);
-        (window as any).CDT = this.cdt;
+        this.triangulatePath(target, shape, shape.points, shape.isClosed);
     }
 
     private addWalls(cdt: CDT): void {
@@ -201,22 +205,8 @@ class VisionState extends Store<State> {
     addToTriangulation(data: { target: TriangulationTarget; shape: string }): void {
         if (this._state.mode === VisibilityMode.TRIANGLE_ITERATIVE) {
             const shape = UuidMap.get(data.shape);
-            if (shape) this.addShapesToTriangulation(data.target, shape);
+            if (shape) this.triangulateShape(data.target, shape);
         }
-    }
-
-    private addShapesToTriangulation(target: TriangulationTarget, ...shapes: Shape[]): void {
-        // console.time("AS");
-        for (const shape of shapes) {
-            if (shape.points.length <= 1) continue;
-            const j = shape.isClosed ? 0 : 1;
-            for (let i = 0; i < shape.points.length - j; i++) {
-                const pa = shape.points[i % shape.points.length];
-                const pb = shape.points[(i + 1) % shape.points.length];
-                this.insertConstraint(target, shape, pa, pb);
-            }
-        }
-        // console.timeEnd("AS");
     }
 
     deleteFromTriangulation(data: { target: TriangulationTarget; shape: string }): void {

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -1,3 +1,4 @@
+import { equalsP } from "../../core/geometry";
 import { Store } from "../../core/store";
 import { floorStore } from "../../store/floor";
 import { UuidMap } from "../../store/shapeMap";
@@ -5,7 +6,7 @@ import { sendLocationOptions } from "../api/emits/location";
 import type { Aura } from "../shapes/interfaces";
 import type { Shape } from "../shapes/shape";
 import type { Asset } from "../shapes/variants/asset";
-import { pathToArray } from "../svg";
+import { getPaths, pathToArray } from "../svg";
 
 import { CDT } from "./cdt";
 import { IterativeDelete } from "./iterative";
@@ -109,18 +110,48 @@ class VisionState extends Store<State> {
             const shape = UuidMap.get(sh)!;
             if (shape.floor.id !== floor) continue;
 
-            if (shape.type === "assetrect" && shape.options.svgPaths !== undefined) {
-                for (const pathString of shape.options.svgPaths ?? []) {
-                    const pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
-                    pathElement.setAttribute("d", pathString);
-                    const paths = pathToArray(shape as Asset, pathElement);
-                    for (const path of paths) {
-                        this.triangulatePath(target, shape, path, false);
+            if (shape.type === "assetrect") {
+                const asset = shape as Asset;
+                if (shape.options.svgAsset !== undefined && asset.svgData !== undefined) {
+                    for (const svgData of asset.svgData) {
+                        if (!equalsP(shape.refPoint, svgData.rp) || svgData.paths === undefined) {
+                            const w = asset.w;
+                            const h = asset.h;
+
+                            const svg = svgData.svg as SVGSVGElement;
+
+                            const dW = w / (svg.width.animVal.valueInSpecifiedUnits ?? 1);
+                            const dH = h / (svg.height.animVal.valueInSpecifiedUnits ?? 1);
+
+                            svgData.paths = [...getPaths(asset, svg as SVGSVGElement, dW, dH)];
+                        }
+                        for (const paths of svgData.paths) {
+                            for (const path of paths) {
+                                this.triangulatePath(target, shape, path, false);
+                            }
+                        }
                     }
+                    continue;
+                } else if (shape.options.svgPaths !== undefined) {
+                    for (const pathString of shape.options.svgPaths ?? []) {
+                        const w = asset.w;
+                        const h = asset.h;
+
+                        const dW = w / (shape.options.svgWidth ?? 1);
+                        const dH = h / (shape.options.svgHeight ?? 1);
+
+                        const pathElement = document.createElementNS("http://www.w3.org/2000/svg", "path");
+                        pathElement.setAttribute("d", pathString);
+                        const paths = pathToArray(shape as Asset, pathElement, dW, dH);
+                        for (const path of paths) {
+                            this.triangulatePath(target, shape, path, false);
+                            break;
+                        }
+                    }
+                    continue;
                 }
-            } else {
-                this.triangulatePath(target, shape, shape.points, shape.isClosed);
             }
+            this.triangulatePath(target, shape, shape.points, shape.isClosed);
         }
         // // console.log(s);
         this.addWalls(cdt);
@@ -311,3 +342,4 @@ class VisionState extends Store<State> {
 }
 
 export const visionState = new VisionState();
+(window as any).visionState = visionState;

--- a/client/src/store/floor.ts
+++ b/client/src/store/floor.ts
@@ -314,7 +314,8 @@ class FloorStore extends Store<FloorState> {
 
     // INVALIDATE
 
-    invalidate(floor: Floor): void {
+    invalidate(floorRepr: FloorRepresentation): void {
+        const floor = this.getFloor(floorRepr, false)!;
         const layers = this.layerMap.get(floor.id)!;
         for (let i = layers.length - 1; i >= 0; i--) {
             layers[i].invalidate(true);


### PR DESCRIPTION
This PR improves multiple aspects regarding the svg as wall map feature.

- scale and translate operations are taken into account
- parent <g> components are also taken into account (not only <path>)
    - If a <path> is nested behind an unknown element (i.e. not <g> or <path>) it will be ignored currently!
- Simple bezier curves are handled better
    - a polygon is now constructed to mimick the curve
    - multi-point variants are not yet covered

The way svg data is tracked now is different compared to the old way and is more future proof.
In order to not ruin someones game I've left the old code in for now, but would like to deprecate this and urge everyone
who uses the svg feature, to reapply the svg to move to the new format. (this cannot be automated)

While we're here, I would like to re-iterate that while this can greatly reduce the DM's prep-work, one must be very careful in how complex the generated svgs are. It should really only be limited to walls. Things like stairs etc only add noise that you don't want on your vision layer. Additionally these svg results are typically way heavier compared to a manually drawn mapping, so keep that in mind!
