### PR TITLE
bug(Sync): Fix "Bring Players" not saving new floor info for players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Fixed
+
+-   floor not being remembered on reload after "Bring Players" action
+
+### Performance
+
+-   Cache Shape.points to prevent frequent recalculations
+
 ## [0.29.0] - 2021-10-28
 
 ### Added

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -100,7 +100,7 @@ socket.on("Board.Floor.Set", (floor: ServerFloor) => {
 // Varia
 
 socket.on("Position.Set", (data: { floor?: string; x: number; y: number; zoom?: number }) => {
-    if (data.floor !== undefined) floorStore.selectFloor({ name: data.floor }, false);
+    if (data.floor !== undefined) floorStore.selectFloor({ name: data.floor }, true);
     if (data.zoom !== undefined) clientStore.setZoomDisplay(data.zoom);
     setCenterPosition(toGP(data.x, data.y));
 });


### PR DESCRIPTION
When the "Bring Players" actions was performed to move players to a different floor, on refresh the players would still be on the old floor due to an incorrect sync condition.