### PR TITLE
bug(AssetManager): Fix assetmanager when using subpath setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ tech changes will usually be stripped from release notes for the public
 -   Shared trackers/aruas removal not showing in client until refresh
 -   Errors in prompt modals were not visible
 -   Resetting location specific settings was not immediately synchronizing to clients until a refresh
+-   The asset manager was no longer useable when using a subpath setup
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/assetManager/socket.ts
+++ b/client/src/assetManager/socket.ts
@@ -29,7 +29,7 @@ socket.on("Folder.Set", async (data: { folder: Asset; path?: number[] }) => {
     assetStore.setFolderData(data.folder.id, data.folder);
     if (!assetStore.state.modalActive) {
         if (data.path) assetStore.setPath(data.path);
-        const path = baseAdjust(`/assets${assetStore.currentFilePath.value}`);
+        const path = `/assets${assetStore.currentFilePath.value}/`;
         if (path !== router.currentRoute.value.path) {
             await router.push({ path });
         }


### PR DESCRIPTION
When using the subpath server setup, the AssetManager was automatically redirecting to a wrong path, in practice making the asset manager functionally useless.

This fixes #1006 