### PR TITLE
bug(AssetManager): Cleanup asset socket connection data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ tech changes will usually be stripped from release notes for the public
 -   Drawtool trying to add shape creation operation to undo stack when the shape was not valid
 -   Points modified by the polygon edit UI are not snappable until a refresh
 -   Logic Permission selector showing error in edgecase
+-   Asset socket was not cleaning up past connections
 -   [server] Admin client was not built in docker
 -   [tech] Ensure router.push calls are always awaited
 

--- a/server/src/api/socket/asset_manager/__init__.py
+++ b/server/src/api/socket/asset_manager/__init__.py
@@ -63,6 +63,14 @@ async def assetmgmt_connect(sid: str, environ):
         await sio.emit("Folder.Root.Set", root.id, room=sid, namespace=ASSET_NS)
 
 
+@sio.on("disconnect", namespace=ASSET_NS)
+async def disconnect(sid):
+    if not asset_state.has_sid(sid):
+        return
+
+    await asset_state.remove_sid(sid)
+
+
 @sio.on("Folder.Get", namespace=ASSET_NS)
 @auth.login_required(app, sio, "asset")
 async def get_folder(sid: str, folder=None):


### PR DESCRIPTION
When communicating with the PA server, the client uses websockets (or socket.io to be specific).
The most used socket connection is the game socket, but there is also a dedicated socket for asset related stuff (e.g. asset manager, setting a campaign logo, ...).

This last connection was not cleaning itself up properly when closed. This is now done.