### PR TITLE
bug(Id): Prevent id 0 bugs

### DIFF
--- a/client/src/game/id.ts
+++ b/client/src/game/id.ts
@@ -15,7 +15,10 @@ const uuids: GlobalId[] = [];
 const idMap: Map<LocalId, IShape> = new Map();
 (window as any).idMap = idMap;
 
-let lastId = -1;
+// we're not giving id 0 on purpose to prevent potential unsafe if checks against this
+// Usually our explicit undefined check catches this, but because of our LocalId typing
+// this can go wrong, preventing 0 from being obtainable solves a lot of future headaches.
+let lastId = 0;
 const freeIds: LocalId[] = [];
 const reservedIds: Map<GlobalId, LocalId> = new Map();
 


### PR DESCRIPTION
With the Local/Global id system now in place, some potentially annoying bugs to find can be triggered by having id 0 be a valid id. This PR addresses this fact, by preventing this from ever happening.