### PR TITLE
bug(UI): Fix scroll bars visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These usually have no immediately visible impact on regular users
 -   Map tool aspect ratio lock no longer working
 -   Modals will now change location when resizing the window would put them out of the visible screen area
 -   Asset manager would not check for stale files when removing a folder
+-   Fix scroll bars being visible due to dice canvas not being sized strictly
 
 ### Performance
 

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -29,6 +29,7 @@ import UI from "./ui/UI.vue";
 import "./api/events";
 
 export default defineComponent({
+    // eslint-disable-next-line vue/multi-word-component-names
     name: "Game",
     components: { UI },
     beforeRouteEnter(to, _from, next) {
@@ -213,5 +214,7 @@ svg {
 #babylon {
     z-index: 11;
     pointer-events: none;
+    width: 100%;
+    height: 100%;
 }
 </style>


### PR DESCRIPTION
In-game it was possible to have scroll bars visible due to the dice canvas not being sized strictly.