### PR TITLE
feat(Performance): Remove brand types at runtime

### DIFF
--- a/client/src/core/geometry.ts
+++ b/client/src/core/geometry.ts
@@ -31,12 +31,12 @@ export type LocalPoint = Point & { __brand: "LocalPoint" };
 export function toGP(array: [number, number]): GlobalPoint;
 export function toGP(x: number, y: number): GlobalPoint;
 export function toGP(first: number | [number, number], second?: number): GlobalPoint {
-    if (first instanceof Array) return { x: first[0], y: first[1], __brand: "GlobalPoint" };
-    return { x: first, y: second!, __brand: "GlobalPoint" };
+    if (first instanceof Array) return { x: first[0], y: first[1] } as GlobalPoint;
+    return { x: first, y: second! } as GlobalPoint;
 }
 
 export function toLP(x: number, y: number): LocalPoint {
-    return { x, y, __brand: "LocalPoint" };
+    return { x, y } as LocalPoint;
 }
 
 export function toArrayP<T extends Point>(a: T): [number, number] {


### PR DESCRIPTION
PA uses 'brands' to mimic nominal typing in typescript. For old types (i.e. GlobalPoint/LocalPoint) these brands were also present in the runtime variables. Newer types have moved to only specify brands during typing. This PR streamlines the Point types to also only specify brands on a type level.

All things considered this will probably have almost no noticeable impact, but it's a performance improvement without any downside anyway.