### PR TITLE
bug(Tech:Socket): Fix game socket query options not going through

### DIFF
--- a/client/src/core/socket.ts
+++ b/client/src/core/socket.ts
@@ -1,6 +1,6 @@
 import { Manager } from "socket.io-client";
 
-function createNewManager(): Manager {
+export function createNewManager(): Manager {
     return new Manager(location.protocol + "//" + location.host, {
         autoConnect: false,
         path: import.meta.env.BASE_URL + "socket.io",

--- a/client/src/game/api/socket.ts
+++ b/client/src/game/api/socket.ts
@@ -1,8 +1,8 @@
 import type { RouteLocationNormalized } from "vue-router";
 
-import { socketManager } from "../../core/socket";
+import { createNewManager } from "../../core/socket";
 
-export const socket = socketManager.socket("/planarally");
+export const socket = createNewManager().socket("/planarally");
 
 export function createConnection(route: RouteLocationNormalized): void {
     // since socket.io v3 this is private, couldn't find an immediate 'clean' fix

--- a/client/test/setup.ts
+++ b/client/test/setup.ts
@@ -4,14 +4,19 @@ import { vi } from "vitest";
 
 vi.mock("path-data-polyfill", vi.fn());
 
+function createMockManager(): { socket: () => { connect: () => void; on: () => void; emit: () => void } } {
+    return {
+        socket: () => ({
+            connect: vi.fn(),
+            on: vi.fn(),
+            emit: vi.fn(),
+        }),
+    };
+}
+
 vi.mock("../src/core/socket", () => {
     return {
-        socketManager: {
-            socket: () => ({
-                connect: vi.fn(),
-                on: vi.fn(),
-                emit: vi.fn(),
-            }),
-        },
+        createNewManager: createMockManager,
+        socketManager: createMockManager(),
     };
 });


### PR DESCRIPTION
The new dashboard socket seemingly messes with the game socket's query option manipulation.
This PR makes sure the game socket is using a completely separate manager.