### PR TITLE
bug(Tracker): Fix tracker/aura init for new shapes

### DIFF
--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -85,6 +85,15 @@ class AuraSystem implements System {
         }
     }
 
+    private getOrCreate(id: LocalId): Aura[] {
+        let idAuras = this.data.get(id);
+        if (idAuras === undefined) {
+            this.inform(id, []);
+            idAuras = this.data.get(id)!;
+        }
+        return idAuras;
+    }
+
     get(id: LocalId, auraId: AuraId, includeParent: boolean): DeepReadonly<Aura> | undefined {
         return this.getAll(id, includeParent).find((t) => t.uuid === auraId);
     }
@@ -104,7 +113,7 @@ class AuraSystem implements System {
     add(id: LocalId, aura: Aura, syncTo: SyncTo): void {
         if (syncTo === SyncTo.SERVER) sendShapeCreateAura(aurasToServer(getGlobalId(id), [aura])[0]);
 
-        this.data.get(id)!.push(aura);
+        this.getOrCreate(id).push(aura);
 
         if (id === this._state.id) this.updateAuraState();
 

--- a/client/src/game/systems/trackers/index.ts
+++ b/client/src/game/systems/trackers/index.ts
@@ -82,6 +82,15 @@ class TrackerSystem implements System {
         }
     }
 
+    private getOrCreate(id: LocalId): Tracker[] {
+        let idTrackers = this.data.get(id);
+        if (idTrackers === undefined) {
+            this.inform(id, []);
+            idTrackers = this.data.get(id)!;
+        }
+        return idTrackers;
+    }
+
     get(id: LocalId, trackerId: TrackerId, includeParent: boolean): DeepReadonly<Tracker> | undefined {
         return this.getAll(id, includeParent).find((t) => t.uuid === trackerId);
     }
@@ -101,7 +110,7 @@ class TrackerSystem implements System {
     add(id: LocalId, tracker: Tracker, syncTo: SyncTo): void {
         if (syncTo === SyncTo.SERVER) sendShapeCreateTracker(trackersToServer(getGlobalId(id), [tracker])[0]);
 
-        this.data.get(id)!.push(tracker);
+        this.getOrCreate(id).push(tracker);
 
         if (id === this._state.id) this.updateTrackerState();
 


### PR DESCRIPTION
When creating new shapes adding trackers or auras was no longer possible until a refresh due to the shapes not being known to the tracker/aura systems, this is now resolved