### PR TITLE
bug(UI): Fix modal handling on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ these changes will usually be stripped from release notes for the public
 -   Asset Manager correctly updates UI when using browser back/forward buttons
 -   Clear client viewports when changing location
 -   Dashboard navigation headers sometimes being wrongly styled
+-   Modal handling on firefox
 -   [tech] Ensure router.push calls are always awaited
 
 ## [2022.1] - 2022-04-25

--- a/client/src/core/components/modals/Modal.vue
+++ b/client/src/core/components/modals/Modal.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 
+import { clearDropCallback, registerDropCallback } from "../../../game/ui/firefox";
+
 const props = withDefaults(defineProps<{ colour?: string; mask?: boolean; visible: boolean }>(), {
     colour: "white",
     mask: true,
@@ -64,6 +66,7 @@ function updatePosition(): void {
 
 function dragStart(event: DragEvent): void {
     if (event === null || event.dataTransfer === null) return;
+    registerDropCallback(dragEnd);
     event.dataTransfer.setData("Hack", "");
     // Because the drag event is happening on the header, we have to change the drag image
     // in order to give the impression that the entire modal is dragged.
@@ -76,20 +79,23 @@ function dragStart(event: DragEvent): void {
 }
 
 function dragEnd(event: DragEvent): void {
-    dragging = false;
-    containerX = event.clientX - offsetX;
-    containerY = event.clientY - offsetY;
-    if (event.clientX === 0 && event.clientY === 0 && event.pageX === 0 && event.pageY === 0) {
-        containerX = parseInt(container.value!.style.left, 10) - (screenX - event.screenX);
-        containerY = parseInt(container.value!.style.top, 10) - (screenY - event.screenY);
+    if (dragging) {
+        dragging = false;
+        clearDropCallback();
+        containerX = event.clientX - offsetX;
+        containerY = event.clientY - offsetY;
+        if (event.clientX === 0 && event.clientY === 0 && event.pageX === 0 && event.pageY === 0) {
+            containerX = parseInt(container.value!.style.left, 10) - (screenX - event.screenX);
+            containerY = parseInt(container.value!.style.top, 10) - (screenY - event.screenY);
+        }
+        if (containerX < 0) containerX = 0;
+        if (containerX > window.innerWidth - 100) containerX = window.innerWidth - 100;
+        if (containerY < 0) containerY = 0;
+        if (containerY > window.innerHeight - 100) containerY = window.innerHeight - 100;
+        container.value!.style.left = `${containerX}px`;
+        container.value!.style.top = `${containerY}px`;
+        container.value!.style.display = "block";
     }
-    if (containerX < 0) containerX = 0;
-    if (containerX > window.innerWidth - 100) containerX = window.innerWidth - 100;
-    if (containerY < 0) containerY = 0;
-    if (containerY > window.innerHeight - 100) containerY = window.innerHeight - 100;
-    container.value!.style.left = `${containerX}px`;
-    container.value!.style.top = `${containerY}px`;
-    container.value!.style.display = "block";
 }
 
 function dragOver(_event: DragEvent): void {

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -27,6 +27,7 @@ import {
 import UI from "./ui/UI.vue";
 
 import "./api/events";
+import { handleDrop } from "./ui/firefox";
 
 export default defineComponent({
     // eslint-disable-next-line vue/multi-word-component-names
@@ -107,6 +108,7 @@ export default defineComponent({
 
         async function drop(event: DragEvent): Promise<void> {
             if (event === null || event.dataTransfer === null) return;
+            handleDrop(event); // FF modal handling workaround
             if (event.dataTransfer.files.length > 0) {
                 await modals.confirm("Warning", "Uploading files should be done through the asset manager.", {
                     yes: "Ok",

--- a/client/src/game/ui/firefox.ts
+++ b/client/src/game/ui/firefox.ts
@@ -1,0 +1,16 @@
+/**
+ * This is a helper file to deal with firefox bugs
+ */
+
+let activeDropHandler: ((event: DragEvent) => void) | undefined = undefined;
+
+export function registerDropCallback(handler: (event: DragEvent) => void): void {
+    activeDropHandler = handler;
+}
+export function clearDropCallback(): void {
+    activeDropHandler = undefined;
+}
+
+export function handleDrop(event: DragEvent): void {
+    if (activeDropHandler !== undefined) activeDropHandler(event);
+}


### PR DESCRIPTION
Firefox does not properly implement the `dragEvent` handler. Reporting wrong clientX/clientY values in multiple cases.

A workaround has been found using the `drop` handler which does report the correct values.