### PR TITLE
feat(Assets): Auto infer asset dimension from name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For server owners using a subpath, some important changes are made, so make sure
             -   Automatically toggle blocking settings for a shape with a single click
         -   teleport zones
             -   Automatically move shapes to spawn points
+-   Dropping an asset with dimension info in its name (e.g. 50x30) will automatically size the asset
 -   [asset-manager] drop support for folders
 -   [server] Added `allow_signups` option in the `General` config section that can be disabled to prevent users from signing up themselves
 -   [server] Added barebones admin dashboard

--- a/client/src/game/api/emits/asset.ts
+++ b/client/src/game/api/emits/asset.ts
@@ -2,8 +2,9 @@ import type { AssetOptions } from "../../models/asset";
 import { socket } from "../socket";
 
 type AssetOptionsRequest<T extends AssetOptions | string> =
-    | { success: true; options: T | null }
+    | { success: true; name: string; options: T | null }
     | { success: false; error: string };
+
 export async function requestAssetOptions(assetId: number): Promise<AssetOptionsRequest<AssetOptions>> {
     socket.emit("Asset.Options.Get", assetId);
     return new Promise((resolve: (value: AssetOptionsRequest<AssetOptions>) => void) =>

--- a/server/api/socket/asset.py
+++ b/server/api/socket/asset.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from typing_extensions import TypedDict
 
 import auth
@@ -23,12 +24,12 @@ async def get_asset_options(sid: str, asset_id: int):
         logger.warning(f"{pr.player.name} attempted to request asset options")
         return
 
-    asset = Asset.get_or_none(id=asset_id)
+    asset: Optional[Asset] = Asset.get_or_none(id=asset_id)
 
     if asset is None:
         options = {"success": False, "error": "AssetNotFound"}
     else:
-        options = {"success": True, "options": asset.options}
+        options = {"success": True, "name": asset.name, "options": asset.options}
 
     await sio.emit("Asset.Options.Info", options, room=sid, namespace=GAME_NS)
 


### PR DESCRIPTION
This PR adds auto sizing of assets dropped on the map when the size can be inferred from the asset name.
The code looks for a sequence in the name matching YxY where Y is a number (can contain multiple digits). Some examples: 120x60, 30x50, 2x2.

The number will be interpreted as the number of grid cells it should occupy in the X and Y direction

This closes #906.