### PR TITLE
bug(Redo): Fix resize redo for snapped point being off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 -   Draw tool door permissions not saving
 -   Door logic toggle not immediately updating UI when shape properties are open
 -   Logic init edge cases breaking UI until refresh
+-   Redo logic on resize operation not remembering correct location when it was snapped
 
 ## [2022.1] - 2022-04-25
 

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -680,7 +680,7 @@ class SelectTool extends Tool implements ISelectTool {
                     }
 
                     if (this.operationList?.type === "resize") {
-                        this.operationList.toPoint = toArrayP(l2g(lp));
+                        this.operationList.toPoint = sel.points[this.resizePoint];
                         this.operationList.resizePoint = this.resizePoint;
                         this.operationList.retainAspectRatio = ctrlOrCmdPressed(event);
                         this.operationReady = true;


### PR DESCRIPTION
When the redo operation was executed for a resize in which the relevant point was snapped, it would redo the resize to the non-snapped location at that time.

This is now fixed.