### PR TITLE
refactor: Move zoom things out of reactive state

### DIFF
--- a/client/src/core/conversions.ts
+++ b/client/src/core/conversions.ts
@@ -1,4 +1,4 @@
-import { clientStore, DEFAULT_GRID_SIZE } from "../store/client";
+import { clientStore, DEFAULT_GRID_SIZE, ZOOM } from "../store/client";
 import { settingsStore } from "../store/settings";
 
 import { Ray, toGP, toLP } from "./geometry";
@@ -6,10 +6,9 @@ import type { GlobalPoint, LocalPoint } from "./geometry";
 
 export function g2l(obj: GlobalPoint): LocalPoint {
     const state = clientStore.state;
-    const z = clientStore.zoomFactor.value;
     const panX = state.panX;
     const panY = state.panY;
-    return toLP((obj.x + panX) * z, (obj.y + panY) * z);
+    return toLP((obj.x + panX) * ZOOM, (obj.y + panY) * ZOOM);
 }
 
 export function g2lx(x: number): number {
@@ -21,7 +20,7 @@ export function g2ly(y: number): number {
 }
 
 export function g2lz(z: number): number {
-    return z * clientStore.zoomFactor.value;
+    return z * ZOOM;
 }
 
 export function getUnitDistance(r: number): number {
@@ -36,7 +35,7 @@ export function l2g(obj: LocalPoint): GlobalPoint;
 export function l2g(obj: Ray<LocalPoint>): Ray<GlobalPoint>;
 export function l2g(obj: LocalPoint | Ray<LocalPoint>): GlobalPoint | Ray<GlobalPoint> {
     const state = clientStore.state;
-    const z = clientStore.zoomFactor.value;
+    const z = ZOOM;
     const panX = state.panX;
     const panY = state.panY;
     if (obj instanceof Ray) {
@@ -55,7 +54,7 @@ export function l2gy(y: number): number {
 }
 
 export function l2gz(z: number): number {
-    return z / clientStore.zoomFactor.value;
+    return z / ZOOM;
 }
 
 export function clampGridLine(point: number): number {

--- a/client/src/game/api/emits/client.ts
+++ b/client/src/game/api/emits/client.ts
@@ -1,4 +1,4 @@
-import { clientStore } from "../../../store/client";
+import { clientStore, ZOOM } from "../../../store/client";
 import type { ServerUserOptions, ServerUserLocationOptions } from "../../models/settings";
 import { wrapSocket } from "../helpers";
 import { socket } from "../socket";
@@ -9,7 +9,7 @@ export function sendClientLocationOptions(): void {
         pan_x: state.panX,
         pan_y: state.panY,
         zoom_display: state.zoomDisplay,
-        zoom_factor: clientStore.zoomFactor.value,
+        zoom_factor: ZOOM,
         client_h: window.innerHeight,
         client_w: window.innerWidth,
     });

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -111,7 +111,7 @@ socket.on("Board.Floor.Set", (floor: ServerFloor) => {
 
 socket.on("Position.Set", (data: { floor?: string; x: number; y: number; zoom?: number }) => {
     if (data.floor !== undefined) floorSystem.selectFloor({ name: data.floor }, true);
-    if (data.zoom !== undefined) clientStore.setZoomDisplay(data.zoom);
+    if (data.zoom !== undefined) clientStore.setZoomDisplay(data.zoom, true);
     setCenterPosition(toGP(data.x, data.y));
 });
 

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -4,7 +4,6 @@ import { clientStore } from "../../../store/client";
 import { userOptionsToClient } from "../../models/settings";
 import type { ServerClient, ServerUserLocationOptions } from "../../models/settings";
 import { moveClientRect } from "../../systems/client/move";
-import { floorSystem } from "../../systems/floors";
 import { socket } from "../socket";
 
 // eslint-disable-next-line import/no-unused-modules
@@ -16,8 +15,7 @@ socket.on("Client.Move", (data: { player: number } & ServerUserLocationOptions) 
         moveClientRect(player, locationData);
     } else {
         clientStore.setPan(data.pan_x, data.pan_y);
-        clientStore.setZoomDisplay(data.zoom_display);
-        floorSystem.invalidateAllFloors();
+        clientStore.setZoomDisplay(data.zoom_display, true);
     }
 });
 
@@ -74,7 +72,7 @@ socket.on("Client.Options.Set", (options: ServerClient) => {
     else clientStore.setInitiativeEffectVisibility(options.default_user_options.initiative_effect_visibility, false);
 
     clientStore.setPan(options.location_user_options.pan_x, options.location_user_options.pan_y);
-    clientStore.setZoomDisplay(options.location_user_options.zoom_display);
+    clientStore.setZoomDisplay(options.location_user_options.zoom_display, true);
 
     activeLayerToselect = options.location_user_options.active_layer;
 });

--- a/client/src/game/layers/variants/grid.ts
+++ b/client/src/game/layers/variants/grid.ts
@@ -1,4 +1,4 @@
-import { clientStore, DEFAULT_GRID_SIZE } from "../../../store/client";
+import { clientStore, DEFAULT_GRID_SIZE, ZOOM } from "../../../store/client";
 import { settingsStore } from "../../../store/settings";
 import { floorState } from "../../systems/floors/state";
 
@@ -29,21 +29,15 @@ export class GridLayer extends Layer {
                 ctx.beginPath();
 
                 if (settingsStore.gridType.value === "SQUARE") {
-                    for (let i = 0; i < this.width; i += DEFAULT_GRID_SIZE * clientStore.zoomFactor.value) {
-                        ctx.moveTo(i + (clientStore.state.panX % DEFAULT_GRID_SIZE) * clientStore.zoomFactor.value, 0);
-                        ctx.lineTo(
-                            i + (clientStore.state.panX % DEFAULT_GRID_SIZE) * clientStore.zoomFactor.value,
-                            this.height,
-                        );
-                        ctx.moveTo(0, i + (clientStore.state.panY % DEFAULT_GRID_SIZE) * clientStore.zoomFactor.value);
-                        ctx.lineTo(
-                            this.width,
-                            i + (clientStore.state.panY % DEFAULT_GRID_SIZE) * clientStore.zoomFactor.value,
-                        );
+                    for (let i = 0; i < this.width; i += DEFAULT_GRID_SIZE * ZOOM) {
+                        ctx.moveTo(i + (clientStore.state.panX % DEFAULT_GRID_SIZE) * ZOOM, 0);
+                        ctx.lineTo(i + (clientStore.state.panX % DEFAULT_GRID_SIZE) * ZOOM, this.height);
+                        ctx.moveTo(0, i + (clientStore.state.panY % DEFAULT_GRID_SIZE) * ZOOM);
+                        ctx.lineTo(this.width, i + (clientStore.state.panY % DEFAULT_GRID_SIZE) * ZOOM);
                     }
                 } else {
                     const s3 = Math.sqrt(3);
-                    const centerDistance = DEFAULT_GRID_SIZE * clientStore.zoomFactor.value;
+                    const centerDistance = DEFAULT_GRID_SIZE * ZOOM;
                     const side = centerDistance / s3;
                     const SECONDARY_SIZE = s3 * side;
                     const SECONDARY_HALF = SECONDARY_SIZE / 2;
@@ -58,12 +52,8 @@ export class GridLayer extends Layer {
 
                     const flat = settingsStore.gridType.value === "FLAT_HEX";
 
-                    const pX =
-                        (clientStore.state.panX % ((flat ? 3 / s3 : 1) * DEFAULT_GRID_SIZE)) *
-                        clientStore.zoomFactor.value;
-                    const pY =
-                        (clientStore.state.panY % ((flat ? 1 : 3 / s3) * DEFAULT_GRID_SIZE)) *
-                        clientStore.zoomFactor.value;
+                    const pX = (clientStore.state.panX % ((flat ? 3 / s3 : 1) * DEFAULT_GRID_SIZE)) * ZOOM;
+                    const pY = (clientStore.state.panY % ((flat ? 1 : 3 / s3) * DEFAULT_GRID_SIZE)) * ZOOM;
 
                     const primaryAxisLimit = (flat ? this.width : this.height) / (2 * side);
                     const secondaryAxisLimit = (flat ? this.height : this.width) / SECONDARY_HALF;

--- a/client/src/game/layers/variants/map.ts
+++ b/client/src/game/layers/variants/map.ts
@@ -1,5 +1,5 @@
 import { baseAdjust } from "../../../core/http";
-import { clientStore } from "../../../store/client";
+import { clientStore, ZOOM } from "../../../store/client";
 import { settingsStore } from "../../../store/settings";
 import { FloorType } from "../../models/floor";
 import { floorSystem } from "../../systems/floors";
@@ -62,10 +62,10 @@ export class MapLayer extends Layer {
             };
         } else if (patternImage.loading) {
             const pattern = this.ctx.createPattern(patternImage, "repeat");
-            const panX = (patternData.offsetX + clientStore.state.panX) * clientStore.zoomFactor.value;
-            const panY = (patternData.offsetY + clientStore.state.panY) * clientStore.zoomFactor.value;
-            const scaleX = patternData.scaleX * clientStore.zoomFactor.value;
-            const scaleY = patternData.scaleY * clientStore.zoomFactor.value;
+            const panX = (patternData.offsetX + clientStore.state.panX) * ZOOM;
+            const panY = (patternData.offsetY + clientStore.state.panY) * ZOOM;
+            const scaleX = patternData.scaleX * ZOOM;
+            const scaleY = patternData.scaleY * ZOOM;
 
             pattern?.setTransform(new DOMMatrix([scaleX, 0, 0, scaleY, panX, panY]));
             return pattern;

--- a/client/src/game/position.ts
+++ b/client/src/game/position.ts
@@ -1,16 +1,13 @@
 import { g2l } from "../core/conversions";
 import type { GlobalPoint } from "../core/geometry";
-import { clientStore } from "../store/client";
+import { clientStore, ZOOM } from "../store/client";
 
 import { sendClientLocationOptions } from "./api/emits/client";
 import { floorSystem } from "./systems/floors";
 
 export function setCenterPosition(position: GlobalPoint): void {
     const localPos = g2l(position);
-    clientStore.increasePan(
-        (window.innerWidth / 2 - localPos.x) / clientStore.zoomFactor.value,
-        (window.innerHeight / 2 - localPos.y) / clientStore.zoomFactor.value,
-    );
+    clientStore.increasePan((window.innerWidth / 2 - localPos.x) / ZOOM, (window.innerHeight / 2 - localPos.y) / ZOOM);
     floorSystem.invalidateAllFloors();
     sendClientLocationOptions();
 }

--- a/client/src/game/shapes/variants/rect.ts
+++ b/client/src/game/shapes/variants/rect.ts
@@ -1,6 +1,6 @@
 import { g2l } from "../../../core/conversions";
 import type { GlobalPoint } from "../../../core/geometry";
-import { clientStore } from "../../../store/client";
+import { ZOOM } from "../../../store/client";
 import { getFogColour } from "../../colour";
 import type { GlobalId, LocalId } from "../../id";
 import type { ServerRect } from "../../models/shapes";
@@ -40,14 +40,13 @@ export class Rect extends BaseRect {
         const props = getProperties(this.id)!;
         if (props.fillColour === "fog") ctx.fillStyle = getFogColour();
         else ctx.fillStyle = props.fillColour;
-        const z = clientStore.zoomFactor.value;
         const loc = g2l(this.refPoint);
         const center = g2l(this.center());
-        ctx.fillRect(loc.x - center.x, loc.y - center.y, this.w * z, this.h * z);
+        ctx.fillRect(loc.x - center.x, loc.y - center.y, this.w * ZOOM, this.h * ZOOM);
         if (props.strokeColour[0] !== "rgba(0, 0, 0, 0)") {
             ctx.strokeStyle = props.strokeColour[0];
             ctx.lineWidth = this.strokeWidth;
-            ctx.strokeRect(loc.x - center.x, loc.y - center.y, this.w * z, this.h * z);
+            ctx.strokeRect(loc.x - center.x, loc.y - center.y, this.w * ZOOM, this.h * ZOOM);
         }
 
         super.drawPost(ctx);

--- a/client/src/game/tools/variants/pan.ts
+++ b/client/src/game/tools/variants/pan.ts
@@ -1,7 +1,7 @@
 import { subtractP, toLP } from "../../../core/geometry";
 import type { LocalPoint } from "../../../core/geometry";
 import { i18n } from "../../../i18n";
-import { clientStore } from "../../../store/client";
+import { clientStore, ZOOM } from "../../../store/client";
 import { sendClientLocationOptions } from "../../api/emits/client";
 import { ToolName } from "../../models/tools";
 import type { ToolPermission } from "../../models/tools";
@@ -20,7 +20,7 @@ class PanTool extends Tool {
     }
 
     panScreen(target: LocalPoint, full: boolean): void {
-        const distance = subtractP(target, this.panStart).multiply(1 / clientStore.zoomFactor.value);
+        const distance = subtractP(target, this.panStart).multiply(1 / ZOOM);
         clientStore.increasePan(Math.round(distance.x), Math.round(distance.y));
         this.panStart = target;
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -20,7 +20,7 @@ import { InvalidationMode, NO_SYNC, SyncMode } from "../../../../core/models/typ
 import { ctrlOrCmdPressed } from "../../../../core/utils";
 import { i18n } from "../../../../i18n";
 import { getGameState } from "../../../../store/_game";
-import { clientStore, DEFAULT_GRID_SIZE } from "../../../../store/client";
+import { clientStore, DEFAULT_GRID_SIZE, ZOOM } from "../../../../store/client";
 import { settingsStore } from "../../../../store/settings";
 import { sendRequest } from "../../../api/emits/logic";
 import { sendShapePositionUpdate, sendShapeSizeUpdate } from "../../../api/emits/shape/core";
@@ -435,9 +435,7 @@ class SelectTool extends Tool implements ISelectTool {
             );
             layer.invalidate(true);
         } else if (layerSelection.length) {
-            let delta = Ray.fromPoints(this.dragRay.get(this.dragRay.tMax), lp).direction.multiply(
-                1 / clientStore.zoomFactor.value,
-            );
+            let delta = Ray.fromPoints(this.dragRay.get(this.dragRay.tMax), lp).direction.multiply(1 / ZOOM);
             const ogDelta = delta;
             if (this.mode === SelectOperations.Drag) {
                 if (ogDelta.length() === 0) return;

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -105,13 +105,13 @@ const zoomDisplay = computed({
         return clientStore.state.zoomDisplay;
     },
     set(zoom: number) {
-        clientStore.setZoomDisplay(zoom);
+        clientStore.setZoomDisplay(zoom, true);
         sendClientLocationOptions();
     },
 });
 
 function setTempZoomDisplay(value: number): void {
-    clientStore.setZoomDisplay(value);
+    clientStore.setZoomDisplay(value, true);
 }
 </script>
 

--- a/client/src/store/client.ts
+++ b/client/src/store/client.ts
@@ -26,7 +26,7 @@ interface State extends UserOptions {
     zoomDisplay: number;
 }
 
-export function setZoomFactor(zoomDisplay: number): void {
+function setZoomFactor(zoomDisplay: number): void {
     const gf = clientStore.gridSize.value / DEFAULT_GRID_SIZE;
     if (clientStore.state.useAsPhysicalBoard) {
         if (ZOOM !== gf) {


### PR DESCRIPTION
Some aspects of the zoom information were being calculated in a reactive fashion, but were exclusively being used in a lot of the critical render loop, which touches no UI and thus was just wasting some cpu cycles.