### PR TITLE
bug(Initiative): Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ tech changes will usually be stripped from release notes for the public
 -   The asset manager was no longer useable when using a subpath setup
 -   Player state clearing on location change
 -   Zoom sensitivity on touchpad
+-   Multiple Initiative bugs
+    -   Server should detect client errors in initiative listings better and reject wrong data
+    -   Modification of the initiative should retain the current active actor under more circumstances
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/api/emits/shape/core.ts
+++ b/client/src/game/api/emits/shape/core.ts
@@ -8,7 +8,17 @@ import { wrapSocket } from "../../helpers";
 import { socket } from "../../socket";
 
 export const sendShapeAdd = wrapSocket<{ shape: ServerShape; temporary: boolean }>("Shape.Add");
-export const sendRemoveShapes = wrapSocket<{ uuids: string[]; temporary: boolean }>("Shapes.Remove");
+export const sendRemoveShapes = (data: { uuids: string[]; temporary: boolean }): void => {
+    if (data.uuids.length === 0) {
+        if (process.env.NODE_ENV === "production") {
+            console.error(
+                "Attempted to send shape removal request for 0 shapes. If you think this is a bug, please report this!",
+            );
+        } else {
+            debugger;
+        }
+    } else wrapSocket<{ uuids: string[]; temporary: boolean }>("Shapes.Remove")(data);
+};
 export const sendShapeOrder = wrapSocket<{ uuid: string; index: number; temporary: boolean }>("Shape.Order.Set");
 export const sendFloorChange = wrapSocket<{ uuids: string[]; floor: string }>("Shapes.Floor.Change");
 export const sendLayerChange = wrapSocket<{ uuids: string[]; layer: string; floor: string }>("Shapes.Layer.Change");

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -76,7 +76,10 @@ class InitiativeStore extends Store<InitiativeState> {
         const initiativeData: InitiativeData<LocalId>[] = [];
         for (const d of data.data) {
             const shape = getLocalId(d.shape, false);
-            if (shape === undefined) continue;
+            if (shape === undefined) {
+                console.debug("Initiative contains unknown shapes");
+                continue;
+            }
             initiativeData.push({ ...d, shape });
         }
         if (this._state.editLock !== -1) this._state.newData = initiativeData;

--- a/server/src/api/socket/initiative.py
+++ b/server/src/api/socket/initiative.py
@@ -87,10 +87,17 @@ async def send_initiative(sio: AsyncServer, data: Dict[str, Any], pr: PlayerRoom
     )
 
 
+def get_turn_order(data: List[Dict[str, Any]], shape: str) -> int:
+    for i, info in enumerate(data):
+        if info["shape"] == shape:
+            return i
+    raise IndexError()
+
+
 @sio.on("Initiative.Request", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def request_initiatives(sid: str):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
     await sio.emit(
         "Initiative.Request",
@@ -103,9 +110,13 @@ async def request_initiatives(sid: str):
 @sio.on("Initiative.Option.Update", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def update_initiative_option(sid: str, data: ServerInitiativeOption):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
     shape = Shape.get_or_none(uuid=data["shape"])
+
+    if shape is None:
+        logger.warning("Attempt to update initiative option for unknown shape")
+        return
 
     if not has_ownership(shape, pr):
         logger.warning(
@@ -141,11 +152,15 @@ async def update_initiative_option(sid: str, data: ServerInitiativeOption):
 @sio.on("Initiative.Add", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def add_initiative(sid: str, data: ServerInitiativeData):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
-    shape = Shape.get_or_none(uuid=data)
+    shape = Shape.get_or_none(uuid=data["shape"])
 
-    if shape is not None and not has_ownership(shape, pr):
+    if shape is None:
+        logger.warning("Attempt to add initiative for unknown shape")
+        return
+
+    if not has_ownership(shape, pr):
         logger.warning(
             f"{pr.player.name} attempted to add initiative to an asset it does not own"
         )
@@ -173,19 +188,25 @@ async def add_initiative(sid: str, data: ServerInitiativeData):
 @sio.on("Initiative.Value.Set", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def set_initiative_value(sid: str, data: ServerSetInitiativeValue):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
-    shape = Shape.get_or_none(uuid=data)
+    shape = Shape.get_or_none(uuid=data["shape"])
 
-    if shape is not None and not has_ownership(shape, pr):
+    if shape is None:
+        logger.warning("Attempt to update initiative value for unknown shape")
+        return
+
+    if not has_ownership(shape, pr):
         logger.warning(
             f"{pr.player.name} attempted to remove initiative of an asset it does not own"
         )
         return
 
     with db.atomic():
-        location_data = Initiative.get(location=pr.active_location)
+        location_data: Initiative = Initiative.get(location=pr.active_location)
         json_data = json.loads(location_data.data)
+
+        active_participant = json_data[location_data.turn]
 
         for initiative in json_data:
             if initiative["shape"] == data["shape"]:
@@ -193,6 +214,10 @@ async def set_initiative_value(sid: str, data: ServerSetInitiativeValue):
                 break
 
         json_data = sort_initiative(json_data, location_data.sort)
+
+        turn_order = get_turn_order(json_data, active_participant["shape"])
+        if location_data.turn != turn_order:
+            location_data.turn = turn_order
 
         location_data.data = json.dumps(json_data)
         location_data.save()
@@ -203,7 +228,7 @@ async def set_initiative_value(sid: str, data: ServerSetInitiativeValue):
 @sio.on("Initiative.Clear", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def clear_initiatives(sid: str):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
     if pr.role != Role.DM:
         logger.warning(f"{pr.player.name} attempted to clear all initiatives")
@@ -229,11 +254,15 @@ async def clear_initiatives(sid: str):
 @sio.on("Initiative.Remove", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def remove_initiative(sid: str, data: str):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
     shape = Shape.get_or_none(uuid=data)
 
-    if shape is not None and not has_ownership(shape, pr):
+    if shape is None:
+        logger.warning("Attempt to remove initiative for unknown shape")
+        return
+
+    if not has_ownership(shape, pr):
         logger.warning(
             f"{pr.player.name} attempted to remove initiative of an asset it does not own"
         )
@@ -259,7 +288,11 @@ async def remove_initiative(sid: str, data: str):
 @sio.on("Initiative.Order.Change", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def change_initiative_order(sid: str, data: ServerInitiativeOrderChange):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
+
+    if Shape.get_or_none(data["shape"]) is None:
+        logger.warning("Attempt to change initiative order for unknown shape")
+        return
 
     if pr.role != Role.DM:
         logger.warning(f"{pr.player.name} attempted to reorder initiatives")
@@ -275,6 +308,8 @@ async def change_initiative_order(sid: str, data: ServerInitiativeOrderChange):
         if json_data[old_index]["shape"] != data["shape"]:
             return
 
+        active_participant = json_data[location_data.turn]
+
         if json_data[new_index].get("initiative", 0) != json_data[old_index].get(
             "initiative", 0
         ):
@@ -283,6 +318,10 @@ async def change_initiative_order(sid: str, data: ServerInitiativeOrderChange):
         json_data.insert(new_index, json_data.pop(old_index))
 
         json_data = sort_initiative(json_data, location_data.sort)
+
+        turn_order = get_turn_order(json_data, active_participant["shape"])
+        if location_data.turn != turn_order:
+            location_data.turn = turn_order
 
         location_data.data = json.dumps(json_data)
         location_data.save()
@@ -293,14 +332,18 @@ async def change_initiative_order(sid: str, data: ServerInitiativeOrderChange):
 @sio.on("Initiative.Turn.Update", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def update_initiative_turn(sid: str, turn: int):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
     location_data: Initiative = Initiative.get(location=pr.active_location)
     json_data = json.loads(location_data.data)
 
-    if pr.role != Role.DM and not has_ownership(
-        Shape.get_or_none(uuid=json_data[location_data.turn]["shape"]), pr
-    ):
+    shape = Shape.get_or_none(uuid=json_data[location_data.turn]["shape"])
+
+    if shape is None:
+        logger.warning("Attempt to modify the initiative turn for an unknown shape")
+        return
+
+    if pr.role != Role.DM and not has_ownership(shape, pr):
         logger.warning(f"{pr.player.name} attempted to advance the initiative tracker")
         return
 
@@ -337,15 +380,22 @@ async def update_initiative_turn(sid: str, turn: int):
 @sio.on("Initiative.Round.Update", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def update_initiative_round(sid: str, data: int):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
     location_data = Initiative.get(location=pr.active_location)
 
     if pr.role != Role.DM:
         json_data = json.loads(location_data.data)
-        if not has_ownership(
-            Shape.get_or_none(uuid=json_data[location_data.turn]["shape"]), pr
-        ):
+
+        shape = Shape.get_or_none(uuid=json_data[location_data.turn]["shape"])
+
+        if shape is None:
+            logger.warning(
+                "Attempt to modify the initiative round for an unknown shape"
+            )
+            return
+
+        if not has_ownership(shape, pr):
             logger.warning(
                 f"{pr.player.name} attempted to advance the initiative tracker"
             )
@@ -367,7 +417,7 @@ async def update_initiative_round(sid: str, data: int):
 @sio.on("Initiative.Sort.Set", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def set_initiative_sort(sid: str, sort: int):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
     if pr.role != Role.DM:
         logger.warning(f"{pr.player.name} attempted to change initiative sort")
@@ -378,7 +428,13 @@ async def set_initiative_sort(sid: str, sort: int):
         location_data.sort = sort
         json_data = json.loads(location_data.data)
 
+        active_participant = json_data[location_data.turn]
+
         json_data = sort_initiative(json_data, location_data.sort)
+
+        turn_order = get_turn_order(json_data, active_participant["shape"])
+        if location_data.turn != turn_order:
+            location_data.turn = turn_order
 
         location_data.data = json.dumps(json_data)
         location_data.save()
@@ -394,9 +450,15 @@ async def set_initiative_sort(sid: str, sort: int):
 @sio.on("Initiative.Effect.New", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def new_initiative_effect(sid: str, data: ServerInitiativeEffectActor):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
-    if not has_ownership(Shape.get_or_none(uuid=data["actor"]), pr):
+    shape = Shape.get_or_none(uuid=data["actor"])
+
+    if shape is None:
+        logger.warning("Attempt to create initiative effect for an unknown shape")
+        return
+
+    if not has_ownership(shape, pr):
         logger.warning(f"{pr.player.name} attempted to create a new initiative effect")
         return
 
@@ -423,9 +485,15 @@ async def new_initiative_effect(sid: str, data: ServerInitiativeEffectActor):
 @sio.on("Initiative.Effect.Rename", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def rename_initiative_effect(sid: str, data: ServerRenameInitiativeEffect):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
-    if not has_ownership(Shape.get_or_none(uuid=data["shape"]), pr):
+    shape = Shape.get_or_none(uuid=data["shape"])
+
+    if shape is None:
+        logger.warning("Attempt to rename initiative effect for an unknown shape")
+        return
+
+    if not has_ownership(shape, pr):
         logger.warning(f"{pr.player.name} attempted to create a new initiative effect")
         return
 
@@ -452,9 +520,15 @@ async def rename_initiative_effect(sid: str, data: ServerRenameInitiativeEffect)
 @sio.on("Initiative.Effect.Turns", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def set_initiative_effect_tuns(sid: str, data: ServerInitiativeEffectTurns):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
-    if not has_ownership(Shape.get_or_none(uuid=data["shape"]), pr):
+    shape = Shape.get_or_none(uuid=data["shape"])
+
+    if shape is None:
+        logger.warning("Attempt to modify initiative effect turns for an unknown shape")
+        return
+
+    if not has_ownership(shape, pr):
         logger.warning(f"{pr.player.name} attempted to create a new initiative effect")
         return
 
@@ -481,9 +555,15 @@ async def set_initiative_effect_tuns(sid: str, data: ServerInitiativeEffectTurns
 @sio.on("Initiative.Effect.Remove", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def remove_initiative_effect(sid: str, data: ServerRemoveInitiativeEffectActor):
-    pr: PlayerRoom = game_state.get(sid)
+    pr = game_state.get(sid)
 
-    if not has_ownership(Shape.get_or_none(uuid=data["shape"]), pr):
+    shape = Shape.get_or_none(uuid=data["shape"])
+
+    if shape is None:
+        logger.warning("Attempt to remove initiative effect for an unknown shape")
+        return
+
+    if not has_ownership(shape, pr):
         logger.warning(f"{pr.player.name} attempted to remove an initiative effect")
         return
 

--- a/server/src/models/initiative.py
+++ b/server/src/models/initiative.py
@@ -17,7 +17,7 @@ class Initiative(BaseModel):
     location = ForeignKeyField(Location, backref="initiative", on_delete="CASCADE")
     round = IntegerField()
     turn = cast(int, IntegerField())
-    sort = IntegerField(default=0)
+    sort = cast(int, IntegerField(default=0))
     data = cast(str, TextField())
 
     def as_dict(self):

--- a/server/src/state/game.py
+++ b/server/src/state/game.py
@@ -28,7 +28,8 @@ class GameState(State[PlayerRoom]):
                 list(self.client_temporaries[sid]),
                 namespace=GAME_NS,
             )
-            del self.client_temporaries[sid]
+            if sid in self.client_temporaries:
+                del self.client_temporaries[sid]
 
     def add_temp(self, sid: str, uid: str) -> None:
         if sid not in self.client_temporaries:


### PR DESCRIPTION
This PR covers a couple of fixes related to initiative.

A first set of fixes is related to making sure that bugs in the client code should have less chance to brick the initiative state. There is a bug somewhere that causes shapes that don't exist on the server to be added to the initiative list, which can cause a whole plethora of shenanigans.  The server will now reject any request that pertains a shape it doesn't know about.

A second set of fixes is related to bugs where the active initiative participant would change when this was not expected. This happened when for example a new shape was added to the initiative with an initiative higher than the current actor. Similar behaviour exists when changing the sort order.

This PR also updates the save_version, because it does a complete scan of the initiative data to make sure no wrong data has been added in the past.