### PR TITLE
feat(Client): Add double stroke to client viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-[DM] denotes changes only useful for the dungeon master
-[server] denotes changes only useful for the server owner
-[tech] denotes internal changes that are only useful for code contributors
+[DM] denotes changes only useful for the dungeon master\
+[server] denotes changes only useful for the server owner\
+[tech] denotes internal changes that are only useful for code contributors\
+these changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
@@ -12,7 +13,9 @@ All notable changes to this project will be documented in this file.
 
 -   Add white outline to the door logic (un)lock icons
 -   Door logic can now specify which block settings to toggle
+-   Add double stroke to client viewport
 -   [tech] SyncTo primitive modified to an alternative Sync structure
+-   [tech] Polygon can now have client-side multi-stroke
 
 ### Fixed
 

--- a/client/src/game/client.ts
+++ b/client/src/game/client.ts
@@ -37,8 +37,8 @@ export function moveClientRect(player: number, data: ServerUserLocationOptions):
     if (polygon === undefined) {
         polygon = new Polygon(toGP(0, 0), undefined, {
             fillColour: "rgba(0, 0, 0, 0)",
-            strokeColour: "rgba(0, 0, 0, 1)",
-            lineWidth: 5,
+            strokeColour: ["rgba(0, 0, 0, 1)", "rgba(255, 255, 255, 1)"],
+            lineWidth: [30, 15],
             openPolygon: true,
             uuid: uuidv4(),
         });

--- a/client/src/game/shapes/interfaces.ts
+++ b/client/src/game/shapes/interfaces.ts
@@ -30,7 +30,7 @@ export interface IShape {
     isLocked: boolean;
 
     fillColour: string;
-    strokeColour: string;
+    strokeColour: string[];
     strokeWidth: number;
 
     assetId?: number;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -87,7 +87,7 @@ export abstract class Shape implements IShape {
 
     // Fill colour of the shape
     fillColour: string;
-    strokeColour: string;
+    strokeColour: string[];
     strokeWidth: number;
 
     assetId?: number;
@@ -126,7 +126,7 @@ export abstract class Shape implements IShape {
         refPoint: GlobalPoint,
         options?: {
             fillColour?: string;
-            strokeColour?: string;
+            strokeColour?: string[];
             id?: LocalId;
             uuid?: GlobalId;
             assetId?: number;
@@ -136,7 +136,7 @@ export abstract class Shape implements IShape {
         this._refPoint = refPoint;
         this.id = options?.id ?? generateLocalId(this, options?.uuid);
         this.fillColour = options?.fillColour ?? "#000";
-        this.strokeColour = options?.strokeColour ?? "rgba(0,0,0,0)";
+        this.strokeColour = options?.strokeColour ?? ["rgba(0,0,0,0)"];
         this.assetId = options?.assetId;
         this.strokeWidth = options?.strokeWidth ?? 5;
     }
@@ -270,13 +270,13 @@ export abstract class Shape implements IShape {
             const location = g2l(bbox.botRight);
             const r = g2lz(10);
             ctx.strokeStyle = "black";
-            ctx.fillStyle = this.strokeColour;
+            ctx.fillStyle = this.strokeColour[0];
             ctx.lineWidth = g2lz(2);
             ctx.beginPath();
             ctx.arc(location.x - r, location.y - r, r, 0, 2 * Math.PI);
             ctx.stroke();
             ctx.fill();
-            ctx.fillStyle = mostReadable(this.strokeColour);
+            ctx.fillStyle = mostReadable(this.strokeColour[0]);
 
             const badgeChars = getBadgeCharacters(this);
             const scalingFactor = 2.3 - 0.5 * badgeChars.length;
@@ -296,7 +296,7 @@ export abstract class Shape implements IShape {
             const crossBR = g2l(bbox.botRight);
             const r = g2lz(10);
             ctx.strokeStyle = "red";
-            ctx.fillStyle = this.strokeColour;
+            ctx.fillStyle = this.strokeColour[0];
             ctx.lineWidth = g2lz(2);
             ctx.beginPath();
             ctx.moveTo(crossTL.x + r, crossTL.y + r);
@@ -430,7 +430,7 @@ export abstract class Shape implements IShape {
             labels: this.labels,
             owners: accessSystem.getOwnersFull(this.id).map((o) => ownerToServer(o)),
             fill_colour: this.fillColour,
-            stroke_colour: this.strokeColour,
+            stroke_colour: this.strokeColour[0],
             stroke_width: this.strokeWidth,
             name: this.name,
             name_visible: this.nameVisible,
@@ -465,7 +465,7 @@ export abstract class Shape implements IShape {
         this.blocksVision = data.vision_obstruction;
         this.labels = data.labels;
         this.fillColour = data.fill_colour;
-        this.strokeColour = data.stroke_colour;
+        this.strokeColour = [data.stroke_colour];
         this.isToken = data.is_token;
         this.isInvisible = data.is_invisible;
         this.isDefeated = data.is_defeated;
@@ -584,7 +584,7 @@ export abstract class Shape implements IShape {
         if (syncTo.server) sendShapeSetStrokeColour({ shape: getGlobalId(this.id), value: colour });
         if (syncTo.ui) this._("setStrokeColour")(colour, syncTo);
 
-        this.strokeColour = colour;
+        this.strokeColour = [colour];
         this.invalidate(true);
     }
 

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -60,28 +60,28 @@ export function createShapeFromDict(shape: ServerShape): IShape | undefined {
         const rect = shape as ServerRect;
         sh = new Rect(refPoint, rect.width, rect.height, {
             fillColour: rect.fill_colour,
-            strokeColour: rect.stroke_colour,
+            strokeColour: [rect.stroke_colour],
             uuid: rect.uuid,
         });
     } else if (shape.type_ === "circle") {
         const circ = shape as ServerCircle;
         sh = new Circle(refPoint, circ.radius, {
             fillColour: circ.fill_colour,
-            strokeColour: circ.stroke_colour,
+            strokeColour: [circ.stroke_colour],
             uuid: circ.uuid,
         });
     } else if (shape.type_ === "circulartoken") {
         const token = shape as ServerCircularToken;
         sh = new CircularToken(refPoint, token.radius, token.text, token.font, {
             fillColour: token.fill_colour,
-            strokeColour: token.stroke_colour,
+            strokeColour: [token.stroke_colour],
             uuid: token.uuid,
         });
     } else if (shape.type_ === "line") {
         const line = shape as ServerLine;
         sh = new Line(refPoint, toGP(line.x2, line.y2), {
             lineWidth: line.line_width,
-            strokeColour: line.stroke_colour,
+            strokeColour: [line.stroke_colour],
             uuid: line.uuid,
         });
     } else if (shape.type_ === "polygon") {
@@ -91,8 +91,8 @@ export function createShapeFromDict(shape: ServerShape): IShape | undefined {
             polygon.vertices.map((v) => toGP(v)),
             {
                 fillColour: polygon.fill_colour,
-                strokeColour: polygon.stroke_colour,
-                lineWidth: polygon.line_width,
+                strokeColour: [polygon.stroke_colour],
+                lineWidth: [polygon.line_width],
                 openPolygon: polygon.open_polygon,
                 uuid: polygon.uuid,
             },
@@ -101,7 +101,7 @@ export function createShapeFromDict(shape: ServerShape): IShape | undefined {
         const text = shape as ServerText;
         sh = new Text(refPoint, text.text, text.font_size, {
             fillColour: text.fill_colour,
-            strokeColour: text.stroke_colour,
+            strokeColour: [text.stroke_colour],
             uuid: text.uuid,
         });
     } else if (shape.type_ === "assetrect") {

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -18,7 +18,7 @@ export class Asset extends BaseRect {
     type: SHAPE_TYPE = "assetrect";
     img: HTMLImageElement;
     src = "";
-    strokeColour = "white";
+    strokeColour = ["white"];
     #loaded: boolean;
 
     svgData?: { svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }[];

--- a/client/src/game/shapes/variants/baseRect.ts
+++ b/client/src/game/shapes/variants/baseRect.ts
@@ -20,7 +20,7 @@ export abstract class BaseRect extends Shape {
         topleft: GlobalPoint,
         w: number,
         h: number,
-        options?: { fillColour?: string; strokeColour?: string; id?: LocalId; uuid?: GlobalId; assetId?: number },
+        options?: { fillColour?: string; strokeColour?: string[]; id?: LocalId; uuid?: GlobalId; assetId?: number },
     ) {
         super(topleft, options);
         this._w = w;

--- a/client/src/game/shapes/variants/circle.ts
+++ b/client/src/game/shapes/variants/circle.ts
@@ -22,7 +22,7 @@ export class Circle extends Shape {
         r: number,
         options?: {
             fillColour?: string;
-            strokeColour?: string;
+            strokeColour?: string[];
             viewingAngle?: number;
             id?: LocalId;
             uuid?: GlobalId;
@@ -79,12 +79,12 @@ export class Circle extends Shape {
         this.drawArc(ctx, this.ignoreZoomSize ? this.r : g2lz(this.r));
         ctx.fill();
 
-        if (this.strokeColour !== "rgba(0, 0, 0, 0)") {
+        if (this.strokeColour[0] !== "rgba(0, 0, 0, 0)") {
             const ogOperation = ctx.globalCompositeOperation;
             if (this.options.borderOperation !== undefined) ctx.globalCompositeOperation = this.options.borderOperation;
             ctx.beginPath();
             ctx.lineWidth = this.ignoreZoomSize ? this.strokeWidth : g2lz(this.strokeWidth);
-            ctx.strokeStyle = this.strokeColour;
+            ctx.strokeStyle = this.strokeColour[0];
             // Inset the border with - borderWidth / 2
             // Slight imperfection added to account for zoom subpixel differences
             const r = this.r - this.strokeWidth / 2.5;

--- a/client/src/game/shapes/variants/circularToken.ts
+++ b/client/src/game/shapes/variants/circularToken.ts
@@ -22,7 +22,7 @@ export class CircularToken extends Circle {
         font: string,
         options?: {
             fillColour?: string;
-            strokeColour?: string;
+            strokeColour?: string[];
             id?: LocalId;
             uuid?: GlobalId;
         },

--- a/client/src/game/shapes/variants/line.ts
+++ b/client/src/game/shapes/variants/line.ts
@@ -18,12 +18,12 @@ export class Line extends Shape {
         endPoint: GlobalPoint,
         options?: {
             lineWidth?: number;
-            strokeColour?: string;
+            strokeColour?: string[];
             id?: LocalId;
             uuid?: GlobalId;
         },
     ) {
-        super(startPoint, { fillColour: "rgba(0, 0, 0, 0)", strokeColour: "#000", ...options });
+        super(startPoint, { fillColour: "rgba(0, 0, 0, 0)", strokeColour: ["#000"], ...options });
         this._endPoint = endPoint;
         this.lineWidth = options?.lineWidth ?? 1;
     }
@@ -78,7 +78,7 @@ export class Line extends Shape {
 
         const center = g2l(this.center());
 
-        ctx.strokeStyle = this.strokeColour;
+        ctx.strokeStyle = this.strokeColour[0];
         ctx.beginPath();
         ctx.moveTo(g2lx(this.refPoint.x) - center.x, g2ly(this.refPoint.y) - center.y);
         ctx.lineTo(g2lx(this.endPoint.x) - center.x, g2ly(this.endPoint.y) - center.y);

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -21,15 +21,15 @@ export class Polygon extends Shape {
     type: SHAPE_TYPE = "polygon";
     private _vertices: GlobalPoint[] = [];
     openPolygon = false;
-    lineWidth: number;
+    lineWidth: number[];
 
     constructor(
         startPoint: GlobalPoint,
         vertices?: GlobalPoint[],
         options?: {
             fillColour?: string;
-            strokeColour?: string;
-            lineWidth?: number;
+            strokeColour?: string[];
+            lineWidth?: number[];
             openPolygon?: boolean;
             id?: LocalId;
             uuid?: GlobalId;
@@ -38,7 +38,7 @@ export class Polygon extends Shape {
         super(startPoint, options);
         this._vertices = vertices || [];
         this.openPolygon = options?.openPolygon ?? false;
-        this.lineWidth = options?.lineWidth ?? 2;
+        this.lineWidth = options?.lineWidth ?? [2];
     }
 
     get isClosed(): boolean {
@@ -73,7 +73,7 @@ export class Polygon extends Shape {
         return Object.assign(this.getBaseDict(), {
             vertices: this._vertices.map((v) => toArrayP(v)),
             open_polygon: this.openPolygon,
-            line_width: this.lineWidth,
+            line_width: this.lineWidth[0],
         });
     }
 
@@ -81,7 +81,7 @@ export class Polygon extends Shape {
         super.fromDict(data);
         this._vertices = data.vertices.map((v) => toGP(v));
         this.openPolygon = data.open_polygon;
-        this.lineWidth = data.line_width;
+        this.lineWidth = [data.line_width];
     }
 
     getBoundingBox(delta = 0): BoundingRect {
@@ -126,10 +126,7 @@ export class Polygon extends Shape {
 
         ctx.lineCap = "round";
         ctx.lineJoin = "round";
-        ctx.lineWidth = this.ignoreZoomSize ? this.lineWidth : g2lz(this.lineWidth);
 
-        if (this.strokeColour === "fog") ctx.strokeStyle = getFogColour();
-        else ctx.strokeStyle = this.strokeColour;
         if (this.fillColour === "fog") ctx.fillStyle = getFogColour();
         else ctx.fillStyle = this.fillColour;
 
@@ -147,12 +144,22 @@ export class Polygon extends Shape {
         }
 
         if (!this.openPolygon) ctx.fill();
+
+        for (const [i, c] of this.strokeColour.entries()) {
+            const lw = this.lineWidth[i] ?? this.lineWidth[0];
+            ctx.lineWidth = this.ignoreZoomSize ? lw : g2lz(lw);
+
+            if (c === "fog") ctx.strokeStyle = getFogColour();
+            else ctx.strokeStyle = c;
+            ctx.stroke();
+        }
+
         ctx.stroke();
         super.drawPost(ctx);
     }
 
     contains(point: GlobalPoint, nearbyThreshold?: number): boolean {
-        if (nearbyThreshold === undefined) nearbyThreshold = this.lineWidth;
+        if (nearbyThreshold === undefined) nearbyThreshold = this.lineWidth[0];
         const bbox = this.getBoundingBox(nearbyThreshold);
         if (!bbox.contains(point)) return false;
         if (this.isClosed) return true;
@@ -216,7 +223,7 @@ export class Polygon extends Shape {
             const vertex = this.vertices[i % this.vertices.length];
 
             const info = getDistanceToSegment(point, [prevVertex, vertex]);
-            if (info.distance < this.lineWidth) {
+            if (info.distance < this.lineWidth[0]) {
                 lastVertex = i - 1;
                 nearVertex = info.nearest;
                 break;
@@ -266,7 +273,7 @@ export class Polygon extends Shape {
             const vertex = this.vertices[i % this.vertices.length];
 
             const info = getDistanceToSegment(point, [prevVertex, vertex]);
-            if (info.distance < this.lineWidth) {
+            if (info.distance < this.lineWidth[0]) {
                 this._vertices.splice(i - 1, 0, info.nearest);
 
                 if (!this.preventSync) sendShapePositionUpdate([this], false);

--- a/client/src/game/shapes/variants/rect.ts
+++ b/client/src/game/shapes/variants/rect.ts
@@ -15,7 +15,7 @@ export class Rect extends BaseRect {
         topleft: GlobalPoint,
         w: number,
         h: number,
-        options?: { fillColour?: string; strokeColour?: string; id?: LocalId; uuid?: GlobalId },
+        options?: { fillColour?: string; strokeColour?: string[]; id?: LocalId; uuid?: GlobalId },
     ) {
         super(topleft, w, h, options);
     }
@@ -36,8 +36,8 @@ export class Rect extends BaseRect {
         const loc = g2l(this.refPoint);
         const center = g2l(this.center());
         ctx.fillRect(loc.x - center.x, loc.y - center.y, this.w * z, this.h * z);
-        if (this.strokeColour !== "rgba(0, 0, 0, 0)") {
-            ctx.strokeStyle = this.strokeColour;
+        if (this.strokeColour[0] !== "rgba(0, 0, 0, 0)") {
+            ctx.strokeStyle = this.strokeColour[0];
             ctx.lineWidth = this.strokeWidth;
             ctx.strokeRect(loc.x - center.x, loc.y - center.y, this.w * z, this.h * z);
         }

--- a/client/src/game/shapes/variants/text.ts
+++ b/client/src/game/shapes/variants/text.ts
@@ -24,7 +24,7 @@ export class Text extends Shape {
         public fontSize: number,
         options?: {
             fillColour?: string;
-            strokeColour?: string;
+            strokeColour?: string[];
             id?: LocalId;
             uuid?: GlobalId;
         },
@@ -75,8 +75,8 @@ export class Text extends Shape {
             if (textInfo.width > this.width) this.width = textInfo.width;
             this.height += textInfo.actualBoundingBoxAscent + textInfo.actualBoundingBoxDescent;
 
-            if (this.strokeColour !== "rgba(0,0,0,0)") {
-                ctx.strokeStyle = this.strokeColour;
+            if (this.strokeColour[0] !== "rgba(0,0,0,0)") {
+                ctx.strokeStyle = this.strokeColour[0];
                 ctx.strokeText(line.text, line.x, line.y);
             }
             ctx.fillText(line.text, line.x, line.y);

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -31,7 +31,7 @@ export class ToggleComposite extends Shape {
         private _variants: { uuid: LocalId; name: string }[],
         options?: {
             fillColour?: string;
-            strokeColour?: string;
+            strokeColour?: string[];
             id?: LocalId;
             uuid?: GlobalId;
         },

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -125,7 +125,7 @@ class DrawTool extends Tool {
             () => {
                 if (this.brushHelper) {
                     this.brushHelper.fillColour = this.state.fillColour;
-                    this.brushHelper.strokeColour = mostReadable(this.state.fillColour);
+                    this.brushHelper.strokeColour = [mostReadable(this.state.fillColour)];
                 }
             },
         );
@@ -334,21 +334,21 @@ class DrawTool extends Tool {
                 case DrawShape.Square: {
                     this.shape = new Rect(cloneP(startPoint), 0, 0, {
                         fillColour: this.state.fillColour,
-                        strokeColour: this.state.borderColour,
+                        strokeColour: [this.state.borderColour],
                     });
                     break;
                 }
                 case DrawShape.Circle: {
                     this.shape = new Circle(cloneP(startPoint), this.helperSize, {
                         fillColour: this.state.fillColour,
-                        strokeColour: this.state.borderColour,
+                        strokeColour: [this.state.borderColour],
                     });
                     break;
                 }
                 case DrawShape.Brush: {
                     this.shape = new Polygon(cloneP(startPoint), [], {
-                        strokeColour: this.state.fillColour,
-                        lineWidth: this.state.brushSize,
+                        strokeColour: [this.state.fillColour],
+                        lineWidth: [this.state.brushSize],
                         openPolygon: true,
                     });
                     this.shape.fillColour = this.state.fillColour;
@@ -362,8 +362,8 @@ class DrawTool extends Tool {
                     }
                     this.shape = new Polygon(cloneP(this.brushHelper.refPoint), [], {
                         fillColour: fill,
-                        strokeColour: stroke,
-                        lineWidth: this.state.brushSize,
+                        strokeColour: [stroke],
+                        lineWidth: [this.state.brushSize],
                         openPolygon: !this.state.isClosedPolygon,
                     });
                     break;
@@ -377,7 +377,7 @@ class DrawTool extends Tool {
                     }
                     this.shape = new Text(cloneP(this.brushHelper.refPoint), text, this.state.fontSize, {
                         fillColour: this.state.fillColour,
-                        strokeColour: this.state.borderColour,
+                        strokeColour: [this.state.borderColour],
                     });
                     break;
                 }
@@ -439,7 +439,7 @@ class DrawTool extends Tool {
             if (this.ruler === undefined) {
                 this.ruler = new Line(lastPoint, lastPoint, {
                     lineWidth: this.state.brushSize,
-                    strokeColour: this.state.fillColour,
+                    strokeColour: [this.state.fillColour],
                 });
                 layer.addShape(this.ruler, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
             } else {
@@ -626,7 +626,7 @@ class DrawTool extends Tool {
         const size = brushSize ?? this.state.brushSize / 2;
         const brush = new Circle(position, size, {
             fillColour: this.state.fillColour,
-            strokeColour: mostReadable(this.state.fillColour),
+            strokeColour: [mostReadable(this.state.fillColour)],
             strokeWidth: Math.max(1, size * 0.05),
         });
         // Make sure we can see the border of the reveal brush
@@ -642,7 +642,7 @@ class DrawTool extends Tool {
             vertices.map((v) => addP(v, vec)),
             {
                 fillColour: "white",
-                strokeColour: "black",
+                strokeColour: ["black"],
                 openPolygon: false,
             },
         );

--- a/client/src/game/tools/variants/map.ts
+++ b/client/src/game/tools/variants/map.ts
@@ -103,7 +103,7 @@ class MapTool extends Tool {
 
         this.active.value = true;
 
-        this.rect = new Rect(cloneP(this.startPoint), 0, 0, { fillColour: "rgba(0,0,0,0)", strokeColour: "black" });
+        this.rect = new Rect(cloneP(this.startPoint), 0, 0, { fillColour: "rgba(0,0,0,0)", strokeColour: ["black"] });
         this.state.hasRect = true;
         this.rect.preventSync = true;
         layer.addShape(this.rect, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });

--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -56,7 +56,7 @@ class PingTool extends Tool {
         this.ping = new Circle(this.startPoint, 20, { fillColour: clientStore.state.rulerColour });
         this.border = new Circle(this.startPoint, 40, {
             fillColour: "#0000",
-            strokeColour: clientStore.state.rulerColour,
+            strokeColour: [clientStore.state.rulerColour],
         });
         this.ping.ignoreZoomSize = true;
         this.border.ignoreZoomSize = true;

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -52,7 +52,7 @@ class RulerTool extends Tool {
     private createNewRuler(start: GlobalPoint, end: GlobalPoint): void {
         const ruler = new Line(start, end, {
             lineWidth: 5,
-            strokeColour: clientStore.state.rulerColour,
+            strokeColour: [clientStore.state.rulerColour],
         });
         ruler.ignoreZoomSize = true;
 
@@ -90,7 +90,7 @@ class RulerTool extends Tool {
         this.createNewRuler(cloneP(this.startPoint), cloneP(this.startPoint));
         this.text = new Text(cloneP(this.startPoint), "", 20, {
             fillColour: "#000",
-            strokeColour: "#fff",
+            strokeColour: ["#fff"],
         });
         this.text.ignoreZoomSize = true;
         accessSystem.addAccess(

--- a/client/src/game/tools/variants/select.ts
+++ b/client/src/game/tools/variants/select.ts
@@ -351,7 +351,7 @@ class SelectTool extends Tool implements ISelectTool {
             if (this.selectionHelper === undefined) {
                 this.selectionHelper = new Rect(this.selectionStartPoint, 0, 0, {
                     fillColour: "rgba(0, 0, 0, 0)",
-                    strokeColour: "#7c253e",
+                    strokeColour: ["#7c253e"],
                 });
                 this.selectionHelper.strokeWidth = 2;
                 this.selectionHelper.options.UiHelper = true;
@@ -798,13 +798,16 @@ class SelectTool extends Tool implements ISelectTool {
         const topCenterPlus = addP(topCenter, new Vector(0, -DEFAULT_GRID_SIZE));
 
         this.angle = 0;
-        this.rotationAnchor = new Line(topCenter, topCenterPlus, { lineWidth: l2gz(1.5), strokeColour: "#7c253e" });
+        this.rotationAnchor = new Line(topCenter, topCenterPlus, { lineWidth: l2gz(1.5), strokeColour: ["#7c253e"] });
         this.rotationBox = new Rect(bbox.topLeft, bbox.w, bbox.h, {
             fillColour: "rgba(0,0,0,0)",
-            strokeColour: "#7c253e",
+            strokeColour: ["#7c253e"],
         });
         this.rotationBox.strokeWidth = 1.5;
-        this.rotationEnd = new Circle(topCenterPlus, l2gz(4), { fillColour: "#7c253e", strokeColour: "rgba(0,0,0,0)" });
+        this.rotationEnd = new Circle(topCenterPlus, l2gz(4), {
+            fillColour: "#7c253e",
+            strokeColour: ["rgba(0,0,0,0)"],
+        });
 
         for (const rotationShape of [this.rotationAnchor, this.rotationBox, this.rotationEnd]) {
             accessSystem.addAccess(
@@ -870,7 +873,7 @@ class SelectTool extends Tool implements ISelectTool {
 
         this.removePolygonEditUi();
 
-        this.polygonTracer = new Circle(toGP(0, 0), 3, { fillColour: "rgba(0,0,0,0)", strokeColour: "black" });
+        this.polygonTracer = new Circle(toGP(0, 0), 3, { fillColour: "rgba(0,0,0,0)", strokeColour: ["black"] });
         const drawLayer = floorStore.getLayer(floorStore.currentFloor.value!, LayerName.Draw)!;
         drawLayer.addShape(this.polygonTracer, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
         this.updatePolygonEditUi(this.lastMousePosition);
@@ -896,15 +899,15 @@ class SelectTool extends Tool implements ISelectTool {
         const selection = selectionState.get({ includeComposites: false });
         const polygon = selection[0] as Polygon;
 
-        const pw = g2lz(polygon.lineWidth);
+        const pw = g2lz(polygon.lineWidth[0]);
 
         const pv = polygon.vertices;
-        let smallest = { distance: polygon.lineWidth * 2, nearest: gp, angle: 0, point: false };
+        let smallest = { distance: polygon.lineWidth[0] * 2, nearest: gp, angle: 0, point: false };
         for (let i = 1; i < pv.length; i++) {
             const prevVertex = pv[i - 1];
             const vertex = pv[i];
             // check prev-vertex
-            if (getPointDistance(prevVertex, gp) < polygon.lineWidth / 1.5) {
+            if (getPointDistance(prevVertex, gp) < polygon.lineWidth[0] / 1.5) {
                 const vec = Vector.fromPoints(prevVertex, vertex);
                 let angle;
                 if (i === 1) {
@@ -918,16 +921,16 @@ class SelectTool extends Tool implements ISelectTool {
             }
             // check edge
             const info = getDistanceToSegment(gp, [prevVertex, vertex]);
-            if (info.distance < polygon.lineWidth / 1.5 && info.distance < smallest.distance) {
+            if (info.distance < polygon.lineWidth[0] / 1.5 && info.distance < smallest.distance) {
                 smallest = { ...info, angle: Vector.fromPoints(prevVertex, vertex).deg(), point: false };
             }
         }
         //check last vertex
-        if (getPointDistance(pv.at(-1)!, gp) < polygon.lineWidth / 2) {
+        if (getPointDistance(pv.at(-1)!, gp) < polygon.lineWidth[0] / 2) {
             smallest = { distance: 0, nearest: pv.at(-1)!, point: true, angle: smallest.angle };
         }
         // Show the UI
-        if (smallest.distance <= polygon.lineWidth) {
+        if (smallest.distance <= polygon.lineWidth[0]) {
             this.polygonUiVisible.value = "visible";
             this.polygonTracer!.refPoint = smallest.nearest;
             this.polygonTracer!.layer.invalidate(true);

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -113,7 +113,7 @@ class SpellTool extends Tool {
         if (this.shape === undefined) return;
 
         this.shape.fillColour = this.state.colour.replace(")", ", 0.7)");
-        this.shape.strokeColour = this.state.colour;
+        this.shape.strokeColour = [this.state.colour];
         accessSystem.addAccess(
             this.shape.id,
             clientStore.state.username,
@@ -148,7 +148,7 @@ class SpellTool extends Tool {
         const selection = [...selectionState.state.selection.values()];
         this.rangeShape = new Circle(getShape(selection[0])!.center(), getUnitDistance(this.state.range), {
             fillColour: "rgba(0,0,0,0)",
-            strokeColour: "black",
+            strokeColour: ["black"],
         });
         layer.addShape(this.rangeShape, SyncMode.NO_SYNC, InvalidationMode.NORMAL, { snappable: false });
     }

--- a/client/src/game/ui/settings/shape/ExtraSettings.vue
+++ b/client/src/game/ui/settings/shape/ExtraSettings.vue
@@ -118,7 +118,7 @@ function applyDDraft(): void {
 
     for (const wall of dDraftData.ddraft_line_of_sight) {
         const points = wall.map((w) => toGP(targetRP.x + w.x * size * dW, targetRP.y + w.y * size * dH));
-        const shape = new Polygon(points[0], points.slice(1), { openPolygon: true, strokeColour: "red" });
+        const shape = new Polygon(points[0], points.slice(1), { openPolygon: true, strokeColour: ["red"] });
         accessSystem.addAccess(
             shape.id,
             clientStore.state.username,
@@ -133,7 +133,7 @@ function applyDDraft(): void {
 
     for (const portal of dDraftData.ddraft_portals) {
         const points = portal.bounds.map((w) => toGP(targetRP.x + w.x * size * dW, targetRP.y + w.y * size * dH));
-        const shape = new Polygon(points[0], points.slice(1), { openPolygon: true, strokeColour: "blue" });
+        const shape = new Polygon(points[0], points.slice(1), { openPolygon: true, strokeColour: ["blue"] });
         accessSystem.addAccess(
             shape.id,
             clientStore.state.username,

--- a/client/src/game/ui/settings/shape/PropertySettings.vue
+++ b/client/src/game/ui/settings/shape/PropertySettings.vue
@@ -174,7 +174,7 @@ function setValue(event: Event): void {
         <div class="row">
             <label for="shapeselectiondialog-strokecolour">{{ t("common.border_color") }}</label>
             <ColourPicker
-                :colour="activeShapeStore.state.strokeColour"
+                :colour="activeShapeStore.state.strokeColour?.[0]"
                 @input:colour="setStrokeColour($event, true)"
                 @update:colour="setStrokeColour($event)"
                 style="grid-column-start: toggle"

--- a/client/src/game/ui/tokendialog/CreateTokenDialog.vue
+++ b/client/src/game/ui/tokendialog/CreateTokenDialog.vue
@@ -50,7 +50,7 @@ function submit(): void {
         getUnitDistance(settingsStore.unitSize.value / 2),
         text.value || "X",
         "10px serif",
-        { fillColour: fillColour.value, strokeColour: borderColour.value },
+        { fillColour: fillColour.value, strokeColour: [borderColour.value] },
     );
     accessSystem.addAccess(token.id, clientStore.state.username, { edit: true, movement: true, vision: true }, UI_SYNC);
     layer.addShape(token, SyncMode.FULL_SYNC, InvalidationMode.WITH_LIGHT);

--- a/client/src/store/activeShape.ts
+++ b/client/src/store/activeShape.ts
@@ -34,7 +34,7 @@ interface ActiveShapeState {
     nameVisible: boolean;
     isToken: boolean;
     isInvisible: boolean;
-    strokeColour: string | undefined;
+    strokeColour: string[] | undefined;
     fillColour: string | undefined;
     blocksMovement: boolean;
     blocksVision: boolean;
@@ -179,7 +179,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
     setStrokeColour(colour: string, syncTo: Sync): void {
         if (this._state.id === undefined) return;
 
-        this._state.strokeColour = colour;
+        this._state.strokeColour = [colour];
 
         if (!syncTo.ui) {
             const shape = getShape(this._state.id)!;


### PR DESCRIPTION
The client viewports were made with a single black stroke, meaning they become invisible on a black or dark background.

They now have a double stroke using black and white to make sure one of the two is always visible.