### PR TITLE
bug(VisionTool): Fix vision tool alert state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Assets not being able to moved up to parent folder
 -   Assets not being removable if a shape with a link to the asset exists
+-   Vision tool alert state was not always accurate
 
 ## [2022.2.2] - 2022-06-17
 

--- a/client/src/game/tools/variants/vision.ts
+++ b/client/src/game/tools/variants/vision.ts
@@ -1,4 +1,7 @@
+import { computed } from "vue";
+
 import { i18n } from "../../../i18n";
+import { gameStore } from "../../../store/game";
 import { ToolName } from "../../models/tools";
 import type { ToolPermission } from "../../models/tools";
 import { Tool } from "../tool";
@@ -8,6 +11,8 @@ import { SelectFeatures } from "./select";
 class VisionTool extends Tool {
     readonly toolName = ToolName.Vision;
     readonly toolTranslation = i18n.global.t("tool.Vision");
+
+    alert = computed(() => gameStore.state.activeTokenFilters !== undefined);
 
     get permittedTools(): ToolPermission[] {
         return [{ name: ToolName.Select, features: { disabled: [SelectFeatures.Resize, SelectFeatures.Rotate] } }];

--- a/client/src/game/ui/tools/VisionTool.vue
+++ b/client/src/game/ui/tools/VisionTool.vue
@@ -30,12 +30,6 @@ const selection = computed(() => {
 function toggle(uuid: LocalId): void {
     if (selection.value.has(uuid)) gameStore.removeActiveToken(uuid);
     else gameStore.addActiveToken(uuid);
-
-    if (gameStore.state.activeTokenFilters !== undefined) {
-        visionTool.alert.value = true;
-    } else {
-        visionTool.alert.value = false;
-    }
 }
 
 function getImageSrc(token: IShape): string {


### PR DESCRIPTION
The vision tool has an orangered background colour if not all vision is taken into account.

This alert state was correctly changing if the vision sources were changed from within the vision tool.
If however an external source changed the vision sources, the alert state would not change.