### PR TITLE
bug(AssetManager): Fix stale file cleanup for folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ These usually have no immediately visible impact on regular users
 -   Default vision shapes always acting as tokens (regardless of isToken)
 -   Map tool aspect ratio lock no longer working
 -   Modals will now change location when resizing the window would put them out of the visible screen area
+-   Asset manager would not check for stale files when removing a folder
 
 ### Performance
 


### PR DESCRIPTION
PA stores assets in a flat folder based on their hash to reduce unnecessary duplicate files if a certain file is added in multiple folders or by multiple people.

When removing a file from the asset manager, PA will check if the file is still in use in some other location and if not, removes it from the disk.

This last check was not properly done when removing folders, which this PR addresses.