### PR TITLE
bug(Undo): Fix undo/redo not persisting for movement/rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ tech changes will usually be stripped from release notes for the public
 -   Logic Permission selector showing error in edgecase
 -   Asset socket was not cleaning up past connections
 -   Auras that are light sources, no longer appear as a black circle of doom when FOW is not turned on
+-   Undo/Redo not persisting to server for movement and rotation
 -   [server] Admin client was not built in docker
 -   [tech] Ensure router.push calls are always awaited
 

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -90,7 +90,7 @@ function handleMovement(shapes: ShapeMovementOperation[], direction: "undo" | "r
     const fullShapes = shapes.map((s) => getShape(s.uuid)!);
     let delta = Vector.fromPoints(toGP(shapes[0].to), toGP(shapes[0].from));
     if (direction === "redo") delta = delta.reverse();
-    moveShapes(fullShapes, delta, true);
+    moveShapes(fullShapes, delta, false);
     (toolMap[ToolName.Select] as ISelectTool).resetRotationHelper();
 }
 
@@ -98,7 +98,7 @@ function handleRotation(shapes: ShapeRotationOperation[], center: GlobalPoint, d
     const fullShapes = shapes.map((s) => getShape(s.uuid)!);
     let angle = shapes[0].from - shapes[0].to;
     if (direction === "redo") angle *= -1;
-    rotateShapes(fullShapes, angle, center, true);
+    rotateShapes(fullShapes, angle, center, false);
     (toolMap[ToolName.Select] as ISelectTool).resetRotationHelper();
 }
 


### PR DESCRIPTION
Undo or Redo operations related to movement or rotation would correctly update on the client and be synced to other players, BUT would not actually persist on the server, causing a reload to return to the original position.