### PR TITLE
feat(AssetManager): Added drop support for folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These usually have no immediately visible impact on regular users
 ### Added
 
 -   [server] Added `allow_signups` option in the `General` config section that can be disabled to prevent users from signing up themselves
+-   [asset-manager] drop support for folders
 
 ### Changed
 

--- a/client/src/assetManager/AssetManager.vue
+++ b/client/src/assetManager/AssetManager.vue
@@ -57,10 +57,45 @@ function stopDrag(event: DragEvent, target: number): void {
             }
         }
         assetStore.clearSelected();
-    } else if (event.dataTransfer && event.dataTransfer.files.length > 0) {
-        assetStore.upload(event.dataTransfer.files, target);
+    } else if (event.dataTransfer && event.dataTransfer.items.length > 0) {
+        parseDirectoryUpload(
+            [...event.dataTransfer.items].map((i) => i.webkitGetAsEntry()),
+            target,
+        );
     }
     draggingSelection = false;
+}
+
+// eslint-disable-next-line no-undef
+function fsToFile(fl: FileSystemFileEntry): Promise<File> {
+    return new Promise((resolve) => fl.file(resolve));
+}
+
+async function parseDirectoryUpload(
+    // eslint-disable-next-line no-undef
+    fileSystemEntries: (FileSystemEntry | null)[],
+    target: number,
+    targetOffset: string[] = [],
+): Promise<void> {
+    // eslint-disable-next-line no-undef
+    const files: FileSystemFileEntry[] = [];
+    for (const entry of fileSystemEntries) {
+        if (entry === null) continue;
+        if (entry.isDirectory) {
+            // eslint-disable-next-line no-undef
+            const fwk = entry as FileSystemDirectoryEntry;
+            const reader = fwk.createReader();
+            reader.readEntries(async (entries) => parseDirectoryUpload(entries, target, [...targetOffset, entry.name]));
+        } else if (entry.isFile) {
+            // eslint-disable-next-line no-undef
+            files.push(entry as FileSystemFileEntry);
+        }
+    }
+    if (files.length > 0) {
+        const fileList = await Promise.all(files.map((f) => fsToFile(f)));
+        console.log("Uploading", fileList, targetOffset);
+        assetStore.upload(fileList as unknown as FileList, target, targetOffset);
+    }
 }
 
 // INODE MANAGEMENT

--- a/client/src/assetManager/socket.ts
+++ b/client/src/assetManager/socket.ts
@@ -31,12 +31,12 @@ socket.on("Folder.Set", (data: { folder: Asset; path?: number[] }) => {
         window.history.pushState(null, "Asset Manager", baseAdjust(`/assets${assetStore.currentFilePath.value}`));
     }
 });
-socket.on("Folder.Create", (folder: Asset) => {
-    assetStore.addAsset(folder);
+socket.on("Folder.Create", (data: { asset: Asset; parent: number }) => {
+    assetStore.addAsset(data.asset, data.parent);
 });
-socket.on("Asset.Upload.Finish", (asset: Asset) => {
-    assetStore.addAsset(asset);
-    assetStore.resolveUpload(asset.name);
+socket.on("Asset.Upload.Finish", (data: { asset: Asset; parent: number }) => {
+    assetStore.addAsset(data.asset, data.parent);
+    assetStore.resolveUpload(data.asset.name);
 });
 
 socket.on("Asset.Export.Finish", (uuid: string) => {

--- a/client/src/assetManager/state.ts
+++ b/client/src/assetManager/state.ts
@@ -139,7 +139,9 @@ class AssetStore extends Store<AssetState> {
 
     // ASSET
 
-    addAsset(asset: Asset): void {
+    addAsset(asset: Asset, parent?: number): void {
+        if (parent !== undefined && parent !== this.currentFolder.value) return;
+
         this._state.idMap.set(asset.id, asset);
         let target: "folders" | "files" = "folders";
         if (asset.file_hash !== null) {
@@ -185,7 +187,7 @@ class AssetStore extends Store<AssetState> {
         }
     }
 
-    async upload(fls?: FileList, target?: number): Promise<void> {
+    async upload(fls?: FileList, target?: number, targetOffset: string[] = []): Promise<void> {
         const files = (document.getElementById("files")! as HTMLInputElement).files;
         if (fls === undefined) {
             if (files) fls = files;
@@ -215,6 +217,7 @@ class AssetStore extends Store<AssetState> {
                             {
                                 name: file.name,
                                 directory: target,
+                                newDirectories: targetOffset,
                                 data: fr.result,
                                 slice,
                                 totalSlices: slices,

--- a/server/api/socket/asset_manager/common.py
+++ b/server/api/socket/asset_manager/common.py
@@ -1,3 +1,4 @@
+from typing import List
 from typing_extensions import TypedDict
 
 from utils import FILE_DIR
@@ -7,6 +8,7 @@ class UploadData(TypedDict):
     uuid: str
     name: str
     directory: int
+    newDirectories: List[str]
     slice: int
     totalSlices: int
     data: bytes


### PR DESCRIPTION
Adding folders via the asset manager was not supported due to browser API not being stable across all major browsers.

I get this request somewhat regularly and there nowadays is some API to do this, this is however a non-standard track API and I'll have to monitor it's progression closely as a result.

Nevertheless, this PR adds support for folders (simple or deeply nested) when dropping on the asset manager.

The upload button still only uploads files, because for some forsaken reason you can only choose either files or folders, but not both. But this feels like an ok trade-off.

This fixes #844