### PR TITLE
bug(Systems): Inform systems of id removal

### DIFF
--- a/client/src/game/id.ts
+++ b/client/src/game/id.ts
@@ -1,6 +1,7 @@
 import { uuidv4 } from "../core/utils";
 
 import type { IShape } from "./shapes/interfaces";
+import { dropFromSystems } from "./systems";
 
 export type Global<T> = {
     [key in keyof T]: T[key] extends LocalId ? GlobalId : T[key] extends LocalId[] ? GlobalId[] : T[key];
@@ -45,6 +46,8 @@ export function generateLocalId(shape: IShape, global?: GlobalId): LocalId {
 }
 
 export function dropId(id: LocalId): void {
+    dropFromSystems(id);
+
     reservedIds.delete(uuids[id]);
     delete uuids[id];
     idMap.delete(id);

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -120,6 +120,13 @@ class AccessSystem implements System {
         initiativeStore._forceUpdate();
     }
 
+    drop(id: LocalId): void {
+        this.access.delete(id);
+        if (this._state.id === id) {
+            this.dropState();
+        }
+    }
+
     getDefault(id: LocalId): DeepReadonly<ShapeAccess> {
         return this.access.get(id)?.get(DEFAULT_ACCESS_SYMBOL) ?? DEFAULT_ACCESS;
     }

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -77,6 +77,13 @@ class AuraSystem implements System {
         }
     }
 
+    drop(id: LocalId): void {
+        this.data.delete(id);
+        if (this._state.id === id) {
+            this.dropState();
+        }
+    }
+
     get(id: LocalId, auraId: AuraId, includeParent: boolean): DeepReadonly<Aura> | undefined {
         return this.getAll(id, includeParent).find((t) => t.uuid === auraId);
     }

--- a/client/src/game/systems/index.ts
+++ b/client/src/game/systems/index.ts
@@ -6,8 +6,15 @@ export function registerSystem(key: string, system: System): void {
     SYSTEMS[key] = system;
 }
 
+export function dropFromSystems(id: LocalId): void {
+    for (const system of Object.values(SYSTEMS)) {
+        system.drop(id);
+    }
+}
+
 export interface System {
     clear(): void;
+    drop(id: LocalId): void;
     inform(id: LocalId, data: any): void;
 }
 

--- a/client/src/game/systems/logic/door/index.ts
+++ b/client/src/game/systems/logic/door/index.ts
@@ -63,6 +63,14 @@ class DoorSystem implements System {
         this.permissions.set(id, permissions ?? DEFAULT_PERMISSIONS);
     }
 
+    drop(id: LocalId): void {
+        this.enabled.delete(id);
+        this.permissions.delete(id);
+        if (this._state.id === id) {
+            this.dropState();
+        }
+    }
+
     toggle(id: LocalId, enabled: boolean, syncTo: SyncTo): void {
         if (syncTo === SyncTo.SERVER) sendShapeIsDoor({ shape: getGlobalId(id), value: enabled });
         if (this._state.id === id) this._state.enabled = enabled;

--- a/client/src/game/systems/logic/tp/index.ts
+++ b/client/src/game/systems/logic/tp/index.ts
@@ -100,6 +100,14 @@ class TeleportZoneSystem implements System {
         this.data.set(id, options ?? DEFAULT_OPTIONS);
     }
 
+    drop(id: LocalId): void {
+        this.enabled.delete(id);
+        this.data.delete(id);
+        if (this._state.id === id) {
+            this.dropState();
+        }
+    }
+
     toggle(id: LocalId, enabled: boolean, syncTo: SyncTo): void {
         if (syncTo === SyncTo.SERVER) sendShapeIsTeleportZone({ shape: getGlobalId(id), value: enabled });
         if (this._state.id === id) this._state.enabled = enabled;

--- a/client/src/game/systems/trackers/index.ts
+++ b/client/src/game/systems/trackers/index.ts
@@ -74,6 +74,13 @@ class TrackerSystem implements System {
         this.data.set(id, trackers);
     }
 
+    drop(id: LocalId): void {
+        this.data.delete(id);
+        if (this._state.id === id) {
+            this.dropState();
+        }
+    }
+
     get(id: LocalId, trackerId: TrackerId, includeParent: boolean): DeepReadonly<Tracker> | undefined {
         return this.getAll(id, includeParent).find((t) => t.uuid === trackerId);
     }


### PR DESCRIPTION
When removing a shape from a layer their `id` is dropped and the related systems have to be informed that any data they have might be stale.