### PR TITLE
bug(Performance): Improve performance for large polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ These usually have no immediately visible impact on regular users
     -   Fix unsnapped move of blocking shape not updating movement triangulation
 -   Composite shape tracker/aura toggles
 -   Movement block not updating directly when not using snapping
+-   Some performance dropoff for big polygons
 
 ## [0.28.0] - 2021-07-21
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -240,9 +240,10 @@ export abstract class Shape implements IShape {
     }
 
     getPointOrientation(i: number): Vector {
-        const prev = toGP(this.points[(this.points.length + i - 1) % this.points.length]);
-        const point = toGP(this.points[i]);
-        const next = toGP(this.points[(i + 1) % this.points.length]);
+        const points = this.points; // this is an expensive function
+        const prev = toGP(points[(points.length + i - 1) % points.length]);
+        const point = toGP(points[i]);
+        const next = toGP(points[(i + 1) % points.length]);
         const vec = subtractP(next, prev);
         const mid = addP(prev, vec.multiply(0.5));
         return subtractP(point, mid).normalize();
@@ -343,8 +344,10 @@ export abstract class Shape implements IShape {
         }
         ctx.stroke();
 
+        const points = this.points; // expensive call
+
         // Draw vertices
-        for (const p of this.points) {
+        for (const p of points) {
             ctx.beginPath();
             ctx.arc(g2lx(p[0]), g2ly(p[1]), 3, 0, 2 * Math.PI);
             ctx.fill();
@@ -352,10 +355,10 @@ export abstract class Shape implements IShape {
 
         // Draw edges
         ctx.beginPath();
-        ctx.moveTo(g2lx(this.points[0][0]), g2ly(this.points[0][1]));
+        ctx.moveTo(g2lx(points[0][0]), g2ly(points[0][1]));
         const j = this.isClosed ? 0 : 1;
-        for (let i = 1; i <= this.points.length - j; i++) {
-            const vertex = this.points[i % this.points.length];
+        for (let i = 1; i <= points.length - j; i++) {
+            const vertex = points[i % points.length];
             ctx.lineTo(g2lx(vertex[0]), g2ly(vertex[1]));
         }
         ctx.stroke();
@@ -387,11 +390,12 @@ export abstract class Shape implements IShape {
     // BOUNDING BOX
 
     getAABB(delta = 0): BoundingRect {
-        let minx = this.points[0][0];
-        let maxx = this.points[0][0];
-        let miny = this.points[0][1];
-        let maxy = this.points[0][1];
-        for (const p of this.points.slice(1)) {
+        const points = this.points; // expensive call
+        let minx = points[0][0];
+        let maxx = points[0][0];
+        let miny = points[0][1];
+        let maxy = points[0][1];
+        for (const p of points.slice(1)) {
             if (p[0] < minx) minx = p[0];
             if (p[0] > maxx) maxx = p[0];
             if (p[1] < miny) miny = p[1];

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -385,19 +385,20 @@ class DrawTool extends Tool {
                 this.ruler.refPoint = lastPoint;
                 this.ruler.endPoint = lastPoint;
             }
-            if (this.shape.blocksVision && this.shape.points.length > 1)
+            const points = this.shape.points; // expensive call
+            if (this.shape.blocksVision && points.length > 1)
                 visionState.insertConstraint(
                     TriangulationTarget.VISION,
                     this.shape,
-                    this.shape.points[this.shape.points.length - 2],
-                    this.shape.points[this.shape.points.length - 1],
+                    points[points.length - 2],
+                    points[points.length - 1],
                 );
-            if (this.shape.blocksMovement && this.shape.points.length > 1)
+            if (this.shape.blocksMovement && points.length > 1)
                 visionState.insertConstraint(
                     TriangulationTarget.MOVEMENT,
                     this.shape,
-                    this.shape.points[this.shape.points.length - 2],
-                    this.shape.points[this.shape.points.length - 1],
+                    points[points.length - 2],
+                    points[points.length - 1],
                 );
             layer.invalidate(false);
             if (!this.shape.preventSync) sendShapeSizeUpdate({ shape: this.shape, temporary: true });
@@ -460,7 +461,8 @@ class DrawTool extends Tool {
             }
             case DrawShape.Brush: {
                 const br = this.shape as Polygon;
-                if (equalPoints(br.points[br.points.length - 1], [endPoint.x, endPoint.y])) return;
+                const points = br.points; // expensive call
+                if (equalPoints(points[points.length - 1], [endPoint.x, endPoint.y])) return;
                 br._vertices.push(endPoint);
                 break;
             }
@@ -539,19 +541,20 @@ class DrawTool extends Tool {
             layer.removeShape(this.ruler!, SyncMode.NO_SYNC, true);
             this.ruler = undefined;
             if (this.state.isClosedPolygon) {
-                if (this.shape.blocksVision && this.shape.points.length > 1)
+                const points = this.shape.points; // expensive call
+                if (this.shape.blocksVision && points.length > 1)
                     visionState.insertConstraint(
                         TriangulationTarget.VISION,
                         this.shape,
-                        this.shape.points[0],
-                        this.shape.points[this.shape.points.length - 1],
+                        points[0],
+                        points[points.length - 1],
                     );
-                if (this.shape.blocksMovement && this.shape.points.length > 1)
+                if (this.shape.blocksMovement && points.length > 1)
                     visionState.insertConstraint(
                         TriangulationTarget.MOVEMENT,
                         this.shape,
-                        this.shape.points[0],
-                        this.shape.points[this.shape.points.length - 1],
+                        points[0],
+                        points[points.length - 1],
                     );
             }
             this.finaliseShape();

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -248,7 +248,8 @@ class SelectTool extends Tool implements ISelectTool {
                     selectionState.set(shape);
                     this.removeRotationUi();
                     this.createRotationUi(features);
-                    this.originalResizePoints = shape.points;
+                    const points = shape.points; // expensive call
+                    this.originalResizePoints = points;
                     this.mode = SelectOperations.Resize;
                     layer.invalidate(true);
                     hit = true;
@@ -256,8 +257,8 @@ class SelectTool extends Tool implements ISelectTool {
                     this.operationList = {
                         type: "resize",
                         uuid: shape.uuid,
-                        fromPoint: shape.points[this.resizePoint],
-                        toPoint: shape.points[this.resizePoint],
+                        fromPoint: points[this.resizePoint],
+                        toPoint: points[this.resizePoint],
                         resizePoint: this.resizePoint,
                         retainAspectRatio: false,
                     };
@@ -473,19 +474,17 @@ class SelectTool extends Tool implements ISelectTool {
                 if (!shape.visibleInCanvas({ w: layer.width, h: layer.height }, { includeAuras: false })) continue;
                 if (layerSelection.some((s) => s.uuid === shape.uuid)) continue;
 
-                if (shape.points.length > 1) {
-                    for (let i = 0; i < shape.points.length; i++) {
-                        const ray = Ray.fromPoints(
-                            toGP(shape.points[i]),
-                            toGP(shape.points[(i + 1) % shape.points.length]),
-                        );
+                const points = shape.points; // expensive call
+                if (points.length > 1) {
+                    for (let i = 0; i < points.length; i++) {
+                        const ray = Ray.fromPoints(toGP(points[i]), toGP(points[(i + 1) % points.length]));
                         if (cbbox.containsRay(ray).hit) {
                             selectionState.push(shape);
-                            i = shape.points.length; // break out of the inner loop
+                            i = points.length; // break out of the inner loop
                         }
                     }
                 } else {
-                    if (cbbox.contains(toGP(shape.points[0]))) {
+                    if (cbbox.contains(toGP(points[0]))) {
                         selectionState.push(shape);
                     }
                 }

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -116,7 +116,8 @@ class VisionState extends Store<State> {
     }
 
     private triangulateShape(target: TriangulationTarget, shape: IShape): void {
-        if (shape.points.length === 0) return;
+        const points = shape.points; // expensive call
+        if (points.length === 0) return;
         if (shape.type === "assetrect") {
             const asset = shape as Asset;
             if (shape.options.svgAsset !== undefined && asset.svgData !== undefined) {
@@ -158,7 +159,7 @@ class VisionState extends Store<State> {
                 return;
             }
         }
-        this.triangulatePath(target, shape, shape.points, shape.isClosed);
+        this.triangulatePath(target, shape, points, shape.isClosed);
     }
 
     private addWalls(cdt: CDT): void {


### PR DESCRIPTION
This PR addresses some expensive calls being made multiple times where they could have been cached, which was especially painful for large polygons.

This is a soft bandaid, in the future the actual `get points()` should be properly memoized for full performance improvements