### PR TITLE
bug(Memory): Fix some memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Selecting a shape that was drawn in reveal mode no longer removes shadow during selection
 -   Removing an asset would remove any campaign using it as their logo
 -   Aura direction number input not synching change to server
+-   Some memory leaks when changing locations
 -   [asset-manager] Asset manager would not check for stale files when removing a folder
 
 ### Performance

--- a/client/src/game/api/emits/initiative.ts
+++ b/client/src/game/api/emits/initiative.ts
@@ -8,21 +8,26 @@ export const sendInitiativeRemove = wrapSocket<GlobalId>("Initiative.Remove");
 export const sendInitiativeSetValue = wrapSocket<{ shape: GlobalId; value: number }>("Initiative.Value.Set");
 export const sendInitiativeTurnUpdate = wrapSocket<number>("Initiative.Turn.Update");
 export const sendInitiativeRoundUpdate = wrapSocket<number>("Initiative.Round.Update");
-export const sendInitiativeNewEffect =
-    wrapSocket<{ actor: GlobalId; effect: InitiativeEffect }>("Initiative.Effect.New");
-export const sendInitiativeRenameEffect =
-    wrapSocket<{ shape: GlobalId; index: number; name: string }>("Initiative.Effect.Rename");
-export const sendInitiativeTurnsEffect =
-    wrapSocket<{ shape: GlobalId; index: number; turns: string }>("Initiative.Effect.Turns");
+export const sendInitiativeNewEffect = wrapSocket<{ actor: GlobalId; effect: InitiativeEffect }>(
+    "Initiative.Effect.New",
+);
+export const sendInitiativeRenameEffect = wrapSocket<{ shape: GlobalId; index: number; name: string }>(
+    "Initiative.Effect.Rename",
+);
+export const sendInitiativeTurnsEffect = wrapSocket<{ shape: GlobalId; index: number; turns: string }>(
+    "Initiative.Effect.Turns",
+);
 export const sendInitiativeRemoveEffect = wrapSocket<{ shape: GlobalId; index: number }>("Initiative.Effect.Remove");
-export const sendInitiativeOptionUpdate =
-    wrapSocket<{ shape: GlobalId; option: string; value: boolean }>("Initiative.Option.Update");
+export const sendInitiativeOptionUpdate = wrapSocket<{ shape: GlobalId; option: string; value: boolean }>(
+    "Initiative.Option.Update",
+);
 export const sendRequestInitiatives = (): void => {
     socket.emit("Initiative.Request");
 };
 export const sendInitiativeClear = (): void => {
     socket.emit("Initiative.Clear");
 };
-export const sendInitiativeReorder =
-    wrapSocket<{ shape: GlobalId; oldIndex: number; newIndex: number }>("Initiative.Order.Change");
+export const sendInitiativeReorder = wrapSocket<{ shape: GlobalId; oldIndex: number; newIndex: number }>(
+    "Initiative.Order.Change",
+);
 export const sendInitiativeSetSort = wrapSocket<InitiativeSort>("Initiative.Sort.Set");

