### PR TITLE
feat(Draw): Improve draw tool UI/UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Changed
+
+-   Draw tool UI now has a tabbed interface
+    -   a shape tab to configure shape and colours
+    -   a visibility tab to configure advanced vision modes as well as blocksVision and blocksMovement changes
+
 ### Fixed
 
 -   floor not being remembered on reload after "Bring Players" action

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,7 +20,7 @@
                 "socket.io-client": "^4.3.2",
                 "swiper": "^7.2.0",
                 "tinycolor2": "^1.4.2",
-                "vue": "^3.2.20",
+                "vue": "^3.2.23",
                 "vue-i18n": "^9.1.9",
                 "vue-router": "^4.0.12",
                 "vue-toastification": "^2.0.0-rc.5",
@@ -36,8 +36,8 @@
                 "@types/tinycolor2": "^1.4.3",
                 "@typescript-eslint/eslint-plugin": "^5.2.0",
                 "@typescript-eslint/parser": "^5.2.0",
-                "@vitejs/plugin-vue": "^1.9.4",
-                "@vue/compiler-sfc": "^3.2.20",
+                "@vitejs/plugin-vue": "^1.10.1",
+                "@vue/compiler-sfc": "^3.2.23",
                 "eslint": "^8.1.0",
                 "eslint-import-resolver-typescript": "^2.5.0",
                 "eslint-plugin-import": "^2.25.2",
@@ -49,8 +49,8 @@
                 "sass-loader": "^12.3.0",
                 "typescript": "~4.4.4",
                 "upath": "^2.0.1",
-                "vite": "^2.6.13",
-                "vue-tsc": "^0.28.10"
+                "vite": "^2.6.14",
+                "vue-tsc": "^0.29.8"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
@@ -692,9 +692,9 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.4.tgz",
-            "integrity": "sha512-0CZqaCoChriPTTtGkERy1LGPcYjGFpi2uYRhBPIkqJqUGV5JnJFhQAgh6oH9j5XZHfrRaisX8W0xSpO4T7S78A==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.10.1.tgz",
+            "integrity": "sha512-oL76QETMSpVE9jIScirGB2bYJEVU/+r+g+K7oG+sXPs9TZljqveoVRsmLyXlMZTjpQkLL8gz527cW80NMGVKJg==",
             "dev": true,
             "engines": {
                 "node": ">=12.0.0"
@@ -704,19 +704,19 @@
             }
         },
         "node_modules/@volar/code-gen": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.28.10.tgz",
-            "integrity": "sha512-MybgBubg1im4MiFoiTUMmxKTC+KZJQfIO5g/TVnysEsCr4ssG0lG1rF3Gg3lbQKefdMiqsH5FNuMyqLC/bsWQg==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.29.8.tgz",
+            "integrity": "sha512-eohLLUqPChHRPDFT5gXn4V6pr/CeTri7Ou5GI26lUvBRRAbP8p+oYfQRcbMPGeKmVkYjfVj0chsxQGx6T8PQ4Q==",
             "dev": true,
             "dependencies": {
-                "@volar/shared": "0.28.10",
-                "@volar/source-map": "0.28.10"
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8"
             }
         },
         "node_modules/@volar/html2pug": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/html2pug/-/html2pug-0.28.10.tgz",
-            "integrity": "sha512-orcNnKyUPZZVb7pRvRHU7R8gk4abKZQELT0zXt2T7EbC5B8usmWNav6Sis9kVzV5Etj5h/IYutv7Df7PiKwLOQ==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/html2pug/-/html2pug-0.29.8.tgz",
+            "integrity": "sha512-bhSNXg8A2aD3w0B+CwmHjqCAaKtj5rORbE5C/q/UdGqptJbC6STCmi30KuRTdfPhR++Xb18Hauf3s/WCmtNAPA==",
             "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0",
@@ -726,9 +726,9 @@
             }
         },
         "node_modules/@volar/shared": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/shared/-/shared-0.28.10.tgz",
-            "integrity": "sha512-MzBEfBM5E5q4EfOd8Gkqmo+XTfbXiuT8IEWtfmpS8ax3GVeofkeAgzK/TadkatW/Nb2cKOaCYkmILpFKvDnDRQ==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/shared/-/shared-0.29.8.tgz",
+            "integrity": "sha512-Y1NN6irkIukD+T0wf4p/dHWYL90sacN2e2lYoDXxRlvoYxwANnHgw0J0Rcp+yw58ElWRScdG7/YntEIuZWeJsw==",
             "dev": true,
             "dependencies": {
                 "upath": "^2.0.1",
@@ -737,22 +737,37 @@
             }
         },
         "node_modules/@volar/source-map": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.28.10.tgz",
-            "integrity": "sha512-hQ2gclwP7yvZIdaVEC1LixViDPIO6JGkCBxAS8Erg9p2d0ruTyzazfd0NLaLuHLoMnxExILYNK2W05yQmIpRIA==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.29.8.tgz",
+            "integrity": "sha512-7w+UoYtnc6UQu30CgMVvx0YN4dzDgP4TIsSmUaW62AGmxU9Lxwp3Kkn/4N8efi91z8ma5Z78v/HddyJPwAC3LA==",
             "dev": true,
             "dependencies": {
-                "@volar/shared": "0.28.10"
+                "@volar/shared": "0.29.8"
             }
         },
         "node_modules/@volar/transforms": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/transforms/-/transforms-0.28.10.tgz",
-            "integrity": "sha512-GOQN3amI733oFweKKjuBBOEOMwy0e/aEAnnJNavrrHa7LY6Ke/JfNsoWhi9Pb2FAPYd+WyruDDFX8yKHjQE1xw==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/transforms/-/transforms-0.29.8.tgz",
+            "integrity": "sha512-o2hRa8CoDwYTO1Mu5KA47+1elUnYUjDaVhCvbyKlRfd8qpHea2llotArq7B6OORSL2M9DVs1IRJ5NGURBFeZ3Q==",
             "dev": true,
             "dependencies": {
-                "@volar/shared": "0.28.10",
+                "@volar/shared": "0.29.8",
                 "vscode-languageserver": "^8.0.0-next.2"
+            }
+        },
+        "node_modules/@volar/vue-code-gen": {
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/vue-code-gen/-/vue-code-gen-0.29.8.tgz",
+            "integrity": "sha512-E1e7P2oktNC/DzgDBditfla4s8+HlUlluZ+BtcLvEdbkl3QEjujkB0x1wxguWzXmpWgLIDPtrS3Jzll5cCOkTg==",
+            "dev": true,
+            "dependencies": {
+                "@volar/code-gen": "0.29.8",
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8",
+                "@vue/compiler-core": "^3.2.21",
+                "@vue/compiler-dom": "^3.2.21",
+                "@vue/shared": "^3.2.21",
+                "upath": "^2.0.1"
             }
         },
         "node_modules/@vscode/emmet-helper": {
@@ -776,36 +791,36 @@
             "dev": true
         },
         "node_modules/@vue/compiler-core": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.20.tgz",
