### PR TITLE
bug(Location): Fix location options reset sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ tech changes will usually be stripped from release notes for the public
 -   Shared trackers/auras not showing up in selection info
 -   Shared trackers/aruas removal not showing in client until refresh
 -   Errors in prompt modals were not visible
+-   Resetting location specific settings was not immediately synchronizing to clients until a refresh
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/api/emits/location.ts
+++ b/client/src/game/api/emits/location.ts
@@ -7,6 +7,7 @@ export const sendLocationOptions = wrapSocket<{
     options: Partial<ServerLocationOptions>;
     location: number | undefined;
 }>("Location.Options.Set");
+export const sendResetLocationOption = wrapSocket<{ key: string; location: number }>("Location.Options.Reset");
 export const sendLocationOrder = wrapSocket<number[]>("Locations.Order.Set");
 export const sendLocationChange = wrapSocket<{
     location: number;

--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -8,7 +8,7 @@ import { settingsStore } from "../../../store/settings";
 import { reserveLocalId } from "../../id";
 import type { GlobalId } from "../../id";
 import type { ServerLocation } from "../../models/general";
-import type { Location, ServerLocationOptions } from "../../models/settings";
+import type { Location, LocationOptions, ServerLocationOptions } from "../../models/settings";
 import { playerSystem } from "../../systems/players";
 import { VisibilityMode, visionState } from "../../vision/state";
 import { socket } from "../socket";
@@ -27,6 +27,10 @@ socket.on("Locations.Settings.Set", (data: { [key: number]: Partial<ServerLocati
 
 socket.on("Location.Options.Set", (data: { options: Partial<ServerLocationOptions>; location: number | null }) => {
     setLocationOptions(data.location ?? undefined, data.options);
+});
+
+socket.on("Location.Options.Reset", (data: { key: keyof LocationOptions; location: number }) => {
+    settingsStore.reset(data.key, data.location, false);
 });
 
 socket.on("Locations.Order.Set", (locations: Location[]) => {

--- a/client/src/game/ui/settings/location/FloorSettings.vue
+++ b/client/src/game/ui/settings/location/FloorSettings.vue
@@ -117,7 +117,7 @@ function setUndergroundBackgroundFromEvent(event: Event): void {
 
 function reset(key: keyof LocationOptions): void {
     if (isGlobal.value) return;
-    settingsStore.reset(key, props.location);
+    settingsStore.reset(key, props.location, true);
 }
 
 function e(k: any): boolean {

--- a/client/src/game/ui/settings/location/GridSettings.vue
+++ b/client/src/game/ui/settings/location/GridSettings.vue
@@ -59,7 +59,7 @@ const unitSizeUnit = computed({
 
 function reset(key: keyof LocationOptions): void {
     if (isGlobal.value) return;
-    settingsStore.reset(key, props.location);
+    settingsStore.reset(key, props.location, true);
 }
 
 function e(k: any): boolean {

--- a/client/src/game/ui/settings/location/VariaSettings.vue
+++ b/client/src/game/ui/settings/location/VariaSettings.vue
@@ -32,7 +32,7 @@ const movePlayerOnTokenChange = computed({
 
 function reset(key: keyof LocationOptions): void {
     if (isGlobal.value) return;
-    settingsStore.reset(key, props.location);
+    settingsStore.reset(key, props.location, true);
 }
 </script>
 

--- a/client/src/game/ui/settings/location/VisionSettings.vue
+++ b/client/src/game/ui/settings/location/VisionSettings.vue
@@ -104,7 +104,7 @@ const visionMaxRange = computed({
 
 function reset(key: keyof LocationOptions): void {
     if (isGlobal.value) return;
-    settingsStore.reset(key, props.location);
+    settingsStore.reset(key, props.location, true);
 }
 
 function changeVisionMode(event: Event): void {

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -3,8 +3,7 @@ import type { ComputedRef } from "vue";
 
 import { Store } from "../core/store";
 import { getValueOrDefault } from "../core/types";
-import { toSnakeCase } from "../core/utils";
-import { sendLocationOptions } from "../game/api/emits/location";
+import { sendLocationOptions, sendResetLocationOption } from "../game/api/emits/location";
 import { getGlobalId } from "../game/id";
 import type { LocalId } from "../game/id";
 import type { LocationOptions } from "../game/models/settings";
@@ -122,14 +121,16 @@ class SettingsStore extends Store<SettingsState> {
         );
     }
 
-    reset(key: keyof LocationOptions, location: number): void {
+    reset(key: keyof LocationOptions, location: number, sync: boolean): void {
         const options = this._state.locationOptions.get(location)!;
         if (key in options) {
             delete options[key];
-            sendLocationOptions({
-                options: { [toSnakeCase(key)]: null },
-                location: location,
-            });
+            if (sync) {
+                sendResetLocationOption({
+                    key,
+                    location: location,
+                });
+            }
 
             if (
                 [


### PR DESCRIPTION
Resetting a location specific option was not immediately updating on clients until a refresh.