### PR TITLE
bug(Navigation): Fix account removal redirect not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Fix movement blockers intersecting with themselves when moving on the token layer
 -   Fix assets becoming invisible when using a subpath setup (only applies to new assets)
 -   Fix colour picker not allowing to change the rgba/hsla/hex values manually
+-   Account removal not properly redirecting to login
 -   [asset-manager] Asset manager would not check for stale files when removing a folder
 
 ### Performance

--- a/client/src/dashboard/AccountSettings.vue
+++ b/client/src/dashboard/AccountSettings.vue
@@ -72,7 +72,7 @@ async function deleteAccount(): Promise<void> {
         const response = await postFetch("/api/users/delete");
         if (response.ok) {
             coreStore.setAuthenticated(false);
-            router.push("/");
+            await router.push("/auth/login");
         } else {
             errorMessage.value = t("settings.AccountSettings.delete_request_error");
         }


### PR DESCRIPTION
When removing your account, the redirect to the login screen was not behaving properly.