### PR TITLE
feat(DrawTool): Add reminder colour to draw tool tabs if active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Changed
+
+-   Draw tool vision and logic tabs will now have a background colour if they are active as a reminder
+
 ### Fixed
 
 -   Assets not being able to moved up to parent folder

--- a/client/src/game/ui/tools/DrawTool.vue
+++ b/client/src/game/ui/tools/DrawTool.vue
@@ -56,6 +56,17 @@ const showBorderColour = computed(() => {
     if (drawTool.state.selectedShape === DrawShape.Polygon && !drawTool.state.isClosedPolygon) return false;
     return true;
 });
+
+const alerts = computed(() => {
+    const a: Set<string> = new Set();
+    if (drawTool.state.blocksMovement || drawTool.state.blocksVision) {
+        a.add("eye");
+    }
+    if (drawTool.state.isDoor) {
+        a.add("cogs");
+    }
+    return a;
+});
 </script>
 
 <template>
@@ -65,7 +76,10 @@ const showBorderColour = computed(() => {
                 v-for="category in categories"
                 :key="category"
                 class="draw-category-option"
-                :class="{ 'draw-category-option-selected': drawTool.state.selectedCategory === category }"
+                :class="{
+                    'draw-category-option-selected': drawTool.state.selectedCategory === category,
+                    'draw-category-alert': drawTool.state.selectedCategory !== category && alerts.has(category),
+                }"
                 @click="drawTool.state.selectedCategory = category"
                 :title="translationMapping[category]"
             >
@@ -222,6 +236,10 @@ const showBorderColour = computed(() => {
 
     .draw-category-option-selected {
         background-color: #82c8a0;
+    }
+
+    .draw-category-alert {
+        background-color: orangered;
     }
 }
 


### PR DESCRIPTION
Since the addition of the door logic feature and especially its integration with the draw tool, drawing maps has been even easier (or at least for me :D).

One thing that however tends to happen is that maybe you've used the draw tool with door integration enabled 20 minutes ago, and you're about to draw something new, but forgot it was still configured as a door and thus end up drawing a bunch of doors.

To "fix" this, the logic tab will now light up with an orangered colour if door logic has been enabled, so that it should be noticeable if this was not desirable.

Similarly the vision tab will also light up if at least 1 of the two block properties has been toggled on.