### PR TITLE
feat(Import): Open the Run section when an import completes

### DIFF
--- a/client/src/dashboard/Dashboard.vue
+++ b/client/src/dashboard/Dashboard.vue
@@ -40,8 +40,9 @@ const modals = useModal();
 const route = useRoute();
 const router = useRouter();
 
-socket.on("Campaign.Import.Done", async (name: string) => {
+socket.on("Campaign.Import.Done", async () => {
     await getRooms();
+    state.activeNavigation = Navigation.Run;
 });
 
 onMounted(async () => {


### PR DESCRIPTION
When an import completes the client will now move to the run section, which should then list the imported campaign among the other campaigns that you already run.