### PR TITLE
bug(AssetManager): Fix ddraft uploads not progressing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ For server owners using a subpath, some important changes are made, so make sure
 -   Aura direction number input not synching change to server
 -   Some memory leaks when changing locations
 -   Floor lighting behaviour for late loading images
+-   DDraft uploads not progressing in the asset manager
 -   [asset-manager] Asset manager would not check for stale files when removing a folder
 
 ### Performance

--- a/server/api/socket/asset_manager/ddraft.py
+++ b/server/api/socket/asset_manager/ddraft.py
@@ -72,4 +72,9 @@ async def handle_ddraft_file(upload_data: UploadData, data: bytes, sid: str):
         options=json.dumps(template),
     )
 
-    await sio.emit("Asset.Upload.Finish", asset.as_dict(), room=sid, namespace=ASSET_NS)
+    await sio.emit(
+        "Asset.Upload.Finish",
+        {"asset": asset.as_dict(), "parent": upload_data["directory"]},
+        room=sid,
+        namespace=ASSET_NS,
+    )


### PR DESCRIPTION
When uploading ddraft files to the asset manager, the progress would become stuck. The file itself would still be uploaded to the server successfully though.