### PR TITLE
bug(Access): Fix access state dropping on deselect

### DIFF
--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -45,14 +45,14 @@ class AccessSystem implements ShapeSystem {
 
     dropState(): void {
         _$.id = undefined;
-        _$.activeTokenFilters?.clear();
-        _$.ownedTokens.clear();
     }
 
     // BEHAVIOUR
 
     clear(): void {
         this.dropState();
+        _$.activeTokenFilters?.clear();
+        _$.ownedTokens.clear();
         this.access.clear();
     }
 
@@ -316,4 +316,4 @@ class AccessSystem implements ShapeSystem {
 }
 
 export const accessSystem = new AccessSystem();
-registerSystem("access", accessSystem, true);
+registerSystem("access", accessSystem, true, accessState);

--- a/client/src/game/systems/index.ts
+++ b/client/src/game/systems/index.ts
@@ -3,10 +3,13 @@ import type { LocalId } from "../id";
 const SYSTEMS: Record<string, System> = {};
 (window as any).systems = SYSTEMS;
 const SHAPE_SYSTEMS: Set<string> = new Set();
+const STATE: Record<string, any> = {};
+(window as any).state = STATE;
 
-export function registerSystem(key: string, system: System, isShapeSystem: boolean): void {
+export function registerSystem(key: string, system: System, isShapeSystem: boolean, state?: any): void {
     SYSTEMS[key] = system;
     if (isShapeSystem) SHAPE_SYSTEMS.add(key);
+    if (state !== undefined) STATE[key] = state;
 }
 
 export function dropFromSystems(id: LocalId): void {


### PR DESCRIPTION
A bug in my recent big refactor caused the access state to be dropped on a simple deselect, causing all kind of shenanigans, one of which was flagged by a user.

This fixes #991