### PR TITLE
bug(Rendering): Improve/Fix late image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Removing an asset would remove any campaign using it as their logo
 -   Aura direction number input not synching change to server
 -   Some memory leaks when changing locations
+-   Floor lighting behaviour for late loading images
 -   [asset-manager] Asset manager would not check for stale files when removing a folder
 
 ### Performance

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -84,12 +84,12 @@ socket.on("Board.Floor.Set", (floor: ServerFloor) => {
     // The very first floor that arrives is the one we want to select
     // When this condition is evaluated after the await, we are at the mercy of the async scheduler
     const selectFloor = floorStore.state.floors.length === 0;
-    if (debugLayers())
+    if (debugLayers)
         console.log(
             `Adding floor ${floor.name} [${floor.layers.reduce((acc, cur) => acc + cur.shapes.length, 0)} shapes]`,
         );
     floorStore.addServerFloor(floor);
-    if (debugLayers()) console.log("Done.");
+    if (debugLayers) console.log("Done.");
 
     if (selectFloor) {
         floorStore.selectFloor({ name: floor.name }, false);

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -23,6 +23,7 @@ import "./events/shape/togglecomposite";
 import { toGP } from "../../core/geometry";
 import { SyncMode } from "../../core/models/types";
 import type { AssetList } from "../../core/models/types";
+import { debugLayers } from "../../localStorageHelpers";
 import { router } from "../../router";
 import { clientStore } from "../../store/client";
 import { coreStore } from "../../store/core";
@@ -83,7 +84,12 @@ socket.on("Board.Floor.Set", (floor: ServerFloor) => {
     // The very first floor that arrives is the one we want to select
     // When this condition is evaluated after the await, we are at the mercy of the async scheduler
     const selectFloor = floorStore.state.floors.length === 0;
+    if (debugLayers())
+        console.log(
+            `Adding floor ${floor.name} [${floor.layers.reduce((acc, cur) => acc + cur.shapes.length, 0)} shapes]`,
+        );
     floorStore.addServerFloor(floor);
+    if (debugLayers()) console.log("Done.");
 
     if (selectFloor) {
         floorStore.selectFloor({ name: floor.name }, false);

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -1,4 +1,5 @@
 import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { debugLayers } from "../../../localStorageHelpers";
 import { activeShapeStore } from "../../../store/activeShape";
 import { clientStore } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
@@ -55,6 +56,11 @@ export class Layer {
     }
 
     invalidate(skipLightUpdate: boolean): void {
+        if (debugLayers()) {
+            console.groupCollapsed(`🗑 [${this.floor}] ${this.name}`);
+            console.trace();
+            console.groupEnd();
+        }
         this.valid = false;
         if (!skipLightUpdate) {
             floorStore.invalidateLight(this.floor);
@@ -251,6 +257,11 @@ export class Layer {
 
     draw(doClear = true): void {
         if (!this.valid) {
+            if (debugLayers()) {
+                console.groupCollapsed(`🖌 [${this.floor}] ${this.name}`);
+                console.trace();
+                console.groupEnd();
+            }
             const ctx = this.ctx;
             const ogOP = ctx.globalCompositeOperation;
 

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -56,7 +56,7 @@ export class Layer {
     }
 
     invalidate(skipLightUpdate: boolean): void {
-        if (debugLayers()) {
+        if (debugLayers) {
             console.groupCollapsed(`🗑 [${this.floor}] ${this.name}`);
             console.trace();
             console.groupEnd();
@@ -257,7 +257,7 @@ export class Layer {
 
     draw(doClear = true): void {
         if (!this.valid) {
-            if (debugLayers()) {
+            if (debugLayers) {
                 console.groupCollapsed(`🖌 [${this.floor}] ${this.name}`);
                 console.trace();
                 console.groupEnd();

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -376,7 +376,7 @@ export abstract class Shape implements IShape {
             visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: this.id });
             visionState.recalculateVision(this.floor.id);
         }
-        this.invalidate(false);
+        this.invalidate(true);
         floorStore.invalidateLightAllFloors();
         if (this.blocksMovement && !alteredMovement) {
             visionState.deleteFromTriangulation({

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -115,7 +115,9 @@ export function createShapeFromDict(shape: ServerShape): IShape | undefined {
         else img.src = baseAdjust(asset.src);
         sh = new Asset(img, refPoint, asset.width, asset.height, { uuid: asset.uuid });
         img.onload = () => {
+            // Late image loading affects floor lighting
             floorStore.getLayer(floorStore.getFloor({ name: shape.floor })!, shape.layer)!.invalidate(true);
+            floorStore.invalidateLightAllFloors();
         };
     } else if (shape.type_ === "togglecomposite") {
         const toggleComposite = shape as ServerToggleComposite;

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -115,9 +115,7 @@ export function createShapeFromDict(shape: ServerShape): IShape | undefined {
         else img.src = baseAdjust(asset.src);
         sh = new Asset(img, refPoint, asset.width, asset.height, { uuid: asset.uuid });
         img.onload = () => {
-            // Late image loading affects floor lighting
-            floorStore.getLayer(floorStore.getFloor({ name: shape.floor })!, shape.layer)!.invalidate(true);
-            floorStore.invalidateLightAllFloors();
+            (sh as Asset).setLoaded();
         };
     } else if (shape.type_ === "togglecomposite") {
         const toggleComposite = shape as ServerToggleComposite;

--- a/client/src/localStorageHelpers.ts
+++ b/client/src/localStorageHelpers.ts
@@ -1,0 +1,5 @@
+// random helpers for interacting with local storage
+
+export function debugLayers(): boolean {
+    return localStorage.getItem("PA_DEBUG_INVALIDATE_DRAW") === "true";
+}

--- a/client/src/localStorageHelpers.ts
+++ b/client/src/localStorageHelpers.ts
@@ -1,5 +1,3 @@
 // random helpers for interacting with local storage
 
-export function debugLayers(): boolean {
-    return localStorage.getItem("PA_DEBUG_INVALIDATE_DRAW") === "true";
-}
+export const debugLayers = localStorage.getItem("PA_DEBUG_INVALIDATE_DRAW") === "true";


### PR DESCRIPTION
tl;dr at the bottom

When rendering user uploaded assets they can only be rendered once the image is actually downloaded by the browser, this is pretty obvious. PA would only draw these images once ready. This in itself is also pretty normal, but can actually cause some undesired behaviour when we add in floors.

Part of the render steps for floor based vision involves overlaying vision info from higher floors to allow light sources that come from up top through some hole.

If however the image that represents the upper area for that upper floor is not downloaded in time, it would just be transparent for the purpose of this thought exercise, which means that the light which is supposed to only come out of the small hole in the upper floor image, is now coming out from the entire ceiling.

So long story short: PA will now render a fog coloured area filling the entire image space until the image is loaded.