### PR TITLE
bug(Export): Fix campaign export - missing assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ These usually have no immediately visible impact on regular users
 
 ## Unreleased
 
+### Fixed
+
+-   Exporting a campaign where there are images that have no specific asset associated with them, would fail
+
 ## [2022.1] - 2022-04-25
 
 For server owners using a subpath, some important changes are made, so make sure to check the changed section before upgrading

--- a/server/export/campaign.py
+++ b/server/export/campaign.py
@@ -3,7 +3,7 @@ import secrets
 from pathlib import Path
 import tarfile
 from time import time
-from typing import Dict, List, Set, cast
+from typing import Dict, List, Optional, Set, cast
 from playhouse.shortcuts import model_to_dict
 
 from models import ALL_MODELS
@@ -431,11 +431,15 @@ class CampaignExporter:
 
         self.groups_exported.add(group_id)
 
-    def export_asset(self, asset_id: int) -> int:
+    def export_asset(self, asset_id: int) -> Optional[int]:
         if asset_id in self.asset_mapping:
             return self.asset_mapping[asset_id]
 
-        asset: Asset = Asset[asset_id]
+        try:
+            asset: Asset = Asset[asset_id]
+        except Asset.DoesNotExist:
+            return None
+
         asset_data = model_to_dict(asset, recurse=False)
         del asset_data["id"]
         asset_data["owner"] = self.user_mapping[asset_data["owner"]]


### PR DESCRIPTION
When exporting a campaign, if some image in the campaign had a broken link to an asset it would fail.

This can happen if the campaign had images in play that were created before the asset-image link was added, or if something goes wrong with that link being created in the first place.

This might be cherry-picked if a fix release for 2022.1 would become necessary later down the line or otherwise will be scheduled for the regular next release.