### PR TITLE
bug(FOW): Fix fow layer shapes being invisible

### DIFF
--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -278,7 +278,7 @@ export class Layer implements ILayer {
             // First to draw the auras and a second time to draw the shapes themselves
             // Otherwise auras from one shape could overlap another shape.
 
-            const currentLayer = floorState.currentLayer.value;
+            const currentLayer = toRaw(floorState.currentLayer.value);
             // To optimize things slightly, we keep track of the shapes that passed the first round
             const visibleShapes: IShape[] = [];
 


### PR DESCRIPTION
A check that hides FOW shapes unless you're on the FOW layer, was no longer working correctly, making the fow shapes also invisible while on the FOW layer.