### PR TITLE
chore(Config): Improve documentation on cors setting in server config

### DIFF
--- a/Dockerfiles/server_config_docker.cfg
+++ b/Dockerfiles/server_config_docker.cfg
@@ -13,10 +13,13 @@ ssl_privkey = cert/privkey.pem
 
 # Allowed CORS origins
 #     If not specified, only the host runnig the server is allowed
-#     Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
-#     More information on the meaning of these values can be found at
-#     https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
-# cors_allowed_origins = ['*']
+#     This value is passed to the socketio server:
+#         https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+#     IMPORTANT TO NOTE HOWEVER is that this config file already interprets strings by default
+#     and you thus do not have to add extra ''.
+#     e.g. to allow cors on all simply write *  and NOT '*'
+#     If you want to pass lists, check the information on python configparser's module to see how you should write it here
+# cors_allowed_origins = *
 
 [General]
 save_file = data/planar.sqlite
@@ -37,7 +40,7 @@ enabled = false
 
 # You can choose to use a HOST:PORT connection or a socket file to listen on
 # If you specifiy a socket, it will be used instead of the HTTP:PORT connection
-host = localhost
+host = 127.0.0.1
 port = 8001
 # socket = /tmp/planarally.sock
 
@@ -49,7 +52,10 @@ ssl_privkey = cert/privkey.pem
 
 # Allowed CORS origins
 #     If not specified, only the host runnig the server is allowed
-#     Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
-#     More information on the meaning of these values can be found at
-#     https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
-# cors_allowed_origins = ['*']
+#     This value is passed to the socketio server:
+#         https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+#     IMPORTANT TO NOTE HOWEVER is that this config file already interprets strings by default
+#     and you thus do not have to add extra ''.
+#     e.g. to allow cors on all simply write *  and NOT '*'
+#     If you want to pass lists, check the information on python configparser's module to see how you should write it here
+# cors_allowed_origins = *

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -13,10 +13,13 @@ ssl_privkey = cert/privkey.pem
 
 # Allowed CORS origins
 #     If not specified, only the host runnig the server is allowed
-#     Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
-#     More information on the meaning of these values can be found at
-#     https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
-# cors_allowed_origins = ['*']
+#     This value is passed to the socketio server:
+#         https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+#     IMPORTANT TO NOTE HOWEVER is that this config file already interprets strings by default
+#     and you thus do not have to add extra ''.
+#     e.g. to allow cors on all simply write *  and NOT '*'
+#     If you want to pass lists, check the information on python configparser's module to see how you should write it here
+# cors_allowed_origins = *
 
 [General]
 save_file = planar.sqlite
@@ -32,12 +35,12 @@ allow_signups = true
 [APIserver]
 # The API server is an administration server on which some API calls can be made.
 # It should use a different port or socket than the main webserver.
-# It's hosted on localhost by default instead of 0.0.0.0
+# It's hosted on 127.0.0.1 by default instead of 0.0.0.0
 enabled = false
 
 # You can choose to use a HOST:PORT connection or a socket file to listen on
 # If you specifiy a socket, it will be used instead of the HTTP:PORT connection
-host = 0.0.0.0
+host = 127.0.0.1
 port = 8001
 # socket = /tmp/planarally.sock
 
@@ -49,8 +52,11 @@ ssl_privkey = cert/privkey.pem
 
 # Allowed CORS origins
 #     If not specified, only the host runnig the server is allowed
-#     Allowed values are: ['*'], ['some-address.xyz', 'other-address.xyz'], []
-#     More information on the meaning of these values can be found at
-#     https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
-# cors_allowed_origins = ['*']
+#     This value is passed to the socketio server:
+#         https://python-socketio.readthedocs.io/en/latest/api.html#asyncserver-class
+#     IMPORTANT TO NOTE HOWEVER is that this config file already interprets strings by default
+#     and you thus do not have to add extra ''.
+#     e.g. to allow cors on all simply write *  and NOT '*'
+#     If you want to pass lists, check the information on python configparser's module to see how you should write it here
+# cors_allowed_origins = *
 


### PR DESCRIPTION
The server config docs on CORS were showing python syntax instead of the configparser's mini language syntax.