### PR TITLE
chore(Docker): Don't run docker pipeline in PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,10 +6,6 @@ on:
             - "dev"
         tags:
             - "v*"
-    pull_request:
-        branches:
-            - "master"
-            - "dev"
 
 jobs:
     docker:
@@ -27,7 +23,7 @@ jobs:
             - name: Set up QEMU
               uses: docker/setup-qemu-action@master
               with:
-                platforms: all
+                  platforms: all
 
             - name: Set up Docker Buildx
               id: buildx


### PR DESCRIPTION
With the recent change to multi-arch builds the docker pipeline takes 8 minutes which is quite long for a regular PR pipeline.

It now only runs on commits on dev and for v* tags