### PR TITLE
feat(Tech:Sync): Refactor SyncTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 [DM] denotes changes only useful for the dungeon master
-[tech]/[server] denotes technical changes or changes specifically for the server owner.
-These usually have no immediately visible impact on regular users
+[server] denotes changes only useful for the server owner
+[tech] denotes internal changes that are only useful for code contributors
 
 ## Unreleased
 
@@ -12,6 +12,7 @@ These usually have no immediately visible impact on regular users
 
 -   Add white outline to the door logic (un)lock icons
 -   Door logic can now specify which block settings to toggle
+-   [tech] SyncTo primitive modified to an alternative Sync structure
 
 ### Fixed
 
@@ -23,6 +24,7 @@ These usually have no immediately visible impact on regular users
 -   Spawn locations loading wrong
 -   Teleport zones triggering from other floors
 -   Draw tool door permissions not saving
+-   Door logic toggle not immediately updating UI when shape properties are open
 
 ## [2022.1] - 2022-04-25
 

--- a/client/src/core/models/types.ts
+++ b/client/src/core/models/types.ts
@@ -30,20 +30,12 @@ export enum InvalidationMode {
     WITH_LIGHT,
 }
 
-/**
- * This enumeration is used to provide the required direction of certain communication streams.
- *
- * * SyncTo.UI is used to sync changes typically coming from the server to the UI
- * * SyncTo.SERVER is used to sync changes typically coming from the UI to the server
- * * SyncTo.SHAPE is a special case that is used to sync UI changes to the core Shape without updating the server.
- *
- * The latter is usually done when a bigger operation can be done by executing smaller existing operations
- * but only needing 1 server message.
- * E.g. Moving typically is equal to removing + creating, this can sometimes be done without ever removing the actual object
- * which would happen if we did it as 2 separate server events
- */
-export enum SyncTo {
-    UI,
-    SERVER,
-    SHAPE,
+export interface Sync {
+    ui: boolean;
+    server: boolean;
 }
+
+export const NO_SYNC: Sync = { server: false, ui: false };
+export const SERVER_SYNC: Sync = { server: true, ui: false };
+export const UI_SYNC: Sync = { server: false, ui: true };
+export const FULL_SYNC: Sync = { server: true, ui: true };

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -1,4 +1,5 @@
-import { SyncTo } from "../../../../core/models/types";
+import { UI_SYNC } from "../../../../core/models/types";
+import type { Sync } from "../../../../core/models/types";
 import { floorStore } from "../../../../store/floor";
 import { getLocalId, getShape } from "../../../id";
 import type { GlobalId } from "../../../id";
@@ -7,11 +8,11 @@ import type { Asset } from "../../../shapes/variants/asset";
 import { visionState } from "../../../vision/state";
 import { socket } from "../../socket";
 
-function wrapCall<T>(func: (value: T, syncTo: SyncTo) => void): (data: { shape: GlobalId; value: T }) => void {
+function wrapCall<T>(func: (value: T, syncTo: Sync) => void): (data: { shape: GlobalId; value: T }) => void {
     return (data) => {
         const shape = getShape(getLocalId(data.shape)!);
         if (shape === undefined) return;
-        func.bind(shape)(data.value, SyncTo.UI);
+        func.bind(shape)(data.value, UI_SYNC);
     };
 }
 
@@ -35,13 +36,13 @@ socket.on("Shape.Options.Label.Remove", wrapCall(Shape.prototype.removeLabel));
 socket.on("Shape.Options.Invisible.Set", (data: { shape: GlobalId; value: boolean }) => {
     const shape = getShape(getLocalId(data.shape)!);
     if (shape === undefined) return;
-    shape.setInvisible(data.value, SyncTo.UI);
+    shape.setInvisible(data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.Defeated.Set", (data: { shape: GlobalId; value: boolean }) => {
     const shape = getShape(getLocalId(data.shape)!);
     if (shape === undefined) return;
-    shape.setDefeated(data.value, SyncTo.UI);
+    shape.setDefeated(data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.SkipDraw.Set", (data: { shape: GlobalId; value: boolean }) => {

--- a/client/src/game/api/events/shape/togglecomposite.ts
+++ b/client/src/game/api/events/shape/togglecomposite.ts
@@ -1,4 +1,4 @@
-import { SyncTo } from "../../../../core/models/types";
+import { UI_SYNC } from "../../../../core/models/types";
 import { getLocalId, getShape } from "../../../id";
 import type { GlobalId } from "../../../id";
 import type { ToggleComposite } from "../../../shapes/variants/toggleComposite";
@@ -19,11 +19,11 @@ socket.on("ToggleComposite.Variants.Add", (data: { shape: GlobalId; variant: Glo
 socket.on("ToggleComposite.Variants.Rename", (data: { shape: GlobalId; variant: GlobalId; name: string }): void => {
     const shape = getShape(getLocalId(data.shape)!) as ToggleComposite;
     if (shape === undefined) return;
-    shape.renameVariant(getLocalId(data.variant)!, data.name, SyncTo.UI);
+    shape.renameVariant(getLocalId(data.variant)!, data.name, UI_SYNC);
 });
 
 socket.on("ToggleComposite.Variants.Remove", (data: { shape: GlobalId; variant: GlobalId }): void => {
     const shape = getShape(getLocalId(data.shape)!) as ToggleComposite;
     if (shape === undefined) return;
-    shape.removeVariant(getLocalId(data.variant)!, SyncTo.UI);
+    shape.removeVariant(getLocalId(data.variant)!, UI_SYNC);
 });

--- a/client/src/game/groups.ts
+++ b/client/src/game/groups.ts
@@ -1,7 +1,7 @@
 import { ref } from "vue";
 import type { Ref } from "vue";
 
-import { SyncTo } from "../core/models/types";
+import { UI_SYNC } from "../core/models/types";
 import { uuidv4 } from "../core/utils";
 
 import {
@@ -41,7 +41,7 @@ export function removeGroup(groupId: string, sync: boolean): void {
     const members = getGroupMembers(groupId);
     for (const member of members) {
         member.groupId = undefined;
-        member.setShowBadge(false, SyncTo.UI);
+        member.setShowBadge(false, UI_SYNC);
     }
     if (sync) sendRemoveGroup(groupId);
     memberMap.value.delete(groupId);
@@ -92,7 +92,7 @@ export function addGroupMembers(groupId: string, members: { uuid: LocalId; badge
             if (shape.groupId !== undefined) {
                 memberMap.value.get(shape.groupId)?.delete(shape.id);
             }
-            shape.setGroupId(groupId, SyncTo.UI);
+            shape.setGroupId(groupId, UI_SYNC);
             shape.badge = member.badge;
             shape.invalidate(true);
         }
@@ -110,7 +110,7 @@ export function removeGroupMember(groupId: string, member: LocalId, sync: boolea
     const members = memberMap.value.get(groupId);
     members?.delete(member);
     const shape = getShape(member);
-    if (shape !== undefined) shape.setShowBadge(false, SyncTo.UI);
+    if (shape !== undefined) shape.setShowBadge(false, UI_SYNC);
     if (sync) {
         sendGroupLeave([{ uuid: getGlobalId(member), group_id: groupId }]);
     }

--- a/client/src/game/input/keyboard.ts
+++ b/client/src/game/input/keyboard.ts
@@ -1,5 +1,5 @@
 import { equalsP, toGP, Vector } from "../../core/geometry";
-import { SyncMode, SyncTo } from "../../core/models/types";
+import { FULL_SYNC, SyncMode } from "../../core/models/types";
 import { ctrlOrCmdPressed } from "../../core/utils";
 import { activeShapeStore } from "../../store/activeShape";
 import { clientStore, DEFAULT_GRID_SIZE } from "../../store/client";
@@ -128,10 +128,7 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
             const selection = selectionState.get({ includeComposites: true });
             for (const shape of selection) {
                 const isDefeated = !shape.isDefeated;
-                shape.setDefeated(isDefeated, SyncTo.SERVER);
-                if (activeShapeStore.state.id === shape.id) {
-                    activeShapeStore.setIsDefeated(isDefeated, SyncTo.UI);
-                }
+                shape.setDefeated(isDefeated, FULL_SYNC);
             }
             event.preventDefault();
             event.stopPropagation();
@@ -141,10 +138,7 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
                 // This and GroupSettings are the only places currently where we would need to update both UI and Server.
                 // Might need to introduce a SyncTo.BOTH
                 const isLocked = !shape.isLocked;
-                shape.setLocked(isLocked, SyncTo.SERVER);
-                if (activeShapeStore.state.id === shape.id) {
-                    activeShapeStore.setLocked(isLocked, SyncTo.UI);
-                }
+                shape.setLocked(isLocked, FULL_SYNC);
             }
             event.preventDefault();
             event.stopPropagation();

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -1,4 +1,4 @@
-import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { InvalidationMode, SyncMode, UI_SYNC } from "../../../core/models/types";
 import { debugLayers } from "../../../localStorageHelpers";
 import { activeShapeStore } from "../../../store/activeShape";
 import { clientStore } from "../../../store/client";
@@ -97,8 +97,8 @@ export class Layer {
 
         this.shapes.push(shape);
 
-        shape.setBlocksVision(shape.blocksVision, SyncTo.UI, invalidate !== InvalidationMode.NO);
-        shape.setBlocksMovement(shape.blocksMovement, SyncTo.UI, invalidate !== InvalidationMode.NO);
+        shape.setBlocksVision(shape.blocksVision, UI_SYNC, invalidate !== InvalidationMode.NO);
+        shape.setBlocksMovement(shape.blocksMovement, UI_SYNC, invalidate !== InvalidationMode.NO);
 
         shape.invalidatePoints();
         if (options?.snappable ?? true) {

--- a/client/src/game/shapes/interfaces.ts
+++ b/client/src/game/shapes/interfaces.ts
@@ -1,5 +1,5 @@
 import type { GlobalPoint, Vector } from "../../core/geometry";
-import type { SyncTo } from "../../core/models/types";
+import type { Sync } from "../../core/models/types";
 import type { LocalId } from "../id";
 import type { Layer } from "../layers/variants/layer";
 import type { Floor, LayerName } from "../models/floor";
@@ -111,28 +111,28 @@ export interface IShape {
 
     // GROUP
 
-    setGroupId(groupId: string | undefined, syncTo: SyncTo): void;
+    setGroupId(groupId: string | undefined, syncTo: Sync): void;
 
     // PROPERTIES
 
-    setName(name: string, syncTo: SyncTo): void;
-    setNameVisible(visible: boolean, syncTo: SyncTo): void;
-    setIsToken(isToken: boolean, syncTo: SyncTo): void;
-    setInvisible(isInvisible: boolean, syncTo: SyncTo): void;
-    setStrokeColour(colour: string, syncTo: SyncTo): void;
-    setFillColour(colour: string, syncTo: SyncTo): void;
-    setBlocksVision(blocksVision: boolean, syncTo: SyncTo, recalculate?: boolean): void;
-    setBlocksMovement(blocksMovement: boolean, syncTo: SyncTo, recalculate?: boolean): boolean;
-    setShowBadge(showBadge: boolean, syncTo: SyncTo): void;
-    setDefeated(isDefeated: boolean, syncTo: SyncTo): void;
-    setLocked(isLocked: boolean, syncTo: SyncTo): void;
+    setName(name: string, syncTo: Sync): void;
+    setNameVisible(visible: boolean, syncTo: Sync): void;
+    setIsToken(isToken: boolean, syncTo: Sync): void;
+    setInvisible(isInvisible: boolean, syncTo: Sync): void;
+    setStrokeColour(colour: string, syncTo: Sync): void;
+    setFillColour(colour: string, syncTo: Sync): void;
+    setBlocksVision(blocksVision: boolean, syncTo: Sync, recalculate?: boolean): void;
+    setBlocksMovement(blocksMovement: boolean, syncTo: Sync, recalculate?: boolean): boolean;
+    setShowBadge(showBadge: boolean, syncTo: Sync): void;
+    setDefeated(isDefeated: boolean, syncTo: Sync): void;
+    setLocked(isLocked: boolean, syncTo: Sync): void;
 
     // EXTRA
 
-    setAnnotation(text: string, syncTo: SyncTo): void;
-    setAnnotationVisible(visible: boolean, syncTo: SyncTo): void;
-    addLabel(label: string, syncTo: SyncTo): void;
-    removeLabel(label: string, syncTo: SyncTo): void;
+    setAnnotation(text: string, syncTo: Sync): void;
+    setAnnotationVisible(visible: boolean, syncTo: Sync): void;
+    addLabel(label: string, syncTo: Sync): void;
+    removeLabel(label: string, syncTo: Sync): void;
 }
 
 export interface Label {

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -4,7 +4,8 @@ import { g2l, g2lx, g2ly, g2lz, getUnitDistance } from "../../core/conversions";
 import { addP, cloneP, equalsP, subtractP, toArrayP, toGP } from "../../core/geometry";
 import type { GlobalPoint, Vector } from "../../core/geometry";
 import { rotateAroundPoint } from "../../core/math";
-import { SyncTo } from "../../core/models/types";
+import { UI_SYNC } from "../../core/models/types";
+import type { Sync } from "../../core/models/types";
 import type { FunctionPropertyNames } from "../../core/types";
 import { mostReadable } from "../../core/utils";
 import { activeShapeStore } from "../../store/activeShape";
@@ -534,17 +535,17 @@ export abstract class Shape implements IShape {
 
     // GROUP
 
-    setGroupId(groupId: string | undefined, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.UI) this._("setGroupId")(groupId, syncTo);
+    setGroupId(groupId: string | undefined, syncTo: Sync): void {
+        if (syncTo.ui) this._("setGroupId")(groupId, syncTo);
 
         this.groupId = groupId;
     }
 
     // PROPERTIES
 
-    setName(name: string, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetName({ shape: getGlobalId(this.id), value: name });
-        if (syncTo === SyncTo.UI) this._("setName")(name, syncTo);
+    setName(name: string, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetName({ shape: getGlobalId(this.id), value: name });
+        if (syncTo.ui) this._("setName")(name, syncTo);
 
         this.name = name;
         // Initiative names are not always updated when renaming shapes
@@ -552,16 +553,16 @@ export abstract class Shape implements IShape {
         // EventBus.$emit("Initiative.ForceUpdate");
     }
 
-    setNameVisible(visible: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetNameVisible({ shape: getGlobalId(this.id), value: visible });
-        if (syncTo === SyncTo.UI) this._("setNameVisible")(visible, syncTo);
+    setNameVisible(visible: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetNameVisible({ shape: getGlobalId(this.id), value: visible });
+        if (syncTo.ui) this._("setNameVisible")(visible, syncTo);
 
         this.nameVisible = visible;
     }
 
-    setIsToken(isToken: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetIsToken({ shape: getGlobalId(this.id), value: isToken });
-        if (syncTo === SyncTo.UI) this._("setIsToken")(isToken, syncTo);
+    setIsToken(isToken: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetIsToken({ shape: getGlobalId(this.id), value: isToken });
+        if (syncTo.ui) this._("setIsToken")(isToken, syncTo);
 
         this.isToken = isToken;
         if (accessSystem.hasAccessTo(this.id, false, { vision: true })) {
@@ -571,43 +572,42 @@ export abstract class Shape implements IShape {
         this.invalidate(false);
     }
 
-    setInvisible(isInvisible: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetInvisible({ shape: getGlobalId(this.id), value: isInvisible });
-        if (syncTo === SyncTo.UI) this._("setIsInvisible")(isInvisible, syncTo);
+    setInvisible(isInvisible: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetInvisible({ shape: getGlobalId(this.id), value: isInvisible });
+        if (syncTo.ui) this._("setIsInvisible")(isInvisible, syncTo);
 
         this.isInvisible = isInvisible;
         this.invalidate(!this.triggersVisionRecalc);
     }
 
-    setStrokeColour(colour: string, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetStrokeColour({ shape: getGlobalId(this.id), value: colour });
-        if (syncTo === SyncTo.UI) this._("setStrokeColour")(colour, syncTo);
+    setStrokeColour(colour: string, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetStrokeColour({ shape: getGlobalId(this.id), value: colour });
+        if (syncTo.ui) this._("setStrokeColour")(colour, syncTo);
 
         this.strokeColour = colour;
         this.invalidate(true);
     }
 
-    setFillColour(colour: string, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetFillColour({ shape: getGlobalId(this.id), value: colour });
-        if (syncTo === SyncTo.UI) this._("setFillColour")(colour, syncTo);
+    setFillColour(colour: string, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetFillColour({ shape: getGlobalId(this.id), value: colour });
+        if (syncTo.ui) this._("setFillColour")(colour, syncTo);
 
         this.fillColour = colour;
         this.invalidate(true);
     }
 
-    setBlocksVision(blocksVision: boolean, syncTo: SyncTo, recalculate = true): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetBlocksVision({ shape: getGlobalId(this.id), value: blocksVision });
-        if (syncTo === SyncTo.UI) this._("setBlocksVision")(blocksVision, syncTo);
+    setBlocksVision(blocksVision: boolean, syncTo: Sync, recalculate = true): void {
+        if (syncTo.server) sendShapeSetBlocksVision({ shape: getGlobalId(this.id), value: blocksVision });
+        if (syncTo.ui) this._("setBlocksVision")(blocksVision, UI_SYNC);
 
         this.blocksVision = blocksVision;
         const alteredVision = this.checkVisionSources(recalculate);
         if (alteredVision && recalculate) this.invalidate(false);
     }
 
-    setBlocksMovement(blocksMovement: boolean, syncTo: SyncTo, recalculate = true): boolean {
-        if (syncTo === SyncTo.SERVER)
-            sendShapeSetBlocksMovement({ shape: getGlobalId(this.id), value: blocksMovement });
-        if (syncTo === SyncTo.UI) this._("setBlocksMovement")(blocksMovement, syncTo);
+    setBlocksMovement(blocksMovement: boolean, syncTo: Sync, recalculate = true): boolean {
+        if (syncTo.server) sendShapeSetBlocksMovement({ shape: getGlobalId(this.id), value: blocksMovement });
+        if (syncTo.ui) this._("setBlocksMovement")(blocksMovement, syncTo);
 
         let alteredMovement = false;
         this.blocksMovement = blocksMovement;
@@ -637,35 +637,35 @@ export abstract class Shape implements IShape {
         return alteredMovement;
     }
 
-    setShowBadge(showBadge: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetShowBadge({ shape: getGlobalId(this.id), value: showBadge });
-        if (syncTo === SyncTo.UI) this._("setShowBadge")(showBadge, syncTo);
+    setShowBadge(showBadge: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetShowBadge({ shape: getGlobalId(this.id), value: showBadge });
+        if (syncTo.ui) this._("setShowBadge")(showBadge, syncTo);
 
         this.showBadge = showBadge;
         this.invalidate(!this.triggersVisionRecalc);
         // EventBus.$emit("EditDialog.Group.Update");
     }
 
-    setDefeated(isDefeated: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetDefeated({ shape: getGlobalId(this.id), value: isDefeated });
-        if (syncTo === SyncTo.UI) this._("setIsDefeated")(isDefeated, syncTo);
+    setDefeated(isDefeated: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetDefeated({ shape: getGlobalId(this.id), value: isDefeated });
+        if (syncTo.ui) this._("setIsDefeated")(isDefeated, syncTo);
 
         this.isDefeated = isDefeated;
         this.invalidate(!this.triggersVisionRecalc);
     }
 
-    setLocked(isLocked: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetLocked({ shape: getGlobalId(this.id), value: isLocked });
-        if (syncTo === SyncTo.UI) this._("setLocked")(isLocked, syncTo);
+    setLocked(isLocked: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetLocked({ shape: getGlobalId(this.id), value: isLocked });
+        if (syncTo.ui) this._("setLocked")(isLocked, syncTo);
 
         this.isLocked = isLocked;
     }
 
     // EXTRA
 
-    setAnnotation(text: string, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetAnnotation({ shape: getGlobalId(this.id), value: text });
-        if (syncTo === SyncTo.UI) this._("setAnnotation")(text, syncTo);
+    setAnnotation(text: string, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetAnnotation({ shape: getGlobalId(this.id), value: text });
+        if (syncTo.ui) this._("setAnnotation")(text, syncTo);
 
         const hadAnnotation = this.annotation !== "";
         this.annotation = text;
@@ -676,24 +676,24 @@ export abstract class Shape implements IShape {
         }
     }
 
-    setAnnotationVisible(visible: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeSetAnnotationVisible({ shape: getGlobalId(this.id), value: visible });
-        if (syncTo === SyncTo.UI) this._("setAnnotationVisible")(visible, syncTo);
+    setAnnotationVisible(visible: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeSetAnnotationVisible({ shape: getGlobalId(this.id), value: visible });
+        if (syncTo.ui) this._("setAnnotationVisible")(visible, syncTo);
 
         this.annotationVisible = visible;
     }
 
-    addLabel(label: string, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeAddLabel({ shape: getGlobalId(this.id), value: label });
-        if (syncTo === SyncTo.UI) this._("addLabel")(label, syncTo);
+    addLabel(label: string, syncTo: Sync): void {
+        if (syncTo.server) sendShapeAddLabel({ shape: getGlobalId(this.id), value: label });
+        if (syncTo.ui) this._("addLabel")(label, syncTo);
 
         const l = gameStore.state.labels.get(label)!;
         this.labels.push(l);
     }
 
-    removeLabel(label: string, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeRemoveLabel({ shape: getGlobalId(this.id), value: label });
-        if (syncTo === SyncTo.UI) this._("removeLabel")(label, syncTo);
+    removeLabel(label: string, syncTo: Sync): void {
+        if (syncTo.server) sendShapeRemoveLabel({ shape: getGlobalId(this.id), value: label });
+        if (syncTo.ui) this._("removeLabel")(label, syncTo);
 
         this.labels = this.labels.filter((l) => l.uuid !== label);
     }

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -1,5 +1,6 @@
 import type { GlobalPoint } from "../../../core/geometry";
-import { SyncTo, SyncMode } from "../../../core/models/types";
+import { SyncMode } from "../../../core/models/types";
+import type { Sync } from "../../../core/models/types";
 import { gameStore } from "../../../store/game";
 import { sendShapePositionUpdate } from "../../api/emits/shape/core";
 import { sendShapeSkipDraw } from "../../api/emits/shape/options";
@@ -58,20 +59,19 @@ export class ToggleComposite extends Shape {
         compositeState.addComposite(this.id, variant, sync);
     }
 
-    renameVariant(uuid: LocalId, name: string, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER)
+    renameVariant(uuid: LocalId, name: string, syncTo: Sync): void {
+        if (syncTo.server)
             sendToggleCompositeRenameVariant({ shape: getGlobalId(this.id), variant: getGlobalId(uuid), name });
-        if (syncTo === SyncTo.UI) this._("renameVariant")(uuid, name, syncTo);
+        if (syncTo.ui) this._("renameVariant")(uuid, name, syncTo);
 
         const variant = this._variants.find((v) => v.uuid === uuid);
         if (variant === undefined) return;
         variant.name = name;
     }
 
-    removeVariant(id: LocalId, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER)
-            sendToggleCompositeRemoveVariant({ shape: getGlobalId(this.id), variant: getGlobalId(id) });
-        if (syncTo === SyncTo.UI) this._("removeVariant")(id, syncTo);
+    removeVariant(id: LocalId, syncTo: Sync): void {
+        if (syncTo.server) sendToggleCompositeRemoveVariant({ shape: getGlobalId(this.id), variant: getGlobalId(id) });
+        if (syncTo.ui) this._("removeVariant")(id, syncTo);
 
         const v = this._variants.findIndex((v) => v.uuid === id);
         if (v === undefined) {

--- a/client/src/game/systems/access/events.ts
+++ b/client/src/game/systems/access/events.ts
@@ -1,4 +1,4 @@
-import { SyncTo } from "../../../core/models/types";
+import { UI_SYNC } from "../../../core/models/types";
 import { socket } from "../../api/socket";
 import { getLocalId } from "../../id";
 
@@ -9,17 +9,17 @@ import { accessSystem } from ".";
 
 socket.on("Shape.Owner.Add", (data: ServerShapeOwner) => {
     const clientData = ownerToClient(data);
-    accessSystem.addAccess(clientData.shape, clientData.user, clientData.access, SyncTo.UI);
+    accessSystem.addAccess(clientData.shape, clientData.user, clientData.access, UI_SYNC);
 });
 
 socket.on("Shape.Owner.Update", (data: ServerShapeOwner) => {
     const id = getLocalId(data.shape);
     if (id === undefined) return;
-    accessSystem.updateAccess(id, data.user, accessToClient(data), SyncTo.UI);
+    accessSystem.updateAccess(id, data.user, accessToClient(data), UI_SYNC);
 });
 
 socket.on("Shape.Owner.Delete", (data: ServerShapeOwner) => {
     const id = getLocalId(data.shape);
     if (id === undefined) return;
-    accessSystem.removeAccess(id, data.user, SyncTo.UI);
+    accessSystem.removeAccess(id, data.user, UI_SYNC);
 });

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -3,7 +3,7 @@ import type { ComputedRef, DeepReadonly } from "vue";
 
 import { registerSystem } from "..";
 import type { System } from "..";
-import { SyncTo } from "../../../core/models/types";
+import type { Sync } from "../../../core/models/types";
 import { clientStore } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
 import { gameStore } from "../../../store/game";
@@ -176,7 +176,7 @@ class AccessSystem implements System {
         return this.access.get(shapeId)?.get(user);
     }
 
-    addAccess(shapeId: LocalId, user: string, access: Partial<ShapeAccess>, syncTo: SyncTo): void {
+    addAccess(shapeId: LocalId, user: string, access: Partial<ShapeAccess>, syncTo: Sync): void {
         if (this.access.get(shapeId)?.has(user) === true) {
             console.error("[ACCESS] Attempt to add access for user with access");
             return;
@@ -188,7 +188,7 @@ class AccessSystem implements System {
         shapeMap.set(user, userAccess);
         this.access.set(shapeId, shapeMap);
 
-        if (syncTo === SyncTo.SERVER) {
+        if (syncTo.server) {
             sendShapeAddOwner(
                 ownerToServer({
                     access: userAccess,
@@ -214,7 +214,7 @@ class AccessSystem implements System {
         initiativeStore._forceUpdate();
     }
 
-    updateAccess(shapeId: LocalId, user: ACCESS_KEY, access: Partial<ShapeAccess>, syncTo: SyncTo): void {
+    updateAccess(shapeId: LocalId, user: ACCESS_KEY, access: Partial<ShapeAccess>, syncTo: Sync): void {
         if (user !== DEFAULT_ACCESS_SYMBOL && this.access.get(shapeId)?.has(user) !== true) {
             console.error("[ACCESS] Attempt to update access for user without access");
             return;
@@ -250,7 +250,7 @@ class AccessSystem implements System {
             }
         }
 
-        if (syncTo === SyncTo.SERVER) {
+        if (syncTo.server) {
             if (user === DEFAULT_ACCESS_SYMBOL) {
                 sendShapeUpdateDefaultOwner({ ...accessToServer(newAccess), shape: getGlobalId(shapeId) });
             } else {
@@ -268,7 +268,7 @@ class AccessSystem implements System {
         initiativeStore._forceUpdate();
     }
 
-    removeAccess(shapeId: LocalId, user: string, syncTo: SyncTo): void {
+    removeAccess(shapeId: LocalId, user: string, syncTo: Sync): void {
         if (this.access.get(shapeId)?.has(user) !== true) {
             console.error("[ACCESS] Attempt to remove access for user without access");
             return;
@@ -277,7 +277,7 @@ class AccessSystem implements System {
         const oldAccess = this.access.get(shapeId)!.get(user)!;
         this.access.get(shapeId)!.delete(user);
 
-        if (syncTo === SyncTo.SERVER) {
+        if (syncTo.server) {
             sendShapeDeleteOwner({
                 user,
                 shape: getGlobalId(shapeId),

--- a/client/src/game/systems/auras/events.ts
+++ b/client/src/game/systems/auras/events.ts
@@ -1,4 +1,4 @@
-import { SyncTo } from "../../../core/models/types";
+import { UI_SYNC } from "../../../core/models/types";
 import { socket } from "../../api/socket";
 import { getLocalId } from "../../id";
 import type { GlobalId } from "../../id";
@@ -11,7 +11,7 @@ import { auraSystem } from ".";
 socket.on("Shape.Options.Aura.Remove", (data: { shape: GlobalId; value: AuraId }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    auraSystem.remove(shape, data.value, SyncTo.UI);
+    auraSystem.remove(shape, data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.Aura.Move", (data: { shape: GlobalId; aura: AuraId; new_shape: GlobalId }): void => {
@@ -21,18 +21,18 @@ socket.on("Shape.Options.Aura.Move", (data: { shape: GlobalId; aura: AuraId; new
     const aura = auraSystem.get(shape, data.aura, false);
     if (aura === undefined) return;
 
-    auraSystem.remove(shape, aura.uuid, SyncTo.UI);
-    auraSystem.add(newShape, aura, SyncTo.UI);
+    auraSystem.remove(shape, aura.uuid, UI_SYNC);
+    auraSystem.add(newShape, aura, UI_SYNC);
 });
 
 socket.on("Shape.Options.Aura.Create", (data: ServerAura): void => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    auraSystem.add(shape, aurasFromServer(data)[0], SyncTo.UI);
+    auraSystem.add(shape, aurasFromServer(data)[0], UI_SYNC);
 });
 
 socket.on("Shape.Options.Aura.Update", (data: { uuid: string; shape: GlobalId } & Partial<Aura>): void => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    auraSystem.update(shape, data.uuid, partialAuraFromServer(data), SyncTo.UI);
+    auraSystem.update(shape, data.uuid, partialAuraFromServer(data), UI_SYNC);
 });

--- a/client/src/game/systems/logic/door/events.ts
+++ b/client/src/game/systems/logic/door/events.ts
@@ -1,4 +1,4 @@
-import { SyncTo } from "../../../../core/models/types";
+import { UI_SYNC } from "../../../../core/models/types";
 import { socket } from "../../../api/socket";
 import { getLocalId } from "../../../id";
 import type { GlobalId } from "../../../id";
@@ -11,17 +11,17 @@ import { doorSystem } from ".";
 socket.on("Shape.Options.IsDoor.Set", (data: { shape: GlobalId; value: boolean }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    doorSystem.toggle(shape, data.value, SyncTo.UI);
+    doorSystem.toggle(shape, data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.Door.Permissions.Set", (data: { shape: GlobalId; value: Permissions }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    doorSystem.setPermissions(shape, data.value, SyncTo.UI);
+    doorSystem.setPermissions(shape, data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.Door.ToggleMode.Set", (data: { shape: GlobalId; value: DOOR_TOGGLE_MODE }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    doorSystem.setToggleMode(shape, data.value, SyncTo.UI);
+    doorSystem.setToggleMode(shape, data.value, UI_SYNC);
 });

--- a/client/src/game/systems/logic/door/index.ts
+++ b/client/src/game/systems/logic/door/index.ts
@@ -3,7 +3,8 @@ import type { DeepReadonly } from "vue";
 
 import { registerSystem } from "../..";
 import type { System } from "../..";
-import { SyncTo } from "../../../../core/models/types";
+import { FULL_SYNC } from "../../../../core/models/types";
+import type { Sync } from "../../../../core/models/types";
 import { getGlobalId, getShape } from "../../../id";
 import type { LocalId } from "../../../id";
 import { canUse } from "../common";
@@ -89,8 +90,8 @@ class DoorSystem implements System {
         }
     }
 
-    toggle(id: LocalId, enabled: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeIsDoor({ shape: getGlobalId(id), value: enabled });
+    toggle(id: LocalId, enabled: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeIsDoor({ shape: getGlobalId(id), value: enabled });
         if (this._state.id === id) this._state.enabled = enabled;
 
         if (enabled) {
@@ -108,21 +109,21 @@ class DoorSystem implements System {
         return this.data.get(id)?.permissions;
     }
 
-    setPermissions(id: LocalId, permissions: Permissions, syncTo: SyncTo): void {
+    setPermissions(id: LocalId, permissions: Permissions, syncTo: Sync): void {
         const options = this.data.get(id);
         if (options === undefined) return;
 
-        if (syncTo === SyncTo.SERVER) sendShapeDoorPermissions({ shape: getGlobalId(id), value: permissions });
+        if (syncTo.server) sendShapeDoorPermissions({ shape: getGlobalId(id), value: permissions });
         if (this._state.id === id) this._state.permissions = permissions;
 
         options.permissions = permissions;
     }
 
-    setToggleMode(id: LocalId, mode: DOOR_TOGGLE_MODE, syncTo: SyncTo): void {
+    setToggleMode(id: LocalId, mode: DOOR_TOGGLE_MODE, syncTo: Sync): void {
         const options = this.data.get(id);
         if (options === undefined) return;
 
-        if (syncTo === SyncTo.SERVER) sendShapeDoorToggleMode({ shape: getGlobalId(id), value: mode });
+        if (syncTo.server) sendShapeDoorToggleMode({ shape: getGlobalId(id), value: mode });
         if (this._state.id === id) this._state.toggleMode = mode;
 
         options.toggleMode = mode;
@@ -134,12 +135,12 @@ class DoorSystem implements System {
         if (shape === undefined || options === undefined) return;
 
         if (options.toggleMode === "both") {
-            shape.setBlocksMovement(!shape.blocksMovement, SyncTo.SERVER, true);
-            shape.setBlocksVision(!shape.blocksVision, SyncTo.SERVER, true);
+            shape.setBlocksMovement(!shape.blocksMovement, FULL_SYNC, true);
+            shape.setBlocksVision(!shape.blocksVision, FULL_SYNC, true);
         } else if (options.toggleMode === "movement") {
-            shape.setBlocksMovement(!shape.blocksMovement, SyncTo.SERVER, true);
+            shape.setBlocksMovement(!shape.blocksMovement, FULL_SYNC, true);
         } else {
-            shape.setBlocksVision(!shape.blocksVision, SyncTo.SERVER, true);
+            shape.setBlocksVision(!shape.blocksVision, FULL_SYNC, true);
         }
     }
 

--- a/client/src/game/systems/logic/tp/events.ts
+++ b/client/src/game/systems/logic/tp/events.ts
@@ -1,4 +1,4 @@
-import { SyncTo } from "../../../../core/models/types";
+import { UI_SYNC } from "../../../../core/models/types";
 import { socket } from "../../../api/socket";
 import { getLocalId } from "../../../id";
 import type { GlobalId } from "../../../id";
@@ -11,23 +11,23 @@ import { teleportZoneSystem } from ".";
 socket.on("Shape.Options.IsTeleportZone.Set", (data: { shape: GlobalId; value: boolean }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    teleportZoneSystem.toggle(shape, data.value, SyncTo.UI);
+    teleportZoneSystem.toggle(shape, data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.IsImmediateTeleportZone.Set", (data: { shape: GlobalId; value: boolean }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    teleportZoneSystem.toggleImmediate(shape, data.value, SyncTo.UI);
+    teleportZoneSystem.toggleImmediate(shape, data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.TeleportZonePermissions.Set", (data: { shape: GlobalId; value: Permissions }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    teleportZoneSystem.setPermissions(shape, data.value, SyncTo.UI);
+    teleportZoneSystem.setPermissions(shape, data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.TeleportZoneTarget.Set", (data: { shape: GlobalId; value: TeleportOptions["location"] }) => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    teleportZoneSystem.setTarget(shape, data.value, SyncTo.UI);
+    teleportZoneSystem.setTarget(shape, data.value, UI_SYNC);
 });

--- a/client/src/game/systems/logic/tp/index.ts
+++ b/client/src/game/systems/logic/tp/index.ts
@@ -6,7 +6,7 @@ import type { ToastID } from "vue-toastification/dist/types/types";
 import { registerSystem } from "../..";
 import type { System } from "../..";
 import SingleButtonToast from "../../../../core/components/toasts/SingleButtonToast.vue";
-import { SyncTo } from "../../../../core/models/types";
+import type { Sync } from "../../../../core/models/types";
 import { floorStore } from "../../../../store/floor";
 import { gameStore } from "../../../../store/game";
 import { settingsStore } from "../../../../store/settings";
@@ -108,8 +108,8 @@ class TeleportZoneSystem implements System {
         }
     }
 
-    toggle(id: LocalId, enabled: boolean, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeIsTeleportZone({ shape: getGlobalId(id), value: enabled });
+    toggle(id: LocalId, enabled: boolean, syncTo: Sync): void {
+        if (syncTo.server) sendShapeIsTeleportZone({ shape: getGlobalId(id), value: enabled });
         if (this._state.id === id) this._state.enabled = enabled;
 
         if (enabled) {
@@ -119,11 +119,11 @@ class TeleportZoneSystem implements System {
         }
     }
 
-    toggleImmediate(id: LocalId, immediate: boolean, syncTo: SyncTo): void {
+    toggleImmediate(id: LocalId, immediate: boolean, syncTo: Sync): void {
         const options = this.data.get(id);
         if (options === undefined) return;
 
-        if (syncTo === SyncTo.SERVER) sendShapeIsImmediateTeleportZone({ shape: getGlobalId(id), value: immediate });
+        if (syncTo.server) sendShapeIsImmediateTeleportZone({ shape: getGlobalId(id), value: immediate });
         if (this._state.id === id) this._state.immediate = immediate;
 
         options.immediate = immediate;
@@ -137,11 +137,11 @@ class TeleportZoneSystem implements System {
         return this.data.get(id)?.permissions;
     }
 
-    setPermissions(id: LocalId, permissions: Permissions, syncTo: SyncTo): void {
+    setPermissions(id: LocalId, permissions: Permissions, syncTo: Sync): void {
         const options = this.data.get(id);
         if (options === undefined) return;
 
-        if (syncTo === SyncTo.SERVER) sendShapeTeleportZonePermissions({ shape: getGlobalId(id), value: permissions });
+        if (syncTo.server) sendShapeTeleportZonePermissions({ shape: getGlobalId(id), value: permissions });
         if (this._state.id === id) this._state.permissions = permissions;
         options.permissions = permissions;
     }
@@ -150,11 +150,11 @@ class TeleportZoneSystem implements System {
         return canUse(id, "tp");
     }
 
-    setTarget(id: LocalId, target: TeleportOptions["location"], syncTo: SyncTo): void {
+    setTarget(id: LocalId, target: TeleportOptions["location"], syncTo: Sync): void {
         const options = this.data.get(id);
         if (options === undefined) return;
 
-        if (syncTo === SyncTo.SERVER) sendShapeTeleportZoneTarget({ shape: getGlobalId(id), value: target });
+        if (syncTo.server) sendShapeTeleportZoneTarget({ shape: getGlobalId(id), value: target });
         if (this._state.id === id) this._state.target = target;
 
         options.location = target;

--- a/client/src/game/systems/trackers/events.ts
+++ b/client/src/game/systems/trackers/events.ts
@@ -1,4 +1,4 @@
-import { SyncTo } from "../../../core/models/types";
+import { UI_SYNC } from "../../../core/models/types";
 import { socket } from "../../api/socket";
 import { getLocalId } from "../../id";
 import type { GlobalId } from "../../id";
@@ -11,19 +11,19 @@ import { trackerSystem } from ".";
 socket.on("Shape.Options.Tracker.Remove", (data: { shape: GlobalId; value: TrackerId }): void => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    trackerSystem.remove(shape, data.value, SyncTo.UI);
+    trackerSystem.remove(shape, data.value, UI_SYNC);
 });
 
 socket.on("Shape.Options.Tracker.Create", (data: ServerTracker): void => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    trackerSystem.add(shape, trackersFromServer(data)[0], SyncTo.UI);
+    trackerSystem.add(shape, trackersFromServer(data)[0], UI_SYNC);
 });
 
 socket.on("Shape.Options.Tracker.Update", (data: { uuid: TrackerId; shape: GlobalId } & Partial<Tracker>): void => {
     const shape = getLocalId(data.shape);
     if (shape === undefined) return;
-    trackerSystem.update(shape, data.uuid, partialTrackerFromServer(data), SyncTo.UI);
+    trackerSystem.update(shape, data.uuid, partialTrackerFromServer(data), UI_SYNC);
 });
 
 socket.on("Shape.Options.Tracker.Move", (data: { shape: GlobalId; tracker: TrackerId; new_shape: GlobalId }): void => {
@@ -33,6 +33,6 @@ socket.on("Shape.Options.Tracker.Move", (data: { shape: GlobalId; tracker: Track
     const tracker = trackerSystem.get(shape, data.tracker, false);
     if (tracker === undefined) return;
 
-    trackerSystem.remove(shape, data.tracker, SyncTo.UI);
-    trackerSystem.add(newShape, tracker, SyncTo.UI);
+    trackerSystem.remove(shape, data.tracker, UI_SYNC);
+    trackerSystem.add(newShape, tracker, UI_SYNC);
 });

--- a/client/src/game/systems/trackers/index.ts
+++ b/client/src/game/systems/trackers/index.ts
@@ -3,7 +3,7 @@ import type { DeepReadonly } from "vue";
 
 import { registerSystem } from "..";
 import type { System } from "..";
-import { SyncTo } from "../../../core/models/types";
+import type { Sync } from "../../../core/models/types";
 import { activeShapeStore } from "../../../store/activeShape";
 import { getGlobalId, getShape } from "../../id";
 import type { LocalId } from "../../id";
@@ -107,8 +107,8 @@ class TrackerSystem implements System {
         return trackers;
     }
 
-    add(id: LocalId, tracker: Tracker, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeCreateTracker(trackersToServer(getGlobalId(id), [tracker])[0]);
+    add(id: LocalId, tracker: Tracker, syncTo: Sync): void {
+        if (syncTo.server) sendShapeCreateTracker(trackersToServer(getGlobalId(id), [tracker])[0]);
 
         this.getOrCreate(id).push(tracker);
 
@@ -117,11 +117,11 @@ class TrackerSystem implements System {
         if (tracker.draw) getShape(id)?.invalidate(false);
     }
 
-    update(id: LocalId, trackerId: TrackerId, delta: Partial<Tracker>, syncTo: SyncTo): void {
+    update(id: LocalId, trackerId: TrackerId, delta: Partial<Tracker>, syncTo: Sync): void {
         const tracker = this.data.get(id)?.find((t) => t.uuid === trackerId);
         if (tracker === undefined) return;
 
-        if (syncTo === SyncTo.SERVER) {
+        if (syncTo.server) {
             sendShapeUpdateTracker({
                 ...partialTrackerToServer({
                     ...delta,
@@ -140,8 +140,8 @@ class TrackerSystem implements System {
         if (tracker.draw || oldDrawTracker) getShape(id)?.invalidate(false);
     }
 
-    remove(id: LocalId, trackerId: TrackerId, syncTo: SyncTo): void {
-        if (syncTo === SyncTo.SERVER) sendShapeRemoveTracker({ shape: getGlobalId(id), value: trackerId });
+    remove(id: LocalId, trackerId: TrackerId, syncTo: Sync): void {
+        if (syncTo.server) sendShapeRemoveTracker({ shape: getGlobalId(id), value: trackerId });
 
         const oldTracker = this.get(id, trackerId, false);
 

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -4,7 +4,7 @@ import { clampGridLine, getUnitDistance, l2g, l2gz } from "../../../core/convers
 import { addP, cloneP, subtractP, toArrayP, toGP, Vector } from "../../../core/geometry";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
 import { equalPoints, snapToPoint } from "../../../core/math";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { InvalidationMode, SyncMode, UI_SYNC } from "../../../core/models/types";
 import type { PromptFunction } from "../../../core/plugins/modals/prompt";
 import { ctrlOrCmdPressed, mostReadable } from "../../../core/utils";
 import { i18n } from "../../../i18n";
@@ -402,14 +402,14 @@ class DrawTool extends Tool {
                 this.shape.id,
                 clientStore.state.username,
                 { edit: true, movement: true, vision: true },
-                SyncTo.UI,
+                UI_SYNC,
             );
             if (this.state.selectedMode === DrawMode.Normal) {
                 if (this.state.blocksMovement) {
-                    this.shape.setBlocksMovement(true, SyncTo.UI, false);
+                    this.shape.setBlocksMovement(true, UI_SYNC, false);
                 }
                 if (this.state.blocksVision) {
-                    this.shape.setBlocksVision(true, SyncTo.UI, false);
+                    this.shape.setBlocksVision(true, UI_SYNC, false);
                 }
             }
             layer.addShape(this.shape, SyncMode.FULL_SYNC, InvalidationMode.NO);

--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -1,6 +1,6 @@
 import { l2g } from "../../../core/conversions";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { InvalidationMode, NO_SYNC, SyncMode } from "../../../core/models/types";
 import { i18n } from "../../../i18n";
 import { clientStore } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
@@ -64,13 +64,13 @@ class PingTool extends Tool {
             this.ping.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.SHAPE,
+            NO_SYNC,
         );
         accessSystem.addAccess(
             this.border.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.SHAPE,
+            NO_SYNC,
         );
         layer.addShape(this.ping, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL, { snappable: false });
         layer.addShape(this.border, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL, { snappable: false });

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -4,7 +4,7 @@ import { l2g } from "../../../core/conversions";
 import { cloneP, toGP } from "../../../core/geometry";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
 import { snapToGridPoint } from "../../../core/math";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { InvalidationMode, NO_SYNC, SyncMode } from "../../../core/models/types";
 import { i18n } from "../../../i18n";
 import { clientStore, DEFAULT_GRID_SIZE } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
@@ -66,7 +66,7 @@ class RulerTool extends Tool {
             ruler.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.SHAPE,
+            NO_SYNC,
         );
         layer.addShape(ruler, this.syncMode, InvalidationMode.NORMAL, { snappable: false });
         this.rulers.push(ruler);
@@ -97,7 +97,7 @@ class RulerTool extends Tool {
             this.text.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.SHAPE,
+            NO_SYNC,
         );
         layer.addShape(this.text, this.syncMode, InvalidationMode.NORMAL, { snappable: false });
     }

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../core/geometry";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
 import { equalPoints, snapToPoint } from "../../../core/math";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { InvalidationMode, NO_SYNC, SyncMode } from "../../../core/models/types";
 import { baseAdjust, ctrlOrCmdPressed } from "../../../core/utils";
 import { i18n } from "../../../i18n";
 import { clientStore, DEFAULT_GRID_SIZE } from "../../../store/client";
@@ -359,7 +359,7 @@ class SelectTool extends Tool implements ISelectTool {
                     this.selectionHelper.id,
                     clientStore.state.username,
                     { edit: true, movement: true, vision: true },
-                    SyncTo.SHAPE,
+                    NO_SYNC,
                 );
                 layer.addShape(this.selectionHelper, SyncMode.NO_SYNC, InvalidationMode.NO, { snappable: false });
             } else {
@@ -811,7 +811,7 @@ class SelectTool extends Tool implements ISelectTool {
                 rotationShape.id,
                 clientStore.state.username,
                 { edit: true, movement: true, vision: true },
-                SyncTo.SHAPE,
+                NO_SYNC,
             );
             layer.addShape(rotationShape, SyncMode.NO_SYNC, InvalidationMode.NO, { snappable: false });
         }

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -3,7 +3,7 @@ import { reactive, watch, watchEffect } from "vue";
 import { g2l, getUnitDistance, l2g, toRadians } from "../../../core/conversions";
 import { equalsP, toGP } from "../../../core/geometry";
 import type { LocalPoint } from "../../../core/geometry";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { InvalidationMode, SyncMode, UI_SYNC } from "../../../core/models/types";
 import { i18n } from "../../../i18n";
 import { clientStore } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
@@ -118,7 +118,7 @@ class SpellTool extends Tool {
             this.shape.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.UI,
+            UI_SYNC,
         );
 
         if (selectionState.hasSelection && (this.state.range === 0 || equalsP(startPosition, ogPoint))) {

--- a/client/src/game/ui/SelectionInfo.vue
+++ b/client/src/game/ui/SelectionInfo.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n";
 
-import { SyncTo } from "../../core/models/types";
+import { SERVER_SYNC } from "../../core/models/types";
 import { useModal } from "../../core/plugins/modals/plugin";
 import { activeShapeStore } from "../../store/activeShape";
 import { getShape } from "../id";
@@ -18,7 +18,7 @@ const shape = activeShapeStore.state;
 
 function setLocked(): void {
     if (accessSystem.$.hasEditAccess.value) {
-        activeShapeStore.setLocked(!shape.isLocked, SyncTo.SERVER);
+        activeShapeStore.setLocked(!shape.isLocked, SERVER_SYNC);
     }
 }
 
@@ -46,11 +46,11 @@ async function changeValue(tracker: Tracker | Aura, isAura: boolean): Promise<vo
     }
 
     if (isAura) {
-        auraSystem.update(shape.id, tracker.uuid as AuraId, { value }, SyncTo.SERVER);
+        auraSystem.update(shape.id, tracker.uuid as AuraId, { value }, SERVER_SYNC);
         const sh = getShape(shape.id)!;
         sh.invalidate(false);
     } else {
-        trackerSystem.update(shape.id, tracker.uuid as TrackerId, { value }, SyncTo.SERVER);
+        trackerSystem.update(shape.id, tracker.uuid as TrackerId, { value }, SERVER_SYNC);
     }
 }
 </script>

--- a/client/src/game/ui/settings/shape/AccessSettings.vue
+++ b/client/src/game/ui/settings/shape/AccessSettings.vue
@@ -2,7 +2,7 @@
 import { computed, ref, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
-import { SyncTo } from "../../../../core/models/types";
+import { SERVER_SYNC } from "../../../../core/models/types";
 import type { PartialPick } from "../../../../core/types";
 import { activeShapeStore } from "../../../../store/activeShape";
 import { gameStore } from "../../../../store/game";
@@ -49,13 +49,13 @@ function addOwner(): void {
         accessSystem.state.id,
         selectedUser,
         { edit: true, movement: true, vision: true },
-        SyncTo.SERVER,
+        SERVER_SYNC,
     );
 }
 
 function removeOwner(user: string): void {
     if (!owned.value || accessSystem.state.id === undefined) return;
-    accessSystem.removeAccess(accessSystem.state.id, user, SyncTo.SERVER);
+    accessSystem.removeAccess(accessSystem.state.id, user, SERVER_SYNC);
 }
 
 function toggleEditAccess(user?: ACCESS_KEY): void {
@@ -74,7 +74,7 @@ function toggleEditAccess(user?: ACCESS_KEY): void {
         access.movement = true;
         access.vision = true;
     }
-    accessSystem.updateAccess(accessSystem.state.id, user, access, SyncTo.SERVER);
+    accessSystem.updateAccess(accessSystem.state.id, user, access, SERVER_SYNC);
 }
 
 function toggleMovementAccess(user?: ACCESS_KEY): void {
@@ -94,7 +94,7 @@ function toggleMovementAccess(user?: ACCESS_KEY): void {
     } else {
         access.edit = false;
     }
-    accessSystem.updateAccess(accessSystem.state.id, user, access, SyncTo.SERVER);
+    accessSystem.updateAccess(accessSystem.state.id, user, access, SERVER_SYNC);
 }
 
 function toggleVisionAccess(user?: ACCESS_KEY): void {
@@ -113,7 +113,7 @@ function toggleVisionAccess(user?: ACCESS_KEY): void {
         access.edit = false;
         access.movement = false;
     }
-    accessSystem.updateAccess(accessSystem.state.id, user, access, SyncTo.SERVER);
+    accessSystem.updateAccess(accessSystem.state.id, user, access, SERVER_SYNC);
 }
 </script>
 

--- a/client/src/game/ui/settings/shape/ExtraSettings.vue
+++ b/client/src/game/ui/settings/shape/ExtraSettings.vue
@@ -5,7 +5,7 @@ import { useI18n } from "vue-i18n";
 
 import { l2gz } from "../../../../core/conversions";
 import { toGP } from "../../../../core/geometry";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../../core/models/types";
+import { InvalidationMode, NO_SYNC, SERVER_SYNC, SyncMode, UI_SYNC } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { getChecked, getValue, uuidv4 } from "../../../../core/utils";
 import { activeShapeStore } from "../../../../store/activeShape";
@@ -44,12 +44,12 @@ function calcHeight(): void {
 function updateAnnotation(event: Event, sync = true): void {
     if (!owned.value) return;
     calcHeight();
-    activeShapeStore.setAnnotation(getValue(event), sync ? SyncTo.SERVER : SyncTo.SHAPE);
+    activeShapeStore.setAnnotation(getValue(event), sync ? SERVER_SYNC : NO_SYNC);
 }
 
 function setAnnotationVisible(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setAnnotationVisible(getChecked(event), SyncTo.SERVER);
+    activeShapeStore.setAnnotationVisible(getChecked(event), SERVER_SYNC);
 }
 
 // LABELS
@@ -58,12 +58,12 @@ const showLabelManager = ref(false);
 
 function addLabel(label: string): void {
     if (!owned.value) return;
-    activeShapeStore.addLabel(label, SyncTo.SERVER);
+    activeShapeStore.addLabel(label, SERVER_SYNC);
 }
 
 function removeLabel(uuid: string): void {
     if (!owned.value) return;
-    activeShapeStore.removeLabel(uuid, SyncTo.SERVER);
+    activeShapeStore.removeLabel(uuid, SERVER_SYNC);
 }
 
 // SVG / DDRAFT
@@ -87,7 +87,7 @@ async function uploadSvg(): Promise<void> {
     if (shape.options === undefined) {
         shape.options = {};
     }
-    activeShapeStore.setSvgAsset(asset.file_hash, SyncTo.SERVER);
+    activeShapeStore.setSvgAsset(asset.file_hash, SERVER_SYNC);
 }
 
 function removeSvg(): void {
@@ -99,7 +99,7 @@ function removeSvg(): void {
     delete shape.options.svgWidth;
     delete shape.options.svgHeight;
     delete shape.options.svgAsset;
-    activeShapeStore.setSvgAsset(undefined, SyncTo.SERVER);
+    activeShapeStore.setSvgAsset(undefined, SERVER_SYNC);
 }
 
 function applyDDraft(): void {
@@ -123,11 +123,11 @@ function applyDDraft(): void {
             shape.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.UI,
+            UI_SYNC,
         );
 
-        shape.setBlocksVision(true, SyncTo.UI, false);
-        shape.setBlocksMovement(true, SyncTo.UI, false);
+        shape.setBlocksVision(true, NO_SYNC, false);
+        shape.setBlocksMovement(true, NO_SYNC, false);
         fowLayer.addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO);
     }
 
@@ -138,12 +138,12 @@ function applyDDraft(): void {
             shape.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.UI,
+            UI_SYNC,
         );
 
         if (portal.closed) {
-            shape.setBlocksVision(true, SyncTo.UI, false);
-            shape.setBlocksMovement(true, SyncTo.UI, false);
+            shape.setBlocksVision(true, NO_SYNC, false);
+            shape.setBlocksMovement(true, NO_SYNC, false);
         }
         fowLayer.addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO);
     }
@@ -172,12 +172,12 @@ function applyDDraft(): void {
 
         tokenLayer.addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO);
 
-        auraSystem.add(shape.id, aura, SyncTo.SERVER);
+        auraSystem.add(shape.id, aura, SERVER_SYNC);
         accessSystem.addAccess(
             shape.id,
             clientStore.state.username,
             { edit: true, movement: true, vision: true },
-            SyncTo.SERVER,
+            SERVER_SYNC,
         );
     }
 

--- a/client/src/game/ui/settings/shape/GroupSettings.vue
+++ b/client/src/game/ui/settings/shape/GroupSettings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, toRef } from "vue";
 
-import { SyncTo } from "../../../../core/models/types";
+import { SERVER_SYNC, UI_SYNC } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { getChecked, getValue } from "../../../../core/utils";
 import { activeShapeStore } from "../../../../store/activeShape";
@@ -131,7 +131,7 @@ const creationOrder = computed({
 function updateToggles(checked: boolean): void {
     if (!owned.value) return;
     for (const member of groupMembers.value) {
-        if (member.showBadge !== checked) member.setShowBadge(checked, SyncTo.SERVER);
+        if (member.showBadge !== checked) member.setShowBadge(checked, SERVER_SYNC);
     }
 }
 
@@ -150,8 +150,8 @@ function showBadge(member: IShape, checked: boolean): void {
     if (!owned.value) return;
     // This and Keyboard are the only places currently where we would need to update both UI and Server.
     // Might need to introduce a SyncTo.BOTH
-    member.setShowBadge(checked, SyncTo.SERVER);
-    if (member.id === activeShapeStore.state.id) activeShapeStore.setShowBadge(checked, SyncTo.UI);
+    member.setShowBadge(checked, SERVER_SYNC);
+    if (member.id === activeShapeStore.state.id) activeShapeStore.setShowBadge(checked, UI_SYNC);
 }
 
 function removeMember(member: IShape): void {

--- a/client/src/game/ui/settings/shape/LogicSettings.vue
+++ b/client/src/game/ui/settings/shape/LogicSettings.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from "vue";
 import type { DeepReadonly } from "vue";
 import { useI18n } from "vue-i18n";
 
-import { SyncTo } from "../../../../core/models/types";
+import { SERVER_SYNC } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { activeShapeStore } from "../../../../store/activeShape";
 import { locationStore } from "../../../../store/location";
@@ -60,10 +60,10 @@ function openPermissions(target: LOGIC_TYPES): void {
 function setPermissions(permissions: Permissions): void {
     if (activeLogic.value === "door") {
         if (doorSystem.state.id === undefined) return;
-        doorSystem.setPermissions(doorSystem.state.id, permissions, SyncTo.SERVER);
+        doorSystem.setPermissions(doorSystem.state.id, permissions, SERVER_SYNC);
     } else {
         if (teleportZoneSystem.state.id === undefined) return;
-        teleportZoneSystem.setPermissions(teleportZoneSystem.state.id, permissions, SyncTo.SERVER);
+        teleportZoneSystem.setPermissions(teleportZoneSystem.state.id, permissions, SERVER_SYNC);
     }
 }
 
@@ -71,26 +71,26 @@ function setPermissions(permissions: Permissions): void {
 
 function toggleDoor(): void {
     if (doorSystem.state.id === undefined) return;
-    doorSystem.toggle(doorSystem.state.id, !doorSystem.state.enabled, SyncTo.SERVER);
+    doorSystem.toggle(doorSystem.state.id, !doorSystem.state.enabled, SERVER_SYNC);
 }
 
 const activeToggleMode = computed(() => doorSystem.state.toggleMode);
 
 function setToggleMode(mode: DOOR_TOGGLE_MODE): void {
     if (doorSystem.state.id === undefined) return;
-    doorSystem.setToggleMode(doorSystem.state.id, mode, SyncTo.SERVER);
+    doorSystem.setToggleMode(doorSystem.state.id, mode, SERVER_SYNC);
 }
 
 // Teleport Zone
 
 function toggleTeleportZone(): void {
     if (teleportZoneSystem.state.id === undefined) return;
-    teleportZoneSystem.toggle(teleportZoneSystem.state.id, !teleportZoneSystem.state.enabled, SyncTo.SERVER);
+    teleportZoneSystem.toggle(teleportZoneSystem.state.id, !teleportZoneSystem.state.enabled, SERVER_SYNC);
 }
 
 function toggleTpImmediate(): void {
     if (teleportZoneSystem.state.id === undefined) return;
-    teleportZoneSystem.toggleImmediate(teleportZoneSystem.state.id, !teleportZoneSystem.state.immediate, SyncTo.SERVER);
+    teleportZoneSystem.toggleImmediate(teleportZoneSystem.state.id, !teleportZoneSystem.state.immediate, SERVER_SYNC);
 }
 
 async function chooseTarget(): Promise<void> {
@@ -136,7 +136,7 @@ async function chooseTarget(): Promise<void> {
 
     // Save tp zone info
 
-    teleportZoneSystem.setTarget(teleportZoneSystem.state.id, targetLocation, SyncTo.SERVER);
+    teleportZoneSystem.setTarget(teleportZoneSystem.state.id, targetLocation, SERVER_SYNC);
 }
 </script>
 

--- a/client/src/game/ui/settings/shape/PropertySettings.vue
+++ b/client/src/game/ui/settings/shape/PropertySettings.vue
@@ -3,7 +3,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../../core/components/ColourPicker.vue";
-import { SyncMode, SyncTo } from "../../../../core/models/types";
+import { NO_SYNC, SERVER_SYNC, SyncMode } from "../../../../core/models/types";
 import { activeShapeStore } from "../../../../store/activeShape";
 import { getShape } from "../../../id";
 import type { CircularToken } from "../../../shapes/variants/circularToken";
@@ -16,57 +16,57 @@ const owned = accessSystem.$.hasEditAccess;
 
 function updateName(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setName((event.target as HTMLInputElement).value, SyncTo.SERVER);
+    activeShapeStore.setName((event.target as HTMLInputElement).value, SERVER_SYNC);
 }
 
 function toggleNameVisible(): void {
     if (!owned.value) return;
-    activeShapeStore.setNameVisible(!activeShapeStore.state.nameVisible, SyncTo.SERVER);
+    activeShapeStore.setNameVisible(!activeShapeStore.state.nameVisible, SERVER_SYNC);
 }
 
 function setToken(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setIsToken((event.target as HTMLInputElement).checked, SyncTo.SERVER);
+    activeShapeStore.setIsToken((event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
 function setInvisible(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setIsInvisible((event.target as HTMLInputElement).checked, SyncTo.SERVER);
+    activeShapeStore.setIsInvisible((event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
 function setDefeated(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setIsDefeated((event.target as HTMLInputElement).checked, SyncTo.SERVER);
+    activeShapeStore.setIsDefeated((event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
 function setLocked(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setLocked((event.target as HTMLInputElement).checked, SyncTo.SERVER);
+    activeShapeStore.setLocked((event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
 function toggleBadge(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setShowBadge((event.target as HTMLInputElement).checked, SyncTo.SERVER);
+    activeShapeStore.setShowBadge((event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
 function setBlocksVision(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setBlocksVision((event.target as HTMLInputElement).checked, SyncTo.SERVER);
+    activeShapeStore.setBlocksVision((event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
 function setBlocksMovement(event: Event): void {
     if (!owned.value) return;
-    activeShapeStore.setBlocksMovement((event.target as HTMLInputElement).checked, SyncTo.SERVER);
+    activeShapeStore.setBlocksMovement((event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
 function setStrokeColour(event: string, temporary = false): void {
     if (!owned.value) return;
-    activeShapeStore.setStrokeColour(event, temporary ? SyncTo.SHAPE : SyncTo.SERVER);
+    activeShapeStore.setStrokeColour(event, temporary ? NO_SYNC : SERVER_SYNC);
 }
 
 function setFillColour(colour: string, temporary = false): void {
     if (!owned.value) return;
-    activeShapeStore.setFillColour(colour, temporary ? SyncTo.SHAPE : SyncTo.SERVER);
+    activeShapeStore.setFillColour(colour, temporary ? NO_SYNC : SERVER_SYNC);
 }
 
 const hasValue = computed(() => {

--- a/client/src/game/ui/settings/shape/TrackerSettings.vue
+++ b/client/src/game/ui/settings/shape/TrackerSettings.vue
@@ -4,7 +4,7 @@ import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../../core/components/ColourPicker.vue";
 import RotationSlider from "../../../../core/components/RotationSlider.vue";
-import { SyncTo } from "../../../../core/models/types";
+import { NO_SYNC, SERVER_SYNC } from "../../../../core/models/types";
 import { getValue } from "../../../../core/utils";
 import { activeShapeStore } from "../../../../store/activeShape";
 import { getGlobalId } from "../../../id";
@@ -30,15 +30,15 @@ function updateTracker(tracker: DeepReadonly<UiTracker>, delta: Partial<Tracker>
     if (!owned.value || activeShapeStore.state.id === undefined) return;
 
     if (tracker.temporary) {
-        trackerSystem.add(tracker.shape, { ...tracker }, SyncTo.SERVER);
+        trackerSystem.add(tracker.shape, { ...tracker }, SERVER_SYNC);
     }
-    trackerSystem.update(tracker.shape, tracker.uuid, delta, syncTo === true ? SyncTo.SERVER : SyncTo.SHAPE);
+    trackerSystem.update(tracker.shape, tracker.uuid, delta, syncTo === true ? SERVER_SYNC : NO_SYNC);
 }
 
 function removeTracker(tracker: TrackerId): void {
     const id = activeShapeStore.state.id;
     if (!owned.value || id === undefined) return;
-    trackerSystem.remove(id, tracker, SyncTo.SERVER);
+    trackerSystem.remove(id, tracker, SERVER_SYNC);
 }
 
 function toggleCompositeTracker(shape: LocalId, trackerId: TrackerId): void {
@@ -49,11 +49,11 @@ function toggleCompositeTracker(shape: LocalId, trackerId: TrackerId): void {
     const tracker = trackerSystem.get(shape, trackerId, true);
     if (tracker === undefined) return;
 
-    trackerSystem.remove(shape, trackerId, SyncTo.SHAPE);
+    trackerSystem.remove(shape, trackerId, NO_SYNC);
 
     const newShape = shape === id ? activeShapeStore.state.parentUuid! : id;
 
-    trackerSystem.add(newShape, tracker, SyncTo.SHAPE);
+    trackerSystem.add(newShape, tracker, NO_SYNC);
 
     sendShapeMoveTracker({
         shape: getGlobalId(shape),
@@ -71,15 +71,15 @@ function updateAura(aura: DeepReadonly<UiAura>, delta: Partial<Aura>, syncTo = t
     if (delta.dim !== undefined && (isNaN(delta.dim) || delta.dim < 0)) delta.dim = 0;
 
     if (aura.temporary) {
-        auraSystem.add(aura.shape, { ...aura }, SyncTo.SERVER);
+        auraSystem.add(aura.shape, { ...aura }, SERVER_SYNC);
     }
-    auraSystem.update(aura.shape, aura.uuid, delta, syncTo === true ? SyncTo.SERVER : SyncTo.SHAPE);
+    auraSystem.update(aura.shape, aura.uuid, delta, syncTo === true ? SERVER_SYNC : NO_SYNC);
 }
 
 function removeAura(aura: AuraId): void {
     const id = activeShapeStore.state.id;
     if (!owned.value || id === undefined) return;
-    auraSystem.remove(id, aura, SyncTo.SERVER);
+    auraSystem.remove(id, aura, SERVER_SYNC);
 }
 
 function toggleCompositeAura(shape: LocalId, auraId: AuraId): void {
@@ -90,11 +90,11 @@ function toggleCompositeAura(shape: LocalId, auraId: AuraId): void {
     const aura = auraSystem.get(shape, auraId, true);
     if (aura === undefined) return;
 
-    auraSystem.remove(shape, auraId, SyncTo.SHAPE);
+    auraSystem.remove(shape, auraId, NO_SYNC);
 
     const newShape = shape === id ? activeShapeStore.state.parentUuid! : id;
 
-    auraSystem.add(newShape, aura, SyncTo.SHAPE);
+    auraSystem.add(newShape, aura, NO_SYNC);
 
     sendShapeMoveAura({
         shape: getGlobalId(shape),

--- a/client/src/game/ui/settings/shape/VariantSwitcher.vue
+++ b/client/src/game/ui/settings/shape/VariantSwitcher.vue
@@ -2,7 +2,7 @@
 import { computed, toRef } from "vue";
 
 import { cloneP } from "../../../../core/geometry";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../../core/models/types";
+import { InvalidationMode, SERVER_SYNC, SyncMode } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { activeShapeStore } from "../../../../store/activeShape";
 import { getShape } from "../../../id";
@@ -84,7 +84,7 @@ async function renameVariant(): Promise<void> {
     const name = await modals.prompt("What name should this variant have?", "Name variant");
     if (name === undefined) return;
 
-    activeShapeStore.renameVariant(vState.id!, name, SyncTo.SERVER);
+    activeShapeStore.renameVariant(vState.id!, name, SERVER_SYNC);
 }
 
 async function removeVariant(): Promise<void> {
@@ -96,7 +96,7 @@ async function removeVariant(): Promise<void> {
     );
     if (remove !== true) return;
 
-    activeShapeStore.removeVariant(vState.id!, SyncTo.SERVER);
+    activeShapeStore.removeVariant(vState.id!, SERVER_SYNC);
 }
 
 const variants = toRef(vState, "variants");

--- a/client/src/game/ui/tokendialog/CreateTokenDialog.vue
+++ b/client/src/game/ui/tokendialog/CreateTokenDialog.vue
@@ -6,7 +6,7 @@ import ColourPicker from "../../../core/components/ColourPicker.vue";
 import Modal from "../../../core/components/modals/Modal.vue";
 import { getUnitDistance, l2g } from "../../../core/conversions";
 import { toLP } from "../../../core/geometry";
-import { InvalidationMode, SyncMode, SyncTo } from "../../../core/models/types";
+import { InvalidationMode, SyncMode, UI_SYNC } from "../../../core/models/types";
 import { calcFontScale, mostReadable } from "../../../core/utils";
 import { clientStore } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
@@ -52,12 +52,7 @@ function submit(): void {
         "10px serif",
         { fillColour: fillColour.value, strokeColour: borderColour.value },
     );
-    accessSystem.addAccess(
-        token.id,
-        clientStore.state.username,
-        { edit: true, movement: true, vision: true },
-        SyncTo.UI,
-    );
+    accessSystem.addAccess(token.id, clientStore.state.username, { edit: true, movement: true, vision: true }, UI_SYNC);
     layer.addShape(token, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);
     close();
 }

--- a/client/src/store/activeShape.ts
+++ b/client/src/store/activeShape.ts
@@ -1,7 +1,7 @@
 import { computed, watchEffect } from "vue";
 import type { ComputedRef } from "vue";
 
-import { SyncTo } from "../core/models/types";
+import type { Sync } from "../core/models/types";
 import { Store } from "../core/store";
 import { sendShapeSvgAsset } from "../game/api/emits/shape/options";
 import { getGlobalId, getShape } from "../game/id";
@@ -119,12 +119,12 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
     // GROUP
 
-    setGroupId(groupId: string | undefined, syncTo: SyncTo): void {
+    setGroupId(groupId: string | undefined, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.groupId = groupId;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setGroupId(groupId, syncTo);
         }
@@ -132,121 +132,121 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
     // PROPERTIES
 
-    setName(name: string, syncTo: SyncTo): void {
+    setName(name: string, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.name = name;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setName(name, syncTo);
         }
     }
 
-    setNameVisible(visible: boolean, syncTo: SyncTo): void {
+    setNameVisible(visible: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.nameVisible = visible;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setNameVisible(visible, syncTo);
         }
     }
 
-    setIsToken(isToken: boolean, syncTo: SyncTo): void {
+    setIsToken(isToken: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.isToken = isToken;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setIsToken(isToken, syncTo);
         }
     }
 
-    setIsInvisible(isInvisible: boolean, syncTo: SyncTo): void {
+    setIsInvisible(isInvisible: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.isInvisible = isInvisible;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setInvisible(isInvisible, syncTo);
         }
     }
 
-    setStrokeColour(colour: string, syncTo: SyncTo): void {
+    setStrokeColour(colour: string, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.strokeColour = colour;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setStrokeColour(colour, syncTo);
         }
     }
 
-    setFillColour(colour: string, syncTo: SyncTo): void {
+    setFillColour(colour: string, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.fillColour = colour;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setFillColour(colour, syncTo);
         }
     }
 
-    setBlocksMovement(blocksMovement: boolean, syncTo: SyncTo): void {
+    setBlocksMovement(blocksMovement: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.blocksMovement = blocksMovement;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setBlocksMovement(blocksMovement, syncTo);
         }
     }
 
-    setBlocksVision(blocksVision: boolean, syncTo: SyncTo): void {
+    setBlocksVision(blocksVision: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.blocksVision = blocksVision;
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setBlocksVision(blocksVision, syncTo);
         }
     }
 
-    setShowBadge(showBadge: boolean, syncTo: SyncTo): void {
+    setShowBadge(showBadge: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.showBadge = showBadge;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setShowBadge(showBadge, syncTo);
         }
     }
 
-    setIsDefeated(isDefeated: boolean, syncTo: SyncTo): void {
+    setIsDefeated(isDefeated: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.isDefeated = isDefeated;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setDefeated(isDefeated, syncTo);
         }
     }
 
-    setLocked(isLocked: boolean, syncTo: SyncTo): void {
+    setLocked(isLocked: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.isLocked = isLocked;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setLocked(isLocked, syncTo);
         }
@@ -254,7 +254,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
     // VARIANTS
 
-    renameVariant(uuid: LocalId, name: string, syncTo: SyncTo): void {
+    renameVariant(uuid: LocalId, name: string, syncTo: Sync): void {
         if (this._state.id === undefined || this._state.parentUuid === undefined) return;
 
         const variant = this._state.variants.find((v) => v.uuid === uuid);
@@ -262,13 +262,13 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
         variant.name = name;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const parent = getShape(this._state.parentUuid) as ToggleComposite;
             parent.renameVariant(uuid, name, syncTo);
         }
     }
 
-    removeVariant(uuid: LocalId, syncTo: SyncTo): void {
+    removeVariant(uuid: LocalId, syncTo: Sync): void {
         if (this._state.id === undefined || this._state.parentUuid === undefined) return;
 
         const index = this._state.variants.findIndex((v) => v.uuid === uuid);
@@ -276,7 +276,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
         this._state.variants.splice(index, 1);
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const parent = getShape(this._state.parentUuid) as ToggleComposite;
             parent.removeVariant(uuid, syncTo);
         }
@@ -284,51 +284,51 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
     // EXTRA
 
-    setAnnotation(annotation: string, syncTo: SyncTo): void {
+    setAnnotation(annotation: string, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.annotation = annotation;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setAnnotation(annotation, syncTo);
         }
     }
 
-    setAnnotationVisible(visible: boolean, syncTo: SyncTo): void {
+    setAnnotationVisible(visible: boolean, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.annotationVisible = visible;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.setAnnotationVisible(visible, syncTo);
         }
     }
 
-    addLabel(label: string, syncTo: SyncTo): void {
+    addLabel(label: string, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.labels.push({ ...gameStore.state.labels.get(label)! });
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.addLabel(label, syncTo);
         }
     }
 
-    removeLabel(label: string, syncTo: SyncTo): void {
+    removeLabel(label: string, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         this._state.labels = this._state.labels.filter((l) => l.uuid !== label);
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;
             shape.removeLabel(label, syncTo);
         }
     }
 
-    setSvgAsset(hash: string | undefined, syncTo: SyncTo): void {
+    setSvgAsset(hash: string | undefined, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
         if (this._state.options === undefined) this._state.options = {};
@@ -337,7 +337,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
 
         const shape = getShape(this._state.id)!;
 
-        if (syncTo !== SyncTo.UI) {
+        if (!syncTo.ui) {
             if (hash === undefined) {
                 visionState.recalculateVision(activeShapeStore.floor.value!);
                 floorStore.invalidate({ id: activeShapeStore.floor.value! });
@@ -347,7 +347,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
             }
         }
 
-        if (syncTo === SyncTo.SERVER) {
+        if (syncTo.server) {
             sendShapeSvgAsset({ shape: getGlobalId(shape.id), value: hash ?? null });
         }
     }

--- a/client/test/game/systems/access/index.test.ts
+++ b/client/test/game/systems/access/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { SyncTo } from "../../../../src/core/models/types";
+import { NO_SYNC, SERVER_SYNC, UI_SYNC } from "../../../../src/core/models/types";
 import { socket } from "../../../../src/game/api/socket";
 import type { LocalId } from "../../../../src/game/id";
 import type { IShape } from "../../../../src/game/shapes/interfaces";
@@ -248,7 +248,7 @@ describe("Access System", () => {
             const access: ShapeAccess = { edit: false, movement: false, vision: true };
             accessSystem.inform(id, { default: DEFAULT_ACCESS, extra: [{ user: "some user", shape: id, access }] });
             // test
-            accessSystem.addAccess(id, "some user", access, SyncTo.SERVER);
+            accessSystem.addAccess(id, "some user", access, SERVER_SYNC);
             expect(errorSpy).toBeCalled();
             expect(emitSpy).not.toBeCalled();
             expect(addOwnedTokenSpy).not.toBeCalled();
@@ -263,7 +263,7 @@ describe("Access System", () => {
                 extra: [{ user: "some user", shape: id, access: someUserAccess }],
             });
             // test
-            accessSystem.addAccess(id, "new user", newUserAccess, SyncTo.SERVER);
+            accessSystem.addAccess(id, "new user", newUserAccess, SERVER_SYNC);
             expect(errorSpy).not.toBeCalled();
             expect(emitSpy).toBeCalled();
             expect(addOwnedTokenSpy).not.toBeCalled();
@@ -282,8 +282,8 @@ describe("Access System", () => {
                 extra: [],
             });
             // test
-            accessSystem.addAccess(id, "some user", someUserAccess, SyncTo.UI);
-            accessSystem.addAccess(id, "new user", newUserAccess, SyncTo.SHAPE);
+            accessSystem.addAccess(id, "some user", someUserAccess, UI_SYNC);
+            accessSystem.addAccess(id, "new user", newUserAccess, NO_SYNC);
             expect(errorSpy).not.toBeCalled();
             expect(emitSpy).not.toBeCalled();
             expect(addOwnedTokenSpy).not.toBeCalled();
@@ -304,8 +304,8 @@ describe("Access System", () => {
             });
             accessSystem.loadState(id);
             // test
-            accessSystem.addAccess(id, "some user", someUserAccess, SyncTo.UI);
-            accessSystem.addAccess(id2, "new user", newUserAccess, SyncTo.SHAPE);
+            accessSystem.addAccess(id, "some user", someUserAccess, UI_SYNC);
+            accessSystem.addAccess(id2, "new user", newUserAccess, NO_SYNC);
             expect(accessSystem.state.playerAccess.get("some user")).toEqual(someUserAccess);
             expect(accessSystem.state.playerAccess.get("new user")).toBeUndefined();
         });
@@ -321,16 +321,16 @@ describe("Access System", () => {
             // test
             // 1. vision: false && username is ok && !isToken
             clientStore.setUsername("some user");
-            accessSystem.addAccess(id, "some user", userWithoutVision, SyncTo.UI);
+            accessSystem.addAccess(id, "some user", userWithoutVision, UI_SYNC);
             expect(addOwnedTokenSpy).not.toBeCalled();
             // 2. vision: true && username is ok && !isToken
             clientStore.setUsername("vision user wo isToken");
-            accessSystem.addAccess(id, "vision user wo isToken", userWithVision, SyncTo.UI);
+            accessSystem.addAccess(id, "vision user wo isToken", userWithVision, UI_SYNC);
             expect(addOwnedTokenSpy).not.toBeCalled();
             // 3. vision: true && username is ok && isToken
             GET_SHAPE_OVERRIDE = () => ({ isToken: true });
             clientStore.setUsername("vision user w isToken");
-            accessSystem.addAccess(id, "vision user w isToken", userWithVision, SyncTo.UI);
+            accessSystem.addAccess(id, "vision user w isToken", userWithVision, UI_SYNC);
             expect(addOwnedTokenSpy).toBeCalled();
         });
     });
@@ -338,7 +338,7 @@ describe("Access System", () => {
         it("should error if the shape is not known to the system", () => {
             // setup
             const id = generateTestLocalId();
-            accessSystem.updateAccess(id, "some user", { edit: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { edit: true }, SERVER_SYNC);
             // test
             expect(errorSpy).toBeCalled();
         });
@@ -346,7 +346,7 @@ describe("Access System", () => {
             // setup
             const id = generateTestLocalId();
             accessSystem.inform(id, { default: DEFAULT_ACCESS, extra: [] });
-            accessSystem.updateAccess(id, "some user", { edit: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { edit: true }, SERVER_SYNC);
             // test
             expect(errorSpy).toBeCalled();
         });
@@ -356,7 +356,7 @@ describe("Access System", () => {
             accessSystem.inform(id, { default: DEFAULT_ACCESS, extra: [] });
             // test
             expect(accessSystem.getDefault(id)).toEqual({ edit: false, movement: false, vision: false });
-            accessSystem.updateAccess(id, DEFAULT_ACCESS_SYMBOL, { edit: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, DEFAULT_ACCESS_SYMBOL, { edit: true }, SERVER_SYNC);
             expect(accessSystem.getDefault(id)).toEqual({ edit: true, movement: false, vision: false });
             expect(errorSpy).not.toBeCalled();
             expect(emitSpy).toBeCalled();
@@ -370,7 +370,7 @@ describe("Access System", () => {
             });
             // test
             expect(accessSystem.getAccess(id, "some user")).toEqual({ edit: false, movement: false, vision: false });
-            accessSystem.updateAccess(id, "some user", { edit: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { edit: true }, SERVER_SYNC);
             expect(accessSystem.getAccess(id, "some user")).toEqual({ edit: true, movement: false, vision: false });
             expect(errorSpy).not.toBeCalled();
             expect(emitSpy).toBeCalled();
@@ -384,19 +384,19 @@ describe("Access System", () => {
             });
             // test
             // 1. without correct username
-            accessSystem.updateAccess(id, "some user", { vision: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { vision: true }, SERVER_SYNC);
             expect(addOwnedTokenSpy).not.toBeCalled();
-            accessSystem.updateAccess(id, "some user", { vision: false }, SyncTo.SERVER); // reset
+            accessSystem.updateAccess(id, "some user", { vision: false }, SERVER_SYNC); // reset
             // 2. without isToken
             clientStore.setUsername("some user");
-            accessSystem.updateAccess(id, "some user", { vision: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { vision: true }, SERVER_SYNC);
             expect(addOwnedTokenSpy).not.toBeCalled();
-            accessSystem.updateAccess(id, "some user", { vision: false }, SyncTo.SERVER); // reset
+            accessSystem.updateAccess(id, "some user", { vision: false }, SERVER_SYNC); // reset
             // 3. correct
             GET_SHAPE_OVERRIDE = () => ({
                 isToken: true,
             });
-            accessSystem.updateAccess(id, "some user", { vision: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { vision: true }, SERVER_SYNC);
             expect(addOwnedTokenSpy).toBeCalled();
         });
         it("should remove from the owned tokens if vision is toggled off for the current user", () => {
@@ -408,19 +408,19 @@ describe("Access System", () => {
             });
             // test
             // 1. without correct username
-            accessSystem.updateAccess(id, "some user", { vision: false }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { vision: false }, SERVER_SYNC);
             expect(removeOwnedTokenSpy).not.toBeCalled();
-            accessSystem.updateAccess(id, "some user", { vision: true }, SyncTo.SERVER); // reset
+            accessSystem.updateAccess(id, "some user", { vision: true }, SERVER_SYNC); // reset
             // 2. without isToken
             clientStore.setUsername("some user");
-            accessSystem.updateAccess(id, "some user", { vision: false }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { vision: false }, SERVER_SYNC);
             expect(removeOwnedTokenSpy).not.toBeCalled();
-            accessSystem.updateAccess(id, "some user", { vision: true }, SyncTo.SERVER); // reset
+            accessSystem.updateAccess(id, "some user", { vision: true }, SERVER_SYNC); // reset
             // 3. correct
             GET_SHAPE_OVERRIDE = () => ({
                 isToken: true,
             });
-            accessSystem.updateAccess(id, "some user", { vision: false }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { vision: false }, SERVER_SYNC);
             expect(removeOwnedTokenSpy).toBeCalled();
         });
         it("should update $state", () => {
@@ -437,7 +437,7 @@ describe("Access System", () => {
                 movement: false,
                 vision: true,
             });
-            accessSystem.updateAccess(id, "some user", { edit: true }, SyncTo.SERVER);
+            accessSystem.updateAccess(id, "some user", { edit: true }, SERVER_SYNC);
             expect(accessSystem.state.playerAccess.get("some user")).toEqual({
                 edit: true,
                 movement: false,
@@ -449,7 +449,7 @@ describe("Access System", () => {
         it("should error if the shape is not known to the system", () => {
             // setup
             const id = generateTestLocalId();
-            accessSystem.removeAccess(id, "some user", SyncTo.SERVER);
+            accessSystem.removeAccess(id, "some user", SERVER_SYNC);
             // test
             expect(errorSpy).toBeCalled();
         });
@@ -457,7 +457,7 @@ describe("Access System", () => {
             // setup
             const id = generateTestLocalId();
             accessSystem.inform(id, { default: DEFAULT_ACCESS, extra: [] });
-            accessSystem.removeAccess(id, "some user", SyncTo.SERVER);
+            accessSystem.removeAccess(id, "some user", SERVER_SYNC);
             // test
             expect(errorSpy).toBeCalled();
         });
@@ -470,7 +470,7 @@ describe("Access System", () => {
             });
             // test
             expect(accessSystem.getAccess(id, "some user")).toEqual({ edit: false, movement: false, vision: false });
-            accessSystem.removeAccess(id, "some user", SyncTo.SERVER);
+            accessSystem.removeAccess(id, "some user", SERVER_SYNC);
             expect(accessSystem.getAccess(id, "some user")).toBeUndefined();
             expect(errorSpy).not.toBeCalled();
             expect(emitSpy).toBeCalled();
@@ -484,19 +484,19 @@ describe("Access System", () => {
             });
             // test
             // 1. without correct username
-            accessSystem.removeAccess(id, "some user", SyncTo.SERVER);
+            accessSystem.removeAccess(id, "some user", SERVER_SYNC);
             expect(removeOwnedTokenSpy).not.toBeCalled();
-            accessSystem.addAccess(id, "some user", { vision: true }, SyncTo.SERVER); // reset
+            accessSystem.addAccess(id, "some user", { vision: true }, SERVER_SYNC); // reset
             // 2. without isToken
             clientStore.setUsername("some user");
-            accessSystem.removeAccess(id, "some user", SyncTo.SERVER);
+            accessSystem.removeAccess(id, "some user", SERVER_SYNC);
             expect(removeOwnedTokenSpy).not.toBeCalled();
-            accessSystem.addAccess(id, "some user", { vision: true }, SyncTo.SERVER); // reset
+            accessSystem.addAccess(id, "some user", { vision: true }, SERVER_SYNC); // reset
             // 3. correct
             GET_SHAPE_OVERRIDE = () => ({
                 isToken: true,
             });
-            accessSystem.removeAccess(id, "some user", SyncTo.SERVER);
+            accessSystem.removeAccess(id, "some user", SERVER_SYNC);
             expect(removeOwnedTokenSpy).toBeCalled();
         });
         it("should update $state", () => {
@@ -509,7 +509,7 @@ describe("Access System", () => {
             accessSystem.loadState(id);
             // test
             expect(accessSystem.state.playerAccess.has("some user")).toBe(true);
-            accessSystem.removeAccess(id, "some user", SyncTo.SERVER);
+            accessSystem.removeAccess(id, "some user", SERVER_SYNC);
             expect(accessSystem.state.playerAccess.has("some user")).toBe(false);
         });
     });
@@ -539,7 +539,7 @@ describe("Access System", () => {
             });
             // test
             expect(accessSystem.getOwners(id)).toEqual(["some user"]);
-            accessSystem.addAccess(id, "other user", DEFAULT_ACCESS, SyncTo.UI);
+            accessSystem.addAccess(id, "other user", DEFAULT_ACCESS, UI_SYNC);
             expect(accessSystem.getOwners(id)).toEqual(["some user", "other user"]);
         });
     });
@@ -571,7 +571,7 @@ describe("Access System", () => {
             expect(accessSystem.getOwnersFull(id)).toEqual([
                 { user: "some user", shape: id, access: { edit: false, movement: false, vision: true } },
             ]);
-            accessSystem.addAccess(id, "other user", DEFAULT_ACCESS, SyncTo.UI);
+            accessSystem.addAccess(id, "other user", DEFAULT_ACCESS, UI_SYNC);
             expect(accessSystem.getOwnersFull(id)).toEqual([
                 { user: "some user", shape: id, access: { edit: false, movement: false, vision: true } },
                 { user: "other user", shape: id, access: { edit: false, movement: false, vision: false } },

--- a/client/test/game/systems/auras/index.test.ts
+++ b/client/test/game/systems/auras/index.test.ts
@@ -7,7 +7,7 @@ vi.mock("../../../../src/store/activeShape", () => ({
     },
 }));
 
-import { SyncTo } from "../../../../src/core/models/types";
+import { NO_SYNC, SERVER_SYNC, UI_SYNC } from "../../../../src/core/models/types";
 import { socket } from "../../../../src/game/api/socket";
 import { compositeState } from "../../../../src/game/layers/state";
 import { auraSystem } from "../../../../src/game/systems/auras";
@@ -110,7 +110,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, []);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.add(id, aura, SyncTo.SHAPE);
+            auraSystem.add(id, aura, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toEqual(aura);
             expect(invalidateSpy).not.toBeCalled();
             expect(addVisionSpy).not.toBeCalled();
@@ -124,7 +124,7 @@ describe("Aura System", () => {
             const aura = generateTestAura({ active: false, visionSource: true });
             auraSystem.inform(id, []);
             // test
-            auraSystem.add(id, aura, SyncTo.SERVER);
+            auraSystem.add(id, aura, SERVER_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toEqual(aura);
             expect(emitSpy).toBeCalled();
         });
@@ -137,7 +137,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, []);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.add(id, aura, SyncTo.SHAPE);
+            auraSystem.add(id, aura, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toEqual(aura);
             expect(invalidateSpy).toBeCalled();
             expect(addVisionSpy).not.toBeCalled();
@@ -152,7 +152,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, []);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.add(id, aura, SyncTo.UI);
+            auraSystem.add(id, aura, UI_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toEqual(aura);
             expect(invalidateSpy).toBeCalled();
             expect(addVisionSpy).toBeCalled();
@@ -183,7 +183,7 @@ describe("Aura System", () => {
                 id,
                 aura.uuid,
                 { angle: 90, borderColour: "blue", direction: -20, name: "changed test aura", visible: true },
-                SyncTo.SHAPE,
+                NO_SYNC,
             );
             expect(auraSystem.get(id, aura.uuid, false)).toMatchObject({
                 active: false,
@@ -214,7 +214,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, [aura]);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.update(id, aura.uuid, { angle: 90, visible: true }, SyncTo.SERVER);
+            auraSystem.update(id, aura.uuid, { angle: 90, visible: true }, SERVER_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toMatchObject({
                 active: false,
                 visionSource: true,
@@ -239,7 +239,7 @@ describe("Aura System", () => {
             addVisionSpy.mockClear();
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.update(id, aura.uuid, { angle: 90, visible: true }, SyncTo.SHAPE);
+            auraSystem.update(id, aura.uuid, { angle: 90, visible: true }, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toMatchObject({
                 active: true,
                 visionSource: true,
@@ -263,7 +263,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, [aura]);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.update(id, aura.uuid, { active: true, angle: 90, visible: true }, SyncTo.SHAPE);
+            auraSystem.update(id, aura.uuid, { active: true, angle: 90, visible: true }, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toMatchObject({
                 active: true,
                 visionSource: true,
@@ -288,7 +288,7 @@ describe("Aura System", () => {
             addVisionSpy.mockClear();
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.update(id, aura.uuid, { visionSource: true, angle: 90, visible: true }, SyncTo.SHAPE);
+            auraSystem.update(id, aura.uuid, { visionSource: true, angle: 90, visible: true }, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toMatchObject({
                 active: true,
                 visionSource: true,
@@ -313,12 +313,7 @@ describe("Aura System", () => {
             addVisionSpy.mockClear();
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.update(
-                id,
-                aura.uuid,
-                { active: false, visionSource: true, angle: 90, visible: true },
-                SyncTo.SHAPE,
-            );
+            auraSystem.update(id, aura.uuid, { active: false, visionSource: true, angle: 90, visible: true }, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toMatchObject({
                 active: false,
                 visionSource: true,
@@ -343,7 +338,7 @@ describe("Aura System", () => {
             addVisionSpy.mockClear();
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.update(id, aura.uuid, { visionSource: false, angle: 90, visible: true }, SyncTo.SHAPE);
+            auraSystem.update(id, aura.uuid, { visionSource: false, angle: 90, visible: true }, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toMatchObject({
                 active: true,
                 visionSource: false,
@@ -365,7 +360,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, [aura]);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.remove(id, aura.uuid, SyncTo.SHAPE);
+            auraSystem.remove(id, aura.uuid, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toBeUndefined();
             expect(invalidateSpy).not.toBeCalled();
             expect(removeVisionSpy).not.toBeCalled();
@@ -378,7 +373,7 @@ describe("Aura System", () => {
             const aura = generateTestAura({ active: false, visionSource: true });
             auraSystem.inform(id, [aura]);
             // test
-            auraSystem.remove(id, aura.uuid, SyncTo.SERVER);
+            auraSystem.remove(id, aura.uuid, SERVER_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toBeUndefined();
             expect(emitSpy).toBeCalled();
         });
@@ -391,7 +386,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, [aura]);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.remove(id, aura.uuid, SyncTo.SHAPE);
+            auraSystem.remove(id, aura.uuid, NO_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toBeUndefined();
             expect(invalidateSpy).toBeCalled();
             expect(removeVisionSpy).not.toBeCalled();
@@ -406,7 +401,7 @@ describe("Aura System", () => {
             auraSystem.inform(id, [aura]);
             const invalidateSpy = vi.spyOn(shape, "invalidate");
             // test
-            auraSystem.remove(id, aura.uuid, SyncTo.UI);
+            auraSystem.remove(id, aura.uuid, UI_SYNC);
             expect(auraSystem.get(id, aura.uuid, false)).toBeUndefined();
             expect(invalidateSpy).toBeCalled();
             expect(removeVisionSpy).toBeCalled();


### PR DESCRIPTION
This PR fixes a UI desync when toggling a logic door and having that shape's UI open at the same time.

The core of this PR however, which made the fix possible, is a refactor of the `SyncTo` enum. This is an internal enum that is used to direct the flow of communication (e.g. to UI or to Server).