### PR TITLE
bug(Door): Fix player door interactions not persisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ tech changes will usually be stripped from release notes for the public
 -   Vision tool alert state was not always accurate
 -   Teleport zone not properly triggering when initiated as a player
 -   Teleport zone not properly landing in the center of the target
+-   Player door toggles not syncing to the server/persisting
 
 ## [2022.2.2] - 2022-06-17
 

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -9,7 +9,7 @@ import { coreStore } from "../store/core";
 
 import { createConnection, socket } from "./api/socket";
 import { dropAsset } from "./dropAsset";
-import { onKeyDown } from "./input/keyboard";
+import { onKeyDown } from "./input/keyboard/down";
 import { scrollZoom } from "./input/mouse";
 import { clearUndoStacks } from "./operations/undo";
 import { floorSystem } from "./systems/floors";

--- a/client/src/game/api/events/logic.ts
+++ b/client/src/game/api/events/logic.ts
@@ -1,5 +1,8 @@
 import { POSITION, useToast } from "vue-toastification";
 
+import { getLocalId } from "../../id";
+import { doorSystem } from "../../systems/logic/door";
+import { Access } from "../../systems/logic/models";
 import type { RequestTypeResponse } from "../../systems/logic/models";
 import LogicRequestHandlerToast from "../../ui/toasts/LogicRequestHandlerToast.vue";
 import { socket } from "../socket";
