### PR TITLE
feat(Performance): Improve draw loop timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ These usually have no immediately visible impact on regular users
 ### Performance
 
 -   Cache Shape.points to prevent frequent recalculations
+-   Changed width/height for devicePixelRatio canvas drawing
+-   Keep track of shapes in view to reduce draw loop calculations
+-   Keep track of vision sources in view to reduce draw loop calculations
 
 ## [0.29.0] - 2021-10-28
 

--- a/client/src/game/layers/variants/fow.ts
+++ b/client/src/game/layers/variants/fow.ts
@@ -24,7 +24,7 @@ export class FowLayer extends Layer {
 
     _draw(): void {
         this.ctx.clearRect(0, 0, this.width, this.height);
-        this.vCtx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+        this.vCtx.clearRect(0, 0, this.width, this.height);
 
         this.ctx.fillStyle = "rgba(0, 0, 0, 1)";
 
@@ -40,13 +40,13 @@ export class FowLayer extends Layer {
                     const mapl = floorStore.getLayer(floor, LayerName.Map);
                     if (mapl === undefined) continue;
                     this.ctx.globalCompositeOperation = "destination-out";
-                    this.ctx.drawImage(mapl.canvas, 0, 0, window.innerWidth, window.innerHeight);
+                    this.ctx.drawImage(mapl.canvas, 0, 0, this.width, this.height);
                 }
                 if (floor.id !== activeFloor) {
                     const fowl = floorStore.getLayer(floor, this.name);
                     if (fowl === undefined) continue;
                     this.ctx.globalCompositeOperation = "source-over";
-                    this.ctx.drawImage(fowl.canvas, 0, 0, window.innerWidth, window.innerHeight);
+                    this.ctx.drawImage(fowl.canvas, 0, 0, this.width, this.height);
                 }
                 if (floor.id === activeFloor) break;
             }

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -120,7 +120,7 @@ export class FowLightingLayer extends FowLayer {
                 }
 
                 this.vCtx.fill();
-                this.ctx.drawImage(this.virtualCanvas, 0, 0, window.innerWidth, window.innerHeight);
+                this.ctx.drawImage(this.virtualCanvas, 0, 0, this.width, this.height);
             }
 
             const activeFloor = floorStore.currentFloor.value!.id;

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -72,14 +72,14 @@ export class FowVisionLayer extends FowLayer {
                     const fowl = floorStore.getLayer(floor, this.name);
                     if (fowl === undefined) continue;
                     this.vCtx.globalCompositeOperation = "destination-over";
-                    this.vCtx.drawImage(fowl.canvas, 0, 0, window.innerWidth, window.innerHeight);
+                    this.vCtx.drawImage(fowl.canvas, 0, 0, this.width, this.height);
                     const mapl = floorStore.getLayer(floor, LayerName.Map);
                     if (mapl === undefined) continue;
                     this.vCtx.globalCompositeOperation = "destination-out";
-                    this.vCtx.drawImage(mapl.canvas, 0, 0, window.innerWidth, window.innerHeight);
+                    this.vCtx.drawImage(mapl.canvas, 0, 0, this.width, this.height);
                 }
                 this.ctx.globalCompositeOperation = "source-over";
-                this.ctx.drawImage(this.virtualCanvas, 0, 0, window.innerWidth, window.innerHeight);
+                this.ctx.drawImage(this.virtualCanvas, 0, 0, this.width, this.height);
             }
 
             // For the players this is done at the beginning of this function.  TODO: why the split up ???

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -205,6 +205,8 @@ export abstract class Shape implements IShape {
     setPositionRepresentation(position: { angle: number; points: [number, number][] }): void {
         this._refPoint = toGP(position.points[0]);
         this.angle = position.angle;
+
+        this.layer.updateShapeView(this);
         this.updateShapeVision(false, false);
     }
 

--- a/client/src/store/floor.ts
+++ b/client/src/store/floor.ts
@@ -324,6 +324,10 @@ class FloorStore extends Store<FloorState> {
 
     invalidateAllFloors(): void {
         for (const floor of this._state.floors) {
+            for (const layer of this.getLayers(floor)) {
+                layer.invalidateView();
+            }
+            visionState.invalidateView(floor.id);
             this.invalidate(floor);
         }
     }
@@ -331,6 +335,10 @@ class FloorStore extends Store<FloorState> {
     invalidateVisibleFloors(): void {
         let floorFound = false;
         for (const floor of this._state.floors) {
+            for (const layer of this.getLayers(floor)) {
+                layer.invalidateView();
+            }
+            visionState.invalidateView(floor.id);
             if (floorFound) this.invalidateLight(floor.id);
             else this.invalidate(floor);
             if (floor === this.currentFloor.value) floorFound = true;


### PR DESCRIPTION
At the heart of PlanarAlly is the draw loop that rerenders the screen on changes in the scene.

This PR adds a couple of tricks to keep track of things that should be visible in the screen so that that specific calculation does not need to be done during the draw loop itself.

So at the cost of some more memory, the timings of the drawloop should go down, whether or not this is noticeable largely depends on your hardware (will be more noticeable on slower machines).

This is another set of changes that depends on correct invalidation of the "in view" set, which means that some cases might have been overlooked, let me know if rendering behaves unexpected