### PR TITLE
bug(Vision): Fix experimental mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ These usually have no immediately visible impact on regular users
 -   Viewport sync
     -   viewport is sent immediately upon connecting (and does not wait for the first pan)
     -   DM viewport move is now throttled and should no longer appear laggy on the client
--   various DPI related fixes
+-   Various DPI related fixes
+-   Multiple experimental vision mode bugs
+    -   Fix startup not working correctly
 
 ## [0.28.0] - 2021-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ These usually have no immediately visible impact on regular users
 -   Various DPI related fixes
 -   Multiple experimental vision mode bugs
     -   Fix startup not working correctly
+    -   Fix unsnapped move of blocking shape not updating movement triangulation
 
 ## [0.28.0] - 2021-07-21
 

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -14,7 +14,7 @@ import { addOperation } from "../../operations/undo";
 import type { Shape } from "../../shapes/shape";
 import { createShapeFromDict } from "../../shapes/utils";
 import { initiativeStore } from "../../ui/initiative/state";
-import { TriangulationTarget, visionState } from "../../vision/state";
+import { TriangulationTarget, VisibilityMode, visionState } from "../../vision/state";
 import { setCanvasDimensions } from "../canvas";
 import { selectionState } from "../selection";
 import { compositeState } from "../state";
@@ -155,7 +155,11 @@ export class Layer {
             console.log(`Shape with unknown type ${serverShape.type_} could not be added`);
             return;
         }
-        this.addShape(shape, SyncMode.NO_SYNC, InvalidationMode.NO);
+        let invalidate = InvalidationMode.NO;
+        if (visionState.state.mode === VisibilityMode.TRIANGLE_ITERATIVE) {
+            invalidate = InvalidationMode.WITH_LIGHT;
+        }
+        this.addShape(shape, SyncMode.NO_SYNC, invalidate);
     }
 
     removeShape(shape: Shape, sync: SyncMode, recalculate: boolean): boolean {

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -449,22 +449,25 @@ class SelectTool extends Tool implements ISelectTool {
                     )
                         continue;
 
+                    // movement is skipped during onMove and definitely has to be done here
+                    if (sel.blocksMovement) {
+                        visionState.deleteFromTriangulation({
+                            target: TriangulationTarget.MOVEMENT,
+                            shape: sel.uuid,
+                        });
+                    }
                     if (
                         settingsStore.useGrid.value &&
                         clientStore.useSnapping(event) &&
                         this.hasFeature(SelectFeatures.Snapping, features) &&
                         !this.deltaChanged
                     ) {
-                        if (sel.blocksVision)
+                        if (sel.blocksVision) {
                             visionState.deleteFromTriangulation({
                                 target: TriangulationTarget.VISION,
                                 shape: sel.uuid,
                             });
-                        if (sel.blocksMovement)
-                            visionState.deleteFromTriangulation({
-                                target: TriangulationTarget.MOVEMENT,
-                                shape: sel.uuid,
-                            });
+                        }
 
                         sel.snapToGrid();
 
@@ -472,11 +475,13 @@ class SelectTool extends Tool implements ISelectTool {
                             visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: sel.uuid });
                             recalcVision = true;
                         }
-                        if (sel.blocksMovement) {
-                            visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: sel.uuid });
-                            recalcMovement = true;
-                        }
                     }
+                    // movement is skipped during onMove and definitely has to be done here
+                    if (sel.blocksMovement) {
+                        visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: sel.uuid });
+                        recalcMovement = true;
+                    }
+
                     if (this.operationList?.type === "movement") {
                         this.operationList.shapes[s].to = toArrayP(sel.refPoint);
                         this.operationReady = true;

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -76,10 +76,14 @@ class VisionState extends Store<State> {
     // CDT
 
     addCdt(floor: number): void {
-        this.cdt.set(floor, { vision: new CDT(), movement: new CDT() });
+        const vision = new CDT();
+        const movement = new CDT();
+        this.cdt.set(floor, { vision, movement });
         this.movementBlockers.set(floor, []);
         this.visionBlockers.set(floor, []);
         this.visionSources.set(floor, []);
+        this.addWalls(vision);
+        this.addWalls(movement);
     }
 
     getCDT(target: TriangulationTarget, floor: number): CDT {
@@ -119,6 +123,11 @@ class VisionState extends Store<State> {
             }
         }
         // // console.log(s);
+        this.addWalls(cdt);
+        (window as any).CDT = this.cdt;
+    }
+
+    private addWalls(cdt: CDT): void {
         // LEFT WALL
         cdt.insertConstraint([-1e8, -1e8], [-1e8, 1e8]);
         cdt.insertConstraint([-1e8, 1e8], [-1e11, 1e8]);
@@ -139,7 +148,6 @@ class VisionState extends Store<State> {
         cdt.insertConstraint([1e8, 1e8], [1e8, 1e11]);
         cdt.insertConstraint([1e8, 1e11], [-1e8, 1e11]);
         cdt.insertConstraint([-1e8, 1e11], [-1e8, 1e8]);
-        (window as any).CDT = this.cdt;
     }
 
     private triangulatePath(target: TriangulationTarget, shape: Shape, path: number[][], closed: boolean): void {


### PR DESCRIPTION
Apparently experimental mode had some glaring issues that prevented it from working at all since the big vue3 refactor.

This has been rectified, additionally a bug has been fixed where the movement triangulation was not updated if you don't use snapping.