### PR TITLE
bug(System:Players): Fix player state clearing on location change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ tech changes will usually be stripped from release notes for the public
 -   Annotations still being visible until refresh after removing player access
 -   Resetting location specific settings was not immediately synchronizing to clients until a refresh
 -   The asset manager was no longer useable when using a subpath setup
+-   Player state clearing on location change
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -77,7 +77,8 @@ socket.on("redirect", async (destination: string) => {
 
 // Bootup events
 
-socket.on("CLEAR", clearGame);
+socket.on("CLEAR", () => clearGame(false));
+socket.on("PARTIAL-CLEAR", () => clearGame(true));
 
 socket.on("Board.Locations.Set", (locationInfo: Location[]) => {
     locationStore.setLocations(locationInfo, false);

--- a/client/src/game/clear.ts
+++ b/client/src/game/clear.ts
@@ -8,7 +8,7 @@ import { clearSystems } from "./systems";
 import { initiativeStore } from "./ui/initiative/state";
 import { visionState } from "./vision/state";
 
-export function clearGame(): void {
+export function clearGame(partial: boolean): void {
     stopDrawLoop();
     gameStore.clear();
     visionState.clear();
@@ -16,6 +16,6 @@ export function clearGame(): void {
     document.getElementById("layers")!.innerHTML = "";
     compositeState.clear();
     initiativeStore.clear();
-    clearSystems();
+    clearSystems(partial);
     clearIds();
 }

--- a/client/src/game/systems/index.ts
+++ b/client/src/game/systems/index.ts
@@ -18,14 +18,14 @@ export function dropFromSystems(id: LocalId): void {
     }
 }
 
-export function clearSystems(): void {
+export function clearSystems(partial: boolean): void {
     for (const system of Object.values(SYSTEMS)) {
-        system.clear();
+        system.clear(partial);
     }
 }
 
 export interface System {
-    clear(): void;
+    clear(partial: boolean): void;
 }
 
 export interface ShapeSystem extends System {

--- a/client/src/game/systems/players/index.ts
+++ b/client/src/game/systems/players/index.ts
@@ -13,8 +13,8 @@ import { playerState } from "./state";
 const { mutableReactive: $ } = playerState;
 
 class PlayerSystem implements System {
-    clear(): void {
-        $.players = [];
+    clear(partial: boolean): void {
+        if (!partial) $.players = [];
     }
 
     setPlayers(players: Player[]): void {

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -34,7 +34,7 @@ const noAssets = computed(() => {
 });
 
 async function exit(): Promise<void> {
-    clearGame();
+    clearGame(false);
     await router.push({ name: "dashboard" });
 }
 

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -91,7 +91,10 @@ async def load_location(sid: str, location: Location, *, complete=False):
 
     # 0. CLEAR
 
-    await sio.emit("CLEAR", room=sid, namespace=GAME_NS)
+    if complete:
+        await sio.emit("CLEAR", room=sid, namespace=GAME_NS)
+    else:
+        await sio.emit("PARTIAL-CLEAR", room=sid, namespace=GAME_NS)
 
     # 1. Load client options
 


### PR DESCRIPTION
The player system was being cleared on every location change.

This mostly impacted the DM causing among other things:
- the location bar to lose info on where players are
- the DM general info panel to lose which players are part of the campaign

A refresh would fix the issue, but this PR fixes it in general :)