### PR TITLE
bug(DrawTool): Fix invalid shape undo errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ these changes will usually be stripped from release notes for the public
 -   Dashboard navigation headers sometimes being wrongly styled
 -   Modal handling on firefox
 -   Color picker resetting saturation panel to red when clicking
+-   Drawtool trying to add shape creation operation to undo stack when the shape was not valid
 -   [tech] Ensure router.push calls are always awaited
 
 ## [2022.1] - 2022-04-25

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -170,7 +170,6 @@ class DrawTool extends Tool {
 
     private finaliseShape(): void {
         if (this.shape === undefined) return;
-        this.shape.updateLayerPoints();
         if (this.shape.points.length <= 1) {
             let mouse: { x: number; y: number } | undefined = undefined;
             if (this.brushHelper !== undefined) {
@@ -179,28 +178,28 @@ class DrawTool extends Tool {
             this.onDeselect();
             this.onSelect(mouse);
         } else {
+            this.shape.updateLayerPoints();
             if (this.shape.blocksVision) visionState.recalculateVision(this.shape.floor.id);
             if (this.shape.blocksMovement) visionState.recalculateMovement(this.shape.floor.id);
             if (!this.shape.preventSync) sendShapeSizeUpdate({ shape: this.shape, temporary: false });
-        }
-        if (this.state.isDoor) {
-            doorSystem.inform(
-                this.shape.id,
-                true,
-                {
-                    permissions: this.state.doorPermissions,
-                    toggleMode: this.state.toggleMode,
-                },
-                true,
-            );
+            if (this.state.isDoor) {
+                doorSystem.inform(
+                    this.shape.id,
+                    true,
+                    {
+                        permissions: this.state.doorPermissions,
+                        toggleMode: this.state.toggleMode,
+                    },
+                    true,
+                );
+            }
+            overrideLastOperation({ type: "shapeadd", shapes: [this.shape.asDict()] });
         }
         this.active.value = false;
         const layer = this.getLayer();
         if (layer !== undefined) {
             layer.invalidate(false);
         }
-
-        overrideLastOperation({ type: "shapeadd", shapes: [this.shape.asDict()] });
     }
 
     // private async showLayerPoints(): Promise<void> {


### PR DESCRIPTION
When drawing shapes the draw tool will add the "shape creation" operation to the undo stack, so that you can ... undo that operation.

Before finalising a shape however the drawtool checks if the shape is valid. At the moment this means, checking if the shape has more than one point, because a single point usually refers to an accidental draw.

In this case the shape is cancelled, but the code was still trying to add this shape to the undo stack, which caused errors to appear in the console even though it didn't end up breaking anything.