### PR TITLE
feat(Zoom): Change the default zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ tech changes will usually be stripped from release notes for the public
 -   Defeat cross now scales better with shape size
 -   Shape badge now scales better with shape size
 -   Show default "no" button in delete/leave campaign prompt
+-   Default location zoom level is now 0.2 instead of 1.0
 -   [server] Added log rotation
 -   [server] Restructure server files
 -   [tech] SyncTo primitive modified to an alternative Sync structure

--- a/server/src/models/campaign.py
+++ b/server/src/models/campaign.py
@@ -321,7 +321,7 @@ class LocationUserOption(BaseModel):
     user = ForeignKeyField(User, backref="location_options", on_delete="CASCADE")
     pan_x = IntegerField(default=0)
     pan_y = IntegerField(default=0)
-    zoom_display = FloatField(default=1.0)
+    zoom_display = FloatField(default=0.2)
     active_layer = ForeignKeyField(Layer, backref="active_users", null=True)
 
     def __repr__(self):


### PR DESCRIPTION
When joining a new Location, the default zoom level was set to 1.0, which is as zoomed out as it can go.

This meant the grid would just be very dense which is pretty unappealing, so I changed it to a more sensible value. (0.2)