### PR TITLE
feat(Server): Add allow_signups config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 [DM] denotes changes only useful for the dungeon master
-[tech] denotes technical changes or changes specifically for the server owner.
+[tech]/[server] denotes technical changes or changes specifically for the server owner.
 These usually have no immediately visible impact on regular users
 
 ## Unreleased
+
+### Added
+
+-   [server] Added `allow_signups` option in the `General` config section that can be disabled to prevent users from signing up themselves
 
 ### Changed
 

--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <link rel="shortcut icon" type="image/png" href="/static/favicon.png" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="PA-signup" content="true" />
         <title>PlanarAlly</title>
     </head>
     <body>

--- a/client/src/auth/Login.vue
+++ b/client/src/auth/Login.vue
@@ -25,6 +25,7 @@ const username = ref("");
 const password = ref("");
 const email = ref("");
 const registerMode = ref(false);
+const allowRegister = (document.querySelector("meta[name='PA-signup']")?.getAttribute("content") ?? "true") === "true";
 
 const showLanguageDropdown = ref(false);
 
@@ -188,11 +189,13 @@ function slideNext(swiper: any): void {
                     <span v-else>enter</span>
                 </button>
             </form>
-            <h4><span>OR</span></h4>
-            <button class="submit" @click="registerMode = !registerMode" :title="t('auth.login.register')">
-                <span v-if="registerMode">return</span>
-                <span v-else>register</span>
-            </button>
+            <template v-if="allowRegister">
+                <h4><span>OR</span></h4>
+                <button class="submit" @click="registerMode = !registerMode" :title="t('auth.login.register')">
+                    <span v-if="registerMode">return</span>
+                    <span v-else>register</span>
+                </button>
+            </template>
         </div>
     </div>
 </template>

--- a/server/api/http/auth.py
+++ b/server/api/http/auth.py
@@ -1,6 +1,7 @@
 from aiohttp import web
 from aiohttp_security import authorized_userid, forget, remember
 
+from config import config
 from models import User
 from models.db import db
 from models.user import UserOptions
@@ -33,6 +34,9 @@ async def login(request):
 
 
 async def register(request):
+    if not config.getboolean("General", "allow_signups"):
+        return web.HTTPForbidden()
+
     username = await authorized_userid(request)
     if username:
         return web.HTTPOk()

--- a/server/routes.py
+++ b/server/routes.py
@@ -8,6 +8,7 @@ from aiohttp_security import authorized_userid, check_authorized, forget, rememb
 
 import api.http
 from app import api_app, app as main_app
+from config import config
 from models import Room, User
 from models.role import Role
 from utils import logger
@@ -22,6 +23,11 @@ async def root(request):
     with open("./templates/index.html", "rb") as f:
         data = f.read()
         data = data.replace(b"/static", bytes(subpath, "utf-8")[:-1] + b"/static")
+
+        if not config.getboolean("General", "allow_signups"):
+            data = data.replace(
+                b'name="PA-signup" content="true"', b'name="PA-signup" content="false"'
+            )
         return web.Response(body=data, content_type="text/html")
 
 
@@ -35,6 +41,11 @@ async def root_dev(request):
         ) as response:
             raw = await response.read()
             raw = raw.replace(b"$BASE_PATH$", bytes(subpath, "utf-8")[:-1])
+            if not config.getboolean("General", "allow_signups"):
+                raw = raw.replace(
+                    b'name="PA-signup" content="true"',
+                    b'name="PA-signup" content="false"',
+                )
 
     return web.Response(body=raw, status=response.status, headers=response.headers)
 

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -22,6 +22,8 @@ ssl_privkey = cert/privkey.pem
 save_file = planar.sqlite
 #public_name = 
 
+allow_signups = false
+
 [APIserver]
 # The API server is an administration server on which some API calls can be made.
 # It should use a different port or socket than the main webserver.

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -22,7 +22,7 @@ ssl_privkey = cert/privkey.pem
 save_file = planar.sqlite
 #public_name = 
 
-allow_signups = false
+allow_signups = true
 
 [APIserver]
 # The API server is an administration server on which some API calls can be made.


### PR DESCRIPTION
This PR adds a new configuration field to the general section in the server config.

`allow_signups` defaults to true, and if set to false, will prevent users from signing up on the server.

This can be used to prevent unknown actors from joining a private server that is publicly facing.

This PR does not add alternative methods to add users as a server owner, that's for a later iteration.