### PR TITLE
release(2022.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+## [2022.2.3] - 2022-07-13
+
+### Fixed
+
+-   [server] Windows executable builds not using the correct directory for certain files (e.g. config/assets)
+
 ## [2022.2.2] - 2022-06-17
 
 ### Changed

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "client",
-    "version": "2022.2.2",
+    "version": "2022.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "client",
-            "version": "2022.1.0",
+            "version": "2022.2.3",
             "dependencies": {
                 "@babylonjs/materials": "^4.2.2",
                 "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "2022.2.2",
+    "version": "2022.2.3",
     "private": true,
     "scripts": {
         "dev": "vite",

--- a/server/VERSION
+++ b/server/VERSION
@@ -1,4 +1,4 @@
-2022.2.2
+2022.2.3
 
 ### Added
 
@@ -56,3 +56,4 @@
 -   [2022.2.2] Ghost initiative entries showing up as ? that cannot be removed
 -   [2022.2.2] Database lock errors while importing during load
 -   [2022.2.2][server] Server not being able to start due to ModuleNotFoundError
+-   [2022.2.3][server] Windows executable builds not using the correct directory for certain files (e.g. config/assets)

--- a/server/src/utils.py
+++ b/server/src/utils.py
@@ -15,12 +15,18 @@ def get_src_dir() -> Path:
     return Path(__file__).resolve().parent
 
 
+def get_file_dir() -> Path:
+    if getattr(sys, "frozen", False):
+        return SRC_DIR
+    return SRC_DIR.parent
+
+
 def get_save_dir() -> Path:
     return FILE_DIR
 
 
 SRC_DIR = get_src_dir()
-FILE_DIR = SRC_DIR.parent
+FILE_DIR = get_file_dir()
 STATIC_DIR = FILE_DIR / "static"
 ASSETS_DIR = STATIC_DIR / "assets"
 TEMP_DIR = STATIC_DIR / "temp"


### PR DESCRIPTION
This release fixes an issue with the Windows executable builds.
Otherwise nothing is changed, so there is no special need to upgrade if you don't use the windows build.