### PR TITLE
bug(UI): Move modals on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These usually have no immediately visible impact on regular users
 -   Shape pasting not properly increasing badge counters
 -   Default vision shapes always acting as tokens (regardless of isToken)
 -   Map tool aspect ratio lock no longer working
+-   Modals will now change location when resizing the window would put them out of the visible screen area
 
 ### Performance
 


### PR DESCRIPTION
When resizing the screen it could occur that some modal is no longer visible due to it being out of the visible area. This PR changes the Modal behaviour to reposition on resize events if necessary