### PR TITLE
feat(Perf): Add raw floor state lookup for perf

### DIFF
--- a/client/src/game/floor/server.ts
+++ b/client/src/game/floor/server.ts
@@ -25,7 +25,16 @@ export function addServerFloor(serverFloor: ServerFloor): void {
     floorSystem.addFloor(floor, serverFloor.index);
     const floorId = floorSystem.getFloor({ name: serverFloor.name })!.id;
     visionState.addCdt(floorId);
-    for (const layer of serverFloor.layers) addServerLayer(layer, floor);
+
+    // we need to draw fow later because it depends on fow-players
+    // and historically we did the draw loop in the other direction
+    let fowLayer: ServerLayer | undefined;
+    for (const layer of serverFloor.layers) {
+        if (layer.name === LayerName.Lighting) fowLayer = layer;
+        else addServerLayer(layer, floor);
+    }
+    if (fowLayer) addServerLayer(fowLayer, floor);
+
     visionState.recalculateVision(floorId);
     visionState.recalculateMovement(floorId);
 

--- a/client/src/game/layers/variants/fow.ts
+++ b/client/src/game/layers/variants/fow.ts
@@ -36,9 +36,9 @@ export class FowLayer extends Layer {
             this.canvas.style.removeProperty("display");
         else if (this.floor !== activeFloor && this.canvas.style.display !== "none") this.canvas.style.display = "none";
 
-        if (this.floor === activeFloor && floorState.$.floors.length > 1) {
-            for (const floor of floorState.$.floors) {
-                if (floor.name !== floorState.$.floors[0].name) {
+        if (this.floor === activeFloor && floorState.__$.floors.length > 1) {
+            for (const floor of floorState.__$.floors) {
+                if (floor.name !== floorState.__$.floors[0].name) {
                     const mapl = floorSystem.getLayer(floor, LayerName.Map);
                     if (mapl === undefined) continue;
                     this.ctx.globalCompositeOperation = "destination-out";

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -39,16 +39,18 @@ export class FowLightingLayer extends FowLayer {
             const originalOperation = this.ctx.globalCompositeOperation;
             super._draw();
 
+            const activeFloor = floorState.currentFloor.value!;
+
             // At all times provide a minimal vision range to prevent losing your tokens in fog.
             if (
                 settingsStore.fullFow.value &&
-                floorSystem.hasLayer(floorState.currentFloor.value!, LayerName.Tokens) &&
-                floorState.currentFloor.value!.id === this.floor
+                floorSystem.hasLayer(activeFloor, LayerName.Tokens) &&
+                activeFloor.id === this.floor
             ) {
                 for (const sh of accessState.activeTokens.value) {
                     const shape = getShape(sh)!;
                     if (shape.options.skipDraw ?? false) continue;
-                    if (shape.floor.id !== floorState.currentFloor.value!.id) continue;
+                    if (shape.floor.id !== activeFloor.id) continue;
                     const bb = shape.getBoundingBox();
                     const lcenter = g2l(shape.center());
                     const alm = 0.8 * g2lz(bb.w);
@@ -137,11 +139,10 @@ export class FowLightingLayer extends FowLayer {
                 }
             }
 
-            const activeFloor = floorState.currentFloor.value!.id;
-            if (settingsStore.fowLos.value && this.floor === activeFloor) {
+            if (settingsStore.fowLos.value && this.floor === activeFloor.id) {
                 this.ctx.globalCompositeOperation = "source-in";
                 this.ctx.drawImage(
-                    floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Vision)!.canvas,
+                    floorSystem.getLayer(activeFloor, LayerName.Vision)!.canvas,
                     0,
                     0,
                     window.innerWidth,
@@ -162,7 +163,7 @@ export class FowLightingLayer extends FowLayer {
                 preShape.globalCompositeOperation = ogComposite;
             }
 
-            if (settingsStore.fullFow.value && this.floor === activeFloor) {
+            if (settingsStore.fullFow.value && this.floor === activeFloor.id) {
                 this.ctx.globalCompositeOperation = "source-out";
                 this.ctx.fillStyle = getFogColour();
                 this.ctx.fillRect(0, 0, this.width, this.height);

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -67,9 +67,9 @@ export class FowVisionLayer extends FowLayer {
             }
 
             const activeFloor = floorState.currentFloor.value!.id;
-            if (this.floor === activeFloor && floorState.$.floors.length > 1) {
-                for (let f = floorState.$.floors.length - 1; f > floorState.$.floorIndex; f--) {
-                    const floor = floorState.$.floors[f];
+            if (this.floor === activeFloor && floorState.__$.floors.length > 1) {
+                for (let f = floorState.__$.floors.length - 1; f > floorState.__$.floorIndex; f--) {
+                    const floor = floorState.__$.floors[f];
                     if (floor.id === activeFloor) break;
                     const fowl = floorSystem.getLayer(floor, this.name);
                     if (fowl === undefined) continue;

--- a/client/src/game/layers/variants/grid.ts
+++ b/client/src/game/layers/variants/grid.ts
@@ -8,10 +8,12 @@ export class GridLayer extends Layer {
     invalidate(): void {
         this.valid = false;
     }
+
     show(): void {
         if (settingsStore.useGrid.value && this.floor === floorState.currentFloor.value!.id)
             this.canvas.style.removeProperty("display");
     }
+
     draw(_doClear?: boolean): void {
         if (!this.valid) {
             if (settingsStore.useGrid.value) {

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -313,8 +313,8 @@ export class Layer implements ILayer {
             }
 
             // If this is the last layer of the floor below, render some shadow
-            if (floorState.$.floorIndex > 0) {
-                const lowerFloor = floorState.$.floors[floorState.$.floorIndex - 1];
+            if (floorState.__$.floorIndex > 0) {
+                const lowerFloor = floorState.__$.floors[floorState.__$.floorIndex - 1];
                 if (lowerFloor.id === this.floor) {
                     const layers = floorSystem.getLayers(lowerFloor);
                     if (layers.at(-1)?.name === this.name) {

--- a/client/src/game/rendering/core.ts
+++ b/client/src/game/rendering/core.ts
@@ -1,5 +1,3 @@
-import type { ILayer } from "../interfaces/layer";
-import { LayerName } from "../models/floor";
 import type { Floor } from "../models/floor";
 import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
@@ -15,7 +13,7 @@ export function stopDrawLoop(): void {
 }
 
 function drawLoop(): void {
-    const state = floorState.$;
+    const state = floorState.__$;
     // First process all other floors
     for (const [f, floor] of state.floors.entries()) {
         if (f === state.floorIndex) continue;
@@ -35,16 +33,8 @@ function drawLoop(): void {
 }
 
 function drawFloor(floor: Floor): void {
-    let fowLayer: ILayer | undefined;
     for (const layer of floorSystem.getLayers(floor)) {
         layer.hide();
-        // we need to draw fow later because it depends on fow-players
-        // and historically we did the draw loop in the other direction
-        if (layer.name === LayerName.Lighting) {
-            fowLayer = layer;
-            continue;
-        }
         layer.draw();
     }
-    if (fowLayer) fowLayer.draw();
 }

--- a/client/src/game/systems/README.md
+++ b/client/src/game/systems/README.md
@@ -26,3 +26,18 @@ For example: when you click on a door in select mode, the select tool who handle
 
 (1) The name `system` is possibly confusing here, but `component` has a naming conflict with vue components. Another name might be used in the future.
 (2) This is handled with vue reactivity, so it doesn't really actively check the UI, but just updates a reactive object
+
+Most systems have a separate state object that usually has a form similar to:
+```
+{
+    $: {...}
+    _$: {...}
+    __$: {...}
+
+    someComputedValue: ...,
+    someOtherComputedValue: ...
+}
+```
+The `state.$` contains a readonly reactive view to the state, which is what most external users of the state should be using.
+`state._$` is a mutable view into the state (still reactive) and is typically exclusively used by the system the state belongs to.
+Lastly `state.__$` is a raw non-reactive view into the state, this should only be used in special cases where performance matters.

--- a/client/src/game/systems/floors/state.ts
+++ b/client/src/game/systems/floors/state.ts
@@ -1,4 +1,4 @@
-import { computed, reactive, readonly } from "vue";
+import { computed, reactive, readonly, toRaw } from "vue";
 
 import type { ILayer } from "../../interfaces/layer";
 import type { Floor, FloorId } from "../../models/floor";
@@ -21,6 +21,7 @@ const state = reactive<FloorState>({
 export const floorState = {
     $: readonly(state),
     _$: state,
+    __$: toRaw(state),
 
     currentFloor: computed(() => {
         if (state.floorIndex < 0) return undefined;


### PR DESCRIPTION
Some of the render internals were accessing floor state through reactive APIs, this PR adds a raw access lookup for performance critical paths.

Also a long overdue change was made to re-order the fow layers the moment they are added the first time, instead of doing some extra bookkeeping in the render loop.