### PR TITLE
feat(Performance): Cache shape.points

### DIFF
--- a/client/src/game/client.ts
+++ b/client/src/game/client.ts
@@ -40,8 +40,7 @@ export function moveClientRect(player: number, data: ServerUserLocationOptions):
     const polygon = UuidMap.get(uuid)! as Polygon;
     const h = data.client_h / data.zoom_factor;
     const w = data.client_w / data.zoom_factor;
-    (polygon as any)._refPoint = toGP(0, 0);
-    polygon._vertices = [toGP(0, h), toGP(w, h), toGP(w, 0), toGP(0, 0)];
+    polygon.vertices = [toGP(0, 0), toGP(0, h), toGP(w, h), toGP(w, 0), toGP(0, 0)];
     polygon.center(toGP(w / 2 - data.pan_x, h / 2 - data.pan_y));
     layer.invalidate(true);
 }

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -91,12 +91,15 @@ export class Layer {
         UuidMap.set(shape.uuid, shape);
         shape.setBlocksVision(shape.blocksVision, SyncTo.UI, invalidate !== InvalidationMode.NO);
         shape.setBlocksMovement(shape.blocksMovement, SyncTo.UI, invalidate !== InvalidationMode.NO);
+
+        shape.invalidatePoints();
         if (options?.snappable ?? true) {
             for (const point of shape.points) {
                 const strp = JSON.stringify(point);
                 this.points.set(strp, (this.points.get(strp) || new Set()).add(shape.uuid));
             }
         }
+
         if (shape.ownedBy(false, { visionAccess: true }) && shape.isToken) gameStore.addOwnedToken(shape.uuid);
         if (shape.annotation.length) gameStore.addAnnotation(shape.uuid);
         if (sync !== SyncMode.NO_SYNC && !shape.preventSync) {

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -48,6 +48,7 @@ export function moveShapes(shapes: readonly IShape[], delta: Vector, temporary: 
             visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: shape.uuid });
         if (shape.blocksVision)
             visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.uuid });
+
         // todo: Fix again
         // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();
         if (!shape.preventSync) updateList.push(shape);

