### PR TITLE
feat(Export): Add export all endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ these changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Added
+
+-   Export all campaigns endpoint
+
 ### Changed
 
 -   Add white outline to the door logic (un)lock icons

--- a/server/api/http/rooms.py
+++ b/server/api/http/rooms.py
@@ -185,9 +185,25 @@ async def export(request: web.Request):
         if room is None:
             return web.HTTPBadRequest()
 
-        asyncio.create_task(export_campaign(room))
+        asyncio.create_task(export_campaign(f"{roomname}-{creator}", [room]))
 
         return web.HTTPAccepted(
             text=f"Processing started. Check /static/temp/{room.name}-{room.creator.name}.pac soon."
+        )
+    return web.HTTPUnauthorized()
+
+
+async def export_all(request: web.Request):
+    user: User = await check_authorized(request)
+
+    creator = request.match_info["creator"]
+
+    if creator == user.name:
+        rooms = [r for r in user.rooms_created]
+
+        asyncio.create_task(export_campaign(f"{creator}-all", rooms))
+
+        return web.HTTPAccepted(
+            text=f"Processing started. Check /static/temp/{creator}-all.pac soon."
         )
     return web.HTTPUnauthorized()

--- a/server/models/campaign.py
+++ b/server/models/campaign.py
@@ -61,6 +61,7 @@ class LocationOptions(BaseModel):
 
 
 class Room(BaseModel):
+    id: int
     logo_id: Optional[int]
     players: List["PlayerRoom"]
     locations: List["Location"]

--- a/server/models/user.py
+++ b/server/models/user.py
@@ -14,6 +14,7 @@ from .base import BaseModel
 
 if TYPE_CHECKING:
     from models.label import Label
+    from models.campaign import Room
 
 
 __all__ = ["User", "UserOptions"]
@@ -66,6 +67,7 @@ class UserOptions(BaseModel):
 class User(BaseModel):
     id: int
     labels: List["Label"]
+    rooms_created: List["Room"]
 
     name = TextField()
     email = TextField(null=True)

--- a/server/routes.py
+++ b/server/routes.py
@@ -101,6 +101,9 @@ main_app.router.add_patch(
 main_app.router.add_get(
     f"{subpath}/api/rooms/{{creator}}/{{roomname}}/export", api.http.rooms.export
 )
+main_app.router.add_get(
+    f"{subpath}/api/rooms/{{creator}}/export", api.http.rooms.export_all
+)
 main_app.router.add_post(f"{subpath}/api/invite", api.http.claim_invite)
 main_app.router.add_get(f"{subpath}/api/version", api.http.version.get_version)
 main_app.router.add_get(f"{subpath}/api/changelog", api.http.version.get_changelog)


### PR DESCRIPTION
Further work on export internals.
The export all endpoint is `/api/rooms/<username>/export`.

The intention is to have UI to interact with all export related things in the future.

Bear in mind that this endpoint also packs all assets that you've uploaded, not just those that are linked to an active campaign.