### PR TITLE
bug(Location): Fix clone location access/luo

### DIFF
--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -187,6 +187,9 @@ class Shape(BaseModel):
         for label in self.labels:
             label.make_copy(new_shape)
 
+        for owner in self.owners:
+            owner.make_copy(new_shape)
+
         return new_shape
 
 
@@ -268,6 +271,12 @@ class ShapeOwner(BaseModel):
             "movement_access": self.movement_access,
             "vision_access": self.vision_access,
         }
+
+    def make_copy(self, new_shape):
+        _dict = self.as_dict()
+        _dict["shape"] = new_shape.uuid
+        _dict["user"] = self.user
+        type(self).create(**_dict)
 
 
 class ShapeType(BaseModel):


### PR DESCRIPTION
With the recent export code being added, I revisited some of the older clone location code and found some things missing here. In particular shape access and location user options were not being copied.

Ultimately I should get rid of this code and merge it with the export code as it shares a lot of concepts and is just kinda duplicate atm in different styles.