### PR TITLE
bug(Spell): Fix spell tool breaking screen

### DIFF
--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -19,7 +19,7 @@ socket.on("Shape.Set", (data: ServerShape) => {
     const old = getShapeFromGlobal(data.uuid);
     const isActive = activeShapeStore.state.id === getLocalId(data.uuid);
     const hasEditDialogOpen = isActive && activeShapeStore.state.showEditDialog;
-    if (old) old.layer.removeShape(old, SyncMode.NO_SYNC, true);
+    if (old) old.layer.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
     const shape = addShape(data, SyncMode.NO_SYNC);
 
     if (shape && isActive) {

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -23,12 +23,12 @@ export class FowLightingLayer extends FowLayer {
         }
     }
 
-    removeShape(shape: IShape, sync: SyncMode, recalculate: boolean): boolean {
+    removeShape(shape: IShape, options: { sync: SyncMode; recalculate: boolean; dropShapeId: boolean }): boolean {
         let idx = -1;
         if (shape.options.preFogShape ?? false) {
             idx = this.preFogShapes.findIndex((s) => s.id === shape.id);
         }
-        const remove = super.removeShape(shape, sync, recalculate);
+        const remove = super.removeShape(shape, options);
         if (remove && idx >= 0) this.preFogShapes.splice(idx, 1);
         return remove;
     }

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -277,7 +277,7 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
         removed.push(getGlobalId(sel.id));
         if (sel.blocksVision) recalculateVision = true;
         if (sel.blocksMovement) recalculateMovement = true;
-        sel.layer.removeShape(sel, SyncMode.NO_SYNC, recalculateIterative);
+        sel.layer.removeShape(sel, { sync: SyncMode.NO_SYNC, recalculate: recalculateIterative, dropShapeId: true });
     }
     if (sync !== SyncMode.NO_SYNC) sendRemoveShapes({ uuids: removed, temporary: sync === SyncMode.TEMP_SYNC });
     if (!recalculateIterative) {

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -72,7 +72,7 @@ export class Asset extends BaseRect {
                 visionState.recalculateMovement(this._floor!);
                 visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: this.id });
             }
-            this.layer.removeShape(cover, SyncMode.NO_SYNC, false);
+            this.layer.removeShape(cover, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
             this.invalidate(false);
         }
     }

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -83,7 +83,7 @@ export class ToggleComposite extends Shape {
         this.setActiveVariant(newVariant, true);
 
         const oldVariant = getShape(id)!;
-        oldVariant.layer.removeShape(oldVariant, SyncMode.FULL_SYNC, true);
+        oldVariant.layer.removeShape(oldVariant, { sync: SyncMode.FULL_SYNC, recalculate: true, dropShapeId: true });
     }
 
     private resetVariants(...variants: LocalId[]): void {

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -214,11 +214,15 @@ class DrawTool extends Tool {
         // Removal
 
         if (oldValue === DrawMode.Normal) {
-            normalLayer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
+            normalLayer.removeShape(this.brushHelper, {
+                sync: SyncMode.NO_SYNC,
+                recalculate: true,
+                dropShapeId: false,
+            });
         } else if (oldValue === DrawMode.Erase) {
-            mapLayer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
+            mapLayer.removeShape(this.brushHelper, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: false });
         } else {
-            fowLayer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
+            fowLayer.removeShape(this.brushHelper, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: false });
         }
 
         // Adding
