### PR TITLE
bug(Select): Fix reveal shape selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Fix assets becoming invisible when using a subpath setup (only applies to new assets)
 -   Fix colour picker not allowing to change the rgba/hsla/hex values manually
 -   Account removal not properly redirecting to login
+-   Selecting a shape that was drawn in reveal mode no longer removes shadow during selection
 -   [asset-manager] Asset manager would not check for stale files when removing a folder
 
 ### Performance

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -332,6 +332,8 @@ export abstract class Shape implements IShape {
     }
 
     drawSelection(ctx: CanvasRenderingContext2D): void {
+        const ogOp = this.layer.ctx.globalCompositeOperation;
+        if (ogOp !== "source-over") this.layer.ctx.globalCompositeOperation = "source-over";
         const bb = this.getBoundingBox();
         ctx.beginPath();
         ctx.moveTo(g2lx(bb.points[0][0]), g2ly(bb.points[0][1]));
@@ -359,6 +361,8 @@ export abstract class Shape implements IShape {
             ctx.lineTo(g2lx(vertex[0]), g2ly(vertex[1]));
         }
         ctx.stroke();
+
+        if (ogOp !== "source-over") this.layer.ctx.globalCompositeOperation = ogOp;
     }
 
     // VISION


### PR DESCRIPTION
Shapes drawn in `reveal` mode would light up the whole screen during selection. This is fixed.