### PR TITLE
feat(Tech:AssetList): Change rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ these changes will usually be stripped from release notes for the public
 -   [tech] SyncTo primitive modified to an alternative Sync structure
 -   [tech] Polygon can now have client-side multi-stroke
 -   [tech] Snappable points are calculated less often
+-   [tech] In-game asset list rendering
 
 ### Fixed
 

--- a/client/src/game/ui/menu/AssetNode.vue
+++ b/client/src/game/ui/menu/AssetNode.vue
@@ -6,11 +6,13 @@ import { baseAdjust } from "../../../core/utils";
 
 interface State {
     hoveredHash: string;
+    openFolders: Set<string>;
 }
 
-const props = defineProps<{ assets: AssetListMap }>();
+const props = defineProps<{ assets: AssetListMap; visible: boolean }>();
 const state: State = reactive({
     hoveredHash: "",
+    openFolders: new Set(),
 });
 
 function childAssets(folder: string): AssetListMap {
@@ -26,11 +28,11 @@ const folders = computed(() => {
     return [...props.assets.keys()].filter((el) => "__files" !== el);
 });
 
-function toggle(event: MouseEvent): void {
-    const children = (event.target as HTMLLIElement).children;
-    for (const child of children) {
-        const el = child as HTMLElement;
-        el.style.display = el.style.display === "" ? "block" : "";
+function toggle(folder: string): void {
+    if (state.openFolders.has(folder)) {
+        state.openFolders.delete(folder);
+    } else {
+        state.openFolders.add(folder);
     }
 }
 
@@ -45,10 +47,10 @@ function dragStart(event: DragEvent, imageSource: string, assetId: number): void
 </script>
 
 <template>
-    <ul>
-        <li v-for="folder in folders" :key="folder" class="folder" @click.stop="toggle">
+    <ul v-if="visible">
+        <li v-for="folder in folders" :key="folder" class="folder" @click.stop="toggle(folder)">
             {{ folder }}
-            <AssetNode :assets="childAssets(folder)" />
+            <AssetNode :assets="childAssets(folder)" :visible="state.openFolders.has(folder)" />
         </li>
         <li
             v-for="file in files"
@@ -111,10 +113,6 @@ DIRECTORY.CSS changes
 
 */
 .folder {
-    > * {
-        display: none;
-    }
-
     &:hover {
         font-weight: bold;
         cursor: pointer;

--- a/client/src/game/ui/menu/AssetParentNode.vue
+++ b/client/src/game/ui/menu/AssetParentNode.vue
@@ -15,5 +15,5 @@ const assets = computed(() =>
 </script>
 
 <template>
-    <AssetNode :assets="assets" />
+    <AssetNode :assets="assets" :visible="true" />
 </template>


### PR DESCRIPTION
This PR changes the rendering of the in-game asset list in the menu bar.

This reduces the amount of active event listeners that are running drastically (scaled directly with the amount of assets you have in your asset manager).

This will however not likely have any visual performance improvement.