### PR TITLE
bug(Tech: Players): Make currentPlayer return undefined

### DIFF
--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -17,7 +17,7 @@ socket.on("Client.Disconnected", (data: ClientId) => {
 
 socket.on("Client.Move", (data: { player: PlayerId; client: ClientId } & ServerUserLocationOptions) => {
     const { player, client, ...locationData } = data;
-    const isCurrentPlayer = playerSystem.getCurrentPlayer().id === data.player;
+    const isCurrentPlayer = playerSystem.getCurrentPlayer()?.id === data.player;
     if (getGameState().isDm && !isCurrentPlayer) {
         playerSystem.setPosition(player, locationData);
     } else if (isCurrentPlayer) {

--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -15,7 +15,7 @@ import { socket } from "../socket";
 
 socket.on("Location.Set", (data: ServerLocation) => {
     settingsStore.setActiveLocation(data.id);
-    playerSystem.updatePlayersLocation([playerSystem.getCurrentPlayer().name], data.id, false);
+    playerSystem.updatePlayersLocation([playerSystem.getCurrentPlayer()!.name], data.id, false);
     clientSystem.updateAllClientRects();
     setLocationOptions(data.id, data.options);
 });

--- a/client/src/game/api/events/player/players.ts
+++ b/client/src/game/api/events/player/players.ts
@@ -25,7 +25,7 @@ socket.on(
                 playerSystem.setPosition(player.core.id, player.position);
             }
 
-            if (player.core.name === playerSystem.getCurrentPlayer().name) {
+            if (player.core.name === playerSystem.getCurrentPlayer()?.name) {
                 found = true;
                 gameStore.setDm(player.core.role === Role.DM);
             }

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -132,7 +132,7 @@ class AccessSystem implements ShapeSystem {
             return true;
         }
 
-        const userAccess = accessMap.get(playerSystem.getCurrentPlayer().name);
+        const userAccess = accessMap.get(playerSystem.getCurrentPlayer()!.name);
         if (userAccess === undefined) return false;
 
         return (
@@ -173,7 +173,7 @@ class AccessSystem implements ShapeSystem {
         }
 
         // todo: some sort of event register instead of calling these other systems manually ?
-        if (userAccess.vision && user === playerSystem.getCurrentPlayer().name) {
+        if (userAccess.vision && user === playerSystem.getCurrentPlayer()?.name) {
             const props = getProperties(shapeId);
             if (props !== undefined && props.isToken) {
                 this.addOwnedToken(shapeId);
@@ -196,7 +196,7 @@ class AccessSystem implements ShapeSystem {
         if (
             access.vision !== undefined &&
             access.vision !== oldAccess.vision &&
-            (user === playerSystem.getCurrentPlayer().name || user === DEFAULT_ACCESS_SYMBOL)
+            (user === playerSystem.getCurrentPlayer()?.name || user === DEFAULT_ACCESS_SYMBOL)
         ) {
             const props = getProperties(shapeId);
             if (props !== undefined && props.isToken) {
@@ -263,7 +263,7 @@ class AccessSystem implements ShapeSystem {
             $.playerAccess.delete(user);
         }
 
-        if (oldAccess.vision && user === playerSystem.getCurrentPlayer().name) {
+        if (oldAccess.vision && user === playerSystem.getCurrentPlayer()?.name) {
             const props = getProperties(shapeId);
             if (props !== undefined && props.isToken) {
                 this.removeOwnedToken(shapeId);

--- a/client/src/game/systems/access/state.ts
+++ b/client/src/game/systems/access/state.ts
@@ -41,7 +41,7 @@ export const accessState = {
         if (getGameState().isDm) return true;
         if (getGameState().isFakePlayer && activeTokens.value.has(state.reactive.id)) return true;
         if (state.reactive.defaultAccess.edit) return true;
-        const username = playerSystem.getCurrentPlayer().name;
+        const username = playerSystem.getCurrentPlayer()?.name;
         return [...state.reactive.playerAccess.entries()].some(([u, a]) => u === username && a.edit === true);
     }),
 

--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -207,7 +207,7 @@ class ClientSystem implements System {
             return undefined;
         }
 
-        if (playerSystem.getCurrentPlayer().location !== playerSystem.getPlayer(player)?.location) {
+        if (playerSystem.getCurrentPlayer()?.location !== playerSystem.getPlayer(player)?.location) {
             return undefined;
         }
 

--- a/client/src/game/systems/players/index.ts
+++ b/client/src/game/systems/players/index.ts
@@ -93,17 +93,16 @@ class PlayerSystem implements System {
         return $.players.get(playerId);
     }
 
-    getCurrentPlayer(): Player {
+    getCurrentPlayer(): Player | undefined {
         for (const player of $.players.values()) {
             if (player.name === coreStore.state.username) {
                 return player;
             }
         }
-        throw new Error("Current player does not exist");
     }
 
     loadPosition(): void {
-        const position = $.playerLocation.get(this.getCurrentPlayer().id)!;
+        const position = $.playerLocation.get(this.getCurrentPlayer()!.id)!;
         positionSystem.setZoomDisplay(position.zoom_display, { invalidate: true, sync: false });
         positionSystem.setPan(position.pan_x, position.pan_y, { needsOffset: false });
         if (position.active_layer !== undefined) floorSystem.selectLayer(position.active_layer, false);

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -413,7 +413,7 @@ class DrawTool extends Tool {
 
             accessSystem.addAccess(
                 this.shape.id,
-                playerSystem.getCurrentPlayer().name,
+                playerSystem.getCurrentPlayer()!.name,
                 { edit: true, movement: true, vision: true },
                 UI_SYNC,
             );

--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -72,13 +72,13 @@ class PingTool extends Tool {
         this.border.ignoreZoomSize = true;
         accessSystem.addAccess(
             this.ping.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             NO_SYNC,
         );
         accessSystem.addAccess(
             this.border.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             NO_SYNC,
         );

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -71,7 +71,7 @@ class RulerTool extends Tool {
 
         accessSystem.addAccess(
             ruler.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             NO_SYNC,
         );
@@ -107,7 +107,7 @@ class RulerTool extends Tool {
         this.text.ignoreZoomSize = true;
         accessSystem.addAccess(
             this.text.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             NO_SYNC,
         );

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -343,7 +343,7 @@ class SelectTool extends Tool implements ISelectTool {
                 this.selectionHelper.options.UiHelper = true;
                 accessSystem.addAccess(
                     this.selectionHelper.id,
-                    playerSystem.getCurrentPlayer().name,
+                    playerSystem.getCurrentPlayer()!.name,
                     { edit: true, movement: true, vision: true },
                     NO_SYNC,
                 );
@@ -819,7 +819,7 @@ class SelectTool extends Tool implements ISelectTool {
         for (const rotationShape of [this.rotationAnchor, this.rotationBox, this.rotationEnd]) {
             accessSystem.addAccess(
                 rotationShape.id,
-                playerSystem.getCurrentPlayer().name,
+                playerSystem.getCurrentPlayer()!.name,
                 { edit: true, movement: true, vision: true },
                 NO_SYNC,
             );

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -120,7 +120,7 @@ class SpellTool extends Tool {
 
         accessSystem.addAccess(
             this.shape.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             UI_SYNC,
         );

--- a/client/src/game/ui/LabelManager.vue
+++ b/client/src/game/ui/LabelManager.vue
@@ -31,7 +31,7 @@ const categories = computed(() => {
     const cat: Map<string, Label[]> = new Map();
     cat.set("", []);
     for (const label of getGameState().labels.values()) {
-        if (label.user !== playerSystem.getCurrentPlayer().name) continue;
+        if (label.user !== playerSystem.getCurrentPlayer()?.name) continue;
         const fullName = `${label.category.toLowerCase()}${label.name.toLowerCase()}`;
         if (state.search.length > 0 && fullName.search(state.search.toLowerCase()) < 0) {
             continue;
@@ -66,7 +66,7 @@ function addLabel(): void {
         category: state.newCategory,
         name: state.newName,
         visible: false,
-        user: playerSystem.getCurrentPlayer().name,
+        user: playerSystem.getCurrentPlayer()!.name,
     };
     gameStore.addLabel(label, true);
     state.newCategory = "";

--- a/client/src/game/ui/menu/LocationBar.vue
+++ b/client/src/game/ui/menu/LocationBar.vue
@@ -75,7 +75,7 @@ async function createLocation(): Promise<void> {
 }
 
 function changeLocation(id: number): void {
-    sendLocationChange({ location: id, users: [playerSystem.getCurrentPlayer().name] });
+    sendLocationChange({ location: id, users: [playerSystem.getCurrentPlayer()!.name] });
     coreStore.setLoading(true);
 }
 

--- a/client/src/game/ui/settings/shape/ExtraSettings.vue
+++ b/client/src/game/ui/settings/shape/ExtraSettings.vue
@@ -140,7 +140,7 @@ function applyDDraft(): void {
         const shape = new Polygon(points[0], points.slice(1), { openPolygon: true }, { strokeColour: ["red"] });
         accessSystem.addAccess(
             shape.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             UI_SYNC,
         );
@@ -155,7 +155,7 @@ function applyDDraft(): void {
         const shape = new Polygon(points[0], points.slice(1), { openPolygon: true }, { strokeColour: ["blue"] });
         accessSystem.addAccess(
             shape.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             UI_SYNC,
         );
@@ -194,7 +194,7 @@ function applyDDraft(): void {
         auraSystem.add(shape.id, aura, SERVER_SYNC);
         accessSystem.addAccess(
             shape.id,
-            playerSystem.getCurrentPlayer().name,
+            playerSystem.getCurrentPlayer()!.name,
             { edit: true, movement: true, vision: true },
             SERVER_SYNC,
         );

--- a/client/src/game/ui/tokendialog/CreateTokenDialog.vue
+++ b/client/src/game/ui/tokendialog/CreateTokenDialog.vue
@@ -55,7 +55,7 @@ function submit(): void {
     );
     accessSystem.addAccess(
         token.id,
-        playerSystem.getCurrentPlayer().name,
+        playerSystem.getCurrentPlayer()!.name,
         { edit: true, movement: true, vision: true },
         UI_SYNC,
     );

--- a/client/src/store/location.ts
+++ b/client/src/store/location.ts
@@ -29,7 +29,7 @@ class LocationStore extends Store<LocationState> {
             const state = getGameState();
             const newLocations = new Map();
             for (const player of playerState.reactive.players.values()) {
-                if (player.name === playerSystem.getCurrentPlayer().name && state.isDm) continue;
+                if (player.name === playerSystem.getCurrentPlayer()?.name && state.isDm) continue;
                 if (!newLocations.has(player.location)) {
                     newLocations.set(player.location, new Set());
                 }


### PR DESCRIPTION
The client store PR refactor assumed a certain order of players arriving, which is not guaranteed.
This just makes it so the currentPlayer function returns undefined instead of throwing an error if the current player info is not yet loaded.