### PR TITLE
bug(Svg): Fix various svg related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ These usually have no immediately visible impact on regular users
 
 -   Exporting a campaign where there are images that have no specific asset associated with them, would fail
 -   Exporting a campaign was not properly copying the active pan and zoom info for users
+-   ExtraSettings svg section not updating immediately until changing tabs
+-   ExtraSettings remove svg not properly working
+-   ExtraSettings add svg not working for shapes with no prior svg properties
 
 ## [2022.1] - 2022-04-25
 

--- a/client/src/game/api/emits/shape/options.ts
+++ b/client/src/game/api/emits/shape/options.ts
@@ -28,4 +28,4 @@ export const sendShapeAddLabel = sendSimpleShapeOption<string>("Shape.Options.La
 export const sendShapeRemoveLabel = sendSimpleShapeOption<string>("Shape.Options.Label.Remove");
 
 export const sendShapeSkipDraw = sendSimpleShapeOption<boolean>("Shape.Options.SkipDraw.Set");
-export const sendShapeSvgAsset = sendSimpleShapeOption<string | undefined>("Shape.Options.SvgAsset.Set");
+export const sendShapeSvgAsset = sendSimpleShapeOption<string | null>("Shape.Options.SvgAsset.Set");

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -1,7 +1,10 @@
 import { SyncTo } from "../../../../core/models/types";
+import { floorStore } from "../../../../store/floor";
 import { getLocalId, getShape } from "../../../id";
 import type { GlobalId } from "../../../id";
 import { Shape } from "../../../shapes/shape";
+import type { Asset } from "../../../shapes/variants/asset";
+import { visionState } from "../../../vision/state";
 import { socket } from "../../socket";
 
 function wrapCall<T>(func: (value: T, syncTo: SyncTo) => void): (data: { shape: GlobalId; value: T }) => void {
@@ -65,7 +68,10 @@ socket.on("Shape.Options.SvgAsset.Set", (data: { shape: GlobalId; value: string 
         delete shape.options.svgHeight;
         delete shape.options.svgPaths;
         delete shape.options.svgWidth;
+        visionState.recalculateVision(shape.floor.id);
+        floorStore.invalidate({ id: shape.floor.id });
     } else {
         shape.options.svgAsset = data.value;
+        (shape as Asset).loadSvgs();
     }
 });

--- a/client/src/game/id.ts
+++ b/client/src/game/id.ts
@@ -69,6 +69,8 @@ export function getGlobalId(local: LocalId): GlobalId {
     return uuids[local];
 }
 
+(window as any).getGlobalId = getGlobalId;
+
 export function getLocalId(global: GlobalId): LocalId | undefined {
     for (const [i, value] of uuids.entries()) {
         if (value === global) return i as LocalId;

--- a/server/api/socket/shape/options.py
+++ b/server/api/socket/shape/options.py
@@ -868,6 +868,7 @@ async def set_skip_draw(sid: str, data: ShapeSetStringValue):
         return
 
     options: List[Any] = json.loads(shape.options)
+
     for i, option in enumerate(options[::-1]):
         if data["value"] is None and option[0] in [
             "svgAsset",
@@ -876,8 +877,13 @@ async def set_skip_draw(sid: str, data: ShapeSetStringValue):
             "svgHeight",
         ]:
             options.pop(i)
+            break
         elif option[0] == "svgAsset":
             option[1] = data["value"]
+            break
+    else:
+        options.append(["svgAsset", data["value"]])
+
     shape.options = json.dumps(options)
     shape.save()
 


### PR DESCRIPTION
There were some logical bugs that could prevent attached svg (walls) information from being removed or new information from being uploaded.

Additionally this PR also fixes the extra settings UI to immediately update the svg state when uploading/removing, instead of having to close the settings and re-opening them.