### PR TITLE
bug(Systems): Load tracker and aura system at all times

### DIFF
--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -1,9 +1,10 @@
-import { reactive } from "vue";
+import { reactive, watchEffect } from "vue";
 import type { DeepReadonly } from "vue";
 
 import { registerSystem } from "..";
 import type { System } from "..";
 import { SyncTo } from "../../../core/models/types";
+import { activeShapeStore } from "../../../store/activeShape";
 import { getGlobalId, getShape } from "../../id";
 import type { LocalId } from "../../id";
 import { compositeState } from "../../layers/state";
@@ -177,3 +178,11 @@ class AuraSystem implements System {
 
 export const auraSystem = new AuraSystem();
 registerSystem("auras", auraSystem);
+
+// Aura System state is active whenever a shape is selected due to the quick selection info
+
+watchEffect(() => {
+    const id = activeShapeStore.state.id;
+    if (id) auraSystem.loadState(id);
+    else auraSystem.dropState();
+});

--- a/client/src/game/systems/index.ts
+++ b/client/src/game/systems/index.ts
@@ -1,6 +1,7 @@
 import type { LocalId } from "../id";
 
 const SYSTEMS: Record<string, System> = {};
+(window as any).systems = SYSTEMS;
 
 export function registerSystem(key: string, system: System): void {
     SYSTEMS[key] = system;
@@ -17,5 +18,3 @@ export interface System {
     drop(id: LocalId): void;
     inform(id: LocalId, data: any): void;
 }
-
-(window as any).systems = SYSTEMS;

--- a/client/src/game/systems/trackers/index.ts
+++ b/client/src/game/systems/trackers/index.ts
@@ -1,9 +1,10 @@
-import { reactive } from "vue";
+import { reactive, watchEffect } from "vue";
 import type { DeepReadonly } from "vue";
 
 import { registerSystem } from "..";
 import type { System } from "..";
 import { SyncTo } from "../../../core/models/types";
+import { activeShapeStore } from "../../../store/activeShape";
 import { getGlobalId, getShape } from "../../id";
 import type { LocalId } from "../../id";
 import { compositeState } from "../../layers/state";
@@ -145,3 +146,11 @@ class TrackerSystem implements System {
 
 export const trackerSystem = new TrackerSystem();
 registerSystem("trackers", trackerSystem);
+
+// Tracker System state is active whenever a shape is selected due to the quick selection info
+
+watchEffect(() => {
+    const id = activeShapeStore.state.id;
+    if (id) trackerSystem.loadState(id);
+    else trackerSystem.dropState();
+});

--- a/client/src/game/ui/settings/shape/TrackerSettings.vue
+++ b/client/src/game/ui/settings/shape/TrackerSettings.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { watch } from "vue";
 import type { DeepReadonly } from "vue";
 import { useI18n } from "vue-i18n";
 
@@ -20,21 +19,7 @@ import type { Tracker, TrackerId, UiTracker } from "../../../systems/trackers/mo
 
 const { t } = useI18n();
 
-const props = defineProps<{ activeSelection: boolean }>();
-
-watch(
-    [() => activeShapeStore.state.id, () => props.activeSelection],
-    ([newId, newSelection], [oldId, oldSelection]) => {
-        if (newSelection && newId !== undefined && (!(oldSelection ?? false) || oldId !== newId)) {
-            trackerSystem.loadState(newId);
-            auraSystem.loadState(newId);
-        } else if ((!newSelection && (oldSelection ?? false)) || newId === undefined) {
-            trackerSystem.dropState();
-            auraSystem.dropState();
-        }
-    },
-    { immediate: true },
-);
+defineProps<{ activeSelection: boolean }>();
 
 const owned = accessSystem.$.hasEditAccess;
 const isComposite = activeShapeStore.isComposite;


### PR DESCRIPTION
These two systems were only being loaded when the trackers edit dialog was opened, but the quick selection info is always visible so should have the info at all times