### PR TITLE
feat(Export): Campaign export

### DIFF
--- a/server/api/http/rooms.py
+++ b/server/api/http/rooms.py
@@ -1,6 +1,7 @@
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPUnauthorized
 from aiohttp_security import check_authorized
+from export.campaign import export_campaign
 
 from models import Location, LocationOptions, PlayerRoom, Room, User
 from models.db import db
@@ -169,4 +170,20 @@ async def delete(request: web.Request):
             pr[0].delete_instance(True)
             return web.HTTPOk()
 
+    return web.HTTPUnauthorized()
+
+
+async def export(request: web.Request):
+    user: User = await check_authorized(request)
+
+    creator = request.match_info["creator"]
+    roomname = request.match_info["roomname"]
+
+    if creator == user.name:
+        room: Room = Room.get_or_none(name=roomname, creator=user)
+        if room is None:
+            return web.HTTPBadRequest()
+
+        export_campaign(room)
+        return web.HTTPOk()
     return web.HTTPUnauthorized()

--- a/server/export/campaign.py
+++ b/server/export/campaign.py
@@ -4,6 +4,7 @@ from playhouse.shortcuts import model_to_dict
 from models.campaign import Floor, Layer, Location, LocationOptions, PlayerRoom, Room
 from models.shape import (
     AssetRect,
+    Aura,
     Circle,
     CircularToken,
     Line,
@@ -13,6 +14,7 @@ from models.shape import (
     ShapeOwner,
     Text,
     ToggleComposite,
+    Tracker,
 )
 from models.user import User, UserOptions
 
@@ -90,6 +92,13 @@ def export_campaign(room: Room):
                         owner = model_to_dict(o, recurse=False)
                         del owner["id"]
                         owners.append(owner)
+
+                    shape_data["trackers"] = [
+                        model_to_dict(t, recurse=False) for t in shape.trackers
+                    ]
+                    shape_data["auras"] = [
+                        model_to_dict(a, recurse=False) for a in shape.auras
+                    ]
 
                     shape_data["access"] = owners
                     shapes.append(shape_data)
@@ -194,6 +203,16 @@ def import_campaign(fp: str):
                         sa = ShapeOwner(**access)
                         sa.user_id = USER_MAPPING[access["user"]]
                         sa.save(force_insert=True)
+
+                    # auras
+
+                    for tracker in shape["trackers"]:
+                        tr = Tracker(**tracker)
+                        tr.save(force_insert=True)
+
+                    for auras in shape["auras"]:
+                        au = Aura(**auras)
+                        au.save(force_insert=True)
 
                     # subtype
 

--- a/server/export/campaign.py
+++ b/server/export/campaign.py
@@ -1,0 +1,214 @@
+import json
+from playhouse.shortcuts import model_to_dict
+
+from models.campaign import Floor, Layer, Location, LocationOptions, PlayerRoom, Room
+from models.shape import (
+    AssetRect,
+    Circle,
+    CircularToken,
+    Line,
+    Polygon,
+    Rect,
+    Shape,
+    Text,
+    ToggleComposite,
+)
+from models.user import User, UserOptions
+
+
+def export_campaign(room: Room):
+    export_data = {}
+    # Room meta info
+    room_data = model_to_dict(room, recurse=False)
+    del room_data["id"]
+    default_options = model_to_dict(room.default_options, recurse=False)
+    del default_options["id"]
+    export_data["room"] = {"_": room_data, "default_options": default_options}
+
+    # Players meta info
+    player_data = []
+    user_data = []
+    for pr in room.players:
+        _p = {}
+        player = model_to_dict(pr, recurse=False)
+        del player["id"]
+        del player["room"]
+        del player["last_played"]
+        _p["_"] = player
+
+        _p["user_options"] = model_to_dict(pr.user_options, recurse=False)
+        del _p["user_options"]["id"]
+
+        player_data.append(_p)
+
+        _u = {}
+        _u["_"] = model_to_dict(pr.player, recurse=False)
+        default_options = model_to_dict(pr.player.default_options, recurse=False)
+        del default_options["id"]
+        _u["default_options"] = default_options
+
+        user_data.append(_u)
+    export_data["players"] = player_data
+    export_data["users"] = user_data
+
+    # Locations meta info
+    locations_data = []
+    for location in room.locations:
+        location_data = {}
+
+        _l = model_to_dict(location, recurse=False)
+        del _l["room"]
+        location_data["_"] = _l
+
+        location_options = model_to_dict(location.options, recurse=False)
+        del location_options["id"]
+        location_data["location_options"] = location_options
+
+        floors = []
+        for floor in location.floors:
+            floor_data = {}
+            _f = model_to_dict(floor, recurse=False)
+            del _f["location"]
+            floor_data["_"] = _f
+
+            layers = []
+            for layer in floor.layers:
+                layer_data = {}
+                _ly = model_to_dict(layer, recurse=False)
+                del _ly["floor"]
+                layer_data["_"] = _ly
+
+                shapes = []
+                for shape in layer.shapes:
+                    shape_data = {}
+                    shape_data["_"] = model_to_dict(shape, recurse=False)
+                    shape_data["st"] = model_to_dict(shape.subtype, recurse=False)
+                    shapes.append(shape_data)
+                layer_data["shapes"] = shapes
+
+                layers.append(layer_data)
+            floor_data["layers"] = layers
+
+            floors.append(floor_data)
+        location_data["floors"] = floors
+
+        locations_data.append(location_data)
+    export_data["locations"] = locations_data
+
+    with open("out.json", "w") as f:
+        json.dump(export_data, f)
+
+
+def import_campaign(fp: str):
+    with open(fp, "r") as f:
+        import_data = json.load(f)
+
+    USER_MAPPING = {}  # old_id -> new_id
+
+    # Load User data
+    for user_data in import_data["users"]:
+        default_options = UserOptions(**user_data["default_options"])
+        default_options.save()
+
+        user = user_data["_"]
+        og_id = user["id"]
+        del user["id"]
+
+        user["default_options"] = default_options
+        u = User(**user)
+        u.save()
+
+        USER_MAPPING[og_id] = u.id
+
+    # Load base room data
+    default_options = LocationOptions(**import_data["room"]["default_options"])
+    default_options.save()
+
+    room_data = import_data["room"]["_"]
+    room_data["default_options"] = default_options
+    room_data["creator"] = USER_MAPPING[room_data["creator"]]
+    r = Room(**room_data)
+    r.save()
+
+    ROOM_ID = r.id
+
+    # Load locations
+
+    LOCATION_MAPPING = {}
+
+    for location in import_data["locations"]:
+        og_id = location["_"]["id"]
+        del location["_"]["id"]
+        location["_"]["room"] = ROOM_ID
+
+        location_options = LocationOptions(**location["location_options"])
+        location_options.save()
+        location["_"]["options"] = location_options
+
+        l = Location(**location["_"])
+        l.save()
+
+        LOCATION_MAPPING[og_id] = l.id
+
+        for floor in location["floors"]:
+            # og_id = floor["_"]["id"]
+            del floor["_"]["id"]
+            floor["_"]["location"] = l.id
+
+            f = Floor(**floor["_"])
+            f.save()
+
+            for layer in floor["layers"]:
+                # og_id =
+                del layer["_"]["id"]
+                layer["_"]["floor"] = f.id
+
+                ly = Layer(**layer["_"])
+                ly.save()
+
+                for shape in layer["shapes"]:
+                    shape["_"]["layer"] = ly
+                    shape["_"]["asset"] = None
+                    shape["_"]["group"] = None
+                    s = Shape(**shape["_"])
+                    s.save(force_insert=True)
+
+                    if s.type_ == "assetrect":
+                        st = AssetRect(**shape["st"])
+                        st.save(force_insert=True)
+                    elif s.type_ == "circulartoken":
+                        st = CircularToken(**shape["st"])
+                        st.save(force_insert=True)
+                    elif s.type_ == "circle":
+                        st = Circle(**shape["st"])
+                        st.save(force_insert=True)
+                    elif s.type_ == "line":
+                        st = Line(**shape["st"])
+                        st.save(force_insert=True)
+                    elif s.type_ == "polygon":
+                        st = Polygon(**shape["st"])
+                        st.save(force_insert=True)
+                    elif s.type_ == "rect":
+                        st = Rect(**shape["st"])
+                        st.save(force_insert=True)
+                    elif s.type_ == "text":
+                        st = Text(**shape["st"])
+                        st.save(force_insert=True)
+                    elif s.type_ == "togglecomposite":
+                        st = ToggleComposite(**shape["st"])
+                        st.save(force_insert=True)
+
+    # Load PlayerRoom data
+
+    for player in import_data["players"]:
+        user_options = UserOptions(**player["user_options"])
+        user_options.save()
+
+        player["_"]["user_options"] = user_options
+        player["_"]["room"] = ROOM_ID
+        player["_"]["player"] = USER_MAPPING[player["_"]["player"]]
+        player["_"]["active_location"] = LOCATION_MAPPING[
+            player["_"]["active_location"]
+        ]
+        pr = PlayerRoom(**player["_"])
+        pr.save()

--- a/server/export/campaign.py
+++ b/server/export/campaign.py
@@ -58,6 +58,7 @@ def export_campaign(room: Room):
 
         _u = {}
         _u["_"] = model_to_dict(pr.player, recurse=False)
+        del _u["_"]["password_hash"]
         default_options = model_to_dict(pr.player.default_options, recurse=False)
         del default_options["id"]
         _u["default_options"] = default_options
@@ -173,6 +174,7 @@ def import_campaign(fp: str):
 
         user["default_options"] = default_options
         u = User(**user)
+        u.set_password("test")
         u.save()
 
         USER_MAPPING[og_id] = u.id

--- a/server/export/campaign.py
+++ b/server/export/campaign.py
@@ -1,4 +1,6 @@
 import json
+import os
+from pathlib import Path
 from playhouse.shortcuts import model_to_dict
 
 from models.campaign import (
@@ -143,8 +145,15 @@ def export_campaign(room: Room):
         locations_data.append(location_data)
     export_data["locations"] = locations_data
 
-    with open("out.json", "w") as f:
-        json.dump(export_data, f)
+    static_folder = Path("static")
+    os.makedirs(static_folder / "temp", exist_ok=True)
+    filename = f"{room.name}-{room.creator.name}.json"
+    fullpath = static_folder / "temp" / filename
+    if os.path.exists(fullpath):
+        os.remove(fullpath)
+    with open(fullpath, "w") as fl:
+        json.dump(export_data, fl)
+    return fullpath, filename
 
 
 def import_campaign(fp: str):

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -42,9 +42,9 @@ class LocationOptions(BaseModel):
     spawn_locations = TextField(default="[]")
     move_player_on_token_change = BooleanField(default=True, null=True)
     grid_type = TextField(default="SQUARE", null=True)
-    air_map_background = TextField(default="rgba(0, 0, 0, 0)")
-    ground_map_background = TextField(default="rgba(0, 0, 0, 0)")
-    underground_map_background = TextField(default="rgba(0, 0, 0, 0)")
+    air_map_background = TextField(default="rgba(0, 0, 0, 0)", null=True)
+    ground_map_background = TextField(default="rgba(0, 0, 0, 0)", null=True)
+    underground_map_background = TextField(default="rgba(0, 0, 0, 0)", null=True)
 
     def as_dict(self):
         return {

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -9,6 +9,7 @@ import getpass
 import os
 import sys
 from urllib.parse import quote, unquote
+from export.campaign import import_campaign
 from utils import FILE_DIR
 from types import SimpleNamespace
 
@@ -167,16 +168,16 @@ def list_main(args):
             print(f"{quote(room.creator.name, safe='')}/{quote(room.name, safe='')}")
 
 
-def get_room(path):
+def get_room(path) -> Room:
     try:
         user, room = path.split("/")
     except ValueError:
         print("Invalid room. The room should have a single '/'")
+        sys.exit(1)
 
     user = User.by_name(unquote(user))
 
-    room = Room.get(name=unquote(room), creator=user)
-    return room
+    return Room.get(name=unquote(room), creator=user)
 
 
 def remove_main(args):
@@ -210,6 +211,10 @@ def reset_password_main(args):
         password = first_password
     user.set_password(password)
     user.save()
+
+
+def import_main(args):
+    import_campaign(args.file)
 
 
 def add_subcommand(name, func, parent_parser, args):
@@ -276,6 +281,18 @@ def main():
             ("name", {"help": "The name of the user."}),
             (
                 "--password",
+                {"help": "The new password. Will be prompted for if not provided."},
+            ),
+        ],
+    )
+
+    add_subcommand(
+        "import",
+        import_main,
+        subparsers,
+        [
+            (
+                "--file",
                 {"help": "The new password. Will be prompted for if not provided."},
             ),
         ],

--- a/server/routes.py
+++ b/server/routes.py
@@ -87,6 +87,9 @@ main_app.router.add_get(
 main_app.router.add_patch(
     f"{subpath}api/rooms/{{creator}}/{{roomname}}/info", api.http.rooms.set_info
 )
+main_app.router.add_get(
+    f"{subpath}api/rooms/{{creator}}/{{roomname}}/export", api.http.rooms.export
+)
 main_app.router.add_post(f"{subpath}api/invite", api.http.claim_invite)
 main_app.router.add_get(f"{subpath}api/version", api.http.version.get_version)
 main_app.router.add_get(f"{subpath}api/changelog", api.http.version.get_changelog)


### PR DESCRIPTION
#### How it currently works:

As the creator of a campaign you can export your campaign by going to `https://<servername>/api/rooms/<creatorname>/<campaignname>/export`.
This will download a json file to your local machine containing most information from the campaign (see status below).

This file can then be imported on another server by doing:
`python planarserver.py import --file=../path/to/campaign.json`

_All users will have a default password 'test' in the target server_

The current iteration is written with the prime purpose to make my life easier to debug user problems on servers they don't control. It is thus written with the idea to be imported in a completely clean db environment!

**NOTE** that behaviour on existing servers is undefined and should only be used **at your own risk**.

#### Future improvements

This PR only scratches the surface of the export topic.
A simple enhancement is providing a UI option to download the file, instead of going to a specific url.

The bigger enhancement is offering import into other servers, this however requires some other topics to be tackled first.

- What with server version differences
- How to handle user imports
- How to handle asset imports

#### status

Done:
- Room
- PlayerRoom
- User
- Location
- Floor
- Layer
- Shapes
- Shape subtypes
- ShapeAccess
- Trackers / Auras
- Labels
- Notes

To be done later:
- Assets