--- a/client/src/game/shapes/interfaces.ts
+++ b/client/src/game/shapes/interfaces.ts
@@ -14,6 +14,7 @@ export interface IShape {
     readonly uuid: string;
 
     get points(): [number, number][];
+    invalidatePoints(): void;
 
     contains(point: GlobalPoint, nearbyThreshold?: number): boolean;
 
@@ -80,7 +81,7 @@ export interface IShape {
     getPositionRepresentation(): { angle: number; points: [number, number][] };
     setPositionRepresentation(position: { angle: number; points: [number, number][] }): void;
     invalidate(skipLightUpdate: boolean): void;
-    updatePoints(): void;
+    updateLayerPoints(): void;
     rotateAround(point: GlobalPoint, angle: number): void;
     rotateAroundAbsolute(point: GlobalPoint, angle: number): void;
     getPointIndex(p: GlobalPoint, delta?: number): number;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -72,7 +72,11 @@ export abstract class Shape implements IShape {
     protected _refPoint: GlobalPoint;
     protected _angle = 0;
 
-    abstract get points(): [number, number][];
+    protected _points: [number, number][] = [];
+    get points(): [number, number][] {
+        return this._points;
+    }
+    abstract invalidatePoints(): void;
 
     abstract contains(point: GlobalPoint, nearbyThreshold?: number): boolean;
 
@@ -176,6 +180,7 @@ export abstract class Shape implements IShape {
     }
     set refPoint(point: GlobalPoint) {
         this._refPoint = point;
+        this.invalidatePoints();
     }
 
     get angle(): number {
@@ -184,7 +189,8 @@ export abstract class Shape implements IShape {
 
     set angle(angle: number) {
         this._angle = angle;
-        this.updatePoints();
+        this.invalidatePoints();
+        this.updateLayerPoints();
     }
 
     setLayer(floor: number, layer: LayerName): void {
@@ -206,7 +212,7 @@ export abstract class Shape implements IShape {
         this.layer.invalidate(skipLightUpdate);
     }
 
-    updatePoints(): void {
+    updateLayerPoints(): void {
         for (const point of this.layer.points) {
             if (point[1].has(this.uuid)) {
                 if (point[1].size === 1) this.layer.points.delete(point[0]);
@@ -225,7 +231,7 @@ export abstract class Shape implements IShape {
         const center = this.center();
         if (!equalsP(point, center)) this.center(rotateAroundPoint(center, point, angle));
         this.angle += angle;
-        this.updatePoints();
+        this.updateLayerPoints();
     }
 
     rotateAroundAbsolute(point: GlobalPoint, angle: number): void {

--- a/client/src/game/shapes/variants/baseRect.ts
+++ b/client/src/game/shapes/variants/baseRect.ts
@@ -31,7 +31,10 @@ export abstract class BaseRect extends Shape {
     }
 
     set w(width: number) {
-        if (width > 0) this._w = width;
+        if (width > 0) {
+            this._w = width;
+            this.invalidatePoints();
+        }
     }
 
     get h(): number {
@@ -39,7 +42,10 @@ export abstract class BaseRect extends Shape {
     }
 
     set h(height: number) {
-        if (height > 0) this._h = height;
+        if (height > 0) {
+            this._h = height;
+            this.invalidatePoints();
+        }
     }
 
     getBaseDict(): ServerBaseRect {
@@ -61,8 +67,11 @@ export abstract class BaseRect extends Shape {
         return bbox;
     }
 
-    get points(): [number, number][] {
-        if (this.w === 0 || this.h === 0) return [[this.refPoint.x, this.refPoint.y]];
+    invalidatePoints(): void {
+        if (this.w === 0 || this.h === 0) {
+            this._points = [[this.refPoint.x, this.refPoint.y]];
+            return;
+        }
 
         const center = this.center();
 
@@ -70,7 +79,7 @@ export abstract class BaseRect extends Shape {
         const botleft = rotateAroundPoint(addP(this.refPoint, new Vector(0, this.h)), center, this.angle);
         const botright = rotateAroundPoint(addP(this.refPoint, new Vector(this.w, this.h)), center, this.angle);
         const topright = rotateAroundPoint(addP(this.refPoint, new Vector(this.w, 0)), center, this.angle);
-        return [
+        this._points = [
             [topleft.x, topleft.y],
             [botleft.x, botleft.y],
             [botright.x, botright.y],
@@ -87,6 +96,7 @@ export abstract class BaseRect extends Shape {
             this.refPoint.y + this.h >= point.y
         );
     }
+
     center(): GlobalPoint;
     center(centerPoint: GlobalPoint): void;
     center(centerPoint?: GlobalPoint): GlobalPoint | void {
@@ -105,6 +115,7 @@ export abstract class BaseRect extends Shape {
         if (coreVisible) return true;
         return false;
     }
+
     snapToGrid(): void {
         const gs = DEFAULT_GRID_SIZE;
         const center = this.center();
@@ -130,6 +141,7 @@ export abstract class BaseRect extends Shape {
 
         this.invalidate(false);
     }
+
     resizeToGrid(resizePoint: number, retainAspectRatio: boolean): void {
         const targetPoint = toGP(
             this.refPoint.x + (resizePoint > 1 ? this.w : 0),
@@ -207,6 +219,9 @@ export abstract class BaseRect extends Shape {
 
         const newResizePoint = (resizePoint + 4) % 4;
         const oppositeNRP = (newResizePoint + 2) % 4;
+
+        // this call needs to happen BEFORE the below code
+        this.invalidatePoints();
 
         const vec = Vector.fromPoints(toGP(this.points[oppositeNRP]), toGP(oldPoints[oppositeNRP]));
         this.refPoint = addP(this.refPoint, vec);

--- a/client/src/game/shapes/variants/line.ts
+++ b/client/src/game/shapes/variants/line.ts
@@ -10,7 +10,7 @@ import { BoundingRect } from "./boundingRect";
 
 export class Line extends Shape {
     type: SHAPE_TYPE = "line";
-    endPoint: GlobalPoint;
+    private _endPoint: GlobalPoint;
     lineWidth: number;
     constructor(
         startPoint: GlobalPoint,
@@ -22,8 +22,17 @@ export class Line extends Shape {
         },
     ) {
         super(startPoint, { fillColour: "rgba(0, 0, 0, 0)", strokeColour: "#000", ...options });
-        this.endPoint = endPoint;
+        this._endPoint = endPoint;
         this.lineWidth = options?.lineWidth ?? 1;
+    }
+
+    get endPoint(): GlobalPoint {
+        return this._endPoint;
+    }
+
+    set endPoint(point: GlobalPoint) {
+        this._endPoint = point;
+        this.invalidatePoints();
     }
 
     get isClosed(): boolean {
@@ -47,12 +56,13 @@ export class Line extends Shape {
         });
     }
 
-    get points(): [number, number][] {
-        return [
+    invalidatePoints(): void {
+        this._points = [
             toArrayP(rotateAroundPoint(this.refPoint, this.center(), this.angle)),
             toArrayP(rotateAroundPoint(this.endPoint, this.center(), this.angle)),
         ];
     }
+
     getBoundingBox(): BoundingRect {
         return new BoundingRect(
             toGP(Math.min(this.refPoint.x, this.endPoint.x), Math.min(this.refPoint.y, this.endPoint.y)),
@@ -60,6 +70,7 @@ export class Line extends Shape {
             Math.abs(this.refPoint.y - this.endPoint.y),
         );
     }
+
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
 
@@ -73,6 +84,7 @@ export class Line extends Shape {
         ctx.stroke();
         super.drawPost(ctx);
     }
+
     contains(_point: GlobalPoint): boolean {
         return false; // TODO
     }
@@ -86,14 +98,18 @@ export class Line extends Shape {
         this.refPoint = toGP(subtractP(centerPoint, subtractP(oldCenter, this.refPoint)).asArray());
         this.endPoint = toGP(subtractP(centerPoint, subtractP(oldCenter, this.endPoint)).asArray());
     }
+
     visibleInCanvas(max: { w: number; h: number }, options: { includeAuras: boolean }): boolean {
         if (super.visibleInCanvas(max, options)) return true;
         return this.getBoundingBox().visibleInCanvas(max);
     }
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     snapToGrid(): void {}
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     resizeToGrid(): void {}
+
     resize(resizePoint: number, point: GlobalPoint): number {
         if (resizePoint === 0) this.refPoint = point;
         else this.endPoint = point;

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -15,7 +15,7 @@ import { BoundingRect } from "./boundingRect";
 
 export class Polygon extends Shape {
     type: SHAPE_TYPE = "polygon";
-    _vertices: GlobalPoint[] = [];
+    private _vertices: GlobalPoint[] = [];
     openPolygon = false;
     lineWidth: number;
 
@@ -47,6 +47,7 @@ export class Polygon extends Shape {
         const delta = subtractP(point, this._refPoint);
         this._refPoint = point;
         for (let i = 0; i < this._vertices.length; i++) this._vertices[i] = addP(this._vertices[i], delta);
+        this.invalidatePoints();
     }
 
     get vertices(): GlobalPoint[] {
@@ -98,9 +99,13 @@ export class Polygon extends Shape {
         super.setPositionRepresentation(position);
     }
 
-    get points(): [number, number][] {
+    private invalidatePoint(point: GlobalPoint, center: GlobalPoint): [number, number] {
+        return toArrayP(rotateAroundPoint(point, center, this.angle));
+    }
+
+    invalidatePoints(): void {
         const center = this.center();
-        return this.vertices.map((point) => toArrayP(rotateAroundPoint(point, center, this.angle)));
+        this._points = this.vertices.map((point) => this.invalidatePoint(point, center));
     }
 
     draw(ctx: CanvasRenderingContext2D): void {
@@ -164,10 +169,13 @@ export class Polygon extends Shape {
         if (super.visibleInCanvas(max, options)) return true;
         return this.getBoundingBox().visibleInCanvas(max);
     }
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     snapToGrid(): void {}
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     resizeToGrid(): void {}
+
     resize(resizePoint: number, point: GlobalPoint): number {
         if (this.angle === 0) {
             if (resizePoint === 0) this._refPoint = point;
@@ -184,6 +192,7 @@ export class Polygon extends Shape {
                 this._vertices[i] = rotateAroundPoint(newPoints[i + 1], newCenter, -this.angle);
             }
         }
+        this.invalidatePoints();
         return resizePoint;
     }
 
@@ -225,11 +234,19 @@ export class Polygon extends Shape {
                 SyncMode.FULL_SYNC,
                 this.blocksVision ? InvalidationMode.WITH_LIGHT : InvalidationMode.NORMAL,
             );
+
+            this.invalidatePoints();
+
             // Do the OG shape update AFTER sending the new polygon or there might (depending on network)
             // be a couple of frames where the new polygon is not shown and the old one is already cut
             // potentially showing hidden stuff
             if (!this.preventSync) sendShapePositionUpdate([this], false);
         }
+    }
+
+    pushPoint(point: GlobalPoint): void {
+        this._vertices.push(point);
+        this._points.push(this.invalidatePoint(point, this.center()));
     }
 
     addPoint(point: GlobalPoint): void {
@@ -247,6 +264,7 @@ export class Polygon extends Shape {
                 break;
             }
         }
+        this.invalidatePoints();
     }
 
     removePoint(point: GlobalPoint): void {
@@ -271,6 +289,7 @@ export class Polygon extends Shape {
             if (this.blocksMovement) visionState.recalculateMovement(this.floor.id);
             if (!this.preventSync) sendShapePositionUpdate([this], false);
 
+            this.invalidatePoints();
             this.invalidate(true);
         }
     }

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -54,6 +54,12 @@ export class Polygon extends Shape {
         return [this._refPoint, ...this._vertices];
     }
 
+    set vertices(v: GlobalPoint[]) {
+        this._refPoint = v[0];
+        this._vertices = v.slice(1);
+        this.invalidatePoints();
+    }
+
     get uniqueVertices(): GlobalPoint[] {
         return filterEqualPoints(this.vertices);
     }

--- a/client/src/game/shapes/variants/text.ts
+++ b/client/src/game/shapes/variants/text.ts
@@ -41,8 +41,8 @@ export class Text extends Shape {
         });
     }
 
-    get points(): [number, number][] {
-        return this.getBoundingBox().points;
+    invalidatePoints(): void {
+        this._points = this.getBoundingBox().points;
     }
 
     getBoundingBox(): BoundingRect {
@@ -102,10 +102,13 @@ export class Text extends Shape {
         if (super.visibleInCanvas(max, options)) return true;
         return this.getBoundingBox().visibleInCanvas(max);
     }
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     snapToGrid(): void {}
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     resizeToGrid(): void {}
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     resize(resizePoint: number, point: GlobalPoint): number {
         point = rotateAroundPoint(point, this.center(), -this.angle);

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -142,8 +142,8 @@ export class ToggleComposite extends Shape {
         });
     }
 
-    get points(): [number, number][] {
-        return [];
+    invalidatePoints(): void {
+        return;
     }
 
     getBoundingBox(): BoundingRect {
@@ -151,7 +151,7 @@ export class ToggleComposite extends Shape {
     }
 
     draw(_ctx: CanvasRenderingContext2D): void {
-        // no-op
+        return;
     }
 
     contains(_point: GlobalPoint): boolean {

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -139,7 +139,7 @@ class DrawTool extends Tool {
 
     private finaliseShape(): void {
         if (this.shape === undefined) return;
-        this.shape.updatePoints();
+        this.shape.updateLayerPoints();
         if (this.shape.points.length <= 1) {
             let mouse: { x: number; y: number } | undefined = undefined;
             if (this.brushHelper !== undefined) {
@@ -370,8 +370,8 @@ class DrawTool extends Tool {
 
             if (clientStore.useSnapping(event) && !this.snappedToPoint)
                 this.brushHelper.refPoint = toGP(clampGridLine(startPoint.x), clampGridLine(startPoint.y));
-            this.shape._vertices.push(cloneP(this.brushHelper.refPoint));
-            this.shape.updatePoints();
+            this.shape.pushPoint(cloneP(this.brushHelper.refPoint));
+            this.shape.updateLayerPoints();
         }
 
         // Start a ruler in polygon mode from the last point
@@ -469,7 +469,7 @@ class DrawTool extends Tool {
                 const br = this.shape as Polygon;
                 const points = br.points; // expensive call
                 if (equalPoints(points[points.length - 1], [endPoint.x, endPoint.y])) return;
-                br._vertices.push(endPoint);
+                br.pushPoint(endPoint);
                 break;
             }
             case DrawShape.Polygon: {

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -572,7 +572,7 @@ class SelectTool extends Tool implements ISelectTool {
                     if (sel.blocksVision) recalcVision = true;
                     if (sel.blocksMovement) recalcMovement = true;
                     if (!sel.preventSync) updateList.push(sel);
-                    sel.updatePoints();
+                    sel.updateLayerPoints();
                 }
                 sendShapePositionUpdate(updateList, false);
             }
@@ -621,7 +621,7 @@ class SelectTool extends Tool implements ISelectTool {
                         this.operationReady = true;
                     }
 
-                    sel.updatePoints();
+                    sel.updateLayerPoints();
                 }
             }
             if (this.mode === SelectOperations.Rotate) {
@@ -644,7 +644,7 @@ class SelectTool extends Tool implements ISelectTool {
                         this.operationReady = true;
                     }
 
-                    sel.updatePoints();
+                    sel.updateLayerPoints();
                 }
 
                 if (this.operationList?.type === "rotation") {


### PR DESCRIPTION
All shapes share a `get points()` function to reason about shape position on an abstract level.
This function was up until now calculated in place, which depending on the shape type could be expensive.

An earlier PR addressed this slightly by making sure the `.points` call would not be made multiple times in the same block.

This PR goes further and properly caches it, while this does mean that it does not have to be recalculated on the fly, this does mean that the cache needs to be invalidated when it no longer is correct. I tried to find all locations where cache invalidation should occur, but I might have missed some.

If selection boxes behave funky after some interaction, this is most likely the result of a stale cache, let me know!