### PR TITLE
bug(Vision): Fix default vision token state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ These usually have no immediately visible impact on regular users
 
 ### Fixed
 
--   floor not being remembered on reload after "Bring Players" action
+-   Floor not being remembered on reload after "Bring Players" action
+-   Shape pasting not properly increasing badge counters
+-   Default vision shapes always acting as tokens (regardless of isToken)
 
 ### Performance
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -722,10 +722,12 @@ export abstract class Shape implements IShape {
             sendShapeUpdateDefaultOwner({ ...accessToServer(this.defaultAccess), shape: this.uuid });
         if (syncTo === SyncTo.UI) this._("setDefaultAccess")(this.defaultAccess, syncTo);
 
-        if (this.defaultAccess.vision) {
-            if (this.ownedBy(false, { visionAccess: true })) gameStore.addOwnedToken(this.uuid);
-        } else {
-            if (!this.ownedBy(false, { visionAccess: true })) gameStore.removeOwnedToken(this.uuid);
+        if (this.isToken) {
+            if (this.defaultAccess.vision) {
+                if (this.ownedBy(false, { visionAccess: true })) gameStore.addOwnedToken(this.uuid);
+            } else {
+                if (!this.ownedBy(false, { visionAccess: true })) gameStore.removeOwnedToken(this.uuid);
+            }
         }
         if (settingsStore.fowLos.value) floorStore.invalidateLightAllFloors();
         initiativeStore._forceUpdate();


### PR DESCRIPTION
Whether or not the `isToken` property of a shape was marked, if the shape had default vision access, it would mistakenly be treated as a token for the minimal vision aura.

Fixes #822