### PR TITLE
feat(ColourPicker): Add colour memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ these changes will usually be stripped from release notes for the public
 ### Added
 
 -   Export all campaigns endpoint
+-   Colour picker now remembers the last 20 used colours for each user.
 
 ### Changed
 

--- a/client/src/core/components/store.ts
+++ b/client/src/core/components/store.ts
@@ -1,0 +1,7 @@
+/**
+ * A small store for some global component logic
+ */
+
+import { ref } from "vue";
+
+export const colourHistory = ref<string[]>([]);

--- a/client/src/game/api/emits/user.ts
+++ b/client/src/game/api/emits/user.ts
@@ -1,0 +1,3 @@
+import { wrapSocket } from "../helpers";
+
+export const sendColourHistoryChanged = wrapSocket<string>("User.ColourHistory.Set");

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -19,6 +19,7 @@ import "./events/shape/core";
 import "./events/shape/options";
 import "./events/shape/text";
 import "./events/shape/togglecomposite";
+import "./events/user";
 
 import { toGP } from "../../core/geometry";
 import { SyncMode } from "../../core/models/types";

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -1,3 +1,4 @@
+import { colourHistory } from "../../../core/components/store";
 import { clientStore } from "../../../store/client";
 import { floorStore } from "../../../store/floor";
 import { gameStore } from "../../../store/game";
@@ -23,6 +24,7 @@ socket.on("Client.Move", (data: { player: number } & ServerUserLocationOptions) 
 
 socket.on("Client.Options.Set", (options: ServerClient) => {
     clientStore.setUsername(options.name);
+    colourHistory.value = options.colour_history === null ? [] : JSON.parse(options.colour_history);
 
     clientStore.setDefaultClientOptions(userOptionsToClient(options.default_user_options));
 

--- a/client/src/game/api/events/user.ts
+++ b/client/src/game/api/events/user.ts
@@ -1,0 +1,6 @@
+import { colourHistory } from "../../../core/components/store";
+import { socket } from "../socket";
+
+socket.on("User.ColourHistory.Set", (data: string) => {
+    colourHistory.value = JSON.parse(data);
+});

--- a/client/src/game/models/settings.ts
+++ b/client/src/game/models/settings.ts
@@ -49,6 +49,7 @@ export interface LocationOptions {
 
 export interface ServerClient {
     name: string;
+    colour_history: string | null;
     location_user_options: ServerUserLocationOptions;
     default_user_options: ServerUserOptions;
     room_user_options?: ServerUserOptions;

--- a/server/src/api/socket/__init__.py
+++ b/server/src/api/socket/__init__.py
@@ -15,4 +15,5 @@ from . import (
     player,
     room,
     shape,
+    user,
 )

--- a/server/src/api/socket/user.py
+++ b/server/src/api/socket/user.py
@@ -1,0 +1,17 @@
+import auth
+from api.socket.constants import GAME_NS
+from app import app, sio
+from models import PlayerRoom
+from state.game import game_state
+
+
+@sio.on("User.ColourHistory.Set", namespace=GAME_NS)
+@auth.login_required(app, sio)
+async def set_colour_history(sid: str, data: str):
+    pr: PlayerRoom = game_state.get(sid)
+
+    pr.player.colour_history = data
+    pr.player.save()
+
+    for psid in game_state.get_sids(player=pr.player, skip_sid=sid):
+        await sio.emit("User.ColourHistory.Set", data, room=psid, namespace=GAME_NS)

--- a/server/src/models/user.py
+++ b/server/src/models/user.py
@@ -1,5 +1,5 @@
 import bcrypt
-from typing import List, TYPE_CHECKING, Type, cast
+from typing import List, TYPE_CHECKING, Optional, cast
 from peewee import (
     FloatField,
     ForeignKeyField,
@@ -78,6 +78,8 @@ class User(BaseModel):
     email = TextField(null=True)
     password_hash = cast(str, TextField())
     default_options = ForeignKeyField(UserOptions, on_delete="CASCADE")
+    
+    colour_history = cast(Optional[str], TextField(null=True))
 
     def __repr__(self):
         return f"<User {self.name}>"

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -13,7 +13,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 71
+SAVE_VERSION = 72
 
 import json
 import logging
@@ -170,6 +170,12 @@ def upgrade(version):
                         "UPDATE shape SET options=? WHERE uuid=?",
                         (json.dumps(unpacked_options), uuid),
                     )
+    elif version == 71:
+        # Add User.colour_history
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE user ADD COLUMN colour_history TEXT DEFAULT NULL"
+            )
     else:
         raise UnknownVersionException(
             f"No upgrade code for save format {version} was found."


### PR DESCRIPTION
The colour picker will now remember the last 20 used colours on a per user basis (across all campaigns).