### PR TITLE
bug(SelectTool): Fix polygon edit UI operations not updating snap points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ these changes will usually be stripped from release notes for the public
 -   Modal handling on firefox
 -   Color picker resetting saturation panel to red when clicking
 -   Drawtool trying to add shape creation operation to undo stack when the shape was not valid
+-   Points modified by the polygon edit UI are not snappable until a refresh
 -   [tech] Ensure router.push calls are always awaited
 
 ## [2022.1] - 2022-04-25

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -117,6 +117,7 @@ export class Polygon extends Shape {
     invalidatePoints(): void {
         const center = this.center();
         this._points = this.vertices.map((point) => this.invalidatePoint(point, center));
+        this.updateLayerPoints();
     }
 
     draw(ctx: CanvasRenderingContext2D): void {


### PR DESCRIPTION
When adding a new point to a polygon, the new point would not be snappable by other shapes until a refresh.

Similar bugs were also fixed for removing a point and cutting polygons