### PR TITLE
feat(Server): Add log rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ client/node_modules/**
 admin-client/node_modules/**
 
 # PlanarAlly
-server/planarallyserver.log
+server/planarallyserver.log*
 server/planar.save*
 server/*.sqlite*
 server/save_backups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ these changes will usually be stripped from release notes for the public
 -   Door logic can now specify which block settings to toggle
 -   Add double stroke to client viewport
 -   Show campaign loading animation earlier (in dashboard)
+-   [server] Added log rotation
 -   [tech] SyncTo primitive modified to an alternative Sync structure
 -   [tech] Polygon can now have client-side multi-stroke
 

--- a/Dockerfiles/server_config_docker.cfg
+++ b/Dockerfiles/server_config_docker.cfg
@@ -22,6 +22,11 @@ ssl_privkey = cert/privkey.pem
 save_file = data/planar.sqlite
 #public_name = 
 
+# These settings are used for log rotating,
+# see https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler for details
+max_log_size_in_bytes = 2000
+max_log_backups = 5
+
 allow_signups = true
 
 [APIserver]

--- a/server/api/socket/asset.py
+++ b/server/api/socket/asset.py
@@ -7,7 +7,7 @@ from app import app, sio
 from models import Asset, PlayerRoom
 from models.role import Role
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 class AssetOptions(TypedDict):

--- a/server/api/socket/asset_manager/__init__.py
+++ b/server/api/socket/asset_manager/__init__.py
@@ -21,7 +21,7 @@ from models import Asset
 from models.user import User
 from state.asset import asset_state
 from state.game import game_state
-from utils import logger
+from logs import logger
 from ..constants import ASSET_NS, GAME_NS
 from .common import UploadData
 from .ddraft import ASSETS_DIR, handle_ddraft_file

--- a/server/api/socket/connection.py
+++ b/server/api/socket/connection.py
@@ -8,7 +8,7 @@ from app import sio
 from models import PlayerRoom, Room, User
 from models.role import Role
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 @sio.on("connect", namespace=GAME_NS)

--- a/server/api/socket/floor.py
+++ b/server/api/socket/floor.py
@@ -8,7 +8,7 @@ from models import Floor, PlayerRoom
 from models.db import db
 from models.role import Role
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 # DATA CLASSES FOR TYPE CHECKING
 class FloorRename(TypedDict):

--- a/server/api/socket/groups.py
+++ b/server/api/socket/groups.py
@@ -7,7 +7,7 @@ from api.socket.constants import GAME_NS
 from app import app, sio
 from models import Group, PlayerRoom, Shape
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 class ServerGroup(TypedDict):

--- a/server/api/socket/initiative.py
+++ b/server/api/socket/initiative.py
@@ -14,7 +14,7 @@ from models.db import db
 from models.role import Role
 from models.shape.access import has_ownership
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 class ServerInitiativeEffect(TypedDict):

--- a/server/api/socket/label.py
+++ b/server/api/socket/label.py
@@ -6,7 +6,7 @@ from api.socket.constants import GAME_NS
 from app import app, sio
 from models import Label, LabelSelection, PlayerRoom, User
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 class LabelVisibilityMessage(TypedDict):

--- a/server/api/socket/location.py
+++ b/server/api/socket/location.py
@@ -24,7 +24,7 @@ from models.asset import Asset
 from models.label import Label, LabelSelection
 from models.role import Role
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 from config import config
 

--- a/server/api/socket/note.py
+++ b/server/api/socket/note.py
@@ -6,7 +6,7 @@ from app import app, sio
 from models import Note, PlayerRoom
 from models.db import db
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 @sio.on("Note.New", namespace=GAME_NS)

--- a/server/api/socket/player.py
+++ b/server/api/socket/player.py
@@ -7,7 +7,7 @@ from models import PlayerRoom
 from models.role import Role
 from models.user import User
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 class BringPlayersData(TypedDict):

--- a/server/api/socket/room.py
+++ b/server/api/socket/room.py
@@ -7,7 +7,7 @@ from models import PlayerRoom
 from models.role import Role
 from models.user import User
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 @sio.on("Room.Info.InviteCode.Refresh", namespace=GAME_NS)

--- a/server/api/socket/shape/__init__.py
+++ b/server/api/socket/shape/__init__.py
@@ -28,7 +28,7 @@ from models.role import Role
 from models.shape.access import has_ownership
 from models.utils import get_table, reduce_data_to_model
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 from . import access, options, toggle_composite
 

--- a/server/api/socket/shape/access.py
+++ b/server/api/socket/shape/access.py
@@ -6,7 +6,7 @@ from models import PlayerRoom, Shape, ShapeOwner, User
 from models.role import Role
 from models.shape.access import has_ownership
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 @sio.on("Shape.Owner.Add", namespace=GAME_NS)

--- a/server/api/socket/shape/utils.py
+++ b/server/api/socket/shape/utils.py
@@ -3,7 +3,7 @@ from typing import Generator, Union
 from models import PlayerRoom, Shape
 from models.shape.access import has_ownership
 from state.game import game_state
-from utils import logger
+from logs import logger
 
 
 def get_shape_or_none(pr: PlayerRoom, shape_id: str, action: str) -> Union[Shape, None]:

--- a/server/logs.py
+++ b/server/logs.py
@@ -1,0 +1,25 @@
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
+
+from config import config
+from utils import FILE_DIR
+
+# SETUP LOGGING
+
+logger = logging.getLogger("PlanarAllyServer")
+logger.setLevel(logging.INFO)
+file_handler = RotatingFileHandler(
+    str(FILE_DIR / "planarallyserver.log"),
+    maxBytes=config.getint("General", "max_log_size_in_bytes"),
+    backupCount=config.getint("General", "max_log_backups")
+)
+file_handler.setLevel(logging.INFO)
+formatter = logging.Formatter(
+    "%(asctime)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+)
+file_handler.setFormatter(formatter)
+stream_handler = logging.StreamHandler(sys.stdout)
+stream_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+logger.addHandler(stream_handler)

--- a/server/models/shape/__init__.py
+++ b/server/models/shape/__init__.py
@@ -5,7 +5,7 @@ from peewee import BooleanField, FloatField, ForeignKeyField, IntegerField, Text
 from playhouse.shortcuts import model_to_dict, update_model_from_dict
 from typing import Any, Dict, List, Tuple
 
-from utils import logger
+from logs import logger
 from ..asset import Asset
 from ..base import BaseModel
 from ..campaign import Layer

--- a/server/planarserver.py
+++ b/server/planarserver.py
@@ -33,8 +33,8 @@ from api.socket import *
 from api.socket.constants import GAME_NS
 from app import admin_app, app as main_app, runners, setup_runner, sio
 from config import config
+from logs import logger
 from models import User, Room
-from utils import logger
 
 loop = asyncio.new_event_loop()
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -12,7 +12,7 @@ from app import admin_app, api_app, app as main_app
 from config import config
 from models import Room, User
 from models.role import Role
-from utils import logger
+from logs import logger
 
 
 subpath = os.environ.get("PA_BASEPATH", "/")

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -22,6 +22,11 @@ ssl_privkey = cert/privkey.pem
 save_file = planar.sqlite
 #public_name = 
 
+# These settings are used for log rotating,
+# see https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler for details
+max_log_size_in_bytes = 2000
+max_log_backups = 5
+
 allow_signups = true
 
 [APIserver]

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import sys
 from pathlib import Path
@@ -25,21 +24,6 @@ SAVE_DIR = get_save_dir()
 
 # SETUP PATHS
 os.chdir(FILE_DIR)
-
-# SETUP LOGGING
-
-logger = logging.getLogger("PlanarAllyServer")
-logger.setLevel(logging.INFO)
-file_handler = logging.FileHandler(str(FILE_DIR / "planarallyserver.log"))
-file_handler.setLevel(logging.INFO)
-formatter = logging.Formatter(
-    "%(asctime)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
-)
-file_handler.setFormatter(formatter)
-stream_handler = logging.StreamHandler(sys.stdout)
-stream_handler.setFormatter(formatter)
-logger.addHandler(file_handler)
-logger.addHandler(stream_handler)
 
 
 class OldVersionException(Exception):


### PR DESCRIPTION
The PA server outputs log info to both console and disk. This disk log was up to now never cleared/truncated by PA itself and thus relied on the server admin themselves to monitor the size of this file.

This PR adds log rotation in the form of Python's built-in [RotatingFileHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler).

It can be configured in the server-config and defaults to 2kB files and 5 rotating backups.