### PR TITLE
bug(ColorPicker): Fix saturation panel background sometimes reverting to red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ these changes will usually be stripped from release notes for the public
 -   Clear client viewports when changing location
 -   Dashboard navigation headers sometimes being wrongly styled
 -   Modal handling on firefox
+-   Color picker resetting saturation panel to red when clicking
 -   [tech] Ensure router.push calls are always awaited
 
 ## [2022.1] - 2022-04-25

--- a/client/src/core/components/ColourPicker.vue
+++ b/client/src/core/components/ColourPicker.vue
@@ -84,6 +84,10 @@ function close(): void {
     visible.value = false;
 }
 
+function isEmptyHsv(data: { h: number; s: number; v: number }): boolean {
+    return data.h === 0 && data.s === 0 && data.v === 0;
+}
+
 function onBlur(event: FocusEvent): void {
     if (event.relatedTarget === null || modal.value === null) {
         close();
@@ -179,7 +183,7 @@ function onSaturationMove(event: PointerEvent): void {
     const dY = Math.min(y - el.y, el.height);
 
     tc.value = tinycolor({
-        ...hsv.value,
+        h: isEmptyHsv(hsv.value) ? hueFallback.value : hsv.value.h,
         s: dX / el.width,
         v: clamp(1 - dY / el.height, 0, 1),
     });


### PR DESCRIPTION
The saturation panel (the top part) of the color picker would sometimes reset to the red spectrum after changing the hue (the color slider).

In particular this happens if the hsv is set to 0,0,0. This PR fixes that case