### PR TITLE
bug(TpZone): Fix tp zones triggering on other floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ These usually have no immediately visible impact on regular users
 -   ExtraSettings remove svg not properly working
 -   ExtraSettings add svg not working for shapes with no prior svg properties
 -   Spawn locations loading wrong
+-   Teleport zones triggering from other floors
 
 ## [2022.1] - 2022-04-25
 

--- a/client/src/game/systems/logic/tp/index.ts
+++ b/client/src/game/systems/logic/tp/index.ts
@@ -178,7 +178,7 @@ class TeleportZoneSystem implements System {
                     shape.id === tp
                 )
                     continue;
-                if (tpShape.contains(shape.center())) {
+                if (tpShape.floor.id === shape.floor.id && tpShape.contains(shape.center())) {
                     shapesToMove.push(shape.id);
                 }
             }


### PR DESCRIPTION
When moving a shape to a position that happens to correlate with a tp zone on another floor, it would trigger.
This PR fixes that problem.