-            "integrity": "sha512-vcEXlKXoPwBXFP5aUTHN9GTZaDfwCofa9Yu9bbW2C5O/QSa9Esdt7OG4+0RRd3EHEMxUvEdj4RZrd/KpQeiJbA==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.23.tgz",
+            "integrity": "sha512-4ZhiI/orx+7EJ1B+0zjgvXMV2uRN+XBfG06UN2sJfND9rH5gtEQT3QmO4erum1o6Irl7y754W8/KSaDJh4EUQg==",
             "dependencies": {
                 "@babel/parser": "^7.15.0",
-                "@vue/shared": "3.2.20",
+                "@vue/shared": "3.2.23",
                 "estree-walker": "^2.0.2",
                 "source-map": "^0.6.1"
             }
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.20.tgz",
-            "integrity": "sha512-QnI77ec/JtV7R0YBbcVayYTDCRcI9OCbxiUQK6izVyqQO0658n0zQuoNwe+bYgtqnvGAIqTR3FShTd5y4oOjdg==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.23.tgz",
+            "integrity": "sha512-X2Nw8QFc5lgoK3kio5ktM95nqmLUH+q+N/PbV4kCHzF1avqv/EGLnAhaaF0Iu4bewNvHJAAhhwPZFeoV/22nbw==",
             "dependencies": {
-                "@vue/compiler-core": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-core": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.20.tgz",
-            "integrity": "sha512-03aZo+6tQKiFLfunHKSPZvdK4Jsn/ftRCyaro8AQIWkuxJbvSosbKK6HTTn+D2c3nPScG155akJoxKENw7rftQ==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.23.tgz",
+            "integrity": "sha512-Aw+pb50Q5zTjyvWod8mNKmYZDRGHJBptmNNWE+84ZxrzEztPgMz8cNYIzWGbwcFVkmJlhvioAMvKnB+LM/sjSA==",
             "dependencies": {
                 "@babel/parser": "^7.15.0",
-                "@vue/compiler-core": "3.2.20",
-                "@vue/compiler-dom": "3.2.20",
-                "@vue/compiler-ssr": "3.2.20",
-                "@vue/ref-transform": "3.2.20",
-                "@vue/shared": "3.2.20",
+                "@vue/compiler-core": "3.2.23",
+                "@vue/compiler-dom": "3.2.23",
+                "@vue/compiler-ssr": "3.2.23",
+                "@vue/ref-transform": "3.2.23",
+                "@vue/shared": "3.2.23",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7",
                 "postcss": "^8.1.10",
@@ -813,12 +828,12 @@
             }
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.20.tgz",
-            "integrity": "sha512-rzzVVYivm+EjbfiGQvNeyiYZWzr6Hkej97RZLZvcumacQlnKv9176Xo9rRyeWwFbBlxmtNdrVMslRXtipMXk2w==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.23.tgz",
+            "integrity": "sha512-Bqzn4jFyXPK1Ehqiq7e/czS8n62gtYF1Zfeu0DrR5uv+SBllh7LIvZjZU6+c8qbocAd3/T3I3gn2cZGmnDb6zg==",
             "dependencies": {
-                "@vue/compiler-dom": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-dom": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "node_modules/@vue/devtools-api": {
@@ -827,60 +842,60 @@
             "integrity": "sha512-ObzQhgkoVeoyKv+e8+tB/jQBL2smtk/NmC9OmFK8UqdDpoOdv/Kf9pyDWL+IFyM7qLD2C75rszJujvGSPSpGlw=="
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.20.tgz",
-            "integrity": "sha512-nSmoLojUTk+H8HNTAkrUduB4+yIUBK2HPihJo2uXVSH4Spry6oqN6lFzE5zpLK+F27Sja+UqR9R1+/kIOsHV5w==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.23.tgz",
+            "integrity": "sha512-8RGVr/5Kpgb/EkCjgHXqttgA5IMc6n0lIXFY4TVbMkzdXrvaIhzBd7Te44oIDsTSYVKZLpfHd6/wEnuDqE8vFw==",
             "dependencies": {
-                "@vue/shared": "3.2.20"
+                "@vue/shared": "3.2.23"
             }
         },
         "node_modules/@vue/ref-transform": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.20.tgz",
-            "integrity": "sha512-Y42d3PGlYZ1lXcF3dbd3+qU/C/a3wYEZ949fyOI5ptzkjDWlkfU6vn74fmOjsLjEcjs10BXK2qO99FqQIK2r1Q==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.23.tgz",
+            "integrity": "sha512-gW0GD2PSAs/th7mC7tPB/UwpIQxclbApVtsDtscDmOJXb2+cdu60ny+SuHNgfrlUT/JqWKQHq7jFKO4woxLNaA==",
             "dependencies": {
                 "@babel/parser": "^7.15.0",
-                "@vue/compiler-core": "3.2.20",
-                "@vue/shared": "3.2.20",
+                "@vue/compiler-core": "3.2.23",
+                "@vue/shared": "3.2.23",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.20.tgz",
-            "integrity": "sha512-d1xfUGhZPfiZzAN7SatStD4vRtT8deJSXib2+Cz3x0brjMWKxe32asQc154FF1E2fFgMCHtnfd4A90bQEzV4GQ==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.23.tgz",
+            "integrity": "sha512-wSI5lmY2kCGLf89iiygqxVh6/5bsawz78Me9n1x4U2bHnN0yf3PWyuhN0WgIE8VfEaF7e75E333uboNEIFjgkg==",
             "dependencies": {
-                "@vue/reactivity": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/reactivity": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.20.tgz",
-            "integrity": "sha512-4TCvZMLhESWCFHFYgqN4QmMA/onnINAlUovhopjlS8ST27G1A8Z0tyxPzLoXLa+b5JrOpbMPheEMPvdKExTJig==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.23.tgz",
+            "integrity": "sha512-z6lp0888NkLmxD9j2sGoll8Kb7J743s8s6w7GbiyUc4WZwm0KJ35B4qTFDMoIU0G7CatS6Z+yRTpPHc6srtByg==",
             "dependencies": {
-                "@vue/runtime-core": "3.2.20",
-                "@vue/shared": "3.2.20",
+                "@vue/runtime-core": "3.2.23",
+                "@vue/shared": "3.2.23",
                 "csstype": "^2.6.8"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.20.tgz",
-            "integrity": "sha512-viIbZGep9XabnrRcaxWIi00cOh1x21QYm2upIL5W0zqzTJ54VdTzpI+zi1osNp+VfRQDTHpV2U7H3Kn4ljYJvg==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.23.tgz",
+            "integrity": "sha512-mgQ2VAE5WjeZELJKNbwE69uiBNpN+3LyL0ZDki1bJWVwHD2fhPfx7pwyYuiucE81xz2LxVsyGxhKKUL997g8vw==",
             "dependencies": {
-                "@vue/compiler-ssr": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-ssr": "3.2.23",
+                "@vue/shared": "3.2.23"
             },
             "peerDependencies": {
-                "vue": "3.2.20"
+                "vue": "3.2.23"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.20.tgz",
-            "integrity": "sha512-FbpX+hD5BvXCQerEYO7jtAGHlhAkhTQ4KIV73kmLWNlawWhTiVuQxizgVb0BOkX5oG9cIRZ42EG++d/k/Efp0w=="
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.23.tgz",
+            "integrity": "sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA=="
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -1427,9 +1442,9 @@
             }
         },
         "node_modules/csstype": {
-            "version": "2.6.18",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
-            "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
+            "version": "2.6.19",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
+            "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
         },
         "node_modules/debug": {
             "version": "4.3.2",
@@ -1539,9 +1554,9 @@
             ]
         },
         "node_modules/domhandler": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
-            "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
+            "integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
             "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
@@ -2759,9 +2774,9 @@
             }
         },
         "node_modules/htmlparser2": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.1.2.tgz",
-            "integrity": "sha512-d6cqsbJba2nRdg8WW2okyD4ceonFHn9jLFxhwlNcLhQWcFPdxXeJulgOLjLKtAK9T6ahd+GQNZwG9fjmGW7lyg==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
             "dev": true,
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -4035,9 +4050,9 @@
             }
         },
         "node_modules/request-light": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.4.tgz",
-            "integrity": "sha512-t3566CMweOFlUk7Y1DJMu5OrtpoZEb6aSTsLQVT3wtrIEJ5NhcY9G/Oqxvjllzl4a15zXfFlcr9q40LbLVQJqw==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.5.tgz",
+            "integrity": "sha512-AvjfJuhyT6dYfhtIBF+IpTPQco+Td1QJ6PsIJ5xui110vQ5p9HxHk+m1XJqXazLQT6CxxSx9eNv6R/+fu4bZig==",
             "dev": true
         },
         "node_modules/resolve": {
@@ -4656,9 +4671,9 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "2.6.13",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.13.tgz",
-            "integrity": "sha512-+tGZ1OxozRirTudl4M3N3UTNJOlxdVo/qBl2IlDEy/ZpTFcskp+k5ncNjayR3bRYTCbqSOFz2JWGN1UmuDMScA==",
+            "version": "2.6.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.14.tgz",
+            "integrity": "sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.13.2",
@@ -4702,9 +4717,9 @@
             }
         },
         "node_modules/vscode-css-languageservice": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.1.8.tgz",
-            "integrity": "sha512-Si1sMykS8U/p8LYgLGPCfZD1YFT0AtvUJQp9XJGw64DZWhtwYo28G2l64USLS9ge4ZPMZpwdpOK7PfbVKfgiiA==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.1.9.tgz",
+            "integrity": "sha512-/tFOWeZBL3Oc9Zc+2MAi3rEwiXJTSZsvjB+M7nSjWLbGPUIjukUA7YzLgsBoUfR35sPJYnXWUkL56PdfIYM8GA==",
             "dev": true,
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -4714,9 +4729,9 @@
             }
         },
         "node_modules/vscode-html-languageservice": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.1.1.tgz",
-            "integrity": "sha512-rrDyCiOgMwOPgchpPGAeLzjYVVEW/Ror2/a1BWUEI3S9+NQhA9vj4SQkzmH6g2Bq9S9SV0OQeadD+xphOf1N3w==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.2.0.tgz",
+            "integrity": "sha512-5ebk/5kMa7PrCPL3JuP27vo8h+coDgSkMP14pSlKz3ISXZxHm+nnCenhVrpy9Ayamtwb28YXeQuN8AqNQH8kVQ==",
             "dev": true,
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -4726,9 +4741,9 @@
             }
         },
         "node_modules/vscode-json-languageservice": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.9.tgz",
-            "integrity": "sha512-kxNHitUy2fCxmP6vAp0SRLrUSuecUYzzxlC+85cC3jJlFHWmvtCJOzikC+kcUnIdls9fQSB8n0yHs8Sl6taxJw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.10.tgz",
+            "integrity": "sha512-IHliMEEYSY0tJjJt0ECb8ESx/nRXpoy9kN42WVQXgaqGyizFAf3jibSiezDQTrrY7f3kywXggCU+kkJEM+OLZQ==",
             "dev": true,
             "dependencies": {
                 "jsonc-parser": "^3.0.0",
@@ -4736,9 +4751,6 @@
                 "vscode-languageserver-types": "^3.16.0",
                 "vscode-nls": "^5.0.0",
                 "vscode-uri": "^3.0.2"
-            },
-            "engines": {
-                "npm": ">=7.0.0"
             }
         },
         "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
