### PR TITLE
feat(VisionTool): Hide private light auras for DM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ tech changes will usually be stripped from release notes for the public
 ### Changed
 
 -   Draw tool vision and logic tabs will now have a background colour if they are active as a reminder
+-   [DM] Hiding a token using the vision tool will now also hide their private light auras
 -   [server] moved all python imports to proper relative imports
     -   this changes the way to manually run the server (again) (sorry)
 

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -103,7 +103,7 @@ class AccessSystem implements ShapeSystem {
         limitToActiveTokens: boolean,
         access: Partial<{ edit: boolean; vision: boolean; movement: boolean }>,
     ): boolean {
-        if (getGameState().isDm) return true;
+        if (getGameState().isDm && !limitToActiveTokens) return true;
 
         const props = getProperties(id);
         if (props === undefined) return false;
@@ -114,7 +114,7 @@ class AccessSystem implements ShapeSystem {
             }
         }
 
-        if (getGameState().isFakePlayer) return true;
+        if (getGameState().isDm || getGameState().isFakePlayer) return true;
 
         const accessMap = this.access.get(id);
         if (accessMap === undefined) return false;

--- a/client/test/game/systems/access/index.test.ts
+++ b/client/test/game/systems/access/index.test.ts
@@ -121,7 +121,7 @@ describe("Access System", () => {
                 extra: [id2TestUser, id2DmUser],
             });
         });
-        it("should always return true if the player is a DM", () => {
+        it("should return correctly if the player is a DM", () => {
             // setup
             gameStore.setDm(true);
             // test
@@ -133,7 +133,7 @@ describe("Access System", () => {
             // 2. shape is a token that is not active and the limiter is active
             GET_PROPERTIES_OVERRIDE = () => ({ isToken: true });
             accessSystem.setActiveTokens();
-            expect(accessSystem.hasAccessTo(id, true, { edit: true })).toBe(true);
+            expect(accessSystem.hasAccessTo(id, true, { edit: true })).toBe(false);
             GET_PROPERTIES_OVERRIDE = undefined;
             // 3. the current user would otherwise not have access
             clientStore.setUsername("userWithNoRights");


### PR DESCRIPTION
The idea of the vision tool is to toggle vision so that you only see what certain tokens can see.
As a DM this would however not toggle the private light auras of tokens you deselect.
You could go through the DM settings and activate 'fake player', but if you want to do a quick check that is a bit cumbersome.

Hence from now on, the vision tool will also hide private light auras from the DM if they have that token deselected in the vision tool.