### PR TITLE
feat(Select): Hide polygon edit UI while moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Draw tool UI now has a tabbed interface
     -   a shape tab to configure shape and colours
     -   a visibility tab to configure advanced vision modes as well as blocksVision and blocksMovement changes
+-   Polygon edit tool will hide UI while dragging a point/shape
 -   [server] Change subpath handling
     -   the client now MUST also set the PA_BASEPATH env variable in production mode
     -   this means the env variable needs to be set at build time

--- a/client/src/game/models/tools.ts
+++ b/client/src/game/models/tools.ts
@@ -26,7 +26,7 @@ export interface ITool {
     readonly toolTranslation: string;
 
     alert: Ref<boolean>;
-    active: boolean;
+    active: Ref<boolean>;
     scaling: boolean;
 
     permittedTools: ToolPermission[];

--- a/client/src/game/tools/tool.ts
+++ b/client/src/game/tools/tool.ts
@@ -12,7 +12,7 @@ export abstract class Tool implements ITool {
     abstract readonly toolName: ToolName;
     abstract readonly toolTranslation: string;
 
-    active = false;
+    active = ref(false);
     scaling = false;
     alert = ref(false);
 

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -131,7 +131,7 @@ class DrawTool extends Tool {
             },
         );
         watchEffect(() => {
-            if (this.shape !== undefined && this.active) {
+            if (this.shape !== undefined && this.active.value) {
                 (this.shape as Polygon).openPolygon = !this.state.isClosedPolygon;
             }
         });
@@ -179,7 +179,7 @@ class DrawTool extends Tool {
         if (this.state.isDoor) {
             doorSystem.toggle(this.shape.id, true, SyncTo.SERVER);
         }
-        this.active = false;
+        this.active.value = false;
         const layer = this.getLayer();
         if (layer !== undefined) {
             layer.invalidate(false);
@@ -291,10 +291,10 @@ class DrawTool extends Tool {
             layer.removeShape(this.ruler, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.ruler = undefined;
         }
-        if (this.active && this.shape !== undefined) {
+        if (this.active.value && this.shape !== undefined) {
             layer.removeShape(this.shape, { sync: SyncMode.FULL_SYNC, recalculate: true, dropShapeId: true });
             this.shape = undefined;
-            this.active = false;
+            this.active.value = false;
             layer.invalidate(false);
         }
         layer.canvas.parentElement!.style.removeProperty("cursor");
@@ -312,9 +312,9 @@ class DrawTool extends Tool {
         }
         if (this.brushHelper === undefined) return;
 
-        if (!this.active) {
+        if (!this.active.value) {
             this.startPoint = startPoint;
-            this.active = true;
+            this.active.value = true;
             switch (this.state.selectedShape) {
                 case DrawShape.Square: {
                     this.shape = new Rect(cloneP(startPoint), 0, 0, {
@@ -357,7 +357,7 @@ class DrawTool extends Tool {
                     event.preventDefault();
                     const text = await this.promptFunction!("What should the text say?", "New text");
                     if (text === undefined) {
-                        this.active = false;
+                        this.active.value = false;
                         return;
                     }
                     this.shape = new Text(cloneP(this.brushHelper.refPoint), text, this.state.fontSize, {
@@ -468,10 +468,10 @@ class DrawTool extends Tool {
         if (this.brushHelper !== undefined) {
             this.brushHelper.r = this.helperSize;
             this.brushHelper.refPoint = endPoint;
-            if (!this.active) layer.invalidate(false);
+            if (!this.active.value) layer.invalidate(false);
         }
 
-        if (!this.active || this.startPoint === undefined || this.shape === undefined) return;
+        if (!this.active.value || this.startPoint === undefined || this.shape === undefined) return;
 
         switch (this.state.selectedShape) {
             case DrawShape.Square: {
@@ -531,7 +531,7 @@ class DrawTool extends Tool {
     // eslint-disable-next-line @typescript-eslint/require-await
     async onUp(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
         if (
-            !this.active ||
+            !this.active.value ||
             this.shape === undefined ||
             (this.shape instanceof Polygon && this.state.selectedShape === DrawShape.Polygon)
         ) {
@@ -566,7 +566,7 @@ class DrawTool extends Tool {
 
     onContextMenu(event: MouseEvent): void {
         if (
-            this.active &&
+            this.active.value &&
             this.shape !== undefined &&
             this.state.selectedShape === DrawShape.Polygon &&
             this.shape instanceof Polygon
@@ -586,14 +586,14 @@ class DrawTool extends Tool {
                     visionState.insertConstraint(TriangulationTarget.MOVEMENT, this.shape, points[0], points.at(-1)!);
             }
             this.finaliseShape();
-        } else if (!this.active) {
+        } else if (!this.active.value) {
             openDefaultContextMenu(event);
         }
     }
 
     onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {
         if (event.defaultPrevented) return;
-        if (event.key === "Escape" && this.active) {
+        if (event.key === "Escape" && this.active.value) {
             let mouse: { x: number; y: number } | undefined = undefined;
             if (this.brushHelper !== undefined) {
                 mouse = { x: this.brushHelper.refPoint.x, y: this.brushHelper.refPoint.y };

--- a/client/src/game/tools/variants/map.ts
+++ b/client/src/game/tools/variants/map.ts
@@ -69,7 +69,7 @@ class MapTool extends Tool {
     }
 
     removeRect(reset = true): void {
-        if (this.shape && reset && this.active) {
+        if (this.shape && reset && this.active.value) {
             this.shape.refPoint = this.ogRP!;
             this.shape.w = this.ogW!;
             this.shape.h = this.ogH!;
@@ -101,7 +101,7 @@ class MapTool extends Tool {
         this.startPoint = startPoint;
         const layer = floorStore.currentLayer.value!;
 
-        this.active = true;
+        this.active.value = true;
 
         this.rect = new Rect(cloneP(this.startPoint), 0, 0, { fillColour: "rgba(0,0,0,0)", strokeColour: "black" });
         this.state.hasRect = true;
@@ -112,7 +112,7 @@ class MapTool extends Tool {
 
     // eslint-disable-next-line @typescript-eslint/require-await
     async onMove(lp: LocalPoint): Promise<void> {
-        if (!this.active || this.rect === undefined || this.startPoint === undefined) return;
+        if (!this.active.value || this.rect === undefined || this.startPoint === undefined) return;
 
         const endPoint = l2g(lp);
 
@@ -126,9 +126,9 @@ class MapTool extends Tool {
 
     // eslint-disable-next-line @typescript-eslint/require-await
     async onUp(): Promise<void> {
-        if (!this.active || this.rect === undefined) return;
+        if (!this.active.value || this.rect === undefined) return;
 
-        this.active = false;
+        this.active.value = false;
 
         if (selectionState.state.selection.size !== 1) {
             this.removeRect();

--- a/client/src/game/tools/variants/pan.ts
+++ b/client/src/game/tools/variants/pan.ts
@@ -33,19 +33,19 @@ class PanTool extends Tool {
     // eslint-disable-next-line @typescript-eslint/require-await
     async onDown(lp: LocalPoint): Promise<void> {
         this.panStart = lp;
-        this.active = true;
+        this.active.value = true;
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
     async onMove(lp: LocalPoint): Promise<void> {
-        if (!this.active) return;
+        if (!this.active.value) return;
         this.panScreen(lp, false);
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
     async onUp(lp: LocalPoint): Promise<void> {
-        if (!this.active) return;
-        this.active = false;
+        if (!this.active.value) return;
+        this.active.value = false;
         this.panScreen(lp, true);
         sendClientLocationOptions();
     }

--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -28,10 +28,10 @@ class PingTool extends Tool {
     }
 
     cleanup(): void {
-        if (!this.active || this.ping === undefined || this.border === undefined || this.startPoint === undefined)
+        if (!this.active.value || this.ping === undefined || this.border === undefined || this.startPoint === undefined)
             return;
 
-        this.active = false;
+        this.active.value = false;
         deleteShapes([this.ping, this.border], SyncMode.TEMP_SYNC);
         this.ping = undefined;
         this.startPoint = undefined;
@@ -52,7 +52,7 @@ class PingTool extends Tool {
             return;
         }
 
-        this.active = true;
+        this.active.value = true;
         this.ping = new Circle(this.startPoint, 20, { fillColour: clientStore.state.rulerColour });
         this.border = new Circle(this.startPoint, 40, {
             fillColour: "#0000",
@@ -78,7 +78,7 @@ class PingTool extends Tool {
 
     // eslint-disable-next-line @typescript-eslint/require-await
     async onMove(lp: LocalPoint): Promise<void> {
-        if (!this.active || this.ping === undefined || this.border === undefined || this.startPoint === undefined)
+        if (!this.active.value || this.ping === undefined || this.border === undefined || this.startPoint === undefined)
             return;
 
         const gp = l2g(lp);

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -86,7 +86,7 @@ class RulerTool extends Tool {
             console.log("No draw layer!");
             return;
         }
-        this.active = true;
+        this.active.value = true;
         this.createNewRuler(cloneP(this.startPoint), cloneP(this.startPoint));
         this.text = new Text(cloneP(this.startPoint), "", 20, {
             fillColour: "#000",
@@ -105,7 +105,7 @@ class RulerTool extends Tool {
     // eslint-disable-next-line @typescript-eslint/require-await
     async onMove(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
         let endPoint = l2g(lp);
-        if (!this.active || this.rulers.length === 0 || this.startPoint === undefined || this.text === undefined)
+        if (!this.active.value || this.rulers.length === 0 || this.startPoint === undefined || this.text === undefined)
             return;
 
         const layer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Draw);
@@ -149,7 +149,7 @@ class RulerTool extends Tool {
 
     onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {
         if (event.defaultPrevented) return;
-        if (event.key === " " && this.active) {
+        if (event.key === " " && this.active.value) {
             const lastRuler = this.rulers.at(-1)!;
             this.createNewRuler(lastRuler.endPoint, lastRuler.endPoint);
             this.previousLength += this.currentLength;
@@ -170,7 +170,7 @@ class RulerTool extends Tool {
     // HELPERS
 
     private cleanup(): void {
-        if (!this.active || this.rulers.length === 0 || this.startPoint === undefined || this.text === undefined)
+        if (!this.active.value || this.rulers.length === 0 || this.startPoint === undefined || this.text === undefined)
             return;
 
         const layer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Draw);
@@ -178,7 +178,7 @@ class RulerTool extends Tool {
             console.log("No active layer!");
             return;
         }
-        this.active = false;
+        this.active.value = false;
 
         for (const ruler of this.rulers) {
             layer.removeShape(ruler, { sync: this.syncMode, recalculate: true, dropShapeId: true });

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -146,7 +146,7 @@ class SelectTool extends Tool implements ISelectTool {
             }
 
             // polygon edit ui logic
-            if (selection.size !== 1) {
+            if (this.active.value || selection.size !== 1) {
                 this.removePolygonEditUi();
             } else {
                 const features = getFeatures(this.toolName);
@@ -381,7 +381,7 @@ class SelectTool extends Tool implements ISelectTool {
         if (this.checkRuler()) {
             rulerTool.onDown(lp, event);
         }
-        if (this.mode !== SelectOperations.Noop) this.active = true;
+        if (this.mode !== SelectOperations.Noop) this.active.value = true;
     }
 
     async onMove(
@@ -419,7 +419,7 @@ class SelectTool extends Tool implements ISelectTool {
 
         // We require move for the resize and rotate cursors
         if (
-            !this.active &&
+            !this.active.value &&
             !(
                 this.hasFeature(SelectFeatures.Resize, features) ||
                 this.hasFeature(SelectFeatures.Rotate, features) ||
@@ -517,8 +517,8 @@ class SelectTool extends Tool implements ISelectTool {
             return;
         }
 
-        if (!this.active) return;
-        this.active = false;
+        if (!this.active.value) return;
+        this.active.value = false;
 
         if (floorStore.currentLayer === undefined) {
             console.log("No active layer!");
@@ -768,7 +768,7 @@ class SelectTool extends Tool implements ISelectTool {
 
     onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {
         if (event.defaultPrevented) return;
-        if (event.key === " " && this.active) {
+        if (event.key === " " && this.active.value) {
             event.preventDefault();
         }
         super.onKeyUp(event, features);


### PR DESCRIPTION
While dragging a shape or point, sometimes the mouse would hover over the polygon edit UI icons and give funky behaviour.

Given that that UI cannot be used while moving, it is now hidden during this action.