@@ -4748,46 +4760,46 @@
             "dev": true
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "8.0.0-next.3",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.3.tgz",
-            "integrity": "sha512-2wRiBR5tZAXZ4UxIO4F0cT/zN6OpruoWO0vc7EpQZxVfumb0pYiSegB+PaOzXCuFQzh7YEshW/XMg4zTz3FGVQ==",
+            "version": "8.0.0-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.4.tgz",
+            "integrity": "sha512-i+wvza5Wd0YV/t9qhnS8I+dJdhJ1fHIhRW4f262rXXM9Mgts5VZhYrRZufGcai4y99RlbZvwaZhplQ6diRXkaA==",
             "dev": true,
             "engines": {
                 "node": ">=8.0.0 || >=10.0.0"
             }
         },
         "node_modules/vscode-languageserver": {
-            "version": "8.0.0-next.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.0-next.3.tgz",
-            "integrity": "sha512-uxL/tKUa/gRdvQINVmMnK32d6LwfTPTvF7l1iZIFDuAdhGrQ+Po+4lS3w4hwQSeUmapM1WMELXNBFca/u3H5Uw==",
+            "version": "8.0.0-next.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.0-next.5.tgz",
+            "integrity": "sha512-3E2W0eWtGKb6QAJqspOnD0thrBRRo8IGUMV5jpDNMcMKvmtkcxMwsBh0VxdvuWaZ51PiNyR4L+B+GUvkYsyFEg==",
             "dev": true,
             "dependencies": {
-                "vscode-languageserver-protocol": "3.17.0-next.9"
+                "vscode-languageserver-protocol": "3.17.0-next.11"
             },
             "bin": {
                 "installServerIntoExtension": "bin/installServerIntoExtension"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.0-next.9",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.9.tgz",
-            "integrity": "sha512-DGkRmbI1hRBMY6HU6MOyza5AvYp0+HcbMf2qdmI98luyQJ26dOfHY5K38OS4hlTHhdJg9RypTQ/uBbLZehmn1Q==",
+            "version": "3.17.0-next.11",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.11.tgz",
+            "integrity": "sha512-9FqHT7XvM6tWFsnLvRfuQA7Zh7wZZYAwA9dK85lYthA8M1aXpXEP9drXVvO/Fe03MUeJpKVf2e4/NvDaFUnttg==",
             "dev": true,
             "dependencies": {
-                "vscode-jsonrpc": "8.0.0-next.3",
-                "vscode-languageserver-types": "3.17.0-next.4"
+                "vscode-jsonrpc": "8.0.0-next.4",
+                "vscode-languageserver-types": "3.17.0-next.5"
             }
         },
         "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
-            "version": "3.17.0-next.4",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.4.tgz",
-            "integrity": "sha512-MraVkZDhfqa3ftnKW9rEDeqsV+ji8OrtEjx6mVjzVGm5U2XXT+mdqDWyQ+y0Gvb2/aa2oJJQyTAaDmRTUKiUbg==",
+            "version": "3.17.0-next.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.5.tgz",
+            "integrity": "sha512-Zcfaw8BznhlJWB09LDR0dscXyxn9+liREqJnPF4pigeUCHwKxYapYqizwuCpMHQ/oLYiAvKwU+f28hPleYu7pA==",
             "dev": true
         },
         "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.2.tgz",
-            "integrity": "sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.3.tgz",
+            "integrity": "sha512-ynEGytvgTb6HVSUwPJIAZgiHQmPCx8bZ8w5um5Lz+q5DjP0Zj8wTFhQpyg8xaMvefDytw2+HH5yzqS+FhsR28A==",
             "dev": true
         },
         "node_modules/vscode-languageserver-types": {
@@ -4803,27 +4815,27 @@
             "dev": true
         },
         "node_modules/vscode-pug-languageservice": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vscode-pug-languageservice/-/vscode-pug-languageservice-0.28.10.tgz",
-            "integrity": "sha512-zhpNmMxltAlid4ZWVq0YrCbD0v2Nk/OsUl2q1pZkSJheGVMj/ZAlcYqDvWjLbMfGPtpvoC6nPxhSCc6sIDN9XA==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vscode-pug-languageservice/-/vscode-pug-languageservice-0.29.8.tgz",
+            "integrity": "sha512-QHYAzDSJLg7GOLxCZ12qsM0dAM0dPeMSS1t4kKfzLsfpErmZpFzkAIXbidVrNMdMffGZMtTuIlcpEyWHbx96Iw==",
             "dev": true,
             "dependencies": {
-                "@volar/code-gen": "0.28.10",
-                "@volar/shared": "0.28.10",
-                "@volar/source-map": "0.28.10",
-                "@volar/transforms": "0.28.10",
+                "@volar/code-gen": "0.29.8",
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8",
+                "@volar/transforms": "0.29.8",
                 "pug-lexer": "^5.0.1",
                 "pug-parser": "^6.0.0",
                 "vscode-languageserver": "^8.0.0-next.2"
             }
         },
         "node_modules/vscode-typescript-languageservice": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.28.10.tgz",
-            "integrity": "sha512-TTJSQss0YR784e0Rr8se5huxd0edqGzO7A51kejEQiPPhIcOlYCEeeFxDtqv3S+/fUUkeFVdRBZA9Ie7Jfrldw==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.29.8.tgz",
+            "integrity": "sha512-eecDqHk4WjEvy6VHQ6teHczppQ9yJO2wExCy7yu7WiFj35qbw0h4G6Erv46MvP3ClL8FggFzD7s1qM6vdqJUfw==",
             "dev": true,
             "dependencies": {
-                "@volar/shared": "0.28.10",
+                "@volar/shared": "0.29.8",
                 "semver": "^7.3.5",
                 "upath": "^2.0.1",
                 "vscode-languageserver": "^8.0.0-next.2",
@@ -4837,20 +4849,20 @@
             "dev": true
         },
         "node_modules/vscode-vue-languageservice": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vscode-vue-languageservice/-/vscode-vue-languageservice-0.28.10.tgz",
-            "integrity": "sha512-xsA9aEiELiA9zHxzhI58Y6crcSfqxtt3EDKyey9rcNYe/bdY1NY0qLh3SRxdXF8YwoxzRvnn4iUw0oxCjHnFUQ==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vscode-vue-languageservice/-/vscode-vue-languageservice-0.29.8.tgz",
+            "integrity": "sha512-qSJdvW5ttyGUB/8uWDKgo8vnIoFnXYlBP4Z/cn54btsRn6ZMw7IJGJU1381e7p/yGvMTLeGbugD53SghbnSa6g==",
             "dev": true,
             "dependencies": {
-                "@volar/code-gen": "0.28.10",
-                "@volar/html2pug": "0.28.10",
-                "@volar/shared": "0.28.10",
-                "@volar/source-map": "0.28.10",
-                "@volar/transforms": "0.28.10",
+                "@volar/code-gen": "0.29.8",
+                "@volar/html2pug": "0.29.8",
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8",
+                "@volar/transforms": "0.29.8",
+                "@volar/vue-code-gen": "0.29.8",
                 "@vscode/emmet-helper": "^2.8.0",
-                "@vue/compiler-dom": "^3.2.20",
-                "@vue/reactivity": "^3.2.20",
-                "@vue/shared": "^3.2.20",
+                "@vue/reactivity": "^3.2.21",
+                "@vue/shared": "^3.2.21",
                 "request-light": "^0.5.4",
                 "upath": "^2.0.1",
                 "vscode-css-languageservice": "^5.1.7",
@@ -4858,20 +4870,20 @@
                 "vscode-json-languageservice": "^4.1.8",
                 "vscode-languageserver": "^8.0.0-next.2",
                 "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-pug-languageservice": "0.28.10",
-                "vscode-typescript-languageservice": "0.28.10"
+                "vscode-pug-languageservice": "0.29.8",
+                "vscode-typescript-languageservice": "0.29.8"
             }
         },
         "node_modules/vue": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.20.tgz",
-            "integrity": "sha512-81JjEP4OGk9oO8+CU0h2nFPGgJBm9mNa3kdCX2k6FuRdrWrC+CNe+tOnuIeTg8EWwQuI+wwdra5Q7vSzp7p4Iw==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.23.tgz",
+            "integrity": "sha512-MGp9JZC37lzGhwSu6c1tQxrQbXbw7XKFqtYh7SFwNrNK899FPxGAHwSHMZijMChTSC3uZrD2BGO/3EHOgMJ0cw==",
             "dependencies": {
-                "@vue/compiler-dom": "3.2.20",
-                "@vue/compiler-sfc": "3.2.20",
-                "@vue/runtime-dom": "3.2.20",
-                "@vue/server-renderer": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-dom": "3.2.23",
+                "@vue/compiler-sfc": "3.2.23",
+                "@vue/runtime-dom": "3.2.23",
+                "@vue/server-renderer": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "node_modules/vue-eslint-parser": {
@@ -4957,13 +4969,13 @@
             }
         },
         "node_modules/vue-tsc": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.28.10.tgz",
