### PR TITLE
feat(UI): Show loading animation earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ these changes will usually be stripped from release notes for the public
 -   Add white outline to the door logic (un)lock icons
 -   Door logic can now specify which block settings to toggle
 -   Add double stroke to client viewport
+-   Show campaign loading animation earlier (in dashboard)
 -   [tech] SyncTo primitive modified to an alternative Sync structure
 -   [tech] Polygon can now have client-side multi-stroke
 

--- a/client/src/dashboard/SessionList.vue
+++ b/client/src/dashboard/SessionList.vue
@@ -4,6 +4,8 @@ import { useI18n } from "vue-i18n";
 
 import { useModal } from "../core/plugins/modals/plugin";
 import { baseAdjust, baseAdjustedFetch, deleteFetch, getValue, patchFetch } from "../core/utils";
+import { router } from "../router";
+import { coreStore } from "../store/core";
 
 import type { RoomInfo } from "./types";
 
@@ -35,6 +37,11 @@ watch(selected, async () => updateInfo());
 async function select(index: number): Promise<void> {
     selectedIndex.value = index;
     await updateInfo();
+}
+
+async function open(session: RoomInfo): Promise<void> {
+    coreStore.setLoading(true);
+    await router.push(`/game/${encodeURIComponent(session.creator)}/${encodeURIComponent(session.name)}`);
 }
 
 async function updateInfo(): Promise<void> {
@@ -119,13 +126,9 @@ async function leaveOrDelete(): Promise<void> {
                 <div class="name">{{ room.name }}</div>
                 <div class="logo">
                     <img :src="baseAdjust(room.logo ? `/static/assets/${room.logo}` : '/static/img/d20.svg')" />
-                    <router-link
-                        v-if="dmMode || !room.is_locked"
-                        class="launch"
-                        :to="'/game/' + encodeURIComponent(room.creator) + '/' + encodeURIComponent(room.name)"
-                    >
+                    <div v-if="dmMode || !room.is_locked" class="launch" @click="open(room)">
                         <font-awesome-icon icon="play" />
-                    </router-link>
+                    </div>
                     <div v-else class="launch"><font-awesome-icon icon="lock" /></div>
                 </div>
             </div>
@@ -140,13 +143,7 @@ async function leaveOrDelete(): Promise<void> {
                 <font-awesome-icon v-if="dmMode" @click="rename" icon="pencil-alt" />
             </div>
             <div class="creator">by {{ selected.creator }}</div>
-            <router-link
-                v-if="dmMode || !selected.is_locked"
-                class="launch"
-                :to="'/game/' + encodeURIComponent(selected.creator) + '/' + encodeURIComponent(selected.name)"
-            >
-                LAUNCH!
-            </router-link>
+            <div v-if="dmMode || !selected.is_locked" class="launch" @click="open(selected!)">LAUNCH!</div>
             <div v-else class="launch">ROOM LOCKED</div>
             <div :style="{ flexGrow: 1 }"></div>
             <div class="header">Last playtime</div>


### PR DESCRIPTION
The loading animation started when the route had been set. Depending on how fast the route changing happens, it could sometimes look like nothing is happening.

To remedy this, I'm showing the loading animation from the moment you click on launch.