### PR TITLE
bug(Export): Fix LUO not exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ These usually have no immediately visible impact on regular users
 ### Fixed
 
 -   Exporting a campaign where there are images that have no specific asset associated with them, would fail
+-   Exporting a campaign was not properly copying the active pan and zoom info for users
 
 ## [2022.1] - 2022-04-25
 

--- a/server/export/campaign.py
+++ b/server/export/campaign.py
@@ -223,9 +223,11 @@ class CampaignExporter:
                 ]
 
             with self.db.bind_ctx([LocationUserOption]):
-                LocationUserOption.update(
-                    **user_option_data
-                )  # SIGNAL already creates a default LUO!
+                LocationUserOption.update(**user_option_data).where(
+                    (LocationUserOption.location == location_id)
+                    & (LocationUserOption.user == user_option_data["user"])
+                ).execute()
+                # SIGNAL already creates a default LUO!
 
     def export_initiative(self, location_id: int, initiative: Initiative):
         initiative_data = model_to_dict(initiative, recurse=False)


### PR DESCRIPTION
LUO, short for LocationUserOptions, contains info on some user options specific to a location (e.g. zoom/pan/active layer etc).
This info was not properly being exported and when you open a save you would thus be reset to the default options.