### PR TITLE
feat(Badge): Render shape badges better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ these changes will usually be stripped from release notes for the public
 -   Add double stroke to client viewport
 -   Show campaign loading animation earlier (in dashboard)
 -   Defeat cross now scales better with shape size
+-   Shape badge now scales better with shape size
 -   [server] Added log rotation
 -   [server] Restructure server files
 -   [tech] SyncTo primitive modified to an alternative Sync structure

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -274,7 +274,8 @@ export abstract class Shape implements IShape {
         if (this.showBadge) {
             bbox = this.getBoundingBox();
             const location = g2l(bbox.botRight);
-            const r = g2lz(10);
+            const crossLength = g2lz(Math.min(bbox.w, bbox.h));
+            const r = crossLength * 0.2;
             ctx.strokeStyle = "black";
             ctx.fillStyle = this.strokeColour[0];
             ctx.lineWidth = g2lz(2);


### PR DESCRIPTION
Shape badges now take the size of the shape into account instead of having a fixed size.