### PR TITLE
bug(Docker): Build admin client in docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ these changes will usually be stripped from release notes for the public
 -   Color picker resetting saturation panel to red when clicking
 -   Drawtool trying to add shape creation operation to undo stack when the shape was not valid
 -   Points modified by the polygon edit UI are not snappable until a refresh
+-   [server] Admin client was not built in docker
 -   [tech] Ensure router.push calls are always awaited
 
 ## [2022.1] - 2022-04-25

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,16 @@
 ################################
 FROM node:16-alpine as BUILDER
 
-WORKDIR /usr/src/client
-
 # Install additional dependencies
 RUN apk add --no-cache python3 make g++
+
+WORKDIR /usr/src/admin-client
+
+# Copy first package.json so changes in code dont require to reinstall all npm modules
+COPY admin-client/package.json admin-client/package-lock.json ./
+RUN npm i
+
+WORKDIR /usr/src/client
 
 # Copy first package.json so changes in code dont require to reinstall all npm modules
 COPY client/package.json client/package-lock.json ./
@@ -15,6 +21,13 @@ RUN npm i
 ARG PA_BASEPATH="/"
 
 COPY . /usr/src
+
+WORKDIR /usr/src/admin-client
+
+RUN npm run build
+
+WORKDIR /usr/src/client
+
 RUN npm run build
 
 # Added here to avoid an extra layer in the final stage


### PR DESCRIPTION
The admin client was not being built in the Dockerfile, making it unusable.