### PR TITLE
bug(Trackers): Fix shared tracker removal not immediately updating UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ tech changes will usually be stripped from release notes for the public
 -   Teleport zone not properly landing in the center of the target
 -   Player door toggles not syncing to the server/persisting
 -   Shared trackers/auras not showing up in selection info
+-   Shared trackers/aruas removal not showing in client until refresh
 
 ## [2022.2.2] - 2022-06-17
 

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -116,7 +116,7 @@ class AuraSystem implements ShapeSystem {
 
         this.getOrCreate(id).push(aura);
 
-        if (id === this._state.id) this.updateAuraState();
+        if (id === this._state.id || id === this._state.parentId) this.updateAuraState();
 
         if (aura.active) {
             const shape = getShape(id);
@@ -162,7 +162,7 @@ class AuraSystem implements ShapeSystem {
             visionState.addVisionSource({ aura: aura.uuid, shape: id }, shape.floor.id);
         }
 
-        if (id === this._state.id) this.updateAuraState();
+        if (id === this._state.id || id === this._state.parentId) this.updateAuraState();
 
         if (aura.active || oldAuraActive) getShape(id)?.invalidate(false);
     }
@@ -174,7 +174,7 @@ class AuraSystem implements ShapeSystem {
 
         this.data.set(id, this.data.get(id)?.filter((au) => au.uuid !== auraId) ?? []);
 
-        if (id === this._state.id) this.updateAuraState();
+        if (id === this._state.id || id === this._state.parentId) this.updateAuraState();
 
         if (oldAura?.active === true) {
             const shape = getShape(id);

--- a/client/src/game/systems/trackers/index.ts
+++ b/client/src/game/systems/trackers/index.ts
@@ -112,7 +112,7 @@ class TrackerSystem implements ShapeSystem {
 
         this.getOrCreate(id).push(tracker);
 
-        if (id === this._state.id) this.updateTrackerState();
+        if (id === this._state.id || id === this._state.parentId) this.updateTrackerState();
 
         if (tracker.draw) getShape(id)?.invalidate(false);
     }
@@ -135,7 +135,7 @@ class TrackerSystem implements ShapeSystem {
 
         Object.assign(tracker, delta);
 
-        if (id === this._state.id) this.updateTrackerState();
+        if (id === this._state.id || id === this._state.parentId) this.updateTrackerState();
 
         if (tracker.draw || oldDrawTracker) getShape(id)?.invalidate(false);
     }
@@ -147,7 +147,7 @@ class TrackerSystem implements ShapeSystem {
 
         this.data.set(id, this.data.get(id)?.filter((tr) => tr.uuid !== trackerId) ?? []);
 
-        if (id === this._state.id) this.updateTrackerState();
+        if (id === this._state.id || id === this._state.parentId) this.updateTrackerState();
 
         if (oldTracker?.draw === true) getShape(id)?.invalidate(false);
     }

--- a/client/src/game/ui/settings/shape/TrackerSettings.vue
+++ b/client/src/game/ui/settings/shape/TrackerSettings.vue
@@ -36,7 +36,9 @@ function updateTracker(tracker: DeepReadonly<UiTracker>, delta: Partial<Tracker>
 }
 
 function removeTracker(tracker: TrackerId): void {
-    const id = activeShapeStore.state.id;
+    const id = trackerSystem.state.parentTrackers.some((t) => t.uuid === tracker)
+        ? activeShapeStore.state.parentUuid
+        : activeShapeStore.state.id;
     if (!owned.value || id === undefined) return;
     trackerSystem.remove(id, tracker, SERVER_SYNC);
 }
@@ -77,7 +79,9 @@ function updateAura(aura: DeepReadonly<UiAura>, delta: Partial<Aura>, syncTo = t
 }
 
 function removeAura(aura: AuraId): void {
-    const id = activeShapeStore.state.id;
+    const id = auraSystem.state.parentAuras.some((a) => a.uuid === aura)
+        ? activeShapeStore.state.parentUuid
+        : activeShapeStore.state.id;
     if (!owned.value || id === undefined) return;
     auraSystem.remove(id, aura, SERVER_SYNC);
 }


### PR DESCRIPTION
When removing a shared tracker or aura, the tracker would not be removed in the UI until a refresh of the game session.