### PR TITLE
server(Subpath): Change subpath handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+For server owners using a subpath, some important changes are made, so make sure to check the changed section before upgrading
+
 ### Added
 
 -   simple logic systems to attach to shapes
@@ -29,6 +31,13 @@ These usually have no immediately visible impact on regular users
 -   Draw tool UI now has a tabbed interface
     -   a shape tab to configure shape and colours
     -   a visibility tab to configure advanced vision modes as well as blocksVision and blocksMovement changes
+-   [server] Change subpath handling
+    -   the client now MUST also set the PA_BASEPATH env variable in production mode
+    -   this means the env variable needs to be set at build time
+    -   the basepath now HAS TO END with a slash
+    -   for docker this means you need to manually build the image
+        -   use `--build-arg PA_BASEPATH='/subpath/'
+        -   you no longer need the `--env PA_BASEPATH` flag
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Modals will now change location when resizing the window would put them out of the visible screen area
 -   Fix scroll bars being visible due to dice canvas not being sized strictly
 -   Fix movement blockers intersecting with themselves when moving on the token layer
+-   Fix assets becoming invisible when using a subpath setup (only applies to new assets)
 -   [asset-manager] Asset manager would not check for stale files when removing a folder
 
 ### Performance

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apk add --no-cache python3 make g++
 COPY client/package.json client/package-lock.json ./
 RUN npm i
 
+ARG PA_BASEPATH="/"
+
 COPY . /usr/src
 RUN npm run build
 
@@ -49,6 +51,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY --from=BUILDER --chown=9000:9000 /usr/src/server/ .
 
 USER 9000
+
+ARG PA_BASEPATH="/"
+ENV PA_BASEPATH=$PA_BASEPATH
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD [ "python", "-u", "planarserver.py"]

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -4,7 +4,6 @@ import { useRoute } from "vue-router";
 
 import { baseAdjust } from "./core/utils";
 import { coreStore } from "./store/core";
-import { BASE_PATH } from "./utils";
 
 const route = useRoute();
 
@@ -13,7 +12,7 @@ const webmError = ref(false);
 const webmStart = 2 * Math.floor(Math.random() * 5);
 
 const loading = computed(() => coreStore.state.loading);
-const backgroundImage = `url('${BASE_PATH}static/img/login_background.png')`;
+const backgroundImage = `url('${import.meta.env.BASE_URL}static/img/login_background.png')`;
 
 watch(
     () => route.name,

--- a/client/src/core/socket.ts
+++ b/client/src/core/socket.ts
@@ -1,11 +1,9 @@
 import { Manager } from "socket.io-client";
 
-import { BASE_PATH } from "../utils";
-
 function createNewManager(): Manager {
     return new Manager(location.protocol + "//" + location.host, {
         autoConnect: false,
-        path: BASE_PATH + "socket.io",
+        path: import.meta.env.BASE_URL + "socket.io",
         transports: ["websocket", "polling"],
     });
 }

--- a/client/src/core/utils.ts
+++ b/client/src/core/utils.ts
@@ -1,7 +1,5 @@
 import tinycolor from "tinycolor2";
 
-import { BASE_PATH } from "../utils";
-
 // Reference: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
 export function uuidv4(): string {
     return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -36,13 +34,13 @@ export function calcFontScale(ctx: CanvasRenderingContext2D, text: string, r: nu
 
 export async function baseAdjustedFetch(url: string): Promise<Response> {
     if (url.startsWith("/")) url = url.slice(1);
-    return fetch(BASE_PATH + url);
+    return fetch(import.meta.env.BASE_URL + url);
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function postFetch(url: string, data?: any): Promise<Response> {
     if (url.startsWith("/")) url = url.slice(1);
-    return fetch(BASE_PATH + url, {
+    return fetch(import.meta.env.BASE_URL + url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data ?? {}),
@@ -52,7 +50,7 @@ export async function postFetch(url: string, data?: any): Promise<Response> {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function patchFetch(url: string, data?: any): Promise<Response> {
     if (url.startsWith("/")) url = url.slice(1);
-    return fetch(BASE_PATH + url, {
+    return fetch(import.meta.env.BASE_URL + url, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data ?? {}),
@@ -62,14 +60,14 @@ export async function patchFetch(url: string, data?: any): Promise<Response> {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function deleteFetch(url: string): Promise<Response> {
     if (url.startsWith("/")) url = url.slice(1);
-    return fetch(BASE_PATH + url, {
+    return fetch(import.meta.env.BASE_URL + url, {
         method: "DELETE",
     });
 }
 
 export function baseAdjust(url: string): string {
     if (url.startsWith("/")) url = url.slice(1);
-    return BASE_PATH + url;
+    return import.meta.env.BASE_URL + url;
 }
 
 export async function getErrorReason(response: Response): Promise<string> {

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -132,7 +132,9 @@ export async function dropAsset(
                 assetId: data.assetId,
                 uuid,
             });
-            asset.src = new URL(image.src).pathname;
+
+            const pathname = new URL(image.src).pathname;
+            asset.src = pathname.replace(import.meta.env.BASE_URL, "/");
 
             if (options) {
                 asset.setLayer(layer.floor, layer.name); // if we don't set this the asDict will fail

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -8,7 +8,6 @@ import Dashboard from "./dashboard/Dashboard.vue";
 import Invitation from "./invitation";
 import { handleNotifications } from "./notifications";
 import { coreStore } from "./store/core";
-import { BASE_PATH } from "./utils";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const AssetManager = () => import("./assetManager/AssetManager.vue");
@@ -62,7 +61,7 @@ const routes: Array<RouteRecordRaw> = [
 ];
 
 export const router = createRouter({
-    history: createWebHistory(BASE_PATH),
+    history: createWebHistory(import.meta.env.BASE_URL),
     routes,
 });
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,3 +1,0 @@
-const ROUTES = ["", "assets", "auth", "dashboard", "game", "invite", "settings"];
-const path = window.location.pathname.split("/");
-export const BASE_PATH = ROUTES.includes(path[1]) ? "/" : `/${path[1]}/`;

--- a/server/app.py
+++ b/server/app.py
@@ -42,7 +42,7 @@ sio = socketio.AsyncServer(
 app = setup_app()
 aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader("templates"))
 basepath = os.environ.get("PA_BASEPATH", "/")[1:]
-socketio_path = basepath + ("/" if len(basepath) > 0 else "") + "socket.io"
+socketio_path = basepath + "socket.io"
 sio.attach(app, socketio_path=socketio_path)
 app["state"] = {}
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -16,15 +16,14 @@ from utils import logger
 
 
 subpath = os.environ.get("PA_BASEPATH", "/")
-if subpath[-1] != "/":
-    subpath = subpath + "/"
+if subpath[-1] == "/":
+    subpath = subpath[:-1]
 
 
 async def root(request, admin_api=False):
     template = "admin-index.html" if admin_api else "index.html"
     with open(f"./templates/{template}", "rb") as f:
         data = f.read()
-        data = data.replace(b"/static", bytes(subpath, "utf-8")[:-1] + b"/static")
 
         if not config.getboolean("General", "allow_signups"):
             data = data.replace(
@@ -37,13 +36,11 @@ async def root_dev(request, admin_api=False):
     port = 8081 if admin_api else 8080
     target_url = f"http://localhost:{port}{request.rel_url}"
     data = await request.read()
-    get_data = request.rel_url.query
     async with aiohttp.ClientSession() as session:
         async with session.request(
             "get", target_url, headers=request.headers, data=data
         ) as response:
             raw = await response.read()
-            raw = raw.replace(b"$BASE_PATH$", bytes(subpath, "utf-8")[:-1])
             if not config.getboolean("General", "allow_signups"):
                 raw = raw.replace(
                     b'name="PA-signup" content="true"',
@@ -79,49 +76,49 @@ async def show_assets(request):
 
 # MAIN ROUTES
 
-main_app.router.add_static(f"{subpath}static", "static")
-main_app.router.add_get(f"{subpath}api/auth", api.http.auth.is_authed)
-main_app.router.add_post(f"{subpath}api/users/email", api.http.users.set_email)
-main_app.router.add_post(f"{subpath}api/users/password", api.http.users.set_password)
-main_app.router.add_post(f"{subpath}api/users/delete", api.http.users.delete_account)
-main_app.router.add_post(f"{subpath}api/login", api.http.auth.login)
-main_app.router.add_post(f"{subpath}api/register", api.http.auth.register)
-main_app.router.add_post(f"{subpath}api/logout", api.http.auth.logout)
-main_app.router.add_get(f"{subpath}api/rooms", api.http.rooms.get_list)
-main_app.router.add_post(f"{subpath}api/rooms", api.http.rooms.create)
+main_app.router.add_static(f"{subpath}/static", "static")
+main_app.router.add_get(f"{subpath}/api/auth", api.http.auth.is_authed)
+main_app.router.add_post(f"{subpath}/api/users/email", api.http.users.set_email)
+main_app.router.add_post(f"{subpath}/api/users/password", api.http.users.set_password)
+main_app.router.add_post(f"{subpath}/api/users/delete", api.http.users.delete_account)
+main_app.router.add_post(f"{subpath}/api/login", api.http.auth.login)
+main_app.router.add_post(f"{subpath}/api/register", api.http.auth.register)
+main_app.router.add_post(f"{subpath}/api/logout", api.http.auth.logout)
+main_app.router.add_get(f"{subpath}/api/rooms", api.http.rooms.get_list)
+main_app.router.add_post(f"{subpath}/api/rooms", api.http.rooms.create)
 main_app.router.add_patch(
-    f"{subpath}api/rooms/{{creator}}/{{roomname}}", api.http.rooms.patch
+    f"{subpath}/api/rooms/{{creator}}/{{roomname}}", api.http.rooms.patch
 )
 main_app.router.add_delete(
-    f"{subpath}api/rooms/{{creator}}/{{roomname}}", api.http.rooms.delete
+    f"{subpath}/api/rooms/{{creator}}/{{roomname}}", api.http.rooms.delete
 )
 main_app.router.add_get(
-    f"{subpath}api/rooms/{{creator}}/{{roomname}}/info", api.http.rooms.get_info
+    f"{subpath}/api/rooms/{{creator}}/{{roomname}}/info", api.http.rooms.get_info
 )
 main_app.router.add_patch(
-    f"{subpath}api/rooms/{{creator}}/{{roomname}}/info", api.http.rooms.set_info
+    f"{subpath}/api/rooms/{{creator}}/{{roomname}}/info", api.http.rooms.set_info
 )
 main_app.router.add_get(
-    f"{subpath}api/rooms/{{creator}}/{{roomname}}/export", api.http.rooms.export
+    f"{subpath}/api/rooms/{{creator}}/{{roomname}}/export", api.http.rooms.export
 )
-main_app.router.add_post(f"{subpath}api/invite", api.http.claim_invite)
-main_app.router.add_get(f"{subpath}api/version", api.http.version.get_version)
-main_app.router.add_get(f"{subpath}api/changelog", api.http.version.get_changelog)
-main_app.router.add_get(f"{subpath}api/notifications", api.http.notifications.collect)
+main_app.router.add_post(f"{subpath}/api/invite", api.http.claim_invite)
+main_app.router.add_get(f"{subpath}/api/version", api.http.version.get_version)
+main_app.router.add_get(f"{subpath}/api/changelog", api.http.version.get_changelog)
+main_app.router.add_get(f"{subpath}/api/notifications", api.http.notifications.collect)
 
 # ADMIN ROUTES
 
-api_app.router.add_post(f"{subpath}notifications", api.http.notifications.create)
-api_app.router.add_get(f"{subpath}notifications", api.http.notifications.collect)
+api_app.router.add_post(f"{subpath}/notifications", api.http.notifications.create)
+api_app.router.add_get(f"{subpath}/notifications", api.http.notifications.collect)
 api_app.router.add_delete(
-    f"{subpath}notifications/{{uuid}}", api.http.notifications.delete
+    f"{subpath}/notifications/{{uuid}}", api.http.notifications.delete
 )
-api_app.router.add_get(f"{subpath}users", api.http.admin.users.collect)
-api_app.router.add_post(f"{subpath}users/reset", api.http.admin.users.reset)
-api_app.router.add_post(f"{subpath}users/remove", api.http.admin.users.remove)
-api_app.router.add_get(f"{subpath}campaigns", api.http.admin.campaigns.collect)
+api_app.router.add_get(f"{subpath}/users", api.http.admin.users.collect)
+api_app.router.add_post(f"{subpath}/users/reset", api.http.admin.users.reset)
+api_app.router.add_post(f"{subpath}/users/remove", api.http.admin.users.remove)
+api_app.router.add_get(f"{subpath}/campaigns", api.http.admin.campaigns.collect)
 
-admin_app.router.add_static(f"{subpath}static", "static")
+admin_app.router.add_static(f"{subpath}/static", "static")
 admin_app.add_subapp("/api/", api_app)
 
 if "dev" in sys.argv:


### PR DESCRIPTION
This PR changes the way subpaths are handled.

In the past the subpath was handled by the server only and the client did some dark magic to figure things out and rewrite things on the fly.

With the recent-ish changes to the client side build system this no longer works and breaks things as pointed out to me recently on both github and discord.

To solve this, the client will now also properly take into account the PA_BASEPATH environment variable during build time.

An **important** change is that the basepath should now end with a slash. (e.g. `PA_BASEPATH='/subpath/')

## docker changes

This has a very important implication for people that user docker. You'll have to manually build your docker image as the build depends on the subpath.

You now have to pass `--build-arg PA_BASEPATH='/subpath/'` to the `docker build` command. The old `--env` variable that was needed can still be passed, but is not necessary anymore and the sole `--build-arg` is enough.