### PR TITLE
feat(Tooling): Add campaign exporter

### DIFF
--- a/server/api/http/rooms.py
+++ b/server/api/http/rooms.py
@@ -1,7 +1,7 @@
+import asyncio
 from typing import Union
 from aiohttp import web
 from aiohttp_security import check_authorized
-from multidict import MultiDict
 from export.campaign import export_campaign
 
 from models import Location, LocationOptions, PlayerRoom, Room, User
@@ -185,8 +185,9 @@ async def export(request: web.Request):
         if room is None:
             return web.HTTPBadRequest()
 
-        fp, fl = export_campaign(room)
-        return web.FileResponse(
-            fp, headers=MultiDict({"Content-Disposition": f"Attachment;filename={fl}"})
+        asyncio.create_task(export_campaign(room))
+
+        return web.HTTPAccepted(
+            text=f"Processing started. Check /static/temp/{room.name}-{room.creator.name}.pac soon."
         )
     return web.HTTPUnauthorized()

--- a/server/config.py
+++ b/server/config.py
@@ -1,11 +1,14 @@
 import configparser
+from pathlib import Path
 
-from utils import FILE_DIR
+from utils import FILE_DIR, SAVE_DIR
 
 config = configparser.ConfigParser()
 config.read([FILE_DIR / "server_config.cfg", FILE_DIR / "data" / "server_config.cfg"])
 
-SAVE_FILE = config["General"]["save_file"]
+save_path = config["General"]["save_file"]
 
-if not SAVE_FILE.startswith("/"):
-    SAVE_FILE = str(FILE_DIR / SAVE_FILE)
+if save_path.startswith("/"):
+    SAVE_FILE = Path(save_path)
+else:
+    SAVE_FILE = SAVE_DIR / save_path

--- a/server/export/campaign.py
+++ b/server/export/campaign.py
@@ -1,22 +1,34 @@
-import json
 import os
+import secrets
 from pathlib import Path
+import tarfile
+from time import time
+from typing import Dict, List, Set, cast
 from playhouse.shortcuts import model_to_dict
 
+from models import ALL_MODELS
+from models.asset import Asset
 from models.campaign import (
     Floor,
     Layer,
     Location,
     LocationOptions,
+    LocationUserOption,
     Note,
     PlayerRoom,
     Room,
 )
+from models.db import open_db
+from models.general import Constants
+from models.groups import Group
+from models.initiative import Initiative
+from models.label import LabelSelection
 from models.shape import (
     AssetRect,
     Aura,
     Circle,
     CircularToken,
+    CompositeShapeAssociation,
     Label,
     Line,
     Polygon,
@@ -29,290 +41,410 @@ from models.shape import (
     Tracker,
 )
 from models.user import User, UserOptions
+from save import SAVE_VERSION
 
 
-def export_campaign(room: Room):
-    export_data = {}
-    # Room meta info
-    room_data = model_to_dict(room, recurse=False)
-    del room_data["id"]
-    default_options = model_to_dict(room.default_options, recurse=False)
-    del default_options["id"]
-    export_data["room"] = {"_": room_data, "default_options": default_options}
-
-    # Players meta info
-    player_data = []
-    user_data = {"_": [], "labels": []}
-    for pr in room.players:
-        _p = {}
-        player = model_to_dict(pr, recurse=False)
-        del player["id"]
-        del player["room"]
-        del player["last_played"]
-        _p["_"] = player
-
-        _p["user_options"] = model_to_dict(pr.user_options, recurse=False)
-        del _p["user_options"]["id"]
-
-        player_data.append(_p)
-
-        _u = {}
-        _u["_"] = model_to_dict(pr.player, recurse=False)
-        del _u["_"]["password_hash"]
-        default_options = model_to_dict(pr.player.default_options, recurse=False)
-        del default_options["id"]
-        _u["default_options"] = default_options
-
-        user_data["_"].append(_u)
-    export_data["players"] = player_data
-    export_data["users"] = user_data
-
-    notes = []
-    for note in room.notes:
-        n = model_to_dict(note, recurse=False)
-        del n["room"]
-        notes.append(n)
-    export_data["room"]["notes"] = notes
-
-    # Locations meta info
-    locations_data = []
-    for location in room.locations:
-        location_data = {}
-
-        _l = model_to_dict(location, recurse=False)
-        del _l["room"]
-        location_data["_"] = _l
-
-        location_options = model_to_dict(location.options, recurse=False)
-        del location_options["id"]
-        location_data["location_options"] = location_options
-
-        floors = []
-        for floor in location.floors:
-            floor_data = {}
-            _f = model_to_dict(floor, recurse=False)
-            del _f["location"]
-            floor_data["_"] = _f
-
-            layers = []
-            for layer in floor.layers:
-                layer_data = {}
-                _ly = model_to_dict(layer, recurse=False)
-                del _ly["floor"]
-                layer_data["_"] = _ly
-
-                shapes = []
-                for shape in layer.shapes:
-                    shape_data = {}
-                    shape_data["_"] = model_to_dict(shape, recurse=False)
-                    shape_data["st"] = model_to_dict(shape.subtype, recurse=False)
-
-                    owners = []
-                    for o in shape.owners:
-                        owner = model_to_dict(o, recurse=False)
-                        del owner["id"]
-                        owners.append(owner)
-
-                    shape_data["trackers"] = [
-                        model_to_dict(t, recurse=False) for t in shape.trackers
-                    ]
-                    shape_data["auras"] = [
-                        model_to_dict(a, recurse=False) for a in shape.auras
-                    ]
-
-                    labels = []
-                    for l in shape.labels:
-                        if not any(
-                            la["uuid"] == l.label.uuid for la in user_data["labels"]
-                        ):
-                            user_data["labels"].append(
-                                model_to_dict(l.label, recurse=False)
-                            )
-                        label = model_to_dict(l, recurse=False)
-                        del label["id"]
-                        labels.append(label)
-                    shape_data["labels"] = labels
-
-                    shape_data["access"] = owners
-                    shapes.append(shape_data)
-                layer_data["shapes"] = shapes
-
-                layers.append(layer_data)
-            floor_data["layers"] = layers
-
-            floors.append(floor_data)
-        location_data["floors"] = floors
-
-        locations_data.append(location_data)
-    export_data["locations"] = locations_data
-
-    static_folder = Path("static")
-    os.makedirs(static_folder / "temp", exist_ok=True)
-    filename = f"{room.name}-{room.creator.name}.json"
-    fullpath = static_folder / "temp" / filename
-    if os.path.exists(fullpath):
-        os.remove(fullpath)
-    with open(fullpath, "w") as fl:
-        json.dump(export_data, fl)
-    return fullpath, filename
+async def export_campaign(room: Room):
+    CampaignExporter(room).pack()
 
 
-def import_campaign(fp: str):
-    with open(fp, "r") as f:
-        import_data = json.load(f)
+class CampaignExporter:
+    def __init__(self, room: Room) -> None:
+        self.room = room
 
-    USER_MAPPING = {}  # old_id -> new_id
+        self.user_mapping: Dict[int, int] = {}
+        self.asset_mapping: Dict[int, int] = {}
+        self.location_mapping: Dict[int, int] = {}
+        self.layer_mapping: Dict[int, int] = {}
+        self.groups_exported: Set[str] = set()
 
-    # Load User data
-    for user_data in import_data["users"]["_"]:
-        default_options = UserOptions(**user_data["default_options"])
-        default_options.save()
+        self.generate_empty_db()
+        self.export_users()
+        self.export_room()
+        self.export_label_selections()
+        self.export_locations()
+        self.export_players()
+        self.export_notes()
 
-        user = user_data["_"]
-        og_id = user["id"]
-        del user["id"]
+    def generate_empty_db(self):
+        static_folder = Path("static")
+        self.output_folder = static_folder / "temp"
+        os.makedirs(self.output_folder, exist_ok=True)
+        self.filename = f"{self.room.name}-{self.room.creator.name}"
+        self.sqlite_name = f"{self.filename}.sqlite"
+        self.sqlite_path = self.output_folder / self.sqlite_name
+        if self.sqlite_path.exists():
+            os.remove(self.sqlite_path)
 
-        user["default_options"] = default_options
-        u = User(**user)
-        u.set_password("test")
-        u.save()
+        self.db = open_db(self.sqlite_path)
+        self.db.foreign_keys = False
 
-        USER_MAPPING[og_id] = u.id
+        # Base model creation
+        with self.db.bind_ctx(ALL_MODELS):
+            self.db.create_tables(ALL_MODELS)
+            # Generate constants (generate new set of tokens to prevent leaking server tokens)
+            Constants.create(
+                save_version=SAVE_VERSION,
+                secret_token=secrets.token_bytes(32),
+                api_token=secrets.token_hex(32),
+            )
 
-    for label in import_data["users"]["labels"]:
-        lb = Label(**label)
-        lb.user_id = USER_MAPPING[label["user"]]
-        lb.save(force_insert=True)
+    def pack(self):
+        self.db.close()
 
-    # Load base room data
-    default_options = LocationOptions(**import_data["room"]["default_options"])
-    default_options.save()
+        static_folder = Path("static")
+        tarname = f"{self.filename}.pac"
+        tarpath = self.output_folder / tarname
 
-    room_data = import_data["room"]["_"]
-    room_data["default_options"] = default_options
-    room_data["creator"] = USER_MAPPING[room_data["creator"]]
-    r = Room(**room_data)
-    r.save()
+        assets_dir_info = tarfile.TarInfo("assets")
+        assets_dir_info.type = tarfile.DIRTYPE
+        assets_dir_info.mode = 0o755
+        assets_dir_info.mtime = time()  # type: ignore
 
-    ROOM_ID = r.id
+        sqlite_info = tarfile.TarInfo(self.sqlite_name)
+        sqlite_info.mode = 0o755
+        sqlite_info.size = self.sqlite_path.stat().st_size
+        sqlite_info.mtime = time()  # type: ignore
 
-    # Load locations
+        try:
+            import bz2
 
-    LOCATION_MAPPING = {}
+            write_mode = "w:bz2"
+        except ImportError:
+            write_mode = "w:gz"
 
-    for location in import_data["locations"]:
-        og_id = location["_"]["id"]
-        del location["_"]["id"]
-        location["_"]["room"] = ROOM_ID
+        with tarfile.open(tarpath, write_mode) as tar:
+            tar.addfile(sqlite_info, open(self.sqlite_path, "rb"))
+            tar.addfile(assets_dir_info)
 
-        location_options = LocationOptions(**location["location_options"])
-        location_options.save()
-        location["_"]["options"] = location_options
+            for asset_id in self.asset_mapping.keys():
+                asset: Asset = Asset[asset_id]
+                if not asset.file_hash:
+                    continue
+                try:
+                    file_path = static_folder / "assets" / asset.file_hash
+                    info = tar.gettarinfo(str(file_path))
+                    info.name = f"assets/{asset.file_hash}"
+                    info.mtime = time()  # type: ignore
+                    info.mode = 0o755
+                    tar.addfile(info, open(file_path, "rb"))  # type: ignore
+                except FileNotFoundError:
+                    pass
 
-        l = Location(**location["_"])
-        l.save()
+        return tarpath, tarname
 
-        LOCATION_MAPPING[og_id] = l.id
+    def export_users(self):
+        for player_room in self.room.players:
+            user = cast(User, player_room.player)
+            user_data = model_to_dict(user, recurse=False)
+            user_options_data = model_to_dict(user.default_options, recurse=False)
+            del user_data["id"]
+            del user_options_data["id"]
 
-        for floor in location["floors"]:
-            # og_id = floor["_"]["id"]
-            del floor["_"]["id"]
-            floor["_"]["location"] = l.id
+            with self.db.bind_ctx([UserOptions, User]):
+                uo = UserOptions.create(**user_options_data)
+                user_data["default_options"] = uo
+                new_user = User.create(**user_data)
+                new_user.set_password("PA_EXPORT")
+                new_user.save()
+                self.user_mapping[user.id] = new_user.id
 
-            f = Floor(**floor["_"])
-            f.save()
+            self.export_labels(new_user.id, user.labels)
 
-            for layer in floor["layers"]:
-                # og_id =
-                del layer["_"]["id"]
-                layer["_"]["floor"] = f.id
+    def export_labels(self, user_id: int, labels: List[Label]):
+        for label in labels:
+            label_data = model_to_dict(label, recurse=False)
+            label_data["user"] = user_id
 
-                ly = Layer(**layer["_"])
-                ly.save()
+            with self.db.bind_ctx([Label]):
+                Label.create(**label_data)
 
-                for shape in layer["shapes"]:
+    def export_label_selections(self):
+        for label_selection in LabelSelection.filter(room=self.room):
+            label_selection_data = model_to_dict(label_selection, recurse=False)
+            del label_selection_data["id"]
+            label_selection_data["user"] = self.user_mapping[
+                label_selection_data["user"]
+            ]
+            label_selection_data["room"] = self.new_room
 
-                    # general shape
+            with self.db.bind_ctx([LabelSelection]):
+                LabelSelection.create(**label_selection_data)
 
-                    shape["_"]["layer"] = ly
-                    shape["_"]["asset"] = None
-                    shape["_"]["group"] = None
-                    s = Shape(**shape["_"])
-                    s.save(force_insert=True)
+    def export_room(self):
+        room_data = model_to_dict(self.room, recurse=False)
+        room_options_data = model_to_dict(self.room.default_options, recurse=False)
+        del room_data["id"]
+        del room_options_data["id"]
+        room_data["creator"] = self.user_mapping[room_data["creator"]]
+        room_data["logo"] = self.export_asset(room_data["logo"])
 
-                    # access
+        with self.db.bind_ctx([Room, LocationOptions]):
+            lo = LocationOptions.create(**room_options_data)
+            room_data["default_options"] = lo
+            self.new_room = Room.create(**room_data)
 
-                    for access in shape["access"]:
-                        if access["user"] not in USER_MAPPING:
-                            continue
+    def export_locations(self):
+        for location in self.room.locations:
+            print(f"[LOC] {location.name}")
+            location_data = model_to_dict(location, recurse=False)
+            del location_data["id"]
+            location_data["room"] = self.new_room
 
-                        sa = ShapeOwner(**access)
-                        sa.user_id = USER_MAPPING[access["user"]]
-                        sa.save(force_insert=True)
+            location_options_data = None
+            if location.options:
+                location_options_data = model_to_dict(location.options, recurse=False)
+                del location_options_data["id"]
 
-                    # auras
+            with self.db.bind_ctx([Location, LocationOptions]):
+                if location_options_data:
+                    lo = LocationOptions.create(**location_options_data)
+                    location_data["options"] = lo
+                new_location = Location.create(**location_data)
+                self.location_mapping[location.id] = new_location.id
 
-                    for tracker in shape["trackers"]:
-                        tr = Tracker(**tracker)
-                        tr.save(force_insert=True)
+            self.export_floors(new_location.id, location.floors)
+            if len(location.initiative) > 0:
+                self.export_initiative(new_location.id, location.initiative[0])
 
-                    for auras in shape["auras"]:
-                        au = Aura(**auras)
-                        au.save(force_insert=True)
+            self.export_location_user_options(new_location.id, location.user_options)
 
-                    # labels
+    def export_location_user_options(
+        self, location_id: int, user_options: List[LocationUserOption]
+    ):
+        for user_option in user_options:
+            user_option_data = model_to_dict(user_option, recurse=False)
+            del user_option_data["id"]
+            user_option_data["location"] = location_id
+            user_option_data["user"] = self.user_mapping[user_option_data["user"]]
+            if user_option_data["active_layer"]:
+                user_option_data["active_layer"] = self.layer_mapping[
+                    user_option_data["active_layer"]
+                ]
 
-                    for label in shape["labels"]:
-                        lb = ShapeLabel(**label)
-                        lb.save(force_insert=True)
+            with self.db.bind_ctx([LocationUserOption]):
+                LocationUserOption.update(
+                    **user_option_data
+                )  # SIGNAL already creates a default LUO!
 
-                    # subtype
+    def export_initiative(self, location_id: int, initiative: Initiative):
+        initiative_data = model_to_dict(initiative, recurse=False)
+        del initiative_data["id"]
+        initiative_data["location"] = location_id
 
-                    if s.type_ == "assetrect":
-                        st = AssetRect(**shape["st"])
-                        st.save(force_insert=True)
-                    elif s.type_ == "circulartoken":
-                        st = CircularToken(**shape["st"])
-                        st.save(force_insert=True)
-                    elif s.type_ == "circle":
-                        st = Circle(**shape["st"])
-                        st.save(force_insert=True)
-                    elif s.type_ == "line":
-                        st = Line(**shape["st"])
-                        st.save(force_insert=True)
-                    elif s.type_ == "polygon":
-                        st = Polygon(**shape["st"])
-                        st.save(force_insert=True)
-                    elif s.type_ == "rect":
-                        st = Rect(**shape["st"])
-                        st.save(force_insert=True)
-                    elif s.type_ == "text":
-                        st = Text(**shape["st"])
-                        st.save(force_insert=True)
-                    elif s.type_ == "togglecomposite":
-                        st = ToggleComposite(**shape["st"])
-                        st.save(force_insert=True)
+        with self.db.bind_ctx([Initiative]):
+            Initiative.create(**initiative_data)
 
-    # Load notes
+    def export_players(self):
+        for player_room in self.room.players:
+            player_data = model_to_dict(player_room, recurse=False)
+            del player_data["id"]
 
-    for note in import_data["room"]["notes"]:
-        nt = Note(**note)
-        nt.location_id = LOCATION_MAPPING[note["location"]]
-        nt.user_id = USER_MAPPING[note["user"]]
-        nt.room_id = ROOM_ID
-        nt.save(force_insert=True)
+            player_options_data = None
+            if player_room.user_options:
+                player_options_data = model_to_dict(
+                    player_room.user_options, recurse=False
+                )
+                del player_options_data["id"]
 
-    # Load PlayerRoom data
+            player_data["room"] = self.new_room
+            player_data["player"] = self.user_mapping[player_data["player"]]
+            player_data["active_location"] = self.location_mapping[
+                player_data["active_location"]
+            ]
 
-    for player in import_data["players"]:
-        user_options = UserOptions(**player["user_options"])
-        user_options.save()
+            with self.db.bind_ctx([PlayerRoom, UserOptions]):
+                if player_options_data:
+                    uo = UserOptions.create(**player_options_data)
+                    player_data["user_options"] = uo
+                PlayerRoom.create(**player_data)
 
-        player["_"]["user_options"] = user_options
-        player["_"]["room"] = ROOM_ID
-        player["_"]["player"] = USER_MAPPING[player["_"]["player"]]
-        player["_"]["active_location"] = LOCATION_MAPPING[
-            player["_"]["active_location"]
-        ]
-        pr = PlayerRoom(**player["_"])
-        pr.save()
+    def export_notes(self):
+        for note in Note.filter(room=self.room):
+            note_data = model_to_dict(note, recurse=False)
+            del note_data["id"]
+            note_data["room"] = self.new_room
+            note_data["user"] = self.user_mapping[note_data["user"]]
+            if note_data["location"]:
+                note_data["location"] = self.location_mapping[note_data["location"]]
+
+            with self.db.bind_ctx([Note]):
+                Note.create(**note_data)
+
+    def export_floors(self, location_id: int, floors: List[Floor]):
+        for floor in floors:
+            print(f" [FL] {floor.name}")
+            floor_data = model_to_dict(floor, recurse=False)
+            del floor_data["id"]
+            floor_data["location"] = location_id
+
+            with self.db.bind_ctx([Floor]):
+                new_floor = Floor.create(**floor_data)
+
+            self.export_layers(new_floor.id, floor.layers)
+
+    def export_layers(self, floor_id: int, layers: List[Layer]):
+        for layer in layers:
+            print(f"  [LAY] {layer.name}")
+            layer_data = model_to_dict(layer, recurse=False)
+            del layer_data["id"]
+            layer_data["floor"] = floor_id
+
+            with self.db.bind_ctx([Layer]):
+                new_layer = Layer.create(**layer_data)
+                self.layer_mapping[layer.id] = new_layer.id
+
+            self.export_shapes(new_layer.id, layer.shapes)
+
+    def export_shapes(self, layer_id: int, shapes: List[Shape]):
+        for shape in shapes:
+            shape_data = model_to_dict(shape, recurse=False)
+            shape_data["layer"] = layer_id
+            if shape_data["asset"]:
+                shape_data["asset"] = self.export_asset(shape_data["asset"])
+            if shape_data["group"]:
+                self.export_group(shape_data["group"])
+
+            with self.db.bind_ctx([Shape]):
+                Shape.create(**shape_data)
+
+            self.export_shape_labels(shape.labels)
+            self.export_trackers(shape.trackers)
+            self.export_auras(shape.auras)
+            self.export_shape_owners(shape.owners)
+            self.export_assetrect(shape.assetrect_set)
+            self.export_circle(shape.circle_set)
+            self.export_circulartoken(shape.circulartoken_set)
+            self.export_line(shape.line_set)
+            self.export_polygon(shape.polygon_set)
+            self.export_rect(shape.rect_set)
+            self.export_text(shape.text_set)
+            self.export_togglecomposite(shape.togglecomposite_set)
+            self.export_composite_shape_associations(shape.shape_variants)
+
+    def export_composite_shape_associations(
+        self, associations: List[CompositeShapeAssociation]
+    ):
+        for association in associations:
+            association_data = model_to_dict(association, recurse=False)
+            del association_data["id"]
+
+            with self.db.bind_ctx([CompositeShapeAssociation]):
+                CompositeShapeAssociation.create(**association_data)
+
+    def export_assetrect(self, rects: List[AssetRect]):
+        for rect in rects:
+            rect_data = model_to_dict(rect, recurse=False)
+
+            with self.db.bind_ctx([AssetRect]):
+                AssetRect.create(**rect_data)
+
+    def export_circle(self, circles: List[Circle]):
+        for circle in circles:
+            circle_data = model_to_dict(circle, recurse=False)
+
+            with self.db.bind_ctx([Circle]):
+                Circle.create(**circle_data)
+
+    def export_circulartoken(self, circulartokens: List[CircularToken]):
+        for circulartoken in circulartokens:
+            circulartoken_data = model_to_dict(circulartoken, recurse=False)
+
+            with self.db.bind_ctx([CircularToken]):
+                CircularToken.create(**circulartoken_data)
+
+    def export_line(self, lines: List[Line]):
+        for line in lines:
+            line_data = model_to_dict(line, recurse=False)
+
+            with self.db.bind_ctx([Line]):
+                Line.create(**line_data)
+
+    def export_polygon(self, polygons: List[Polygon]):
+        for polygon in polygons:
+            polygon_data = model_to_dict(polygon, recurse=False)
+
+            with self.db.bind_ctx([Polygon]):
+                Polygon.create(**polygon_data)
+
+    def export_rect(self, rects: List[Rect]):
+        for rect in rects:
+            rect_data = model_to_dict(rect, recurse=False)
+
+            with self.db.bind_ctx([Rect]):
+                Rect.create(**rect_data)
+
+    def export_text(self, texts: List[Text]):
+        for text in texts:
+            text_data = model_to_dict(text, recurse=False)
+
+            with self.db.bind_ctx([Text]):
+                Text.create(**text_data)
+
+    def export_togglecomposite(self, togglecomposites: List[ToggleComposite]):
+        for togglecomposite in togglecomposites:
+            togglecomposite_data = model_to_dict(togglecomposite, recurse=False)
+
+            with self.db.bind_ctx([ToggleComposite]):
+                ToggleComposite.create(**togglecomposite_data)
+
+    def export_trackers(self, trackers: List[Tracker]):
+        for tracker in trackers:
+            tracker_data = model_to_dict(tracker, recurse=False)
+
+            with self.db.bind_ctx([Tracker]):
+                Tracker.create(**tracker_data)
+
+    def export_auras(self, auras: List[Aura]):
+        for aura in auras:
+            aura_data = model_to_dict(aura, recurse=False)
+
+            with self.db.bind_ctx([Aura]):
+                Aura.create(**aura_data)
+
+    def export_shape_owners(self, owners: List[ShapeOwner]):
+        for owner in owners:
+            owner_data = model_to_dict(owner, recurse=False)
+            del owner_data["id"]
+            owner_data["user"] = self.user_mapping[owner_data["user"]]
+
+            with self.db.bind_ctx([ShapeOwner]):
+                ShapeOwner.create(**owner_data)
+
+    def export_shape_labels(self, labels: List[ShapeLabel]):
+        for label in labels:
+            label_data = model_to_dict(label, recurse=False)
+            del label_data["id"]
+
+            with self.db.bind_ctx([ShapeLabel]):
+                ShapeLabel.create(**label_data)
+
+    def export_group(self, group_id: str):
+        if group_id in self.groups_exported:
+            return
+
+        group = Group[group_id]
+        group_data = model_to_dict(group, recurse=False)
+
+        with self.db.bind_ctx([Group]):
+            Group.create(**group_data)
+
+        self.groups_exported.add(group_id)
+
+    def export_asset(self, asset_id: int) -> int:
+        if asset_id in self.asset_mapping:
+            return self.asset_mapping[asset_id]
+
+        asset: Asset = Asset[asset_id]
+        asset_data = model_to_dict(asset, recurse=False)
+        del asset_data["id"]
+        asset_data["owner"] = self.user_mapping[asset_data["owner"]]
+
+        if asset.parent is not None:
+            self.export_asset(asset_data["parent"])
+            asset_data["parent"] = self.asset_mapping[asset_data["parent"]]
+
+        with self.db.bind_ctx([Asset]):
+            asset = Asset.create(**asset_data)
+            self.asset_mapping[asset_id] = asset.id
+        return asset.id

--- a/server/models/asset.py
+++ b/server/models/asset.py
@@ -11,6 +11,8 @@ __all__ = ["Asset"]
 
 
 class Asset(BaseModel):
+    id: int
+
     owner = ForeignKeyField(User, backref="assets", on_delete="CASCADE")
     parent = ForeignKeyField("self", backref="children", null=True, on_delete="CASCADE")
     name = TextField()

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -9,7 +9,11 @@ from peewee import (
     TextField,
 )
 from playhouse.shortcuts import model_to_dict
-from typing import Set
+from typing import List, Optional, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models.initiative import Initiative
+    from models.shape import Shape
 
 from .asset import Asset
 from .base import BaseModel
@@ -57,6 +61,10 @@ class LocationOptions(BaseModel):
 
 
 class Room(BaseModel):
+    logo_id: Optional[int]
+    players: List["PlayerRoom"]
+    locations: List["Location"]
+
     name = TextField()
     creator = ForeignKeyField(User, backref="rooms_created", on_delete="CASCADE")
     invitation_code = TextField(default=uuid.uuid4, unique=True)
@@ -86,6 +94,11 @@ class Room(BaseModel):
 
 
 class Location(BaseModel):
+    id: int
+    floors: List["Floor"]
+    initiative: List["Initiative"]
+    user_options: List["LocationUserOption"]
+
     room = ForeignKeyField(Room, backref="locations", on_delete="CASCADE")
     name = TextField()
     options = ForeignKeyField(LocationOptions, on_delete="CASCADE", null=True)
@@ -210,6 +223,9 @@ class Note(BaseModel):
 
 
 class Floor(BaseModel):
+    id: int
+    layers: List["Layer"]
+
     location = ForeignKeyField(Location, backref="floors", on_delete="CASCADE")
     index = IntegerField()
     name = TextField()
@@ -235,6 +251,9 @@ class Floor(BaseModel):
 
 
 class Layer(BaseModel):
+    id: int
+    shapes: List["Shape"]
+
     floor = ForeignKeyField(Floor, backref="layers", on_delete="CASCADE")
     name = TextField()
     type_ = TextField()

--- a/server/models/db.py
+++ b/server/models/db.py
@@ -1,14 +1,11 @@
+from pathlib import Path
 from playhouse.sqlite_ext import SqliteExtDatabase
 
 from config import SAVE_FILE
 
-db = SqliteExtDatabase(
-    SAVE_FILE,
-    pragmas={
-        # "journal_mode": "wal",
-        # "cache_size": -1 * 6400,
-        "foreign_keys": 1,
-        # "ignore_check_constraints": 0,
-        # "synchronous": 0,
-    },
-)
+
+def open_db(path: Path) -> SqliteExtDatabase:
+    return SqliteExtDatabase(path, pragmas={"foreign_keys": 1})
+
+
+db = open_db(SAVE_FILE)

--- a/server/models/label.py
+++ b/server/models/label.py
@@ -1,3 +1,4 @@
+from typing import List
 from uuid import uuid4
 
 from peewee import BooleanField, ForeignKeyField, TextField
@@ -12,6 +13,8 @@ __all__ = ["Label", "LabelSelection"]
 
 
 class Label(BaseModel):
+    labelselection_set: List["LabelSelection"]
+
     uuid = TextField(primary_key=True)
     user = ForeignKeyField(User, backref="labels", on_delete="CASCADE")
     category = TextField(null=True)

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -31,6 +31,21 @@ __all__ = [
 
 
 class Shape(BaseModel):
+    labels: List["ShapeLabel"]
+    trackers: List["Tracker"]
+    auras: List["Aura"]
+    owners: List["ShapeOwner"]
+    assetrect_set: List["AssetRect"]
+    circle_set: List["Circle"]
+    circulartoken_set: List["CircularToken"]
+    line_set: List["Line"]
+    polygon_set: List["Polygon"]
+    rect_set: List["Rect"]
+    text_set: List["Text"]
+    togglecomposite_set: List["ToggleComposite"]
+    composite_parent: List["CompositeShapeAssociation"]
+    shape_variants: List["CompositeShapeAssociation"]
+
     uuid = TextField(primary_key=True)
     layer = ForeignKeyField(Layer, backref="shapes", on_delete="CASCADE")
     type_ = TextField()

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -1,5 +1,5 @@
-from logging import disable
 import bcrypt
+from typing import List, TYPE_CHECKING
 from peewee import (
     FloatField,
     ForeignKeyField,
@@ -11,6 +11,9 @@ from peewee import (
 from playhouse.shortcuts import model_to_dict
 
 from .base import BaseModel
+
+if TYPE_CHECKING:
+    from models.label import Label
 
 
 __all__ = ["User", "UserOptions"]
@@ -61,6 +64,9 @@ class UserOptions(BaseModel):
 
 
 class User(BaseModel):
+    id: int
+    labels: List["Label"]
+
     name = TextField()
     email = TextField(null=True)
     password_hash = TextField()

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -9,7 +9,6 @@ import getpass
 import os
 import sys
 from urllib.parse import quote, unquote
-from export.campaign import import_campaign
 from utils import FILE_DIR
 from types import SimpleNamespace
 
@@ -213,10 +212,6 @@ def reset_password_main(args):
     user.save()
 
 
-def import_main(args):
-    import_campaign(args.file)
-
-
 def add_subcommand(name, func, parent_parser, args):
     sub_parser = parent_parser.add_parser(name, help=func.__doc__)
     for arg in args:
@@ -281,18 +276,6 @@ def main():
             ("name", {"help": "The name of the user."}),
             (
                 "--password",
-                {"help": "The new password. Will be prompted for if not provided."},
-            ),
-        ],
-    )
-
-    add_subcommand(
-        "import",
-        import_main,
-        subparsers,
-        [
-            (
-                "--file",
                 {"help": "The new password. Will be prompted for if not provided."},
             ),
         ],

--- a/server/utils.py
+++ b/server/utils.py
@@ -10,13 +10,18 @@ def all_subclasses(cls):
     )
 
 
-def get_file_dir():
+def get_file_dir() -> Path:
     if getattr(sys, "frozen", False):
         return Path(sys.executable).resolve().parent
     return Path(__file__).resolve().parent
 
 
+def get_save_dir() -> Path:
+    return FILE_DIR
+
+
 FILE_DIR = get_file_dir()
+SAVE_DIR = get_save_dir()
 
 # SETUP PATHS
 os.chdir(FILE_DIR)


### PR DESCRIPTION
There already was export/import code hidden in the codebase, but I wasn't really happy with it.

This is a redo and instead of exporting to a .json file, this exports a .sqlite file as well as the assets (which the previous version didn't do).

This combination is all you need to just run the campaign (together with the main server code of course), instead of having to import it again.

Importing in an existing server (i.e. adding to an existing save file) has not yet been written, and will be for another release. For this reason I will probably not promote it as a new thing in the release notes, but will just be a tool for me to help debug other people's saves.

_Also there were a bunch of things missing in the previous exporter I noticed_