--- a/client/src/game/api/emits/shape/core.ts
+++ b/client/src/game/api/emits/shape/core.ts
@@ -62,12 +62,14 @@ export async function requestShapeInfo(shape: string): Promise<{ shape: ServerSh
 
 // helpers
 
-const _sendRectSizeUpdate =
-    wrapSocket<{ uuid: string; w: number; h: number; temporary: boolean }>("Shape.Rect.Size.Update");
+const _sendRectSizeUpdate = wrapSocket<{ uuid: string; w: number; h: number; temporary: boolean }>(
+    "Shape.Rect.Size.Update",
+);
 const _sendCircleSizeUpdate = wrapSocket<{ uuid: string; r: number; temporary: boolean }>("Shape.Circle.Size.Update");
 
-const _sendTextSizeUpdate =
-    wrapSocket<{ uuid: string; font_size: number; temporary: boolean }>("Shape.Text.Size.Update");
+const _sendTextSizeUpdate = wrapSocket<{ uuid: string; font_size: number; temporary: boolean }>(
+    "Shape.Text.Size.Update",
+);
 
 function _sendShapePositionUpdate(
     shapes: { uuid: string; position: { angle: number; points: number[][] } }[],

--- a/client/src/game/api/emits/shape/toggleComposite.ts
+++ b/client/src/game/api/emits/shape/toggleComposite.ts
@@ -4,8 +4,9 @@ export const sendToggleCompositeActiveVariant = wrapSocket<{ shape: string; vari
     "ToggleComposite.Variants.Active.Set",
 );
 
-export const sendToggleCompositeAddVariant =
-    wrapSocket<{ shape: string; variant: string; name: string }>("ToggleComposite.Variants.Add");
+export const sendToggleCompositeAddVariant = wrapSocket<{ shape: string; variant: string; name: string }>(
+    "ToggleComposite.Variants.Add",
+);
 
 export const sendToggleCompositeRenameVariant = wrapSocket<{ shape: string; variant: string; name: string }>(
     "ToggleComposite.Variants.Rename",

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -30,16 +30,14 @@ import { floorStore } from "../../store/floor";
 import { gameStore } from "../../store/game";
 import { locationStore } from "../../store/location";
 import { convertAssetListToMap } from "../assets/utils";
-import { startDrawLoop, stopDrawLoop } from "../draw";
+import { clearGame } from "../clear";
+import { startDrawLoop } from "../draw";
 import { getLocalId, getShapeFromGlobal } from "../id";
 import type { GlobalId } from "../id";
-import { compositeState } from "../layers/state";
 import type { Note, ServerFloor } from "../models/general";
 import type { Location } from "../models/settings";
 import { setCenterPosition } from "../position";
 import { deleteShapes } from "../shapes/utils";
-import { initiativeStore } from "../ui/initiative/state";
-import { visionState } from "../vision/state";
 
 import { sendClientLocationOptions } from "./emits/client";
 import { activeLayerToselect } from "./events/client";
@@ -76,14 +74,8 @@ socket.on("redirect", (destination: string) => {
 // Bootup events
 
 socket.on("Board.Locations.Set", (locationInfo: Location[]) => {
-    stopDrawLoop();
-    gameStore.clear();
-    visionState.clear();
+    clearGame();
     locationStore.setLocations(locationInfo, false);
-    document.getElementById("layers")!.innerHTML = "";
-    floorStore.clear();
-    compositeState.clear();
-    initiativeStore.clear();
 });
 
 socket.on("Board.Floor.Set", (floor: ServerFloor) => {

--- a/client/src/game/clear.ts
+++ b/client/src/game/clear.ts
@@ -1,0 +1,21 @@
+import { floorStore } from "../store/floor";
+import { gameStore } from "../store/game";
+import { locationStore } from "../store/location";
+
+import { stopDrawLoop } from "./draw";
+import { clearIds } from "./id";
+import { compositeState } from "./layers/state";
+import { initiativeStore } from "./ui/initiative/state";
+import { visionState } from "./vision/state";
+
+export function clearGame(): void {
+    stopDrawLoop();
+    gameStore.clear();
+    visionState.clear();
+    locationStore.setLocations([], false);
+    document.getElementById("layers")!.innerHTML = "";
+    floorStore.clear();
+    compositeState.clear();
+    initiativeStore.clear();
+    clearIds();
+}

--- a/client/src/game/id.ts
+++ b/client/src/game/id.ts
@@ -10,7 +10,7 @@ export type GlobalId = string & { __brand: "globalId" };
 export type LocalId = number & { __brand: "localId" };
 
 // Array of GlobalId indexed by localId
-const uuids: GlobalId[] = [];
+let uuids: GlobalId[] = [];
 
 const idMap: Map<LocalId, IShape> = new Map();
 (window as any).idMap = idMap;
@@ -19,8 +19,16 @@ const idMap: Map<LocalId, IShape> = new Map();
 // Usually our explicit undefined check catches this, but because of our LocalId typing
 // this can go wrong, preventing 0 from being obtainable solves a lot of future headaches.
 let lastId = 0;
-const freeIds: LocalId[] = [];
+let freeIds: LocalId[] = [];
 const reservedIds: Map<GlobalId, LocalId> = new Map();
+
+export function clearIds(): void {
+    uuids = [];
+    idMap.clear();
+    lastId = 0;
+    freeIds = [];
+    reservedIds.clear();
+}
 
 function generateId(): LocalId {
     return freeIds.pop() ?? (++lastId as LocalId);

--- a/client/src/game/systems/trackers/emits.ts
+++ b/client/src/game/systems/trackers/emits.ts
@@ -4,8 +4,9 @@ import { socket } from "../../api/socket";
 import type { ServerTracker, TrackerId } from "./models";
 
 export const sendShapeRemoveTracker = sendSimpleShapeOption<TrackerId>("Shape.Options.Tracker.Remove");
-export const sendShapeMoveTracker =
-    sendShapeOption<{ tracker: TrackerId; new_shape: string }>("Shape.Options.Tracker.Move");
+export const sendShapeMoveTracker = sendShapeOption<{ tracker: TrackerId; new_shape: string }>(
+    "Shape.Options.Tracker.Move",
+);
 
 export const sendShapeCreateTracker = (data: ServerTracker): void => {
     socket.emit("Shape.Options.Tracker.Create", data);

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, ref, toRef } from "vue";
 import { useI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
 
 import type { AssetFile } from "../../../core/models/types";
 import { baseAdjust, uuidv4 } from "../../../core/utils";
 import { gameStore } from "../../../store/game";
 import { uiStore } from "../../../store/ui";
+import { clearGame } from "../../clear";
 import { getShape } from "../../id";
 import type { LocalId } from "../../id";
 import type { Note } from "../../models/general";
@@ -13,6 +15,7 @@ import NoteDialog from "../NoteDialog.vue";
 
 import AssetParentNode from "./AssetParentNode.vue";
 
+const router = useRouter();
 const { t } = useI18n();
 
 const showNote = ref(false);
@@ -27,6 +30,11 @@ const markers = toRef(gameState, "markers");
 const noAssets = computed(() => {
     return gameState.assets.size === 1 && (gameState.assets.get("__files") as AssetFile[]).length <= 0;
 });
+
+async function exit(): Promise<void> {
+    clearGame();
+    await router.push({ name: "dashboard" });
+}
 
 function settingsClick(event: MouseEvent): void {
     const target = event.target as HTMLDivElement;
@@ -134,13 +142,13 @@ const openClientSettings = (): void => uiStore.showClientSettings(!uiStore.state
                 {{ t("game.ui.menu.MenuBar.client_settings") }}
             </button>
         </div>
-        <router-link
-            to="/dashboard"
+        <div
+            @click="exit"
             class="menu-accordion"
             style="width: 200px; box-sizing: border-box; text-decoration: none; display: inline-block"
         >
             {{ t("common.exit") }}
-        </router-link>
+        </div>
     </div>
 </template>
 

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -47,6 +47,7 @@ class VisionState extends Store<State> {
         this.visionBlockers.clear();
         this.movementBlockers.clear();
         this.visionSources.clear();
+        this.cdt.clear();
     }
 
     setVisionMode(mode: VisibilityMode, sync: boolean): void {

--- a/client/src/store/floor.ts
+++ b/client/src/store/floor.ts
@@ -74,6 +74,7 @@ class FloorStore extends Store<FloorState> {
         this._state.floorIndex = -1 as FloorId;
         this._state.layerIndex = -1;
         this.layerMap.clear();
+        this.lastFloorId = 0;
     }
 
     // FLOOR


### PR DESCRIPTION
This PR fixes memory leaks related to changing/leaving a location.

Some things were not properly being cleared which means that memory was just sitting around no longer being used, but not being able to be garbage collected. Most noticeably the vision CDT information was not being cleared AND the floorId was not resetting to 0 which together meant that the vision information for all locations/sessions would stay in memory