### PR TITLE
bug(Game): Fix exit to dashboard not always working

### DIFF
--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -2,7 +2,6 @@ import { throttle } from "lodash";
 
 import { registerSystem } from "..";
 import type { System } from "..";
-import { SyncMode } from "../../../core/models/types";
 import { sendMoveClient } from "../../api/emits/client";
 import { getShape } from "../../id";
 import type { LocalId } from "../../id";
@@ -19,11 +18,6 @@ class ClientSystem implements System {
     }
 
     clearClientRects(): void {
-        for (const id of _$.playerRectIds.values()) {
-            const p = getShape(id);
-            if (p === undefined) continue;
-            p.layer.removeShape(p, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
-        }
         _$.playerRectIds.clear();
         _$.playerLocationData.clear();
     }


### PR DESCRIPTION
When trying to exit to the dashboard from a game session, the game is cleared.

The cleaning of client rectangles depended on the floor system still being loaded, which since recent refactors is no longer guaranteed to be the case.

As a fix the cleanup of the client rectangles will no longer actively be done, as they will be removed automatically when the floor system cleans up anyway.