### PR TITLE
bug(Movement): Fix movement blocker intersections on token layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ These usually have no immediately visible impact on regular users
 -   Modals will now change location when resizing the window would put them out of the visible screen area
 -   Asset manager would not check for stale files when removing a folder
 -   Fix scroll bars being visible due to dice canvas not being sized strictly
+-   Fix movement blockers intersecting with themselves when moving on the token layer
 
 ### Performance
 

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -292,12 +292,16 @@ class SelectTool extends Tool implements ISelectTool {
 
                     // don't use layerSelection here as it can be outdated by the pushSelection setSelection above
                     this.operationList = { type: "movement", shapes: [] };
-                    for (const shape of selectionState.get({ includeComposites: false }))
+                    for (const shape of selectionState.get({ includeComposites: false })) {
                         this.operationList.shapes.push({
                             uuid: shape.uuid,
                             from: toArrayP(shape.refPoint),
                             to: toArrayP(shape.refPoint),
                         });
+                        if (shape.blocksMovement && shape.layer.name === LayerName.Tokens) {
+                            visionState.removeBlocker(TriangulationTarget.MOVEMENT, shape.floor.id, shape, true);
+                        }
+                    }
                 }
                 layer.invalidate(true);
                 hit = true;
@@ -560,6 +564,8 @@ class SelectTool extends Tool implements ISelectTool {
                     }
                     // movementBlock is skipped during onMove and definitely has to be done here
                     if (sel.blocksMovement) {
+                        if (sel.layer.name === LayerName.Tokens)
+                            visionState.addBlocker(TriangulationTarget.MOVEMENT, sel.uuid, sel.floor.id, false);
                         visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: sel.uuid });
                         recalcMovement = true;
                     }


### PR DESCRIPTION
When moving a shape on the token layer, intersections with walls and other movement blocking shapes are tested.  If you however move a movement-blocking shape itself, the original position was also being tested against.