### PR TITLE
bug(Initiative): Initiative data sent to server using local ids

### DIFF
--- a/client/src/game/api/emits/initiative.ts
+++ b/client/src/game/api/emits/initiative.ts
@@ -1,20 +1,22 @@
+import type { GlobalId } from "../../id";
 import type { InitiativeData, InitiativeEffect, InitiativeSort } from "../../models/initiative";
 import { wrapSocket } from "../helpers";
 import { socket } from "../socket";
 
-export const sendInitiativeAdd = wrapSocket<InitiativeData>("Initiative.Add");
-export const sendInitiativeRemove = wrapSocket<string>("Initiative.Remove");
-export const sendInitiativeSetValue = wrapSocket<{ shape: string; value: number }>("Initiative.Value.Set");
+export const sendInitiativeAdd = wrapSocket<InitiativeData<GlobalId>>("Initiative.Add");
+export const sendInitiativeRemove = wrapSocket<GlobalId>("Initiative.Remove");
+export const sendInitiativeSetValue = wrapSocket<{ shape: GlobalId; value: number }>("Initiative.Value.Set");
 export const sendInitiativeTurnUpdate = wrapSocket<number>("Initiative.Turn.Update");
 export const sendInitiativeRoundUpdate = wrapSocket<number>("Initiative.Round.Update");
-export const sendInitiativeNewEffect = wrapSocket<{ actor: string; effect: InitiativeEffect }>("Initiative.Effect.New");
+export const sendInitiativeNewEffect =
+    wrapSocket<{ actor: GlobalId; effect: InitiativeEffect }>("Initiative.Effect.New");
 export const sendInitiativeRenameEffect =
-    wrapSocket<{ shape: string; index: number; name: string }>("Initiative.Effect.Rename");
+    wrapSocket<{ shape: GlobalId; index: number; name: string }>("Initiative.Effect.Rename");
 export const sendInitiativeTurnsEffect =
-    wrapSocket<{ shape: string; index: number; turns: string }>("Initiative.Effect.Turns");
-export const sendInitiativeRemoveEffect = wrapSocket<{ shape: string; index: number }>("Initiative.Effect.Remove");
+    wrapSocket<{ shape: GlobalId; index: number; turns: string }>("Initiative.Effect.Turns");
+export const sendInitiativeRemoveEffect = wrapSocket<{ shape: GlobalId; index: number }>("Initiative.Effect.Remove");
 export const sendInitiativeOptionUpdate =
-    wrapSocket<{ shape: string; option: string; value: boolean }>("Initiative.Option.Update");
+    wrapSocket<{ shape: GlobalId; option: string; value: boolean }>("Initiative.Option.Update");
 export const sendRequestInitiatives = (): void => {
     socket.emit("Initiative.Request");
 };
@@ -22,5 +24,5 @@ export const sendInitiativeClear = (): void => {
     socket.emit("Initiative.Clear");
 };
 export const sendInitiativeReorder =
-    wrapSocket<{ shape: string; oldIndex: number; newIndex: number }>("Initiative.Order.Change");
+    wrapSocket<{ shape: GlobalId; oldIndex: number; newIndex: number }>("Initiative.Order.Change");
 export const sendInitiativeSetSort = wrapSocket<InitiativeSort>("Initiative.Sort.Set");

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -100,7 +100,7 @@ class InitiativeStore extends Store<InitiativeState> {
         } else {
             actor.initiative = initiative;
         }
-        sendInitiativeAdd(actor);
+        sendInitiativeAdd({ ...actor, shape: getGlobalId(actor.shape) });
     }
 
     setInitiative(shapeId: LocalId, value: number, sync: boolean): void {
@@ -285,11 +285,11 @@ class InitiativeStore extends Store<InitiativeState> {
     }
 
     owns(shapeId?: LocalId): boolean {
+        if (gameStore.state.isDm) return true;
         if (shapeId === undefined) {
             shapeId = this._state.locationData[this._state.turnCounter]?.shape;
             if (shapeId === undefined) return false;
         }
-        if (gameStore.state.isDm) return true;
         return accessSystem.hasAccessTo(shapeId, false, { edit: true });
     }
 


### PR DESCRIPTION
The data the game sends to the server was using a local id, which has no meaning as soon as it leaves the client.

If you happen to have played around with initiative on a recent dev branch and have initiative entries you can't remove, use the following python script in the server folder to fix those:


```python
import json
from models import *

for initiative in Initiative.select():
    data = json.loads(initiative.data)
    modified = False
    l = len(data)
    for index, d in enumerate(data[::-1]):
        if type(d["shape"]) != str:
            data.pop(l - index - 1)
            modified = True
    if modified:
        initiative.data = json.dumps(data)
        initiative.save()
```
        