-            "integrity": "sha512-tGD7eC74MHqKH2/F66AYkC1zNiLrgnhMzeYWou3p/wApMaUEM4h29HqYoKN6uE+pq87uvq/penYqUSBXhIwLiA==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.29.8.tgz",
+            "integrity": "sha512-pT0wLRjvRuSmB+J4WJT6uuV9mO0KtSSXEAtaVXZQzyk5+DJdbLIQTbRce/TXSkfqt1l1WogO78RjtOJFiMCgfQ==",
             "dev": true,
             "dependencies": {
-                "@volar/shared": "0.28.10",
-                "vscode-vue-languageservice": "0.28.10"
+                "@volar/shared": "0.29.8",
+                "vscode-vue-languageservice": "0.29.8"
             },
             "bin": {
                 "vue-tsc": "bin/vue-tsc.js"
@@ -5738,26 +5750,26 @@
             }
         },
         "@vitejs/plugin-vue": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.9.4.tgz",
-            "integrity": "sha512-0CZqaCoChriPTTtGkERy1LGPcYjGFpi2uYRhBPIkqJqUGV5JnJFhQAgh6oH9j5XZHfrRaisX8W0xSpO4T7S78A==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-1.10.1.tgz",
+            "integrity": "sha512-oL76QETMSpVE9jIScirGB2bYJEVU/+r+g+K7oG+sXPs9TZljqveoVRsmLyXlMZTjpQkLL8gz527cW80NMGVKJg==",
             "dev": true,
             "requires": {}
         },
         "@volar/code-gen": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.28.10.tgz",
-            "integrity": "sha512-MybgBubg1im4MiFoiTUMmxKTC+KZJQfIO5g/TVnysEsCr4ssG0lG1rF3Gg3lbQKefdMiqsH5FNuMyqLC/bsWQg==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.29.8.tgz",
+            "integrity": "sha512-eohLLUqPChHRPDFT5gXn4V6pr/CeTri7Ou5GI26lUvBRRAbP8p+oYfQRcbMPGeKmVkYjfVj0chsxQGx6T8PQ4Q==",
             "dev": true,
             "requires": {
-                "@volar/shared": "0.28.10",
-                "@volar/source-map": "0.28.10"
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8"
             }
         },
         "@volar/html2pug": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/html2pug/-/html2pug-0.28.10.tgz",
-            "integrity": "sha512-orcNnKyUPZZVb7pRvRHU7R8gk4abKZQELT0zXt2T7EbC5B8usmWNav6Sis9kVzV5Etj5h/IYutv7Df7PiKwLOQ==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/html2pug/-/html2pug-0.29.8.tgz",
+            "integrity": "sha512-bhSNXg8A2aD3w0B+CwmHjqCAaKtj5rORbE5C/q/UdGqptJbC6STCmi30KuRTdfPhR++Xb18Hauf3s/WCmtNAPA==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.2.0",
@@ -5767,9 +5779,9 @@
             }
         },
         "@volar/shared": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/shared/-/shared-0.28.10.tgz",
-            "integrity": "sha512-MzBEfBM5E5q4EfOd8Gkqmo+XTfbXiuT8IEWtfmpS8ax3GVeofkeAgzK/TadkatW/Nb2cKOaCYkmILpFKvDnDRQ==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/shared/-/shared-0.29.8.tgz",
+            "integrity": "sha512-Y1NN6irkIukD+T0wf4p/dHWYL90sacN2e2lYoDXxRlvoYxwANnHgw0J0Rcp+yw58ElWRScdG7/YntEIuZWeJsw==",
             "dev": true,
             "requires": {
                 "upath": "^2.0.1",
@@ -5778,22 +5790,37 @@
             }
         },
         "@volar/source-map": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.28.10.tgz",
-            "integrity": "sha512-hQ2gclwP7yvZIdaVEC1LixViDPIO6JGkCBxAS8Erg9p2d0ruTyzazfd0NLaLuHLoMnxExILYNK2W05yQmIpRIA==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.29.8.tgz",
+            "integrity": "sha512-7w+UoYtnc6UQu30CgMVvx0YN4dzDgP4TIsSmUaW62AGmxU9Lxwp3Kkn/4N8efi91z8ma5Z78v/HddyJPwAC3LA==",
             "dev": true,
             "requires": {
-                "@volar/shared": "0.28.10"
+                "@volar/shared": "0.29.8"
             }
         },
         "@volar/transforms": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/@volar/transforms/-/transforms-0.28.10.tgz",
-            "integrity": "sha512-GOQN3amI733oFweKKjuBBOEOMwy0e/aEAnnJNavrrHa7LY6Ke/JfNsoWhi9Pb2FAPYd+WyruDDFX8yKHjQE1xw==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/transforms/-/transforms-0.29.8.tgz",
+            "integrity": "sha512-o2hRa8CoDwYTO1Mu5KA47+1elUnYUjDaVhCvbyKlRfd8qpHea2llotArq7B6OORSL2M9DVs1IRJ5NGURBFeZ3Q==",
             "dev": true,
             "requires": {
-                "@volar/shared": "0.28.10",
+                "@volar/shared": "0.29.8",
                 "vscode-languageserver": "^8.0.0-next.2"
+            }
+        },
+        "@volar/vue-code-gen": {
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/@volar/vue-code-gen/-/vue-code-gen-0.29.8.tgz",
+            "integrity": "sha512-E1e7P2oktNC/DzgDBditfla4s8+HlUlluZ+BtcLvEdbkl3QEjujkB0x1wxguWzXmpWgLIDPtrS3Jzll5cCOkTg==",
+            "dev": true,
+            "requires": {
+                "@volar/code-gen": "0.29.8",
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8",
+                "@vue/compiler-core": "^3.2.21",
+                "@vue/compiler-dom": "^3.2.21",
+                "@vue/shared": "^3.2.21",
+                "upath": "^2.0.1"
             }
         },
         "@vscode/emmet-helper": {
@@ -5819,36 +5846,36 @@
             }
         },
         "@vue/compiler-core": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.20.tgz",
-            "integrity": "sha512-vcEXlKXoPwBXFP5aUTHN9GTZaDfwCofa9Yu9bbW2C5O/QSa9Esdt7OG4+0RRd3EHEMxUvEdj4RZrd/KpQeiJbA==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.23.tgz",
+            "integrity": "sha512-4ZhiI/orx+7EJ1B+0zjgvXMV2uRN+XBfG06UN2sJfND9rH5gtEQT3QmO4erum1o6Irl7y754W8/KSaDJh4EUQg==",
             "requires": {
                 "@babel/parser": "^7.15.0",
-                "@vue/shared": "3.2.20",
+                "@vue/shared": "3.2.23",
                 "estree-walker": "^2.0.2",
                 "source-map": "^0.6.1"
             }
         },
         "@vue/compiler-dom": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.20.tgz",
-            "integrity": "sha512-QnI77ec/JtV7R0YBbcVayYTDCRcI9OCbxiUQK6izVyqQO0658n0zQuoNwe+bYgtqnvGAIqTR3FShTd5y4oOjdg==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.23.tgz",
+            "integrity": "sha512-X2Nw8QFc5lgoK3kio5ktM95nqmLUH+q+N/PbV4kCHzF1avqv/EGLnAhaaF0Iu4bewNvHJAAhhwPZFeoV/22nbw==",
             "requires": {
-                "@vue/compiler-core": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-core": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "@vue/compiler-sfc": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.20.tgz",
-            "integrity": "sha512-03aZo+6tQKiFLfunHKSPZvdK4Jsn/ftRCyaro8AQIWkuxJbvSosbKK6HTTn+D2c3nPScG155akJoxKENw7rftQ==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.23.tgz",
+            "integrity": "sha512-Aw+pb50Q5zTjyvWod8mNKmYZDRGHJBptmNNWE+84ZxrzEztPgMz8cNYIzWGbwcFVkmJlhvioAMvKnB+LM/sjSA==",
             "requires": {
                 "@babel/parser": "^7.15.0",
-                "@vue/compiler-core": "3.2.20",
-                "@vue/compiler-dom": "3.2.20",
-                "@vue/compiler-ssr": "3.2.20",
-                "@vue/ref-transform": "3.2.20",
-                "@vue/shared": "3.2.20",
+                "@vue/compiler-core": "3.2.23",
+                "@vue/compiler-dom": "3.2.23",
+                "@vue/compiler-ssr": "3.2.23",
+                "@vue/ref-transform": "3.2.23",
+                "@vue/shared": "3.2.23",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7",
                 "postcss": "^8.1.10",
@@ -5856,12 +5883,12 @@
             }
         },
         "@vue/compiler-ssr": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.20.tgz",
