### PR TITLE
bug(ColourPicker): Fix hsv color input resetting opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ these changes will usually be stripped from release notes for the public
 -   Clear client viewports when changing location
 -   Dashboard navigation headers sometimes being wrongly styled
 -   Modal handling on firefox
--   Color picker resetting saturation panel to red when clicking
+-   Colour picker resetting saturation panel to red when clicking
+-   Colour picker resetting opacity when setting hsv color
 -   Drawtool trying to add shape creation operation to undo stack when the shape was not valid
 -   Points modified by the polygon edit UI are not snappable until a refresh
 -   [server] Admin client was not built in docker

--- a/client/src/core/components/ColourPicker.vue
+++ b/client/src/core/components/ColourPicker.vue
@@ -95,6 +95,9 @@ function close(): void {
             colourHistory.value.splice(idx, 1);
         }
         colourHistory.value.unshift(color);
+        if (colourHistory.value.length > 20) {
+            colourHistory.value = colourHistory.value.slice(0, 20);
+        }
         sendColourHistoryChanged(JSON.stringify(colourHistory.value));
     }
 }
@@ -201,6 +204,7 @@ function onSaturationMove(event: PointerEvent): void {
         h: isEmptyHsv(hsv.value) ? hueFallback.value : hsv.value.h,
         s: dX / el.width,
         v: clamp(1 - dY / el.height, 0, 1),
+        a: tc.value.getAlpha(),
     });
     emit("input:colour", rgbaString.value);
 }


### PR DESCRIPTION
When using the saturation panel (the coloured rectangle on the top of the colour picker), the opacity would always be reset to 1.0, instead of keeping the current opacity.