### PR TITLE
feat(Draw): Add mouse pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These usually have no immediately visible impact on regular users
 ### Added
 
 -   Dice rolling tool
+-   Pointer to the draw tool
 
 ### Changed
 


### PR DESCRIPTION
A while ago, the decision was made to no longer show the mouse pointer when using the draw tool as it is never 100% in sync with the PA draw loop causing some visual lagging between the real cursor and the in-game assumed cursor.

Without the out-of-sync cursor draw operations feel more smooth, _but_ it became rather easy to lose track of where on the canvas you actually are. This even more so when you're drawing in transparent colors or colors very close to the background of the map.

This PR re-adds a mouse cursor, not the real OS mouse cursor, but a fake mouse cursor that is just a polygon in PA itself, which as it is a PA shape will always be in sync with the draw loop and thus feel smooth.