-            "integrity": "sha512-rzzVVYivm+EjbfiGQvNeyiYZWzr6Hkej97RZLZvcumacQlnKv9176Xo9rRyeWwFbBlxmtNdrVMslRXtipMXk2w==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.23.tgz",
+            "integrity": "sha512-Bqzn4jFyXPK1Ehqiq7e/czS8n62gtYF1Zfeu0DrR5uv+SBllh7LIvZjZU6+c8qbocAd3/T3I3gn2cZGmnDb6zg==",
             "requires": {
-                "@vue/compiler-dom": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-dom": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "@vue/devtools-api": {
@@ -5870,57 +5897,57 @@
             "integrity": "sha512-ObzQhgkoVeoyKv+e8+tB/jQBL2smtk/NmC9OmFK8UqdDpoOdv/Kf9pyDWL+IFyM7qLD2C75rszJujvGSPSpGlw=="
         },
         "@vue/reactivity": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.20.tgz",
-            "integrity": "sha512-nSmoLojUTk+H8HNTAkrUduB4+yIUBK2HPihJo2uXVSH4Spry6oqN6lFzE5zpLK+F27Sja+UqR9R1+/kIOsHV5w==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.23.tgz",
+            "integrity": "sha512-8RGVr/5Kpgb/EkCjgHXqttgA5IMc6n0lIXFY4TVbMkzdXrvaIhzBd7Te44oIDsTSYVKZLpfHd6/wEnuDqE8vFw==",
             "requires": {
-                "@vue/shared": "3.2.20"
+                "@vue/shared": "3.2.23"
             }
         },
         "@vue/ref-transform": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.20.tgz",
-            "integrity": "sha512-Y42d3PGlYZ1lXcF3dbd3+qU/C/a3wYEZ949fyOI5ptzkjDWlkfU6vn74fmOjsLjEcjs10BXK2qO99FqQIK2r1Q==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.23.tgz",
+            "integrity": "sha512-gW0GD2PSAs/th7mC7tPB/UwpIQxclbApVtsDtscDmOJXb2+cdu60ny+SuHNgfrlUT/JqWKQHq7jFKO4woxLNaA==",
             "requires": {
                 "@babel/parser": "^7.15.0",
-                "@vue/compiler-core": "3.2.20",
-                "@vue/shared": "3.2.20",
+                "@vue/compiler-core": "3.2.23",
+                "@vue/shared": "3.2.23",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.25.7"
             }
         },
         "@vue/runtime-core": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.20.tgz",
-            "integrity": "sha512-d1xfUGhZPfiZzAN7SatStD4vRtT8deJSXib2+Cz3x0brjMWKxe32asQc154FF1E2fFgMCHtnfd4A90bQEzV4GQ==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.23.tgz",
+            "integrity": "sha512-wSI5lmY2kCGLf89iiygqxVh6/5bsawz78Me9n1x4U2bHnN0yf3PWyuhN0WgIE8VfEaF7e75E333uboNEIFjgkg==",
             "requires": {
-                "@vue/reactivity": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/reactivity": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "@vue/runtime-dom": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.20.tgz",
-            "integrity": "sha512-4TCvZMLhESWCFHFYgqN4QmMA/onnINAlUovhopjlS8ST27G1A8Z0tyxPzLoXLa+b5JrOpbMPheEMPvdKExTJig==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.23.tgz",
+            "integrity": "sha512-z6lp0888NkLmxD9j2sGoll8Kb7J743s8s6w7GbiyUc4WZwm0KJ35B4qTFDMoIU0G7CatS6Z+yRTpPHc6srtByg==",
             "requires": {
-                "@vue/runtime-core": "3.2.20",
-                "@vue/shared": "3.2.20",
+                "@vue/runtime-core": "3.2.23",
+                "@vue/shared": "3.2.23",
                 "csstype": "^2.6.8"
             }
         },
         "@vue/server-renderer": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.20.tgz",
-            "integrity": "sha512-viIbZGep9XabnrRcaxWIi00cOh1x21QYm2upIL5W0zqzTJ54VdTzpI+zi1osNp+VfRQDTHpV2U7H3Kn4ljYJvg==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.23.tgz",
+            "integrity": "sha512-mgQ2VAE5WjeZELJKNbwE69uiBNpN+3LyL0ZDki1bJWVwHD2fhPfx7pwyYuiucE81xz2LxVsyGxhKKUL997g8vw==",
             "requires": {
-                "@vue/compiler-ssr": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-ssr": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "@vue/shared": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.20.tgz",
-            "integrity": "sha512-FbpX+hD5BvXCQerEYO7jtAGHlhAkhTQ4KIV73kmLWNlawWhTiVuQxizgVb0BOkX5oG9cIRZ42EG++d/k/Efp0w=="
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.23.tgz",
+            "integrity": "sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA=="
         },
         "@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -6383,9 +6410,9 @@
             }
         },
         "csstype": {
-            "version": "2.6.18",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
-            "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
+            "version": "2.6.19",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
+            "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
         },
         "debug": {
             "version": "4.3.2",
@@ -6468,9 +6495,9 @@
             "dev": true
         },
         "domhandler": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
-            "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
+            "integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.2.0"
@@ -7352,9 +7379,9 @@
             "integrity": "sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA=="
         },
         "htmlparser2": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.1.2.tgz",
-            "integrity": "sha512-d6cqsbJba2nRdg8WW2okyD4ceonFHn9jLFxhwlNcLhQWcFPdxXeJulgOLjLKtAK9T6ahd+GQNZwG9fjmGW7lyg==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+            "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
@@ -8343,9 +8370,9 @@
             "dev": true
         },
         "request-light": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.4.tgz",
-            "integrity": "sha512-t3566CMweOFlUk7Y1DJMu5OrtpoZEb6aSTsLQVT3wtrIEJ5NhcY9G/Oqxvjllzl4a15zXfFlcr9q40LbLVQJqw==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.5.tgz",
+            "integrity": "sha512-AvjfJuhyT6dYfhtIBF+IpTPQco+Td1QJ6PsIJ5xui110vQ5p9HxHk+m1XJqXazLQT6CxxSx9eNv6R/+fu4bZig==",
             "dev": true
         },
         "resolve": {
@@ -8780,9 +8807,9 @@
             "dev": true
         },
         "vite": {
-            "version": "2.6.13",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.13.tgz",
-            "integrity": "sha512-+tGZ1OxozRirTudl4M3N3UTNJOlxdVo/qBl2IlDEy/ZpTFcskp+k5ncNjayR3bRYTCbqSOFz2JWGN1UmuDMScA==",
+            "version": "2.6.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.14.tgz",
+            "integrity": "sha512-2HA9xGyi+EhY2MXo0+A2dRsqsAG3eFNEVIo12olkWhOmc8LfiM+eMdrXf+Ruje9gdXgvSqjLI9freec1RUM5EA==",
             "dev": true,
             "requires": {
                 "esbuild": "^0.13.2",
@@ -8799,9 +8826,9 @@
             "dev": true
         },
         "vscode-css-languageservice": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.1.8.tgz",
-            "integrity": "sha512-Si1sMykS8U/p8LYgLGPCfZD1YFT0AtvUJQp9XJGw64DZWhtwYo28G2l64USLS9ge4ZPMZpwdpOK7PfbVKfgiiA==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-5.1.9.tgz",
+            "integrity": "sha512-/tFOWeZBL3Oc9Zc+2MAi3rEwiXJTSZsvjB+M7nSjWLbGPUIjukUA7YzLgsBoUfR35sPJYnXWUkL56PdfIYM8GA==",
             "dev": true,
             "requires": {
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -8811,9 +8838,9 @@
             }
         },
         "vscode-html-languageservice": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.1.1.tgz",
-            "integrity": "sha512-rrDyCiOgMwOPgchpPGAeLzjYVVEW/Ror2/a1BWUEI3S9+NQhA9vj4SQkzmH6g2Bq9S9SV0OQeadD+xphOf1N3w==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.2.0.tgz",
+            "integrity": "sha512-5ebk/5kMa7PrCPL3JuP27vo8h+coDgSkMP14pSlKz3ISXZxHm+nnCenhVrpy9Ayamtwb28YXeQuN8AqNQH8kVQ==",
             "dev": true,
             "requires": {
                 "vscode-languageserver-textdocument": "^1.0.1",
@@ -8823,9 +8850,9 @@
             }
         },
         "vscode-json-languageservice": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.9.tgz",
