### PR TITLE
bug(AssetManager): Fix asset removal not possible when linked to shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ tech changes will usually be stripped from release notes for the public
 ### Fixed
 
 -   Assets not being able to moved up to parent folder
+-   Assets not being removable if a shape with a link to the asset exists
 
 ## [2022.2.2] - 2022-06-17
 

--- a/server/src/models/shape/__init__.py
+++ b/server/src/models/shape/__init__.py
@@ -77,7 +77,9 @@ class Shape(BaseModel):
     is_locked = cast(bool, BooleanField(default=False))
     angle = cast(float, FloatField(default=0))
     stroke_width = IntegerField(default=2)
-    asset = ForeignKeyField(Asset, backref="shapes", null=True, default=None)
+    asset = ForeignKeyField(
+        Asset, backref="shapes", null=True, default=None, on_delete="SET NULL"
+    )
     group = cast(
         Optional[Group],
         ForeignKeyField(Group, backref="members", null=True, default=None),


### PR DESCRIPTION
When dropping shapes on the map they remember which asset they were made from.
When removing an asset that has a link to at least 1 such shape, an error would be thrown on the server, preventing the removal of the asset.

This fix now removes the link, allowing the asset to be removed.

Fixes #968 