@@ -275,20 +279,20 @@ class DrawTool extends Tool {
         const layer = this.getLayer(data);
         if (layer === undefined) return;
         if (this.brushHelper !== undefined) {
-            layer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
+            layer.removeShape(this.brushHelper, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.brushHelper = undefined;
         }
         if (this.pointer !== undefined) {
             const drawLayer = floorStore.getLayer(data?.floor ?? floorStore.currentFloor.value!, LayerName.Draw);
-            drawLayer!.removeShape(this.pointer, SyncMode.NO_SYNC, true);
+            drawLayer!.removeShape(this.pointer, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.pointer = undefined;
         }
         if (this.ruler !== undefined) {
-            layer.removeShape(this.ruler, SyncMode.NO_SYNC, true);
+            layer.removeShape(this.ruler, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.ruler = undefined;
         }
         if (this.active && this.shape !== undefined) {
-            layer.removeShape(this.shape, SyncMode.FULL_SYNC, true);
+            layer.removeShape(this.shape, { sync: SyncMode.FULL_SYNC, recalculate: true, dropShapeId: true });
             this.shape = undefined;
             this.active = false;
             layer.invalidate(false);
@@ -572,7 +576,7 @@ class DrawTool extends Tool {
                 console.log("No active layer!");
                 return;
             }
-            layer.removeShape(this.ruler!, SyncMode.NO_SYNC, true);
+            layer.removeShape(this.ruler!, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.ruler = undefined;
             if (this.state.isClosedPolygon) {
                 const points = this.shape.points; // expensive call
@@ -660,7 +664,9 @@ class DrawTool extends Tool {
         }
         const refPoint = this.brushHelper?.refPoint;
         const bs = this.brushHelper?.r;
-        if (this.brushHelper !== undefined) layer.removeShape(this.brushHelper, SyncMode.NO_SYNC, true);
+        if (this.brushHelper !== undefined) {
+            layer.removeShape(this.brushHelper, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
+        }
         this.brushHelper = this.createBrush(toGP(-1000, -1000), bs);
         this.setupBrush();
         layer.addShape(this.brushHelper, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false }); // during mode change the shape is already added

--- a/client/src/game/tools/variants/map.ts
+++ b/client/src/game/tools/variants/map.ts
@@ -80,7 +80,7 @@ class MapTool extends Tool {
         }
         if (this.rect !== undefined) {
             const layer = floorStore.currentLayer.value!;
-            layer.removeShape(this.rect, SyncMode.NO_SYNC, true);
+            layer.removeShape(this.rect, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.rect = undefined;
             this.state.hasRect = false;
         }

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -180,8 +180,10 @@ class RulerTool extends Tool {
         }
         this.active = false;
 
-        for (const ruler of this.rulers) layer.removeShape(ruler, this.syncMode, true);
-        layer.removeShape(this.text, this.syncMode, true);
+        for (const ruler of this.rulers) {
+            layer.removeShape(ruler, { sync: this.syncMode, recalculate: true, dropShapeId: true });
+        }
+        layer.removeShape(this.text, { sync: this.syncMode, recalculate: true, dropShapeId: true });
         this.startPoint = this.text = undefined;
         this.rulers = [];
         this.previousLength = 0;

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -561,7 +561,7 @@ class SelectTool extends Tool implements ISelectTool {
 
             layerSelection = selectionState.get({ includeComposites: false });
 
-            layer.removeShape(this.selectionHelper!, SyncMode.NO_SYNC, true);
+            layer.removeShape(this.selectionHelper!, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.selectionHelper = undefined;
 
             if (layerSelection.some((s) => !s.isLocked)) {
@@ -831,9 +831,9 @@ class SelectTool extends Tool implements ISelectTool {
     removeRotationUi(): void {
         if (this.rotationUiActive) {
             const layer = this.rotationAnchor!.layer;
-            layer.removeShape(this.rotationAnchor!, SyncMode.NO_SYNC, true);
-            layer.removeShape(this.rotationBox!, SyncMode.NO_SYNC, true);
-            layer.removeShape(this.rotationEnd!, SyncMode.NO_SYNC, true);
+            layer.removeShape(this.rotationAnchor!, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
+            layer.removeShape(this.rotationBox!, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
+            layer.removeShape(this.rotationEnd!, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.rotationAnchor = this.rotationBox = this.rotationEnd = undefined;
             this.rotationUiActive = false;
 
@@ -880,7 +880,11 @@ class SelectTool extends Tool implements ISelectTool {
     removePolygonEditUi(): void {
         if (this.polygonTracer !== null) {
             const drawLayer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Draw)!;
-            drawLayer.removeShape(this.polygonTracer, SyncMode.NO_SYNC, false);
+            drawLayer.removeShape(this.polygonTracer, {
+                sync: SyncMode.NO_SYNC,
+                recalculate: false,
+                dropShapeId: true,
+            });
             drawLayer.invalidate(true);
             this.polygonTracer = null;
             this.polygonUiVisible.value = "hidden";

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -89,7 +89,7 @@ class SpellTool extends Tool {
         if (this.shape !== undefined) {
             startPosition = this.shape.refPoint;
             const syncMode = this.state.showPublic !== syncChanged ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC;
-            layer.removeShape(this.shape, syncMode, false);
+            layer.removeShape(this.shape, { sync: syncMode, recalculate: false, dropShapeId: true });
         }
 
         switch (this.state.selectedSpellShape) {
@@ -140,7 +140,7 @@ class SpellTool extends Tool {
         const layer = floorStore.currentLayer.value!;
 
         if (this.rangeShape !== undefined) {
-            layer.removeShape(this.rangeShape, SyncMode.NO_SYNC, false);
+            layer.removeShape(this.rangeShape, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
         }
 
         if (!selectionState.hasSelection || this.state.range === 0) return;
@@ -165,11 +165,19 @@ class SpellTool extends Tool {
         const layer = floorStore.currentLayer.value!;
 
         if (this.shape !== undefined) {
-            layer.removeShape(this.shape, this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC, false);
+            layer.removeShape(this.shape, {
+                sync: this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC,
+                recalculate: false,
+                dropShapeId: true,
+            });
             this.shape = undefined;
         }
         if (this.rangeShape !== undefined) {
-            layer.removeShape(this.rangeShape, this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC, false);
+            layer.removeShape(this.rangeShape, {
+                sync: this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC,
+                recalculate: false,
+                dropShapeId: true,
+            });
             this.rangeShape = undefined;
         }
     }
@@ -179,7 +187,11 @@ class SpellTool extends Tool {
         if (this.shape === undefined) return;
         const layer = floorStore.currentLayer.value!;
 
-        layer.removeShape(this.shape, this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC, false);
+        layer.removeShape(this.shape, {
+            sync: this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC,
+            recalculate: false,
+            dropShapeId: false,
+        });
         this.shape.isInvisible = !this.state.showPublic;
         layer.addShape(this.shape, SyncMode.FULL_SYNC, InvalidationMode.NORMAL, { snappable: false });
         this.shape = undefined;
@@ -211,7 +223,11 @@ class SpellTool extends Tool {
         if (this.shape !== undefined) {
             const layer = floorStore.currentLayer.value!;
 
-            layer.removeShape(this.shape, this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC, false);
+            layer.removeShape(this.shape, {
+                sync: this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC,
+                recalculate: false,
+                dropShapeId: true,
+            });
             this.shape = undefined;
         }
         activateTool(ToolName.Select);


### PR DESCRIPTION
Using the spell tool was no longer possible since the global-local id changes due to a bug where the smarter shape re-use that spell tool does was not taken into account