### PR TITLE
feat(Server:Assets): Add alternate assets location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Added
+
+-   [server] option to specify alternative location for static files
+
 ### Changed
 
 -   Draw tool vision and logic tabs will now have a background colour if they are active as a reminder

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -30,6 +30,7 @@ max_upload_size_in_bytes = 10_485_760
 
 [General]
 save_file = planar.sqlite
+#assets_directory = 
 #public_name = 
 
 # These settings are used for log rotating,

--- a/server/src/api/socket/asset_manager/__init__.py
+++ b/server/src/api/socket/asset_manager/__init__.py
@@ -22,10 +22,10 @@ from ....models import Asset
 from ....models.user import User
 from ....state.asset import asset_state
 from ....state.game import game_state
-from ....utils import TEMP_DIR
+from ....utils import ASSETS_DIR, TEMP_DIR
 from ..constants import ASSET_NS, GAME_NS
 from .common import UploadData
-from .ddraft import ASSETS_DIR, handle_ddraft_file
+from .ddraft import handle_ddraft_file
 
 
 class AssetDict(TypedDict):

--- a/server/src/api/socket/asset_manager/common.py
+++ b/server/src/api/socket/asset_manager/common.py
@@ -12,8 +12,3 @@ class UploadData(TypedDict):
     slice: int
     totalSlices: int
     data: bytes
-
-
-ASSETS_DIR = FILE_DIR / "static" / "assets"
-if not ASSETS_DIR.exists():
-    ASSETS_DIR.mkdir()

--- a/server/src/api/socket/asset_manager/ddraft.py
+++ b/server/src/api/socket/asset_manager/ddraft.py
@@ -7,8 +7,9 @@ from typing_extensions import TypedDict
 from ....app import sio
 from ....models import Asset
 from ....state.asset import asset_state
+from ....utils import ASSETS_DIR
 from ..constants import ASSET_NS
-from .common import ASSETS_DIR, UploadData
+from .common import UploadData
 
 
 class Coord(TypedDict):

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -1,7 +1,7 @@
 import configparser
 from pathlib import Path
 
-from .utils import FILE_DIR, SAVE_DIR
+from .utils import FILE_DIR, SAVE_DIR, set_assets_dir
 
 config = configparser.ConfigParser()
 config.read([FILE_DIR / "server_config.cfg", FILE_DIR / "data" / "server_config.cfg"])
@@ -12,3 +12,7 @@ if save_path.startswith("/"):
     SAVE_FILE = Path(save_path)
 else:
     SAVE_FILE = SAVE_DIR / save_path
+
+assets_path = config["General"].get("assets_directory")
+if assets_path is not None:
+    set_assets_dir(Path(assets_path))

--- a/server/src/routes.py
+++ b/server/src/routes.py
@@ -16,7 +16,7 @@ from .api.http import users
 from .api.http import version
 from .app import admin_app, api_app, app as main_app
 from .config import config
-from .utils import FILE_DIR, STATIC_DIR
+from .utils import ASSETS_DIR, FILE_DIR, STATIC_DIR
 
 
 subpath = os.environ.get("PA_BASEPATH", "/")
@@ -56,6 +56,7 @@ async def root_dev(request, admin_api=False):
 
 # MAIN ROUTES
 
+main_app.router.add_static(f"{subpath}/static/assets", ASSETS_DIR)
 main_app.router.add_static(f"{subpath}/static", STATIC_DIR)
 main_app.router.add_get(f"{subpath}/api/auth", auth.is_authed)
 main_app.router.add_post(f"{subpath}/api/users/email", users.set_email)

--- a/server/src/utils.py
+++ b/server/src/utils.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 
@@ -19,12 +18,23 @@ def get_save_dir() -> Path:
     return FILE_DIR
 
 
+def set_assets_dir(assets_dir: Path):
+    global ASSETS_DIR
+    ASSETS_DIR = assets_dir
+
+    if not ASSETS_DIR.exists():
+        ASSETS_DIR.mkdir()
+
+
 SRC_DIR = get_src_dir()
 FILE_DIR = SRC_DIR.parent
 STATIC_DIR = FILE_DIR / "static"
 ASSETS_DIR = STATIC_DIR / "assets"
 TEMP_DIR = STATIC_DIR / "temp"
 SAVE_DIR = get_save_dir()
+
+if not ASSETS_DIR.exists():
+    ASSETS_DIR.mkdir()
 
 
 class OldVersionException(Exception):


### PR DESCRIPTION
A new server config option has been added `General.assets_directory` this should be a path to the directory where the raw asset files should be stored/served.