### PR TITLE
feat(UI): Show no in leave room modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ tech changes will usually be stripped from release notes for the public
 -   Show campaign loading animation earlier (in dashboard)
 -   Defeat cross now scales better with shape size
 -   Shape badge now scales better with shape size
+-   Show default "no" button in delete/leave campaign prompt
 -   [server] Added log rotation
 -   [server] Restructure server files
 -   [tech] SyncTo primitive modified to an alternative Sync structure

--- a/client/src/dashboard/SessionList.vue
+++ b/client/src/dashboard/SessionList.vue
@@ -98,9 +98,7 @@ async function leaveOrDelete(): Promise<void> {
     if (selected.value === undefined) return;
 
     const actionWord = props.dmMode ? "Removing" : "Leaving";
-    const answer = await modals.confirm(`${actionWord} ${selected.value.name}!`, "Are you sure?", {
-        showNo: false,
-    });
+    const answer = await modals.confirm(`${actionWord} ${selected.value.name}!`, "Are you sure?");
     if (answer !== true) return;
     const response = await http.delete(`/api/rooms/${selected.value.creator}/${selected.value.name}`);
     if (response.ok) {


### PR DESCRIPTION
When leaving or deleting a campaign, a modal pops up asking for confirmation.
For some reason I decided in the past to not show the "No" option and only show the "yes" option.

I have no idea why, so "no" is back in town with this PR.