### PR TITLE
bug(Text): Fix resize not live-syncing to other clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ These usually have no immediately visible impact on regular users
 -   Some performance dropoff for big polygons
 -   Remove lingering rotation UI when removing a shape in build mode
 -   Select tool showing ruler without selection
+-   Text resize not live-syncing to other clients
 
 ## [0.28.0] - 2021-07-21
 

--- a/client/src/game/api/events/shape/text.ts
+++ b/client/src/game/api/events/shape/text.ts
@@ -9,3 +9,11 @@ socket.on("Shape.Text.Value.Set", (data: { uuid: string; text: string }) => {
     shape.text = data.text;
     shape.layer.invalidate(true);
 });
+
+socket.on("Shape.Text.Size.Update", (data: { uuid: string; font_size: number }) => {
+    const shape = UuidMap.get(data.uuid) as Text | undefined;
+    if (shape === undefined) return;
+
+    shape.fontSize = data.font_size;
+    shape.layer.invalidate(!shape.triggersVisionRecalc);
+});


### PR DESCRIPTION
When resizing text shapes the other clients were not actively listening on this event and would thus not reflect the resize until a refresh.