### PR TITLE
bug(State): Fix readonly state not properly updating

### DIFF
--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -87,7 +87,7 @@ socket.on("Board.Floor.Set", (floor: ServerFloor) => {
     // It is important that this condition is evaluated before the async addFloor call.
     // The very first floor that arrives is the one we want to select
     // When this condition is evaluated after the await, we are at the mercy of the async scheduler
-    const selectFloor = floorState.readonly.floors.length === 0;
+    const selectFloor = floorState.raw.floors.length === 0;
     if (debugLayers)
         console.log(
             `Adding floor ${floor.name} [${floor.layers.reduce((acc, cur) => acc + cur.shapes.length, 0)} shapes]`,

--- a/client/src/game/input/keyboard/down.ts
+++ b/client/src/game/input/keyboard/down.ts
@@ -158,29 +158,28 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
             undoOperation();
             event.preventDefault();
             event.stopPropagation();
-        } else if (event.key === "PageUp" && floorState.readonly.floorIndex < floorState.readonly.floors.length - 1) {
+        } else if (event.key === "PageUp" && floorState.raw.floorIndex < floorState.raw.floors.length - 1) {
             // Page Up - Move floor up
             // Alt + Page Up - Move selected shapes floor up
             // Alt + Shift + Page Up - Move selected shapes floor up AND move floor up
             event.preventDefault();
             event.stopPropagation();
-            const targetFloor = floorState.readonly.floors.findIndex(
-                (f, i) => i > floorState.readonly.floorIndex && (getGameState().isDm || f.playerVisible),
+            const targetFloor = floorState.raw.floors.findIndex(
+                (f, i) => i > floorState.raw.floorIndex && (getGameState().isDm || f.playerVisible),
             );
 
             changeFloor(event, targetFloor);
-        } else if (event.key === "PageDown" && floorState.readonly.floorIndex > 0) {
+        } else if (event.key === "PageDown" && floorState.raw.floorIndex > 0) {
             // Page Down - Move floor down
             // Alt + Page Down - Move selected shape floor down
             // Alt + Shift + Page Down - Move selected shapes floor down AND move floor down
             event.preventDefault();
             event.stopPropagation();
-            const maxLength = floorState.readonly.floors.length - 1;
-            let targetFloor = [...floorState.readonly.floors]
+            const maxLength = floorState.raw.floors.length - 1;
+            let targetFloor = [...floorState.raw.floors]
                 .reverse()
                 .findIndex(
-                    (f, i) =>
-                        maxLength - i < floorState.readonly.floorIndex && (getGameState().isDm || f.playerVisible),
+                    (f, i) => maxLength - i < floorState.raw.floorIndex && (getGameState().isDm || f.playerVisible),
                 );
             targetFloor = maxLength - targetFloor;
 
@@ -193,9 +192,9 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
 }
 
 function changeFloor(event: KeyboardEvent, targetFloor: number): void {
-    if (targetFloor < 0 || targetFloor > floorState.readonly.floors.length - 1) return;
+    if (targetFloor < 0 || targetFloor > floorState.raw.floors.length - 1) return;
     const selection = selectedSystem.get({ includeComposites: true });
-    const newFloor = floorState.readonly.floors[targetFloor];
+    const newFloor = floorState.raw.floors[targetFloor];
 
     if (event.altKey) {
         moveFloor([...selection], newFloor, true);

--- a/client/src/game/layers/floor.ts
+++ b/client/src/game/layers/floor.ts
@@ -4,7 +4,7 @@ import { floorState } from "../systems/floors/state";
 
 export function recalculateZIndices(): void {
     let i = 0;
-    for (const floor of floorState.readonly.floors) {
+    for (const floor of floorState.raw.floors) {
         for (const layer of floorSystem.getLayers(floor)) {
             layer.canvas.style.zIndex = `${i}`;
             i += 1;

--- a/client/src/game/layers/variants/fow.ts
+++ b/client/src/game/layers/variants/fow.ts
@@ -36,9 +36,9 @@ export class FowLayer extends Layer {
             this.canvas.style.removeProperty("display");
         else if (this.floor !== activeFloor && this.canvas.style.display !== "none") this.canvas.style.display = "none";
 
-        if (this.floor === activeFloor && floorState.readonly.floors.length > 1) {
-            for (const floor of floorState.readonly.floors) {
-                if (floor.name !== floorState.readonly.floors[0].name) {
+        if (this.floor === activeFloor && floorState.raw.floors.length > 1) {
+            for (const floor of floorState.raw.floors) {
+                if (floor.name !== floorState.raw.floors[0].name) {
                     const mapl = floorSystem.getLayer(floor, LayerName.Map);
                     if (mapl === undefined) continue;
                     this.ctx.globalCompositeOperation = "destination-out";

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -67,9 +67,9 @@ export class FowVisionLayer extends FowLayer {
             }
 
             const activeFloor = floorState.currentFloor.value!.id;
-            if (this.floor === activeFloor && floorState.readonly.floors.length > 1) {
-                for (let f = floorState.readonly.floors.length - 1; f > floorState.readonly.floorIndex; f--) {
-                    const floor = floorState.readonly.floors[f];
+            if (this.floor === activeFloor && floorState.raw.floors.length > 1) {
+                for (let f = floorState.raw.floors.length - 1; f > floorState.raw.floorIndex; f--) {
+                    const floor = floorState.raw.floors[f];
                     if (floor.id === activeFloor) break;
                     const fowl = floorSystem.getLayer(floor, this.name);
                     if (fowl === undefined) continue;

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -325,8 +325,8 @@ export class Layer implements ILayer {
             }
 
             // If this is the last layer of the floor below, render some shadow
-            if (floorState.readonly.floorIndex > 0) {
-                const lowerFloor = floorState.readonly.floors[floorState.readonly.floorIndex - 1];
+            if (floorState.raw.floorIndex > 0) {
+                const lowerFloor = floorState.raw.floors[floorState.raw.floorIndex - 1];
                 if (lowerFloor.id === this.floor) {
                     const layers = floorSystem.getLayers(lowerFloor);
                     if (layers.at(-1)?.name === this.name) {

--- a/client/src/game/rendering/core.ts
+++ b/client/src/game/rendering/core.ts
@@ -13,7 +13,7 @@ export function stopDrawLoop(): void {
 }
 
 function drawLoop(): void {
-    const state = floorState.readonly;
+    const state = floorState.raw;
     // First process all other floors
     for (const [f, floor] of state.floors.entries()) {
         if (f === state.floorIndex) continue;

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -177,9 +177,9 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
     if (sync !== SyncMode.NO_SYNC) sendRemoveShapes({ uuids: removed, temporary: sync === SyncMode.TEMP_SYNC });
     if (!recalculateIterative) {
         if (recalculateMovement)
-            visionState.recalculate({ target: TriangulationTarget.MOVEMENT, floor: floorState.readonly.floorIndex });
+            visionState.recalculate({ target: TriangulationTarget.MOVEMENT, floor: floorState.raw.floorIndex });
         if (recalculateVision)
-            visionState.recalculate({ target: TriangulationTarget.VISION, floor: floorState.readonly.floorIndex });
+            visionState.recalculate({ target: TriangulationTarget.VISION, floor: floorState.raw.floorIndex });
         floorSystem.invalidateVisibleFloors();
     }
 }

--- a/client/src/game/systems/README.md
+++ b/client/src/game/systems/README.md
@@ -27,5 +27,5 @@ For example: when you click on a door in select mode, the select tool who handle
 (1) The name `system` is possibly confusing here, but `component` has a naming conflict with vue components. Another name might be used in the future.
 (2) This is handled with vue reactivity, so it doesn't really actively check the UI, but just updates a reactive object
 
-Most systems have a separate state that has a readonly reactive and a non-reactive view into the state, accessible with `.reactive` and `.readonly` respectively. The reactive view also has a mutable variant `.mutableReactive`, which should be used to alter the state.
-A pure non-reactive mutable view is not directly accessible as it will not update any reactive watchers, but could be accessible for a specific system.
+Most systems have a separate state that has a readonly reactive and non-reactive view into the state, accessible with `.reactive` and `.raw` respectively. The reactive view also has a mutable variant `.mutableReactive`, which should be used to alter the state.
+A pure non-reactive mutable view is not directly accessible as it will not update any reactive watchers. There is however also the possibility to add state that will never be reactive. Properties part of this non-reactive state are available as `.readonly` and `.mutable`.

--- a/client/src/game/systems/state.ts
+++ b/client/src/game/systems/state.ts
@@ -30,10 +30,11 @@ export function buildState<T extends object, U = void>(
     reactive: DeepReadonly<UnwrapNestedRefs<T>>;
     mutableReactive: UnwrapNestedRefs<T>;
 } {
-    const reactiveState = reactive(state);
+    const fullState = { ...state, ...nonReactiveProperties };
+    const reactiveState = reactive(fullState);
     return {
-        readonly: { ...state, ...nonReactiveProperties } as DeepReadonly<T & U>,
-        mutable: nonReactiveProperties,
+        readonly: fullState as DeepReadonly<T & U>,
+        mutable: fullState as unknown as U,
         reactive: reactiveState as DeepReadonly<UnwrapNestedRefs<T>>,
         mutableReactive: reactiveState,
     };

--- a/client/src/game/systems/state.ts
+++ b/client/src/game/systems/state.ts
@@ -5,36 +5,32 @@ import type { DeepReadonly, UnwrapNestedRefs } from "vue";
 // we can work with readonly purely as typing
 // and not bother with explicit readonly() calls
 
-export function buildState<T extends object>(
-    state: T,
-): {
-    readonly: DeepReadonly<T>;
+interface ReactiveState<T extends object> {
+    raw: DeepReadonly<T>;
     reactive: DeepReadonly<UnwrapNestedRefs<T>>;
     mutableReactive: UnwrapNestedRefs<T>;
-};
+}
+
+export function buildState<T extends object>(state: T): ReactiveState<T>;
 export function buildState<T extends object, U>(
     state: T,
     nonReactiveProperties: U,
-): {
-    readonly: DeepReadonly<T & U>;
+): ReactiveState<T> & {
+    readonly: DeepReadonly<U>;
     mutable: U;
-    reactive: DeepReadonly<UnwrapNestedRefs<T>>;
-    mutableReactive: UnwrapNestedRefs<T>;
 };
 export function buildState<T extends object, U = void>(
     state: T,
     nonReactiveProperties?: U,
-): {
-    readonly: DeepReadonly<T & U>;
+): ReactiveState<T> & {
+    readonly: DeepReadonly<U>;
     mutable: U | undefined;
-    reactive: DeepReadonly<UnwrapNestedRefs<T>>;
-    mutableReactive: UnwrapNestedRefs<T>;
 } {
-    const fullState = { ...state, ...nonReactiveProperties };
-    const reactiveState = reactive(fullState);
+    const reactiveState = reactive(state);
     return {
-        readonly: fullState as DeepReadonly<T & U>,
-        mutable: fullState as unknown as U,
+        readonly: nonReactiveProperties as DeepReadonly<U>,
+        mutable: nonReactiveProperties,
+        raw: state as DeepReadonly<T>,
         reactive: reactiveState as DeepReadonly<UnwrapNestedRefs<T>>,
         mutableReactive: reactiveState,
     };

--- a/client/src/game/ui/settings/FloorSettings.vue
+++ b/client/src/game/ui/settings/FloorSettings.vue
@@ -44,7 +44,7 @@ function setFloorType(event: Event): void {
 }
 
 async function removeFloor(): Promise<void> {
-    if (floor.value === undefined || floorState.readonly.floors.length <= 1) return;
+    if (floor.value === undefined || floorState.raw.floors.length <= 1) return;
 
     const doRemove = await modals.confirm(
         t("common.warning"),

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -55,7 +55,7 @@ class VisionState extends Store<State> {
     setVisionMode(mode: VisibilityMode, sync: boolean): void {
         this._state.mode = mode;
 
-        for (const floor of floorState.readonly.floors) {
+        for (const floor of floorState.raw.floors) {
             visionState.recalculateVision(floor.id);
             visionState.recalculateMovement(floor.id);
         }

--- a/client/src/store/client.ts
+++ b/client/src/store/client.ts
@@ -185,7 +185,7 @@ class ClientStore extends Store<State> {
 
     setGridColour(colour: string, sync: boolean): void {
         this._state.gridColour = colour;
-        for (const floor of floorState.readonly.floors) {
+        for (const floor of floorState.raw.floors) {
             floorSystem.getGridLayer(floor)!.invalidate();
         }
         if (sync) sendRoomClientOptions({ grid_colour: colour });

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -149,12 +149,12 @@ class SettingsStore extends Store<SettingsState> {
             } else if (["fullFow", "fowOpacity"].includes(key)) {
                 floorSystem.invalidateLightAllFloors();
             } else if (key === "gridType") {
-                for (const floor of floorState.readonly.floors) {
+                for (const floor of floorState.raw.floors) {
                     const gridLayer = floorSystem.getGridLayer(floor)!;
                     gridLayer.invalidate();
                 }
             } else if (key === "useGrid") {
-                for (const floor of floorState.readonly.floors) {
+                for (const floor of floorState.raw.floors) {
                     const gridLayer = floorSystem.getGridLayer(floor)!;
                     if (this.useGrid.value) gridLayer.canvas.style.display = "block";
                     else gridLayer.canvas.style.display = "none";
@@ -195,7 +195,7 @@ class SettingsStore extends Store<SettingsState> {
             throw new Error("Unknown grid type set");
         }
         if (this.mutate("gridType", gridType, location)) {
-            for (const floor of floorState.readonly.floors) {
+            for (const floor of floorState.raw.floors) {
                 const gridLayer = floorSystem.getGridLayer(floor)!;
                 gridLayer.invalidate();
             }
@@ -224,7 +224,7 @@ class SettingsStore extends Store<SettingsState> {
 
     setUseGrid(useGrid: boolean, location: number | undefined, sync: boolean): void {
         if (this.mutate("useGrid", useGrid, location)) {
-            for (const floor of floorState.readonly.floors) {
+            for (const floor of floorState.raw.floors) {
                 const gridLayer = floorSystem.getGridLayer(floor)!;
                 if (useGrid) gridLayer.canvas.style.display = "block";
                 else gridLayer.canvas.style.display = "none";


### PR DESCRIPTION
The new unified state system had a small bug in it :D

The `.readonly` state was not properly updating, whereas all other states where properly updating.
This was due to unpacking the state together with the non-reactive state in a new object.

The non reactive properties will now be available as `.mutable` and `.readonly`, whereas the reactive properties will be available as `.reactive`, `.mutableReactive` and `.raw`. The raw view is readonly and no mutable direct view in the state is available in order to prevent subtle bugs due to skipping the reactivity system