### PR TITLE
bug(Initiative): Fix initiative not using the correct ids

### DIFF
--- a/client/src/game/models/initiative.ts
+++ b/client/src/game/models/initiative.ts
@@ -1,7 +1,7 @@
-import type { LocalId } from "../id";
+import type { GlobalId, LocalId } from "../id";
 
-export interface InitiativeData {
-    shape: LocalId;
+export interface InitiativeData<T = LocalId> {
+    shape: T;
     initiative?: number;
     isVisible: boolean;
     isGroup: boolean;
@@ -25,7 +25,7 @@ export type InitiativeSettings = {
     round: number;
     turn: number;
     sort: InitiativeSort;
-    data: InitiativeData[];
+    data: InitiativeData<GlobalId>[];
 };
 
 export enum InitiativeEffectMode {

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -17,7 +17,7 @@ import {
     sendInitiativeReorder,
     sendInitiativeSetSort,
 } from "../../api/emits/initiative";
-import { getGlobalId, getShape } from "../../id";
+import { getGlobalId, getLocalId, getShape } from "../../id";
 import type { LocalId } from "../../id";
 import { InitiativeSort } from "../../models/initiative";
 import type { InitiativeData, InitiativeEffect, InitiativeSettings } from "../../models/initiative";
@@ -70,8 +70,9 @@ class InitiativeStore extends Store<InitiativeState> {
     }
 
     setData(data: InitiativeSettings): void {
-        if (this._state.editLock !== -1) this._state.newData = data.data;
-        else this._state.locationData = data.data;
+        const initiativeData = data.data.map((d) => ({ ...d, shape: getLocalId(d.shape)! }));
+        if (this._state.editLock !== -1) this._state.newData = initiativeData;
+        else this._state.locationData = initiativeData;
 
         this.setRoundCounter(data.round, false);
         this.setTurnCounter(data.turn, false);


### PR DESCRIPTION
Recently the concept of Global and Local ids was introduced and a mistake in the event types made it so that the initiative tool was using a global id thinking it was a local id, which doesn't work.