### PR TITLE
refactor: Unify pan functions

### DIFF
--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -15,8 +15,7 @@ socket.on("Client.Move", (data: { player: number } & ServerUserLocationOptions) 
     if (getGameState().isDm) {
         moveClientRect(player, locationData);
     } else {
-        clientStore.setPanX(data.pan_x);
-        clientStore.setPanY(data.pan_y);
+        clientStore.setPan(data.pan_x, data.pan_y);
         clientStore.setZoomDisplay(data.zoom_display);
         floorSystem.invalidateAllFloors();
     }
@@ -74,8 +73,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
         clientStore.setInitiativeEffectVisibility(options.room_user_options.initiative_effect_visibility, false);
     else clientStore.setInitiativeEffectVisibility(options.default_user_options.initiative_effect_visibility, false);
 
-    clientStore.setPanX(options.location_user_options.pan_x);
-    clientStore.setPanY(options.location_user_options.pan_y);
+    clientStore.setPan(options.location_user_options.pan_x, options.location_user_options.pan_y);
     clientStore.setZoomDisplay(options.location_user_options.zoom_display);
 
     activeLayerToselect = options.location_user_options.active_layer;

--- a/client/src/game/input/keyboard/down.ts
+++ b/client/src/game/input/keyboard/down.ts
@@ -90,8 +90,7 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
                 await moveShapes(selection, delta, false);
             } else {
                 // The pan offsets should be in the opposite direction to give the correct feel.
-                clientStore.increasePanX(offsetX * -1);
-                clientStore.increasePanY(offsetY * -1);
+                clientStore.increasePan(offsetX * -1, offsetY * -1);
                 floorSystem.invalidateAllFloors();
                 sendClientLocationOptions();
             }

--- a/client/src/game/position.ts
+++ b/client/src/game/position.ts
@@ -7,8 +7,10 @@ import { floorSystem } from "./systems/floors";
 
 export function setCenterPosition(position: GlobalPoint): void {
     const localPos = g2l(position);
-    clientStore.increasePanX((window.innerWidth / 2 - localPos.x) / clientStore.zoomFactor.value);
-    clientStore.increasePanY((window.innerHeight / 2 - localPos.y) / clientStore.zoomFactor.value);
+    clientStore.increasePan(
+        (window.innerWidth / 2 - localPos.x) / clientStore.zoomFactor.value,
+        (window.innerHeight / 2 - localPos.y) / clientStore.zoomFactor.value,
+    );
     floorSystem.invalidateAllFloors();
     sendClientLocationOptions();
 }

--- a/client/src/game/tools/variants/pan.ts
+++ b/client/src/game/tools/variants/pan.ts
@@ -21,8 +21,7 @@ class PanTool extends Tool {
 
     panScreen(target: LocalPoint, full: boolean): void {
         const distance = subtractP(target, this.panStart).multiply(1 / clientStore.zoomFactor.value);
-        clientStore.increasePanX(Math.round(distance.x));
-        clientStore.increasePanY(Math.round(distance.y));
+        clientStore.increasePan(Math.round(distance.x), Math.round(distance.y));
         this.panStart = target;
 
         if (full) floorSystem.invalidateAllFloors();

--- a/client/src/store/client.ts
+++ b/client/src/store/client.ts
@@ -119,20 +119,14 @@ class ClientStore extends Store<State> {
     }
 
     // POSITION
-    setPanX(x: number): void {
+    setPan(x: number, y: number): void {
         this._state.panX = x;
-    }
-
-    setPanY(y: number): void {
         this._state.panY = y;
     }
 
-    increasePanX(increase: number): void {
-        this._state.panX += increase;
-    }
-
-    increasePanY(increase: number): void {
-        this._state.panY += increase;
+    increasePan(x: number, y: number): void {
+        this._state.panX += x;
+        this._state.panY += y;
     }
 
     // ZOOM


### PR DESCRIPTION
There were several separate functions for X and Y pan related options, which just causes a bunch of duplicate code for no reason.

Definitely because at this point in time there is not a single instance where only 1 of the 2 is modified.