-            "integrity": "sha512-kxNHitUy2fCxmP6vAp0SRLrUSuecUYzzxlC+85cC3jJlFHWmvtCJOzikC+kcUnIdls9fQSB8n0yHs8Sl6taxJw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.10.tgz",
+            "integrity": "sha512-IHliMEEYSY0tJjJt0ECb8ESx/nRXpoy9kN42WVQXgaqGyizFAf3jibSiezDQTrrY7f3kywXggCU+kkJEM+OLZQ==",
             "dev": true,
             "requires": {
                 "jsonc-parser": "^3.0.0",
@@ -8844,42 +8871,42 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "8.0.0-next.3",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.3.tgz",
-            "integrity": "sha512-2wRiBR5tZAXZ4UxIO4F0cT/zN6OpruoWO0vc7EpQZxVfumb0pYiSegB+PaOzXCuFQzh7YEshW/XMg4zTz3FGVQ==",
+            "version": "8.0.0-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.0-next.4.tgz",
+            "integrity": "sha512-i+wvza5Wd0YV/t9qhnS8I+dJdhJ1fHIhRW4f262rXXM9Mgts5VZhYrRZufGcai4y99RlbZvwaZhplQ6diRXkaA==",
             "dev": true
         },
         "vscode-languageserver": {
-            "version": "8.0.0-next.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.0-next.3.tgz",
-            "integrity": "sha512-uxL/tKUa/gRdvQINVmMnK32d6LwfTPTvF7l1iZIFDuAdhGrQ+Po+4lS3w4hwQSeUmapM1WMELXNBFca/u3H5Uw==",
+            "version": "8.0.0-next.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.0-next.5.tgz",
+            "integrity": "sha512-3E2W0eWtGKb6QAJqspOnD0thrBRRo8IGUMV5jpDNMcMKvmtkcxMwsBh0VxdvuWaZ51PiNyR4L+B+GUvkYsyFEg==",
             "dev": true,
             "requires": {
-                "vscode-languageserver-protocol": "3.17.0-next.9"
+                "vscode-languageserver-protocol": "3.17.0-next.11"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.17.0-next.9",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.9.tgz",
-            "integrity": "sha512-DGkRmbI1hRBMY6HU6MOyza5AvYp0+HcbMf2qdmI98luyQJ26dOfHY5K38OS4hlTHhdJg9RypTQ/uBbLZehmn1Q==",
+            "version": "3.17.0-next.11",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.0-next.11.tgz",
+            "integrity": "sha512-9FqHT7XvM6tWFsnLvRfuQA7Zh7wZZYAwA9dK85lYthA8M1aXpXEP9drXVvO/Fe03MUeJpKVf2e4/NvDaFUnttg==",
             "dev": true,
             "requires": {
-                "vscode-jsonrpc": "8.0.0-next.3",
-                "vscode-languageserver-types": "3.17.0-next.4"
+                "vscode-jsonrpc": "8.0.0-next.4",
+                "vscode-languageserver-types": "3.17.0-next.5"
             },
             "dependencies": {
                 "vscode-languageserver-types": {
-                    "version": "3.17.0-next.4",
-                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.4.tgz",
-                    "integrity": "sha512-MraVkZDhfqa3ftnKW9rEDeqsV+ji8OrtEjx6mVjzVGm5U2XXT+mdqDWyQ+y0Gvb2/aa2oJJQyTAaDmRTUKiUbg==",
+                    "version": "3.17.0-next.5",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.0-next.5.tgz",
+                    "integrity": "sha512-Zcfaw8BznhlJWB09LDR0dscXyxn9+liREqJnPF4pigeUCHwKxYapYqizwuCpMHQ/oLYiAvKwU+f28hPleYu7pA==",
                     "dev": true
                 }
             }
         },
         "vscode-languageserver-textdocument": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.2.tgz",
-            "integrity": "sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.3.tgz",
+            "integrity": "sha512-ynEGytvgTb6HVSUwPJIAZgiHQmPCx8bZ8w5um5Lz+q5DjP0Zj8wTFhQpyg8xaMvefDytw2+HH5yzqS+FhsR28A==",
             "dev": true
         },
         "vscode-languageserver-types": {
@@ -8895,27 +8922,27 @@
             "dev": true
         },
         "vscode-pug-languageservice": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vscode-pug-languageservice/-/vscode-pug-languageservice-0.28.10.tgz",
-            "integrity": "sha512-zhpNmMxltAlid4ZWVq0YrCbD0v2Nk/OsUl2q1pZkSJheGVMj/ZAlcYqDvWjLbMfGPtpvoC6nPxhSCc6sIDN9XA==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vscode-pug-languageservice/-/vscode-pug-languageservice-0.29.8.tgz",
+            "integrity": "sha512-QHYAzDSJLg7GOLxCZ12qsM0dAM0dPeMSS1t4kKfzLsfpErmZpFzkAIXbidVrNMdMffGZMtTuIlcpEyWHbx96Iw==",
             "dev": true,
             "requires": {
-                "@volar/code-gen": "0.28.10",
-                "@volar/shared": "0.28.10",
-                "@volar/source-map": "0.28.10",
-                "@volar/transforms": "0.28.10",
+                "@volar/code-gen": "0.29.8",
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8",
+                "@volar/transforms": "0.29.8",
                 "pug-lexer": "^5.0.1",
                 "pug-parser": "^6.0.0",
                 "vscode-languageserver": "^8.0.0-next.2"
             }
         },
         "vscode-typescript-languageservice": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.28.10.tgz",
-            "integrity": "sha512-TTJSQss0YR784e0Rr8se5huxd0edqGzO7A51kejEQiPPhIcOlYCEeeFxDtqv3S+/fUUkeFVdRBZA9Ie7Jfrldw==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vscode-typescript-languageservice/-/vscode-typescript-languageservice-0.29.8.tgz",
+            "integrity": "sha512-eecDqHk4WjEvy6VHQ6teHczppQ9yJO2wExCy7yu7WiFj35qbw0h4G6Erv46MvP3ClL8FggFzD7s1qM6vdqJUfw==",
             "dev": true,
             "requires": {
-                "@volar/shared": "0.28.10",
+                "@volar/shared": "0.29.8",
                 "semver": "^7.3.5",
                 "upath": "^2.0.1",
                 "vscode-languageserver": "^8.0.0-next.2",
@@ -8929,20 +8956,20 @@
             "dev": true
         },
         "vscode-vue-languageservice": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vscode-vue-languageservice/-/vscode-vue-languageservice-0.28.10.tgz",
-            "integrity": "sha512-xsA9aEiELiA9zHxzhI58Y6crcSfqxtt3EDKyey9rcNYe/bdY1NY0qLh3SRxdXF8YwoxzRvnn4iUw0oxCjHnFUQ==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vscode-vue-languageservice/-/vscode-vue-languageservice-0.29.8.tgz",
+            "integrity": "sha512-qSJdvW5ttyGUB/8uWDKgo8vnIoFnXYlBP4Z/cn54btsRn6ZMw7IJGJU1381e7p/yGvMTLeGbugD53SghbnSa6g==",
             "dev": true,
             "requires": {
-                "@volar/code-gen": "0.28.10",
-                "@volar/html2pug": "0.28.10",
-                "@volar/shared": "0.28.10",
-                "@volar/source-map": "0.28.10",
-                "@volar/transforms": "0.28.10",
+                "@volar/code-gen": "0.29.8",
+                "@volar/html2pug": "0.29.8",
+                "@volar/shared": "0.29.8",
+                "@volar/source-map": "0.29.8",
+                "@volar/transforms": "0.29.8",
+                "@volar/vue-code-gen": "0.29.8",
                 "@vscode/emmet-helper": "^2.8.0",
-                "@vue/compiler-dom": "^3.2.20",
-                "@vue/reactivity": "^3.2.20",
-                "@vue/shared": "^3.2.20",
+                "@vue/reactivity": "^3.2.21",
+                "@vue/shared": "^3.2.21",
                 "request-light": "^0.5.4",
                 "upath": "^2.0.1",
                 "vscode-css-languageservice": "^5.1.7",
@@ -8950,20 +8977,20 @@
                 "vscode-json-languageservice": "^4.1.8",
                 "vscode-languageserver": "^8.0.0-next.2",
                 "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-pug-languageservice": "0.28.10",
-                "vscode-typescript-languageservice": "0.28.10"
+                "vscode-pug-languageservice": "0.29.8",
+                "vscode-typescript-languageservice": "0.29.8"
             }
         },
         "vue": {
-            "version": "3.2.20",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.20.tgz",
-            "integrity": "sha512-81JjEP4OGk9oO8+CU0h2nFPGgJBm9mNa3kdCX2k6FuRdrWrC+CNe+tOnuIeTg8EWwQuI+wwdra5Q7vSzp7p4Iw==",
+            "version": "3.2.23",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.23.tgz",
+            "integrity": "sha512-MGp9JZC37lzGhwSu6c1tQxrQbXbw7XKFqtYh7SFwNrNK899FPxGAHwSHMZijMChTSC3uZrD2BGO/3EHOgMJ0cw==",
             "requires": {
-                "@vue/compiler-dom": "3.2.20",
-                "@vue/compiler-sfc": "3.2.20",
-                "@vue/runtime-dom": "3.2.20",
-                "@vue/server-renderer": "3.2.20",
-                "@vue/shared": "3.2.20"
+                "@vue/compiler-dom": "3.2.23",
+                "@vue/compiler-sfc": "3.2.23",
+                "@vue/runtime-dom": "3.2.23",
+                "@vue/server-renderer": "3.2.23",
+                "@vue/shared": "3.2.23"
             }
         },
         "vue-eslint-parser": {
@@ -9025,13 +9052,13 @@
             "requires": {}
         },
         "vue-tsc": {
-            "version": "0.28.10",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.28.10.tgz",
-            "integrity": "sha512-tGD7eC74MHqKH2/F66AYkC1zNiLrgnhMzeYWou3p/wApMaUEM4h29HqYoKN6uE+pq87uvq/penYqUSBXhIwLiA==",
+            "version": "0.29.8",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.29.8.tgz",
+            "integrity": "sha512-pT0wLRjvRuSmB+J4WJT6uuV9mO0KtSSXEAtaVXZQzyk5+DJdbLIQTbRce/TXSkfqt1l1WogO78RjtOJFiMCgfQ==",
             "dev": true,
             "requires": {
-                "@volar/shared": "0.28.10",
-                "vscode-vue-languageservice": "0.28.10"
+                "@volar/shared": "0.29.8",
+                "vscode-vue-languageservice": "0.29.8"
             }
         },
         "vue3-markdown-it": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
                 "core-js": "^3.19.0",
                 "path-data-polyfill": "^1.0.3",
                 "socket.io-client": "^4.3.2",
