### PR TITLE
chore(Tech:Dependencies): Remove jinja2 from codebase

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,4 @@
-jinja2==3.0.3
 aiohttp==3.8.1
-aiohttp_jinja2==1.5
 aiohttp_security==0.4.0
 aiohttp_session==2.11.0
 bcrypt==3.2.0

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -1,10 +1,8 @@
 import os
 from typing import Callable, Iterable, List, Type
 
-import aiohttp_jinja2
 import aiohttp_security
 import aiohttp_session
-import jinja2
 from aiohttp import web
 from aiohttp_security import SessionIdentityPolicy
 from aiohttp_session.cookie_storage import EncryptedCookieStorage
@@ -38,7 +36,6 @@ sio = TypedAsyncServer(
     cors_allowed_origins=config.get("Webserver", "cors_allowed_origins", fallback=None)
 )
 app = setup_app()
-aiohttp_jinja2.setup(app, loader=jinja2.FileSystemLoader("templates"))
 basepath = os.environ.get("PA_BASEPATH", "/")[1:]
 socketio_path = basepath + "socket.io"
 sio.attach(app, socketio_path=socketio_path)


### PR DESCRIPTION
I only now realised that jinja2 is still a dependency of the server, while that has no longer be needed for more than 3 years at least.