@@ -7,6 +10,17 @@ import { socket } from "../socket";
 const toast = useToast();
 
 socket.on("Logic.Request", (data: RequestTypeResponse) => {
+    if (data.logic === "door") {
+        const doorId = getLocalId(data.door);
+        if (doorId === undefined) return;
+        const canUse = doorSystem.canUse(doorId);
+        if (canUse === Access.Enabled) {
+            doorSystem.toggleDoor(doorId);
+            return;
+        } else if (canUse === Access.Disabled) {
+            return;
+        }
+    }
     toast.info(
         { component: LogicRequestHandlerToast, props: { data } },
         {

--- a/client/src/game/input/keyboard/down.ts
+++ b/client/src/game/input/keyboard/down.ts
@@ -1,50 +1,21 @@
-import { equalsP, toGP, Vector } from "../../core/geometry";
-import { FULL_SYNC, SyncMode } from "../../core/models/types";
-import { ctrlOrCmdPressed } from "../../core/utils";
-import { getGameState } from "../../store/_game";
-import { activeShapeStore } from "../../store/activeShape";
-import { clientStore, DEFAULT_GRID_SIZE } from "../../store/client";
-import { gameStore } from "../../store/game";
-import { settingsStore } from "../../store/settings";
-import { sendClientLocationOptions } from "../api/emits/client";
-import { calculateDelta } from "../drag";
-import { getShape } from "../id";
-import { selectionState } from "../layers/selection";
-import { moveShapes } from "../operations/movement";
-import { undoOperation, redoOperation } from "../operations/undo";
-import { setCenterPosition } from "../position";
-import { deleteShapes, copyShapes, pasteShapes } from "../shapes/utils";
-import { accessState } from "../systems/access/state";
-import { floorSystem } from "../systems/floors";
-import { floorState } from "../systems/floors/state";
-import { moveFloor } from "../temp";
-import { toggleActiveMode } from "../tools/tools";
-
-export function onKeyUp(event: KeyboardEvent): void {
-    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
-        // no-op (condition is cleaner this way)
-    } else {
-        if (event.key === "Delete" || event.key === "Del" || event.key === "Backspace") {
-            const selection = selectionState.get({ includeComposites: true });
-            deleteShapes(selection, SyncMode.FULL_SYNC);
-        }
-        if (event.key === " " || (event.code === "Numpad0" && !ctrlOrCmdPressed(event))) {
-            // Spacebar or numpad-zero: cycle through own tokens
-            // numpad-zero only if Ctrl is not pressed, as this would otherwise conflict with Ctrl + 0
-            const tokens = [...accessState.$.ownedTokens].map((o) => getShape(o)!);
-            if (tokens.length === 0) return;
-            const i = tokens.findIndex((o) => equalsP(o.center(), clientStore.screenCenter));
-            const token = tokens[(i + 1) % tokens.length];
-            setCenterPosition(token.center());
-            floorSystem.selectFloor({ name: token.floor.name }, true);
-        }
-        if (event.key === "Enter") {
-            if (selectionState.hasSelection) {
-                activeShapeStore.setShowEditDialog(true);
-            }
-        }
-    }
-}
+import { toGP, Vector } from "../../../core/geometry";
+import { FULL_SYNC } from "../../../core/models/types";
+import { ctrlOrCmdPressed } from "../../../core/utils";
+import { getGameState } from "../../../store/_game";
+import { clientStore, DEFAULT_GRID_SIZE } from "../../../store/client";
+import { gameStore } from "../../../store/game";
+import { settingsStore } from "../../../store/settings";
+import { sendClientLocationOptions } from "../../api/emits/client";
+import { calculateDelta } from "../../drag";
+import { selectionState } from "../../layers/selection";
+import { moveShapes } from "../../operations/movement";
+import { redoOperation, undoOperation } from "../../operations/undo";
+import { setCenterPosition } from "../../position";
+import { copyShapes, pasteShapes } from "../../shapes/utils";
+import { floorSystem } from "../../systems/floors";
+import { floorState } from "../../systems/floors/state";
+import { moveFloor } from "../../temp";
+import { toggleActiveMode } from "../../tools/tools";
 
 export async function onKeyDown(event: KeyboardEvent): Promise<void> {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {

--- a/client/src/game/input/keyboard/up.ts
+++ b/client/src/game/input/keyboard/up.ts
@@ -1,0 +1,37 @@
+import { equalsP } from "../../../core/geometry";
+import { SyncMode } from "../../../core/models/types";
+import { ctrlOrCmdPressed } from "../../../core/utils";
+import { activeShapeStore } from "../../../store/activeShape";
+import { clientStore } from "../../../store/client";
+import { getShape } from "../../id";
+import { selectionState } from "../../layers/selection";
+import { setCenterPosition } from "../../position";
+import { deleteShapes } from "../../shapes/utils";
+import { accessState } from "../../systems/access/state";
+import { floorSystem } from "../../systems/floors";
+
+export function onKeyUp(event: KeyboardEvent): void {
+    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        // no-op (condition is cleaner this way)
+    } else {
+        if (event.key === "Delete" || event.key === "Del" || event.key === "Backspace") {
+            const selection = selectionState.get({ includeComposites: true });
+            deleteShapes(selection, SyncMode.FULL_SYNC);
+        }
+        if (event.key === " " || (event.code === "Numpad0" && !ctrlOrCmdPressed(event))) {
+            // Spacebar or numpad-zero: cycle through own tokens
+            // numpad-zero only if Ctrl is not pressed, as this would otherwise conflict with Ctrl + 0
+            const tokens = [...accessState.$.ownedTokens].map((o) => getShape(o)!);
+            if (tokens.length === 0) return;
+            const i = tokens.findIndex((o) => equalsP(o.center(), clientStore.screenCenter));
+            const token = tokens[(i + 1) % tokens.length];
+            setCenterPosition(token.center());
+            floorSystem.selectFloor({ name: token.floor.name }, true);
+        }
+        if (event.key === "Enter") {
+            if (selectionState.hasSelection) {
+                activeShapeStore.setShowEditDialog(true);
+            }
+        }
+    }
+}

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -613,6 +613,7 @@ export abstract class Shape implements IShape {
         this.blocksVision = blocksVision;
         const alteredVision = this.checkVisionSources(recalculate);
         if (alteredVision && recalculate) this.invalidate(false);
+        doorSystem.checkCursorState(this.id);
     }
 
     setBlocksMovement(blocksMovement: boolean, syncTo: Sync, recalculate = true): boolean {
@@ -643,6 +644,8 @@ export abstract class Shape implements IShape {
             );
             alteredMovement = true;
         }
+
+        doorSystem.checkCursorState(this.id);
 
         return alteredMovement;
     }

--- a/client/src/game/systems/logic/door/index.ts
+++ b/client/src/game/systems/logic/door/index.ts
@@ -1,80 +1,38 @@
-import { reactive } from "vue";
-import type { DeepReadonly } from "vue";
-
 import { registerSystem } from "../..";
 import type { ShapeSystem } from "../..";
+import { baseAdjust } from "../../../../core/http";
 import { FULL_SYNC } from "../../../../core/models/types";
 import type { Sync } from "../../../../core/models/types";
 import { getGlobalId, getShape } from "../../../id";
 import type { LocalId } from "../../../id";
+import { selectToolState } from "../../../tools/variants/select/state";
 import { canUse } from "../common";
-import { DEFAULT_PERMISSIONS } from "../models";
 import type { Access, Permissions } from "../models";
 
 import { sendShapeIsDoor, sendShapeDoorPermissions, sendShapeDoorToggleMode } from "./emits";
 import type { DoorOptions, DOOR_TOGGLE_MODE } from "./models";
+import { doorLogicState } from "./state";
 
-const DEFAULT_OPTIONS: () => DoorOptions = () => ({
-    permissions: DEFAULT_PERMISSIONS(),
-    toggleMode: "both",
-});
-
-interface ReactiveDoorState {
-    id: LocalId | undefined;
-    enabled: boolean;
-    permissions?: Permissions;
-    toggleMode: DOOR_TOGGLE_MODE;
-}
+const { _, _$, dropState, DEFAULT_OPTIONS } = doorLogicState;
 
 class DoorSystem implements ShapeSystem {
-    private enabled: Set<LocalId> = new Set();
-    private data: Map<LocalId, DoorOptions> = new Map();
-
-    // REACTIVE STATE
-
-    private _state: ReactiveDoorState;
-
-    constructor() {
-        this._state = reactive({
-            id: undefined,
-            enabled: false,
-            toggleMode: "both",
-        });
-    }
-
-    get state(): DeepReadonly<ReactiveDoorState> {
-        return this._state;
-    }
-
-    loadState(id: LocalId): void {
-        const data = this.data.get(id) ?? DEFAULT_OPTIONS();
-        this._state.id = id;
-        this._state.enabled = this.enabled.has(id);
-        this._state.permissions = data.permissions;
-        this._state.toggleMode = data.toggleMode;
-    }
-
-    dropState(): void {
-        this._state.id = undefined;
-    }
-
     // BEHAVIOUR
 
     clear(): void {
-        this.dropState();
-        this.enabled.clear();
-        this.data.clear();
+        dropState();
+        _.enabled.clear();
+        _.data.clear();
     }
 
     // Inform the system about the state of a certain LocalId
     inform(id: LocalId, enabled: boolean, options?: DoorOptions, syncToServer = false): void {
         if (enabled) {
-            this.enabled.add(id);
+            _.enabled.add(id);
         }
-        this.data.set(id, { ...DEFAULT_OPTIONS(), ...options });
+        _.data.set(id, { ...DEFAULT_OPTIONS(), ...options });
 
         if (syncToServer) {
-            const options = this.data.get(id)!;
+            const options = _.data.get(id)!;
             const shape = getGlobalId(id);
             sendShapeIsDoor({ shape, value: enabled });
             if (options.permissions) sendShapeDoorPermissions({ shape, value: options.permissions });
@@ -83,61 +41,61 @@ class DoorSystem implements ShapeSystem {
     }
 
     drop(id: LocalId): void {
-        this.enabled.delete(id);
-        this.data.delete(id);
-        if (this._state.id === id) {
-            this.dropState();
+        _.enabled.delete(id);
+        _.data.delete(id);
+        if (_$.id === id) {
+            dropState();
         }
     }
 
     toggle(id: LocalId, enabled: boolean, syncTo: Sync): void {
         if (syncTo.server) sendShapeIsDoor({ shape: getGlobalId(id), value: enabled });
-        if (this._state.id === id) this._state.enabled = enabled;
+        if (_$.id === id) _$.enabled = enabled;
 
         if (enabled) {
-            this.enabled.add(id);
+            _.enabled.add(id);
         } else {
-            this.enabled.delete(id);
+            _.enabled.delete(id);
         }
     }
 
     isDoor(id: LocalId): boolean {
-        return this.enabled.has(id);
+        return _.enabled.has(id);
     }
 
     getPermissions(id: LocalId): Readonly<Permissions> | undefined {
-        return this.data.get(id)?.permissions;
+        return _.data.get(id)?.permissions;
     }
 
     setPermissions(id: LocalId, permissions: Permissions, syncTo: Sync): void {
-        let options = this.data.get(id);
+        let options = _.data.get(id);
         if (options === undefined) {
             options = DEFAULT_OPTIONS();
-            this.data.set(id, options);
+            _.data.set(id, options);
         }
 
         if (syncTo.server) sendShapeDoorPermissions({ shape: getGlobalId(id), value: permissions });
-        if (this._state.id === id) this._state.permissions = permissions;
+        if (_$.id === id) _$.permissions = permissions;
 
         options.permissions = permissions;
     }
 
     setToggleMode(id: LocalId, mode: DOOR_TOGGLE_MODE, syncTo: Sync): void {
-        let options = this.data.get(id);
+        let options = _.data.get(id);
         if (options === undefined) {
             options = DEFAULT_OPTIONS();
-            this.data.set(id, options);
+            _.data.set(id, options);
         }
 
         if (syncTo.server) sendShapeDoorToggleMode({ shape: getGlobalId(id), value: mode });
-        if (this._state.id === id) this._state.toggleMode = mode;
+        if (_$.id === id) _$.toggleMode = mode;
 
         options.toggleMode = mode;
     }
 
     toggleDoor(id: LocalId): undefined {
         const shape = getShape(id);
-        const options = this.data.get(id);
+        const options = _.data.get(id);
         if (shape === undefined || options === undefined) return;
 
         if (options.toggleMode === "both") {
@@ -148,11 +106,24 @@ class DoorSystem implements ShapeSystem {
         } else {
             shape.setBlocksVision(!shape.blocksVision, FULL_SYNC, true);
         }
+
+        this.checkCursorState(id);
+    }
+
+    checkCursorState(id: LocalId): void {
+        const hoverId = selectToolState._.hoveredDoor;
+        console.log(id === hoverId);
+        if (id === hoverId) {
+            const state = this.getCursorState(hoverId);
+            if (state !== undefined) {
+                document.body.style.cursor = `url('${baseAdjust(`static/img/${state}.svg`)}') 16 16, auto`;
+            }
+        }
     }
 
     getCursorState(id: LocalId): "lock-solid" | "lock-open-solid" | "eye-solid" | "eye-slash-solid" | undefined {
         const shape = getShape(id);
-        const options = this.data.get(id);
+        const options = _.data.get(id);
         if (shape === undefined || options === undefined) return;
 
         if (options.toggleMode === "vision") {
@@ -166,7 +137,7 @@ class DoorSystem implements ShapeSystem {
     }
 
     getDoors(): Readonly<IterableIterator<LocalId>> {
-        return this.enabled.values();
+        return _.enabled.values();
     }
 }
 

--- a/client/src/game/systems/logic/door/state.ts
+++ b/client/src/game/systems/logic/door/state.ts
@@ -1,0 +1,56 @@
+import { reactive, readonly } from "vue";
+
+import type { LocalId } from "../../../id";
+import { DEFAULT_PERMISSIONS } from "../models";
+import type { Permissions } from "../models";
+
+import type { DoorOptions, DOOR_TOGGLE_MODE } from "./models";
+
+interface DoorState {
+    data: Map<LocalId, DoorOptions>;
+    enabled: Set<LocalId>;
+}
+
+interface ReactiveDoorState {
+    id: LocalId | undefined;
+    enabled: boolean;
+    permissions?: Permissions;
+    toggleMode: DOOR_TOGGLE_MODE;
+}
+
+const reactiveState = reactive<ReactiveDoorState>({
+    id: undefined,
+    enabled: false,
+    toggleMode: "both",
+});
+
+const state: DoorState = {
+    data: new Map(),
+    enabled: new Set(),
+};
+
+function loadState(id: LocalId): void {
+    const data = state.data.get(id) ?? DEFAULT_OPTIONS();
+    reactiveState.id = id;
+    reactiveState.enabled = state.enabled.has(id);
+    reactiveState.permissions = data.permissions;
+    reactiveState.toggleMode = data.toggleMode;
+}
+
+function dropState(): void {
+    reactiveState.id = undefined;
+}
+
+const DEFAULT_OPTIONS: () => DoorOptions = () => ({
+    permissions: DEFAULT_PERMISSIONS(),
+    toggleMode: "both",
+});
+
+export const doorLogicState = {
+    $: readonly(reactiveState),
+    _$: reactiveState,
+    _: state,
+    dropState,
+    loadState,
+    DEFAULT_OPTIONS,
+};

--- a/client/src/game/tools/tool.ts
+++ b/client/src/game/tools/tool.ts
@@ -2,7 +2,7 @@ import { computed } from "vue";
 import { ref } from "vue";
 
 import type { LocalPoint } from "../../core/geometry";
-import { onKeyUp } from "../input/keyboard";
+import { onKeyUp } from "../input/keyboard/up";
 import { getLocalPointFromEvent } from "../input/mouse";
 import type { ToolFeatures, ITool, ToolMode, ToolName, ToolPermission } from "../models/tools";
 

--- a/client/src/game/tools/variants/select/state.ts
+++ b/client/src/game/tools/variants/select/state.ts
@@ -1,0 +1,41 @@
+import { reactive, readonly } from "vue";
+
+import type { LocalId } from "../../../id";
+
+interface SelectState {
+    hoveredDoor?: LocalId;
+}
+
+interface ReactiveSelectState {
+    hasSelection: boolean;
+    showRuler: boolean;
+
+    polygonUiLeft: string;
+    polygonUiTop: string;
+    polygonUiAngle: string;
+    polygonUiVisible: string;
+    polygonUiSizeX: string;
+    polygonUiSizeY: string;
+    polygonUiVertex: boolean;
+}
+
+const reactiveState = reactive<ReactiveSelectState>({
+    hasSelection: false,
+    showRuler: false,
+
+    polygonUiLeft: "0px",
+    polygonUiTop: "0px",
+    polygonUiAngle: "0deg",
+    polygonUiVisible: "hidden",
+    polygonUiSizeX: "25px",
+    polygonUiSizeY: "25px",
+    polygonUiVertex: false,
+});
+
+const state: SelectState = {};
+
+export const selectToolState = {
+    $: readonly(reactiveState),
+    _$: reactiveState,
+    _: state,
+};

--- a/client/src/game/ui/settings/shape/LogicSettings.vue
+++ b/client/src/game/ui/settings/shape/LogicSettings.vue
@@ -12,6 +12,7 @@ import type { GlobalId } from "../../../id";
 import { doorSystem } from "../../../systems/logic/door";
 import { DOOR_TOGGLE_MODES } from "../../../systems/logic/door/models";
 import type { DOOR_TOGGLE_MODE } from "../../../systems/logic/door/models";
+import { doorLogicState } from "../../../systems/logic/door/state";
 import { DEFAULT_PERMISSIONS } from "../../../systems/logic/models";
 import type { LOGIC_TYPES, Permissions } from "../../../systems/logic/models";
 import { teleportZoneSystem } from "../../../systems/logic/tp";
@@ -26,10 +27,10 @@ watch(
     [() => activeShapeStore.state.id, () => props.activeSelection],
     ([newId, newSelection], [oldId, oldSelection]) => {
         if (newSelection && newId !== undefined && (!(oldSelection ?? false) || oldId !== newId)) {
-            doorSystem.loadState(newId);
+            doorLogicState.loadState(newId);
             teleportZoneSystem.loadState(newId);
         } else if ((!newSelection && (oldSelection ?? false)) || newId === undefined) {
-            doorSystem.dropState();
+            doorLogicState.dropState();
             teleportZoneSystem.dropState();
         }
     },
@@ -45,7 +46,7 @@ const showPermissions = ref(false);
 const activePermissions = computed(() => {
     let permissions: DeepReadonly<Permissions> | undefined;
     if (activeLogic.value === "door") {
-        permissions = doorSystem.state.permissions;
+        permissions = doorLogicState.$.permissions;
     } else {
         permissions = teleportZoneSystem.state.permissions;
     }
@@ -59,8 +60,8 @@ function openPermissions(target: LOGIC_TYPES): void {
 
 function setPermissions(permissions: Permissions): void {
     if (activeLogic.value === "door") {
-        if (doorSystem.state.id === undefined) return;
-        doorSystem.setPermissions(doorSystem.state.id, permissions, SERVER_SYNC);
+        if (doorLogicState.$.id === undefined) return;
+        doorSystem.setPermissions(doorLogicState.$.id, permissions, SERVER_SYNC);
     } else {
         if (teleportZoneSystem.state.id === undefined) return;
         teleportZoneSystem.setPermissions(teleportZoneSystem.state.id, permissions, SERVER_SYNC);
@@ -70,15 +71,15 @@ function setPermissions(permissions: Permissions): void {
 // Door
 
 function toggleDoor(): void {
-    if (doorSystem.state.id === undefined) return;
-    doorSystem.toggle(doorSystem.state.id, !doorSystem.state.enabled, SERVER_SYNC);
+    if (doorLogicState.$.id === undefined) return;
+    doorSystem.toggle(doorLogicState.$.id, !doorLogicState.$.enabled, SERVER_SYNC);
 }
 
-const activeToggleMode = computed(() => doorSystem.state.toggleMode);
+const activeToggleMode = computed(() => doorLogicState.$.toggleMode);
 
 function setToggleMode(mode: DOOR_TOGGLE_MODE): void {
-    if (doorSystem.state.id === undefined) return;
-    doorSystem.setToggleMode(doorSystem.state.id, mode, SERVER_SYNC);
+    if (doorLogicState.$.id === undefined) return;
+    doorSystem.setToggleMode(doorLogicState.$.id, mode, SERVER_SYNC);
 }
 
 // Teleport Zone
@@ -155,7 +156,7 @@ async function chooseTarget(): Promise<void> {
             id="logic-dialog-door-toggle"
             type="checkbox"
             class="styled-checkbox center"
-            :checked="doorSystem.state.enabled"
+            :checked="doorLogicState.$.enabled"
             @click="toggleDoor"
         />
         <label for="logic-dialog-door-toggles">Toggle</label>

--- a/client/src/game/ui/tools/SelectTool.vue
+++ b/client/src/game/ui/tools/SelectTool.vue
@@ -5,24 +5,24 @@ import { computed, onMounted, ref, toRef, watch } from "vue";
 import { selectionState } from "../../layers/selection";
 import type { Polygon } from "../../shapes/variants/polygon";
 import { selectTool } from "../../tools/variants/select";
+import { selectToolState } from "../../tools/variants/select/state";
 
 import { useToolPosition } from "./toolPosition";
 
 const right = ref("0px");
 const arrow = ref("0px");
 
-const hasSelection = selectTool.hasSelection;
+const { $, _$ } = selectToolState;
+
 const selected = selectTool.isActiveTool;
-const showRuler = selectTool.showRuler;
 const toolStyle = computed(() => ({ "--detailRight": right.value, "--detailArrow": arrow.value } as CSSProperties));
 
-const polygonUiLeft = selectTool.polygonUiLeft;
-const polygonUiTop = selectTool.polygonUiTop;
-const polygonUiAngle = selectTool.polygonUiAngle;
-const polygonUiVisible = selectTool.polygonUiVisible;
-const polygonUiSizeX = selectTool.polygonUiSizeX;
-const polygonUiSizeY = selectTool.polygonUiSizeY;
-const polygonUiVertex = selectTool.polygonUiVertex;
+const polygonUiLeft = $.polygonUiLeft;
+const polygonUiTop = $.polygonUiTop;
+const polygonUiAngle = $.polygonUiAngle;
+const polygonUiVisible = $.polygonUiVisible;
+const polygonUiSizeX = $.polygonUiSizeX;
+const polygonUiSizeY = $.polygonUiSizeY;
 
 onMounted(() => {
     ({ right: right.value, arrow: arrow.value } = useToolPosition(selectTool.toolName));
@@ -34,7 +34,7 @@ onMounted(() => {
 
 function toggleShowRuler(event: MouseEvent): void {
     const state = (event.target as HTMLButtonElement).getAttribute("aria-pressed") ?? "false";
-    selectTool.showRuler.value = state === "false";
+    _$.showRuler = state === "false";
     selectTool.checkRuler();
 }
 
@@ -56,13 +56,13 @@ function removePoint(): void {
 
 <template>
     <div id="polygon-edit">
-        <div @click="removePoint" v-if="polygonUiVertex"><font-awesome-icon icon="trash-alt" /></div>
+        <div @click="removePoint" v-if="$.polygonUiVertex"><font-awesome-icon icon="trash-alt" /></div>
         <div @click="addPoint" v-else><font-awesome-icon icon="plus-square" /></div>
         <div @click="cutPolygon"><font-awesome-icon icon="cut" /></div>
     </div>
 
-    <div id="ruler" class="tool-detail" v-if="selected && hasSelection" :style="toolStyle">
-        <button @click="toggleShowRuler" :aria-pressed="showRuler">Show ruler</button>
+    <div id="ruler" class="tool-detail" v-if="selected && $.hasSelection" :style="toolStyle">
+        <button @click="toggleShowRuler" :aria-pressed="$.showRuler">Show ruler</button>
     </div>
 </template>
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -10,6 +10,9 @@ import { PlanarAllyModalsPlugin } from "./core/plugins/modals/plugin";
 import { loadFontAwesome } from "./fa";
 import { i18n } from "./i18n";
 import { router } from "./router";
+import { bootstrapRouter } from "./router/bootstrap";
+
+bootstrapRouter();
 
 loadFontAwesome();
 

--- a/client/src/router/bootstrap.ts
+++ b/client/src/router/bootstrap.ts
@@ -1,0 +1,66 @@
+import type { RouteRecordRaw } from "vue-router";
+
+import Login from "../auth/Login.vue";
+import { Logout } from "../auth/logout";
+import Dashboard from "../dashboard/Dashboard.vue";
+import Invitation from "../invitation";
+
+import { router } from ".";
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const AssetManager = () => import("../assetManager/AssetManager.vue");
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const Game = () => import("../game/Game.vue");
+
+const routes: Array<RouteRecordRaw> = [
+    {
+        path: "/",
+        redirect: "/dashboard",
+    },
+    {
+        path: "/assets/:folder*",
+        component: AssetManager,
+        name: "assets",
+        meta: {
+            auth: true,
+        },
+    },
+    {
+        path: "/auth/login",
+        component: Login,
+        name: "login", // name used for transition
+    },
+    {
+        path: "/auth/logout",
+        component: Logout,
+    },
+    {
+        path: "/dashboard",
+        name: "dashboard", // name used for transition
+        component: Dashboard,
+        meta: {
+            auth: true,
+        },
+    },
+    {
+        path: "/invite/:code",
+        component: Invitation,
+        meta: {
+            auth: true,
+        },
+    },
+    {
+        path: "/game/:creator/:room",
+        component: Game,
+        name: "game",
+        meta: {
+            auth: true,
+        },
+    },
+];
+
+export function bootstrapRouter(): void {
+    for (const route of routes) {
+        router.addRoute(route);
+    }
+}

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,69 +1,12 @@
 import { createRouter, createWebHistory } from "vue-router";
-import type { RouteRecordRaw } from "vue-router";
 
-import Login from "./auth/Login.vue";
-import { Logout } from "./auth/logout";
-import { http } from "./core/http";
-import Dashboard from "./dashboard/Dashboard.vue";
-import Invitation from "./invitation";
-import { handleNotifications } from "./notifications";
-import { coreStore } from "./store/core";
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const AssetManager = () => import("./assetManager/AssetManager.vue");
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-const Game = () => import("./game/Game.vue");
-
-const routes: Array<RouteRecordRaw> = [
-    {
-        path: "/",
-        redirect: "/dashboard",
-    },
-    {
-        path: "/assets/:folder*",
-        component: AssetManager,
-        name: "assets",
-        meta: {
-            auth: true,
-        },
-    },
-    {
-        path: "/auth/login",
-        component: Login,
-        name: "login", // name used for transition
-    },
-    {
-        path: "/auth/logout",
-        component: Logout,
-    },
-    {
-        path: "/dashboard",
-        name: "dashboard", // name used for transition
-        component: Dashboard,
-        meta: {
-            auth: true,
-        },
-    },
-    {
-        path: "/invite/:code",
-        component: Invitation,
-        meta: {
-            auth: true,
-        },
-    },
-    {
-        path: "/game/:creator/:room",
-        component: Game,
-        name: "game",
-        meta: {
-            auth: true,
-        },
-    },
-];
+import { http } from "../core/http";
+import { handleNotifications } from "../notifications";
+import { coreStore } from "../store/core";
 
 export const router = createRouter({
     history: createWebHistory(import.meta.env.BASE_URL),
-    routes,
+    routes: [],
 });
 
 router.beforeEach(async (to, _from, next) => {


### PR DESCRIPTION
This fixes #980.

When players had free access to toggle doors, the server was rejecting these changes because the player usually has no access to toggle the block properties.

It now behaves similarly to the Request mode where the request is routed through the DM invisibly, who does have permission.