### PR TITLE
bug(Location): Fix location options reset sync event casing

### DIFF
--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -3,6 +3,7 @@ import type { ComputedRef } from "vue";
 
 import { Store } from "../core/store";
 import { getValueOrDefault } from "../core/types";
+import { toSnakeCase } from "../core/utils";
 import { sendLocationOptions, sendResetLocationOption } from "../game/api/emits/location";
 import { getGlobalId } from "../game/id";
 import type { LocalId } from "../game/id";
@@ -127,7 +128,7 @@ class SettingsStore extends Store<SettingsState> {
             delete options[key];
             if (sync) {
                 sendResetLocationOption({
-                    key,
+                    key: toSnakeCase(key),
                     location: location,
                 });
             }


### PR DESCRIPTION
This PR is related to #1001, in which I fixed the reset behaviour of location settings.
I did miss a bug with those settings that consist of multiple words behind the scenes (e.g. full fow), as these are cased differently on server and client. (server: snake_case, client: camelCase).

The client will now send the appropriate casing to the server.