### PR TITLE
bug(AssetManager): Fix browser back/forward buttons not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 -   Door logic toggle not immediately updating UI when shape properties are open
 -   Logic init edge cases breaking UI until refresh
 -   Redo logic on resize operation not remembering correct location when it was snapped
+-   Asset Manager correctly updates UI when using browser back/forward buttons
 -   [tech] Ensure router.push calls are always awaited
 
 ## [2022.1] - 2022-04-25

--- a/client/src/assetManager/socket.ts
+++ b/client/src/assetManager/socket.ts
@@ -1,6 +1,7 @@
 import type { Asset } from "../core/models/types";
 import { socketManager } from "../core/socket";
 import { baseAdjust } from "../core/utils";
+import { router } from "../router";
 
 import { assetStore } from "./state";
 
@@ -23,12 +24,15 @@ socket.on("redirect", (destination: string) => {
 socket.on("Folder.Root.Set", (root: number) => {
     assetStore.setRoot(root);
 });
-socket.on("Folder.Set", (data: { folder: Asset; path?: number[] }) => {
+socket.on("Folder.Set", async (data: { folder: Asset; path?: number[] }) => {
     assetStore.clear();
     assetStore.setFolderData(data.folder.id, data.folder);
     if (!assetStore.state.modalActive) {
         if (data.path) assetStore.setPath(data.path);
-        window.history.pushState(null, "Asset Manager", baseAdjust(`/assets${assetStore.currentFilePath.value}`));
+        const path = baseAdjust(`/assets${assetStore.currentFilePath.value}`);
+        if (path !== router.currentRoute.value.path) {
+            await router.push({ path });
+        }
     }
 });
 socket.on("Folder.Create", (data: { asset: Asset; parent: number }) => {


### PR DESCRIPTION
When using the browser back/forward buttons (or some mouse/keyboard shortcuts for these actions), the Asset Manager would not properly update its UI.

This is now fixed.