### PR TITLE
bug(Aura): Fix light source aura behaviour in no-fow context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ tech changes will usually be stripped from release notes for the public
 -   Points modified by the polygon edit UI are not snappable until a refresh
 -   Logic Permission selector showing error in edgecase
 -   Asset socket was not cleaning up past connections
+-   Auras that are light sources, no longer appear as a black circle of doom when FOW is not turned on
 -   [server] Admin client was not built in docker
 -   [tech] Ensure router.push calls are always awaited
 

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -69,69 +69,72 @@ export class FowLightingLayer extends FowLayer {
             }
 
             // First cut out all the light sources
-            for (const light of visionState.getVisionSources(this.floor)) {
-                const shape = getShape(light.shape);
-                if (shape === undefined) continue;
-                const aura = auraSystem.get(shape.id, light.aura, true);
-                if (aura === undefined) continue;
+            if (settingsStore.fullFow.value) {
+                for (const light of visionState.getVisionSources(this.floor)) {
+                    const shape = getShape(light.shape);
+                    if (shape === undefined) continue;
+                    const aura = auraSystem.get(shape.id, light.aura, true);
+                    if (aura === undefined) continue;
 
-                if (!accessSystem.hasAccessTo(light.shape, true, { vision: true }) && !aura.visible) continue;
+                    if (!accessSystem.hasAccessTo(light.shape, true, { vision: true }) && !aura.visible) continue;
 
-                const auraValue = aura.value > 0 && !isNaN(aura.value) ? aura.value : 0;
-                const auraDim = aura.dim > 0 && !isNaN(aura.dim) ? aura.dim : 0;
+                    const auraValue = aura.value > 0 && !isNaN(aura.value) ? aura.value : 0;
+                    const auraDim = aura.dim > 0 && !isNaN(aura.dim) ? aura.dim : 0;
 
-                const auraLength = getUnitDistance(auraValue + auraDim);
-                const center = shape.center();
-                const lcenter = g2l(center);
-                const innerRange = g2lr(auraValue + auraDim);
+                    const auraLength = getUnitDistance(auraValue + auraDim);
+                    const center = shape.center();
+                    const lcenter = g2l(center);
+                    const innerRange = g2lr(auraValue + auraDim);
 
-                const auraCircle = new Circle(center, auraLength);
-                if (!auraCircle.visibleInCanvas({ w: this.width, h: this.height }, { includeAuras: true })) continue;
+                    const auraCircle = new Circle(center, auraLength);
+                    if (!auraCircle.visibleInCanvas({ w: this.width, h: this.height }, { includeAuras: true }))
+                        continue;
 
-                this.vCtx.globalCompositeOperation = "source-over";
-                this.vCtx.fillStyle = "rgba(0, 0, 0, 1)";
-                const polygon = computeVisibility(center, TriangulationTarget.VISION, shape.floor.id);
-                this.vCtx.beginPath();
-                this.vCtx.moveTo(g2lx(polygon[0][0]), g2ly(polygon[0][1]));
-                for (const point of polygon) this.vCtx.lineTo(g2lx(point[0]), g2ly(point[1]));
-                this.vCtx.closePath();
-                this.vCtx.fill();
-                if (auraDim > 0) {
-                    // Fill the light aura with a radial dropoff towards the outside.
-                    const gradient = this.vCtx.createRadialGradient(
-                        lcenter.x,
-                        lcenter.y,
-                        g2lr(auraValue),
-                        lcenter.x,
-                        lcenter.y,
-                        innerRange,
-                    );
-                    gradient.addColorStop(0, "rgba(0, 0, 0, 1)");
-                    gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
-                    this.vCtx.fillStyle = gradient;
-                } else {
+                    this.vCtx.globalCompositeOperation = "source-over";
                     this.vCtx.fillStyle = "rgba(0, 0, 0, 1)";
-                }
-                this.vCtx.globalCompositeOperation = "source-in";
-                this.vCtx.beginPath();
+                    const polygon = computeVisibility(center, TriangulationTarget.VISION, shape.floor.id);
+                    this.vCtx.beginPath();
+                    this.vCtx.moveTo(g2lx(polygon[0][0]), g2ly(polygon[0][1]));
+                    for (const point of polygon) this.vCtx.lineTo(g2lx(point[0]), g2ly(point[1]));
+                    this.vCtx.closePath();
+                    this.vCtx.fill();
+                    if (auraDim > 0) {
+                        // Fill the light aura with a radial dropoff towards the outside.
+                        const gradient = this.vCtx.createRadialGradient(
+                            lcenter.x,
+                            lcenter.y,
+                            g2lr(auraValue),
+                            lcenter.x,
+                            lcenter.y,
+                            innerRange,
+                        );
+                        gradient.addColorStop(0, "rgba(0, 0, 0, 1)");
+                        gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
+                        this.vCtx.fillStyle = gradient;
+                    } else {
+                        this.vCtx.fillStyle = "rgba(0, 0, 0, 1)";
+                    }
+                    this.vCtx.globalCompositeOperation = "source-in";
+                    this.vCtx.beginPath();
 
-                const angleA = shape.angle + toRadians(aura.direction - aura.angle / 2);
-                const angleB = shape.angle + toRadians(aura.direction + aura.angle / 2);
+                    const angleA = shape.angle + toRadians(aura.direction - aura.angle / 2);
+                    const angleB = shape.angle + toRadians(aura.direction + aura.angle / 2);
 
-                if (aura.angle < 360) {
-                    this.vCtx.moveTo(lcenter.x, lcenter.y);
-                    this.vCtx.lineTo(
-                        lcenter.x + innerRange * Math.cos(angleA),
-                        lcenter.y + innerRange * Math.sin(angleA),
-                    );
-                }
-                this.vCtx.arc(lcenter.x, lcenter.y, innerRange, angleA, angleB);
-                if (aura.angle < 360) {
-                    this.vCtx.lineTo(lcenter.x, lcenter.y);
-                }
+                    if (aura.angle < 360) {
+                        this.vCtx.moveTo(lcenter.x, lcenter.y);
+                        this.vCtx.lineTo(
+                            lcenter.x + innerRange * Math.cos(angleA),
+                            lcenter.y + innerRange * Math.sin(angleA),
+                        );
+                    }
+                    this.vCtx.arc(lcenter.x, lcenter.y, innerRange, angleA, angleB);
+                    if (aura.angle < 360) {
+                        this.vCtx.lineTo(lcenter.x, lcenter.y);
+                    }
 
-                this.vCtx.fill();
-                this.ctx.drawImage(this.virtualCanvas, 0, 0, window.innerWidth, window.innerHeight);
+                    this.vCtx.fill();
+                    this.ctx.drawImage(this.virtualCanvas, 0, 0, window.innerWidth, window.innerHeight);
+                }
             }
 
             const activeFloor = floorStore.currentFloor.value!.id;


### PR DESCRIPTION
When a location has fog of war not turned on, lights are not useful in the current state of PA.
Auras configured as light sources run on logic that requires fog of war to be present.
Which caused these auras to appear as black circles of doom when used in a non-fow setup.

Even though there is no real usecase for marking an aura as a light source in a non-fow setup, it has been pointed out in the past that sometimes one might move characters from a fow location to a non-fow location and in these cases it can be cumbersome to toggle all the auras.

This PR changes the behaviour of these auras to simply not do anything in a non-fow setup.