### PR TITLE
bug(Aura): Fix aura direction input not syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Account removal not properly redirecting to login
 -   Selecting a shape that was drawn in reveal mode no longer removes shadow during selection
 -   Removing an asset would remove any campaign using it as their logo
+-   Aura direction number input not synching change to server
 -   [asset-manager] Asset manager would not check for stale files when removing a folder
 
 ### Performance

--- a/client/src/core/components/RotationSlider.vue
+++ b/client/src/core/components/RotationSlider.vue
@@ -46,6 +46,10 @@ function mouseUp(): void {
     active = false;
 }
 
+function syncDegreeAngle(): void {
+    emit("change", toDegrees(radianAngle.value));
+}
+
 function mouseMove(event: MouseEvent): void {
     if (active) {
         const circleRect = circle.value!.getBoundingClientRect();
@@ -71,7 +75,7 @@ function mouseMove(event: MouseEvent): void {
         >
             <div class="slider" :style="{ left: `${left}px`, top: `${top}px` }"></div>
         </div>
-        <div v-if="showNumberInput"><input type="number" v-model.number="degreeAngle" /></div>
+        <div v-if="showNumberInput"><input type="number" v-model.number="degreeAngle" @change="syncDegreeAngle" /></div>
     </div>
 </template>
 


### PR DESCRIPTION
The manual number input would update the client's direction, but not synchronise this change to the server. (The other direction input did sync correctly)