### PR TITLE
bug(AssetManager): Fix assets not being able to move up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Fixed
+
+-   Assets not being able to moved up to parent folder
+
 ## [2022.2.2] - 2022-06-17
 
 ### Changed

--- a/client/src/assetManager/AssetManager.vue
+++ b/client/src/assetManager/AssetManager.vue
@@ -73,7 +73,8 @@ function leaveDrag(event: DragEvent): void {
 function stopDrag(event: DragEvent, target: number): void {
     (event.target as HTMLElement).classList.remove("inode-selected");
     if (draggingSelection) {
-        if ((target === state.root || state.folders.includes(target)) && !state.selected.includes(target)) {
+        if (state.selected.includes(target)) return;
+        if (target === parentFolder.value || target === state.root || state.folders.includes(target)) {
             for (const inode of state.selected) {
                 assetStore.moveInode(inode, target);
             }


### PR DESCRIPTION
It apparently hasn't been possible for a while now to move an asset in the asset manager to its parent folder by dropping it on the "..".

This fixes #969 