### PR TITLE
bug(Prompt): Fix prompt errors not being shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ tech changes will usually be stripped from release notes for the public
 -   Player door toggles not syncing to the server/persisting
 -   Shared trackers/auras not showing up in selection info
 -   Shared trackers/aruas removal not showing in client until refresh
+-   Errors in prompt modals were not visible
 
 ## [2022.2.2] - 2022-06-17
 

--- a/client/src/core/components/PluginContainer.vue
+++ b/client/src/core/components/PluginContainer.vue
@@ -30,6 +30,7 @@ export default defineComponent({
         :visible="prompt.visible.value"
         :title="prompt.title.value"
         :question="prompt.question.value"
+        :error="prompt.error.value"
         @close="prompt.close"
         @submit="prompt.submit"
     />


### PR DESCRIPTION
When a prompt modal appears and the value inserted was invalid, the actual error message was no longer visible.