### PR TITLE
bug(Client): Clear client viewports when changing location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 -   Logic init edge cases breaking UI until refresh
 -   Redo logic on resize operation not remembering correct location when it was snapped
 -   Asset Manager correctly updates UI when using browser back/forward buttons
+-   Clear client viewports when changing location
 -   [tech] Ensure router.push calls are always awaited
 
 ## [2022.1] - 2022-04-25

--- a/client/src/game/clear.ts
+++ b/client/src/game/clear.ts
@@ -2,6 +2,7 @@ import { floorStore } from "../store/floor";
 import { gameStore } from "../store/game";
 import { locationStore } from "../store/location";
 
+import { clearClientRects } from "./client";
 import { stopDrawLoop } from "./draw";
 import { clearIds } from "./id";
 import { compositeState } from "./layers/state";
@@ -11,6 +12,7 @@ import { visionState } from "./vision/state";
 
 export function clearGame(): void {
     stopDrawLoop();
+    clearClientRects();
     gameStore.clear();
     visionState.clear();
     locationStore.setLocations([], false);

--- a/client/src/game/client.ts
+++ b/client/src/game/client.ts
@@ -13,18 +13,28 @@ import { LayerName } from "./models/floor";
 import type { ServerUserLocationOptions } from "./models/settings";
 import { Polygon } from "./shapes/variants/polygon";
 
-const playerRectUuids: Map<number, LocalId> = new Map();
+const playerRectIds: Map<number, LocalId> = new Map();
 const playerLocationData: Map<number, ServerUserLocationOptions> = new Map();
 
 const sendMoveClientThrottled = throttle(sendMoveClient, 50, { trailing: true });
 
+export function clearClientRects(): void {
+    for (const id of playerRectIds.values()) {
+        const p = getShape(id)!;
+        p.layer.removeShape(p, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
+    }
+    playerRectIds.clear();
+    playerLocationData.clear();
+}
+
 export function moveClientRect(player: number, data: ServerUserLocationOptions): void {
     playerLocationData.set(player, data);
+
+    const id = playerRectIds.get(player);
     const layer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Dm)!;
-    let polygon: Polygon;
-    if (playerRectUuids.has(player)) {
-        polygon = getShape(playerRectUuids.get(player)!)! as Polygon;
-    } else {
+
+    let polygon: Polygon | undefined = id ? (getShape(id) as Polygon) : undefined;
+    if (polygon === undefined) {
         polygon = new Polygon(toGP(0, 0), undefined, {
             fillColour: "rgba(0, 0, 0, 0)",
             strokeColour: "rgba(0, 0, 0, 1)",
@@ -32,7 +42,7 @@ export function moveClientRect(player: number, data: ServerUserLocationOptions):
             openPolygon: true,
             uuid: uuidv4(),
         });
-        playerRectUuids.set(player, polygon.id);
+        playerRectIds.set(player, polygon.id);
         polygon.options.isPlayerRect = true;
         polygon.options.skipDraw = !(gameStore.state.players.find((p) => p.id === player)?.showRect ?? false);
         polygon.preventSync = true;
@@ -46,7 +56,7 @@ export function moveClientRect(player: number, data: ServerUserLocationOptions):
 }
 
 export function moveClient(rectUuid: LocalId): void {
-    const player = [...playerRectUuids.entries()].find(([_, uuid]) => uuid === rectUuid)?.[0] ?? -1;
+    const player = [...playerRectIds.entries()].find(([_, uuid]) => uuid === rectUuid)?.[0] ?? -1;
     if (player < 0) return;
     const rect = getShape(rectUuid)!;
     if (rect === undefined) return;
@@ -62,7 +72,7 @@ export function moveClient(rectUuid: LocalId): void {
 }
 
 export function showClientRect(player: number, show: boolean): void {
-    const rectUuid = playerRectUuids.get(player);
+    const rectUuid = playerRectIds.get(player);
     if (rectUuid === undefined) return;
     const rect = getShape(rectUuid)!;
     if (rect === undefined) return;


### PR DESCRIPTION
The DM Can optionally see the viewports of all connected clients and move them.

The rectangle representing such a viewport was not getting cleared when changing locations.