### PR TITLE
bug(Logic): Bandaid fix for null permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ these changes will usually be stripped from release notes for the public
 -   Colour picker resetting opacity when setting hsv color
 -   Drawtool trying to add shape creation operation to undo stack when the shape was not valid
 -   Points modified by the polygon edit UI are not snappable until a refresh
+-   Logic Permission selector showing error in edgecase
 -   [server] Admin client was not built in docker
 -   [tech] Ensure router.push calls are always awaited
 

--- a/client/src/game/ui/settings/shape/LogicPermissions.vue
+++ b/client/src/game/ui/settings/shape/LogicPermissions.vue
@@ -112,7 +112,7 @@ function hideModal(): void {
 
             <draggable
                 class="condition-sorter"
-                :modelValue="props.permissions.enabled"
+                :modelValue="props.permissions.enabled.filter((x) => x !== null)"
                 group="door"
                 @change="change($event, 'enabled')"
                 item-key="uuid"
@@ -127,7 +127,7 @@ function hideModal(): void {
             </draggable>
             <draggable
                 class="condition-sorter"
-                :modelValue="props.permissions.request"
+                :modelValue="props.permissions.request.filter((x) => x !== null)"
                 group="door"
                 @change="change($event, 'request')"
                 item-key="uuid"
@@ -142,7 +142,7 @@ function hideModal(): void {
             </draggable>
             <draggable
                 class="condition-sorter"
-                :modelValue="props.permissions.disabled"
+                :modelValue="props.permissions.disabled.filter((x) => x !== null)"
                 group="door"
                 @change="change($event, 'disabled')"
                 item-key="uuid"


### PR DESCRIPTION
For some reason a `null` value can sneak into the permissions object causing the logic permissions modal to show an error.

I've not yet identified the root source of this problem, but applied a bandaid fix so that the permissions modal does not error out.