-                "swiper": "^7.2.0",
+                "swiper": "^7.3.1",
                 "tinycolor2": "^1.4.2",
                 "vue": "^3.2.23",
                 "vue-i18n": "^9.1.9",
@@ -4387,9 +4387,9 @@
             }
         },
         "node_modules/swiper": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/swiper/-/swiper-7.2.0.tgz",
-            "integrity": "sha512-CUL6Nvzcf3fU0b8dHaraYphgBT7l44PY1B6T8b+E12pim4DEcwFZDy/KZoIKrAnn+rfbayCmcksYmSDIP5nDHg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-7.3.1.tgz",
+            "integrity": "sha512-YHa8uI22UwF9Q6F9tCDSai7/BJo8uVHKampKYAIShlFrWoHfM+sCCn24Yeq3oqIKZv2bfSULzXKsXmh0VpCNeQ==",
             "funding": [
                 {
                     "type": "patreon",
@@ -8599,9 +8599,9 @@
             "dev": true
         },
         "swiper": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/swiper/-/swiper-7.2.0.tgz",
-            "integrity": "sha512-CUL6Nvzcf3fU0b8dHaraYphgBT7l44PY1B6T8b+E12pim4DEcwFZDy/KZoIKrAnn+rfbayCmcksYmSDIP5nDHg==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-7.3.1.tgz",
+            "integrity": "sha512-YHa8uI22UwF9Q6F9tCDSai7/BJo8uVHKampKYAIShlFrWoHfM+sCCn24Yeq3oqIKZv2bfSULzXKsXmh0VpCNeQ==",
             "requires": {
                 "dom7": "^4.0.1",
                 "ssr-window": "^4.0.1"

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
         "core-js": "^3.19.0",
         "path-data-polyfill": "^1.0.3",
         "socket.io-client": "^4.3.2",
-        "swiper": "^7.2.0",
+        "swiper": "^7.3.1",
         "tinycolor2": "^1.4.2",
         "vue": "^3.2.23",
         "vue-i18n": "^9.1.9",

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
         "socket.io-client": "^4.3.2",
         "swiper": "^7.2.0",
         "tinycolor2": "^1.4.2",
-        "vue": "^3.2.20",
+        "vue": "^3.2.23",
         "vue-i18n": "^9.1.9",
         "vue-router": "^4.0.12",
         "vue-toastification": "^2.0.0-rc.5",
@@ -41,8 +41,8 @@
         "@types/tinycolor2": "^1.4.3",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
-        "@vitejs/plugin-vue": "^1.9.4",
-        "@vue/compiler-sfc": "^3.2.20",
+        "@vitejs/plugin-vue": "^1.10.1",
+        "@vue/compiler-sfc": "^3.2.23",
         "eslint": "^8.1.0",
         "eslint-import-resolver-typescript": "^2.5.0",
         "eslint-plugin-import": "^2.25.2",
@@ -54,8 +54,8 @@
         "sass-loader": "^12.3.0",
         "typescript": "~4.4.4",
         "upath": "^2.0.1",
-        "vite": "^2.6.13",
-        "vue-tsc": "^0.28.10"
+        "vite": "^2.6.14",
+        "vue-tsc": "^0.29.8"
     },
     "madge": {
         "detectiveOptions": {

--- a/client/src/auth/Login.vue
+++ b/client/src/auth/Login.vue
@@ -79,7 +79,7 @@ function focusout(event: FocusEvent): void {
     }
 }
 
-function slideNext(swiper: Swiper): void {
+function slideNext(swiper: any): void {
     swiper.slideNext();
 }
 </script>

--- a/client/src/game/ui/tools/DrawTool.vue
+++ b/client/src/game/ui/tools/DrawTool.vue
@@ -6,7 +6,7 @@ import { useI18n } from "vue-i18n";
 import ColourPicker from "../../../core/components/ColourPicker.vue";
 import { useModal } from "../../../core/plugins/modals/plugin";
 import { gameStore } from "../../../store/game";
-import { DrawMode, DrawShape, drawTool } from "../../tools/variants/draw";
+import { DrawCategory, DrawMode, DrawShape, drawTool } from "../../tools/variants/draw";
 
 import { useToolPosition } from "./toolPosition";
 
@@ -23,6 +23,7 @@ const state = reactive({
 const hasBrushSize = drawTool.hasBrushSize;
 const isDm = toRef(gameStore.state, "isDm");
 const modes = Object.values(DrawMode);
+const categories = Object.values(DrawCategory);
 const selected = drawTool.isActiveTool;
 const shapes = Object.values(DrawShape);
 const toolStyle = computed(() => ({ "--detailRight": state.right, "--detailArrow": state.arrow } as CSSProperties));
@@ -52,72 +53,155 @@ const showBorderColour = computed(() => {
 
 <template>
     <div class="tool-detail" v-if="selected" :style="toolStyle">
-        <div v-show="isDm">{{ t("game.ui.tools.DrawTool.mode") }}</div>
-        <div v-show="isDm" class="draw-select-group">
+        <div id="draw-tool-categories">
             <div
-                v-for="mode in modes"
-                :key="mode"
-                class="draw-select-option"
-                :class="{ 'draw-select-option-selected': drawTool.state.selectedMode === mode }"
-                @click="drawTool.state.selectedMode = mode"
+                v-for="category in categories"
+                :key="category"
+                class="draw-category-option"
+                :class="{ 'draw-category-option-selected': drawTool.state.selectedCategory === category }"
+                @click="drawTool.state.selectedCategory = category"
             >
-                {{ translationMapping[mode] }}
+                <font-awesome-icon :icon="category" />
             </div>
         </div>
-        <div>{{ t("common.shape") }}</div>
-        <div class="draw-select-group">
-            <div
-                v-for="shape in shapes"
-                :key="shape"
-                class="draw-select-option"
-                :class="{ 'draw-select-option-selected': drawTool.state.selectedShape === shape }"
-                @click="drawTool.state.selectedShape = shape"
-                :title="translationMapping[shape]"
-            >
-                <font-awesome-icon :icon="shape" />
+        <template v-if="drawTool.state.selectedCategory === 'square'">
+            <div class="draw-center-header">{{ t("common.shape") }}</div>
+            <div class="draw-select-group">
+                <div
+                    v-for="shape in shapes"
+                    :key="shape"
+                    class="draw-select-option"
+                    :class="{ 'draw-select-option-selected': drawTool.state.selectedShape === shape }"
+                    @click="drawTool.state.selectedShape = shape"
+                    :title="translationMapping[shape]"
+                >
+                    <font-awesome-icon :icon="shape" />
+                </div>
             </div>
-        </div>
-        <div>{{ t("common.colours") }}</div>
-        <div class="draw-select-group">
-            <ColourPicker
-                class="draw-select-option"
-                :class="{ 'radius-right': !showBorderColour }"
-                :title="t('game.ui.tools.DrawTool.foreground_color')"
-                v-model:colour="drawTool.state.fillColour"
-            />
-            <ColourPicker
-                class="draw-select-option"
-                :vShow="showBorderColour"
-                :title="t('game.ui.tools.DrawTool.background_color')"
-                v-model:colour="drawTool.state.borderColour"
-            />
-        </div>
-        <div v-show="drawTool.state.selectedShape === DrawShape.Polygon" style="display: flex">
-            <label for="polygon-close" style="flex: 5">{{ t("game.ui.tools.DrawTool.closed_polygon") }}</label>
-            <input
-                type="checkbox"
-                id="polygon-close"
-                style="flex: 1; align-self: center"
-                v-model="drawTool.state.isClosedPolygon"
-            />
-        </div>
-        <div v-show="drawTool.state.selectedShape === DrawShape.Text" style="display: flex">
-            <label for="font-size" style="flex: 5">{{ t("game.ui.tools.DrawTool.font_size") }}</label>
-            <input type="number" id="font-size" style="flex: 1; align-self: center" v-model="drawTool.state.fontSize" />
-        </div>
-        <div v-show="hasBrushSize" style="display: flex">
-            <label for="brush-size" style="flex: 5">{{ t("game.ui.tools.DrawTool.brush_size") }}</label>
-            <input
-                type="input"
-                id="brush-size"
-                v-model="drawTool.state.brushSize"
-                style="flex: 4; align-self: center; max-width: 100px"
-            />
-        </div>
+            <div id="draw-colour-header">
+                <div>Fill</div>
+                <div v-show="showBorderColour">Stroke</div>
+            </div>
+            <div class="draw-select-group">
+                <ColourPicker
+                    class="draw-select-option"
+                    :class="{ 'radius-right': !showBorderColour }"
+                    :title="t('game.ui.tools.DrawTool.foreground_color')"
+                    v-model:colour="drawTool.state.fillColour"
+                />
+                <ColourPicker
+                    class="draw-select-option"
+                    :vShow="showBorderColour"
+                    :title="t('game.ui.tools.DrawTool.background_color')"
+                    v-model:colour="drawTool.state.borderColour"
+                />
+            </div>
+            <div v-show="drawTool.state.selectedShape === DrawShape.Polygon" class="draw-checkbox-line">
+                <label for="polygon-close">{{ t("game.ui.tools.DrawTool.closed_polygon") }}</label>
+                <input type="checkbox" id="polygon-close" v-model="drawTool.state.isClosedPolygon" />
+            </div>
+            <div v-show="hasBrushSize" class="draw-input-line">
+                <label for="brush-size">{{ t("game.ui.tools.DrawTool.brush_size") }}</label>
+                <input type="input" id="brush-size" v-model="drawTool.state.brushSize" />
+            </div>
+            <div v-show="drawTool.state.selectedShape === DrawShape.Text" class="draw-input-line">
+                <label for="font-size">{{ t("game.ui.tools.DrawTool.font_size") }}</label>
+                <input type="number" id="font-size" v-model="drawTool.state.fontSize" />
+            </div>
+        </template>
+        <template v-else>
+            <div class="draw-center-header">{{ t("game.ui.tools.DrawTool.mode") }}</div>
+            <div v-show="isDm" class="draw-select-group">
+                <div
+                    v-for="mode in modes"
+                    :key="mode"
+                    class="draw-select-option"
+                    :class="{ 'draw-select-option-selected': drawTool.state.selectedMode === mode }"
+                    @click="drawTool.state.selectedMode = mode"
+                >
+                    {{ translationMapping[mode] }}
+                </div>
+            </div>
+            <div class="draw-checkbox-line">
+                <div>Blocks vision</div>
+                <div>
+                    <input
+                        type="checkbox"
+                        v-model="drawTool.state.blocksVision"
+                        @click="drawTool.state.blocksVision = !drawTool.state.blocksVision"
+                        :disabled="drawTool.state.selectedMode !== 'normal'"
+                    />
+                </div>
+            </div>
+            <div class="draw-checkbox-line">
+                <div>Blocks movement</div>
+                <div>
+                    <input
+                        type="checkbox"
+                        v-model="drawTool.state.blocksMovement"
+                        @click="drawTool.state.blocksMovement = !drawTool.state.blocksMovement"
+                        :disabled="drawTool.state.selectedMode !== 'normal'"
+                    />
+                </div>
+            </div>
+        </template>
     </div>
 </template>
 
 <style lang="scss">
+#draw-tool-categories {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    position: absolute;
+    left: -50px;
+    bottom: 0;
+
+    background-color: white;
+    font-size: 20px;
+
+    .draw-category-option {
+        display: flex;
+        justify-content: center;
+
+        padding: 10px;
+        width: 20px;
+
+        &:hover {
+            cursor: pointer;
+            background-color: #82c8a0;
+        }
+    }
+
+    .draw-category-option-selected {
+        background-color: #82c8a0;
+    }
+}
+
+.draw-center-header {
+    display: flex;
+    justify-content: center;
+}
+
+#draw-colour-header {
+    margin-top: 5px;
+    display: flex;
+    justify-content: space-around;
+}
+
+.draw-checkbox-line {
+    display: grid;
+    grid-template-columns: auto 25px;
+    margin-top: 5px;
+}
+
+.draw-input-line {
+    display: grid;
+    grid-template-columns: auto 50px;
+    margin-top: 5px;
+}
+
 .draw-select-group {
     display: flex;
 
@@ -159,5 +243,6 @@ const showBorderColour = computed(() => {
 <style scoped lang="scss">
 .tool-detail {
     display: block;
+    min-height: 125px;
 }
 </style>

--- a/client/src/game/ui/tools/DrawTool.vue
+++ b/client/src/game/ui/tools/DrawTool.vue
@@ -38,6 +38,8 @@ const translationMapping = {
     [DrawShape.Polygon]: t("game.ui.tools.DrawTool.draw-polygon"),
     [DrawShape.Brush]: t("game.ui.tools.DrawTool.paint-brush"),
     [DrawShape.Text]: t("game.ui.tools.DrawTool.text"),
+    [DrawCategory.Shape]: t("game.ui.tools.DrawTool.shape-category"),
+    [DrawCategory.Vision]: t("game.ui.tools.DrawTool.vision-category"),
 };
 
 onMounted(() => {
@@ -60,6 +62,7 @@ const showBorderColour = computed(() => {
                 class="draw-category-option"
                 :class="{ 'draw-category-option-selected': drawTool.state.selectedCategory === category }"
                 @click="drawTool.state.selectedCategory = category"
+                :title="translationMapping[category]"
             >
                 <font-awesome-icon :icon="category" />
             </div>
@@ -79,8 +82,8 @@ const showBorderColour = computed(() => {
                 </div>
             </div>
             <div id="draw-colour-header">
-                <div>Fill</div>
-                <div v-show="showBorderColour">Stroke</div>
+                <div>{{ t("common.fill_color_short") }}</div>
+                <div v-show="showBorderColour">{{ t("common.stroke_color_short") }}</div>
             </div>
             <div class="draw-select-group">
                 <ColourPicker
@@ -123,7 +126,7 @@ const showBorderColour = computed(() => {
                 </div>
             </div>
             <div class="draw-checkbox-line">
-                <div>Blocks vision</div>
+                <div>{{ t("game.ui.selection.edit_dialog.dialog.block_vision_light") }}</div>
                 <div>
                     <input
                         type="checkbox"
@@ -134,7 +137,7 @@ const showBorderColour = computed(() => {
                 </div>
             </div>
             <div class="draw-checkbox-line">
-                <div>Blocks movement</div>
+                <div>{{ t("game.ui.selection.edit_dialog.dialog.block_movement") }}</div>
                 <div>
                     <input
                         type="checkbox"

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -52,6 +52,8 @@
         "markers": "Markers",
         "border_color": "Border colour",
         "fill_color": "Fill colour",
+        "fill_color_short": "Fill",
+        "stroke_color_short": "Stroke",
         "trackers": "Trackers",
         "auras": "Auras",
         "labels": "Labels",
@@ -355,14 +357,16 @@
                     "font_size": "Font size",
                     "square": "square",
                     "circle": "circle",
-                    "draw-polygon": "draw-polygon",
-                    "paint-brush": "paint-brush",
+                    "draw-polygon": "polygon",
+                    "paint-brush": "brush",
                     "normal": "normal",
                     "reveal": "reveal",
                     "hide": "hide",
                     "erase": "erase",
                     "cone": "cone",
-                    "text": "text"
+                    "text": "text",
+                    "shape-category": "Basic settings",
+                    "vision-category": "Vision settings"
                 },
                 "FilterTool": {
                     "no_category": "no category"

--- a/client/src/shims/swiper.d.ts
+++ b/client/src/shims/swiper.d.ts
@@ -1,8 +1,0 @@
-declare module "swiper/vue" {
-    import component from "*.vue";
-    import _Vue from "vue";
-
-    export class Swiper extends component {}
-
-    export class SwiperSlide extends component {}
-}


### PR DESCRIPTION
This PR splits up the draw tool UI in two separate "tabs".
Swapping between these tabs can be done with a new UI element in the bottomleft of the popover

### Basic settings

The first tab presents basic options: shape and colour.

![image](https://user-images.githubusercontent.com/1814713/144269098-f76d3951-3122-43ce-a224-ea799cf706c1.png)

Nothing exotic here, the same shape specific options still appear here as well when for example selecting the polygon shape.

One noticeable improvement is that the colour selector now has an explicit header to show which selector does what. This was not always clear to users that don't interact with the colour selectors often.

### Vision settings

The second tab presents more advanced vision related options.

![image](https://user-images.githubusercontent.com/1814713/144269410-c95b62e2-013f-4397-813e-cb83711e2b1f.png)

The DM-only "vision mode" option has been moved to this tab as it is a very niche setting.

A new addition to the draw tool UI is the option to immediately configure the block options. When you draw a window you want to block movement, but allow vision. Up until now this always required manual adjustment after drawing.

The existing auto-change behaviour when moving to and from the fow layer still exists, so behaviour shouldn't change for users used to the old system.