### PR TITLE
bug(SpawnLocations): Fix spawn locations no longer saving properly

### DIFF
--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -5,6 +5,8 @@ import { coreStore } from "../../../store/core";
 import { gameStore } from "../../../store/game";
 import { locationStore } from "../../../store/location";
 import { settingsStore } from "../../../store/settings";
+import { getLocalId } from "../../id";
+import type { GlobalId } from "../../id";
 import type { ServerLocation } from "../../models/general";
 import type { Location, ServerLocationOptions } from "../../models/settings";
 import { VisibilityMode, visionState } from "../../vision/state";
@@ -61,5 +63,12 @@ export function setLocationOptions(id: number | undefined, options: Partial<Serv
         settingsStore.setGroundMapBackground(options.ground_map_background, id, false);
     if (options?.underground_map_background !== undefined)
         settingsStore.setUndergroundMapBackground(options.underground_map_background, id, false);
-    if (id !== undefined) settingsStore.setSpawnLocations(JSON.parse(options.spawn_locations ?? "[]"), id, false);
+    if (id !== undefined) {
+        const spawnLocations: GlobalId[] = JSON.parse(options.spawn_locations ?? "[]");
+        settingsStore.setSpawnLocations(
+            spawnLocations.map((s) => getLocalId(s)!),
+            id,
+            false,
+        );
+    }
 }

--- a/client/src/game/models/settings.ts
+++ b/client/src/game/models/settings.ts
@@ -1,4 +1,5 @@
-import type { LocalId } from "../id";
+import { getLocalId } from "../id";
+import type { GlobalId, LocalId } from "../id";
 
 import type { InitiativeEffectMode } from "./initiative";
 
@@ -106,6 +107,11 @@ export interface UserOptions {
     initiativeEffectVisibility: InitiativeEffectMode;
 }
 
+function parseSpawnLocations(spawn_locations: string): LocalId[] {
+    const spawnLocations: GlobalId[] = JSON.parse(spawn_locations);
+    return spawnLocations.map((s) => getLocalId(s)!);
+}
+
 export const optionsToClient = (options: ServerLocationOptions): LocationOptions => ({
     useGrid: options.use_grid,
     gridType: options.grid_type ?? "SQUARE",
@@ -117,7 +123,7 @@ export const optionsToClient = (options: ServerLocationOptions): LocationOptions
     fowLos: options.fow_los,
     visionMinRange: options.vision_min_range,
     visionMaxRange: options.vision_max_range,
-    spawnLocations: JSON.parse(options.spawn_locations),
+    spawnLocations: parseSpawnLocations(options.spawn_locations),
     movePlayerOnTokenChange: options.move_player_on_token_change,
 
     airMapBackground: options.air_map_background ?? null,

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -5,6 +5,7 @@ import { Store } from "../core/store";
 import { getValueOrDefault } from "../core/types";
 import { toSnakeCase } from "../core/utils";
 import { sendLocationOptions } from "../game/api/emits/location";
+import { getGlobalId } from "../game/id";
 import type { LocalId } from "../game/id";
 import type { LocationOptions } from "../game/models/settings";
 
@@ -181,7 +182,7 @@ class SettingsStore extends Store<SettingsState> {
             floorStore.invalidateAllFloors();
             if (sync)
                 sendLocationOptions({
-                    options: { spawn_locations: JSON.stringify(spawnLocations) },
+                    options: { spawn_locations: JSON.stringify(spawnLocations.map((s) => getGlobalId(s))) },
                     location,
                 });
         }


### PR DESCRIPTION
Spawn locations were being sent by their local id to the server, which is meaningless.
This PR fixes this to send the proper global id to the server.