### PR TITLE
feat(Tech: Performance): Memorize shape centers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ tech changes will usually be stripped from release notes for the public
 -   [DM] Hiding a token using the vision tool will now also hide their private light auras
 -   [server] moved all python imports to proper relative imports
     -   this changes the way to manually run the server (again) (sorry)
+-   [tech] keep shape centers in memory instead of recalculating on the fly
 
 ### Fixed
 

--- a/client/src/game/drag.ts
+++ b/client/src/game/drag.ts
@@ -11,7 +11,7 @@ import { cw, ccw, intersection, orientation } from "./vision/triag";
 // And it does now, so hey ¯\_(ツ)_/¯
 export function calculateDelta(delta: Vector, sel: IShape, shrink = false): Vector {
     if (delta.x === 0 && delta.y === 0) return delta;
-    const center = toArrayP(sel.center());
+    const center = toArrayP(sel.center);
     const centerTriangle = visionState.getCDT(TriangulationTarget.MOVEMENT, sel.floor.id).locate(center, null).loc;
     for (let point of sel.points) {
         if (shrink) {

--- a/client/src/game/input/keyboard/up.ts
+++ b/client/src/game/input/keyboard/up.ts
@@ -23,9 +23,9 @@ export function onKeyUp(event: KeyboardEvent): void {
             // numpad-zero only if Ctrl is not pressed, as this would otherwise conflict with Ctrl + 0
             const tokens = [...accessState.raw.ownedTokens].map((o) => getShape(o)!);
             if (tokens.length === 0) return;
-            const i = tokens.findIndex((o) => equalsP(o.center(), positionSystem.screenCenter));
+            const i = tokens.findIndex((o) => equalsP(o.center, positionSystem.screenCenter));
             const token = tokens[(i + 1) % tokens.length];
-            setCenterPosition(token.center());
+            setCenterPosition(token.center);
             floorSystem.selectFloor({ name: token.floor.name }, true);
         }
         if (event.key === "Enter") {

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -10,7 +10,7 @@ import type { Label } from "./label";
 import type { ILayer } from "./layer";
 
 export interface SimpleShape {
-    center(): GlobalPoint;
+    get center(): GlobalPoint;
 }
 
 export interface IShape extends SimpleShape {
@@ -47,8 +47,9 @@ export interface IShape extends SimpleShape {
 
     options: Partial<ShapeOptions>;
 
-    center(): GlobalPoint;
-    center(centerPoint: GlobalPoint): void;
+    __center(): GlobalPoint;
+    get center(): GlobalPoint;
+    set center(centerPoint: GlobalPoint);
 
     get isClosed(): boolean;
 

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -52,7 +52,7 @@ export class FowLightingLayer extends FowLayer {
                     if (shape.options.skipDraw ?? false) continue;
                     if (shape.floor.id !== activeFloor.id) continue;
                     const bb = shape.getBoundingBox();
-                    const lcenter = g2l(shape.center());
+                    const lcenter = g2l(shape.center);
                     const alm = 0.8 * g2lz(bb.w);
                     this.ctx.beginPath();
                     this.ctx.arc(lcenter.x, lcenter.y, alm, 0, 2 * Math.PI);
@@ -85,7 +85,7 @@ export class FowLightingLayer extends FowLayer {
                     const auraDim = aura.dim > 0 && !isNaN(aura.dim) ? aura.dim : 0;
 
                     const auraLength = getUnitDistance(auraValue + auraDim);
-                    const center = shape.center();
+                    const center = shape.center;
                     const lcenter = g2l(center);
                     const innerRange = g2lr(auraValue + auraDim);
 

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -38,7 +38,7 @@ export class FowVisionLayer extends FowLayer {
             for (const tokenId of accessState.activeTokens.value) {
                 const token = getShape(tokenId);
                 if (token === undefined || token.floor.id !== this.floor) continue;
-                const center = token.center();
+                const center = token.center;
                 const lcenter = g2l(center);
 
                 // Add a gradient vision dropoff
@@ -55,7 +55,7 @@ export class FowVisionLayer extends FowLayer {
                 this.ctx.fillStyle = gradient;
 
                 try {
-                    const polygon = computeVisibility(token.center(), TriangulationTarget.VISION, token.floor.id);
+                    const polygon = computeVisibility(token.center, TriangulationTarget.VISION, token.floor.id);
                     this.ctx.beginPath();
                     this.ctx.moveTo(g2lx(polygon[0][0]), g2ly(polygon[0][1]));
                     for (const point of polygon) this.ctx.lineTo(g2lx(point[0]), g2ly(point[1]));

--- a/client/src/game/rendering/auras.ts
+++ b/client/src/game/rendering/auras.ts
@@ -7,7 +7,7 @@ import { TriangulationTarget } from "../vision/state";
 import { computeVisibility } from "../vision/te";
 
 export function drawAuras(shape: IShape, ctx: CanvasRenderingContext2D): void {
-    const center = shape.center();
+    const center = shape.center;
     const lCenter = g2l(center);
 
     for (const aura of auraSystem.getAll(shape.id, true)) {

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -90,7 +90,7 @@ export class Asset extends BaseRect {
 
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
-        const center = g2l(this.center());
+        const center = g2l(this.center);
         if (!this.#loaded) {
             ctx.fillStyle = FOG_COLOUR;
             ctx.fillRect(

--- a/client/src/game/shapes/variants/baseRect.ts
+++ b/client/src/game/shapes/variants/baseRect.ts
@@ -32,6 +32,7 @@ export abstract class BaseRect extends Shape {
         super(topleft, options, properties);
         this._w = w;
         this._h = h;
+        this._center = this.__center();
     }
 
     get w(): number {
@@ -81,7 +82,7 @@ export abstract class BaseRect extends Shape {
             return;
         }
 
-        const center = this.center();
+        const center = this.center;
 
         const topleft = rotateAroundPoint(this.refPoint, center, this.angle);
         const botleft = rotateAroundPoint(addP(this.refPoint, new Vector(0, this.h)), center, this.angle);
@@ -96,7 +97,7 @@ export abstract class BaseRect extends Shape {
     }
 
     contains(point: GlobalPoint): boolean {
-        if (this.angle !== 0) point = rotateAroundPoint(point, this.center(), -this.angle);
+        if (this.angle !== 0) point = rotateAroundPoint(point, this.center, -this.angle);
         return (
             this.refPoint.x <= point.x &&
             this.refPoint.x + this.w >= point.x &&
@@ -105,10 +106,15 @@ export abstract class BaseRect extends Shape {
         );
     }
 
-    center(): GlobalPoint;
-    center(centerPoint: GlobalPoint): void;
-    center(centerPoint?: GlobalPoint): GlobalPoint | void {
-        if (centerPoint === undefined) return addP(this.refPoint, new Vector(this.w / 2, this.h / 2));
+    __center(): GlobalPoint {
+        return addP(this.refPoint, new Vector(this.w / 2, this.h / 2));
+    }
+
+    get center(): GlobalPoint {
+        return this._center;
+    }
+
+    set center(centerPoint: GlobalPoint) {
         this.refPoint = toGP(centerPoint.x - this.w / 2, centerPoint.y - this.h / 2);
     }
 
@@ -126,7 +132,7 @@ export abstract class BaseRect extends Shape {
 
     snapToGrid(): void {
         const gs = DEFAULT_GRID_SIZE;
-        const center = this.center();
+        const center = this.center;
         const mx = center.x;
         const my = center.y;
 
@@ -157,14 +163,14 @@ export abstract class BaseRect extends Shape {
         );
         this.resize(
             resizePoint,
-            clampToGrid(rotateAroundPoint(targetPoint, this.center(), this.angle)),
+            clampToGrid(rotateAroundPoint(targetPoint, this.center, this.angle)),
             retainAspectRatio,
         );
     }
 
     // point is expected to be the point as on the map, irregardless of rotation
     resize(resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean): number {
-        point = rotateAroundPoint(point, this.center(), -this.angle);
+        point = rotateAroundPoint(point, this.center, -this.angle);
 
         const aspectRatio = this.w / this.h;
         const oldW = this.w;

--- a/client/src/game/shapes/variants/circle.ts
+++ b/client/src/game/shapes/variants/circle.ts
@@ -33,6 +33,7 @@ export class Circle extends Shape {
     ) {
         super(center, options, properties);
         this._r = r || 1;
+        this._center = this.__center();
         this.viewingAngle = options?.viewingAngle ?? null;
     }
 
@@ -118,10 +119,15 @@ export class Circle extends Shape {
         return (point.x - this.refPoint.x) ** 2 + (point.y - this.refPoint.y) ** 2 < this.r ** 2;
     }
 
-    center(): GlobalPoint;
-    center(centerPoint: GlobalPoint): void;
-    center(centerPoint?: GlobalPoint): GlobalPoint | void {
-        if (centerPoint === undefined) return this.refPoint;
+    __center(): GlobalPoint {
+        return this.refPoint;
+    }
+
+    get center(): GlobalPoint {
+        return this._center;
+    }
+
+    set center(centerPoint: GlobalPoint) {
         this.refPoint = centerPoint;
     }
 

--- a/client/src/game/shapes/variants/circularToken.ts
+++ b/client/src/game/shapes/variants/circularToken.ts
@@ -53,7 +53,7 @@ export class CircularToken extends Circle {
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
 
-        const center = g2l(this.center());
+        const center = g2l(this.center);
         const props = getProperties(this.id)!;
 
         ctx.font = this.font;

--- a/client/src/game/shapes/variants/line.ts
+++ b/client/src/game/shapes/variants/line.ts
@@ -28,6 +28,7 @@ export class Line extends Shape {
     ) {
         super(startPoint, options, { fillColour: "rgba(0, 0, 0, 0)", strokeColour: ["#000"], ...properties });
         this._endPoint = endPoint;
+        this._center = this.__center();
         this.lineWidth = options?.lineWidth ?? 1;
     }
 
@@ -63,8 +64,8 @@ export class Line extends Shape {
 
     invalidatePoints(): void {
         this._points = [
-            toArrayP(rotateAroundPoint(this.refPoint, this.center(), this.angle)),
-            toArrayP(rotateAroundPoint(this.endPoint, this.center(), this.angle)),
+            toArrayP(rotateAroundPoint(this.refPoint, this.center, this.angle)),
+            toArrayP(rotateAroundPoint(this.endPoint, this.center, this.angle)),
         ];
     }
 
@@ -79,7 +80,7 @@ export class Line extends Shape {
     draw(ctx: CanvasRenderingContext2D): void {
         super.draw(ctx);
 
-        const center = g2l(this.center());
+        const center = g2l(this.center);
         const props = getProperties(this.id)!;
 
         ctx.strokeStyle = props.strokeColour[0];
@@ -95,14 +96,18 @@ export class Line extends Shape {
         return false; // TODO
     }
 
-    center(): GlobalPoint;
-    center(centerPoint: GlobalPoint): void;
-    center(centerPoint?: GlobalPoint): GlobalPoint | void {
-        if (centerPoint === undefined)
-            return addP(this.refPoint, subtractP(this.endPoint, this.refPoint).multiply(1 / 2));
-        const oldCenter = this.center();
-        this.refPoint = toGP(subtractP(centerPoint, subtractP(oldCenter, this.refPoint)).asArray());
+    __center(): GlobalPoint {
+        return addP(this.refPoint, subtractP(this.endPoint, this.refPoint).multiply(1 / 2));
+    }
+
+    get center(): GlobalPoint {
+        return this._center;
+    }
+
+    set center(centerPoint: GlobalPoint) {
+        const oldCenter = this.center;
         this.endPoint = toGP(subtractP(centerPoint, subtractP(oldCenter, this.endPoint)).asArray());
+        this.refPoint = toGP(subtractP(centerPoint, subtractP(oldCenter, this.refPoint)).asArray());
     }
 
     visibleInCanvas(max: { w: number; h: number }, options: { includeAuras: boolean }): boolean {

--- a/client/src/game/shapes/variants/rect.ts
+++ b/client/src/game/shapes/variants/rect.ts
@@ -41,7 +41,7 @@ export class Rect extends BaseRect {
         if (props.fillColour === "fog") ctx.fillStyle = FOG_COLOUR;
         else ctx.fillStyle = props.fillColour;
         const loc = g2l(this.refPoint);
-        const center = g2l(this.center());
+        const center = g2l(this.center);
         const state = positionState.readonly;
         ctx.fillRect(loc.x - center.x, loc.y - center.y, this.w * state.zoom, this.h * state.zoom);
         if (props.strokeColour[0] !== "rgba(0, 0, 0, 0)") {

--- a/client/src/game/shapes/variants/simple/asset.ts
+++ b/client/src/game/shapes/variants/simple/asset.ts
@@ -4,7 +4,7 @@ import type { GlobalPoint } from "../../../../core/geometry";
 export class SimpleAsset {
     constructor(public topleft: GlobalPoint, public w: number, public h: number) {}
 
-    center(): GlobalPoint {
+    get center(): GlobalPoint {
         return addP(this.topleft, new Vector(this.w / 2, this.h / 2));
     }
 }

--- a/client/src/game/shapes/variants/simple/boundingRect.ts
+++ b/client/src/game/shapes/variants/simple/boundingRect.ts
@@ -33,7 +33,7 @@ export class BoundingRect implements SimpleShape {
     }
 
     contains(point: GlobalPoint): boolean {
-        if (this.angle !== 0) point = rotateAroundPoint(point, this.center(), -this.angle);
+        if (this.angle !== 0) point = rotateAroundPoint(point, this.center, -this.angle);
         return (
             this.topLeft.x <= point.x &&
             this.topRight.x >= point.x &&
@@ -45,7 +45,7 @@ export class BoundingRect implements SimpleShape {
     get points(): [number, number][] {
         if (this.w === 0 || this.h === 0) return [[this.topLeft.x, this.topLeft.y]];
 
-        const center = this.center();
+        const center = this.center;
 
         const topleft = rotateAroundPoint(this.topLeft, center, this.angle);
         const botleft = rotateAroundPoint(this.botLeft, center, this.angle);
@@ -114,10 +114,11 @@ export class BoundingRect implements SimpleShape {
         return { hit: txmin < ray.tMax && txmax > 0, min: txmin, max: txmax };
     }
 
-    center(): GlobalPoint;
-    center(centerPoint: GlobalPoint): BoundingRect;
-    center(centerPoint?: GlobalPoint): GlobalPoint | BoundingRect {
-        if (centerPoint === undefined) return addP(this.topLeft, new Vector(this.w / 2, this.h / 2));
+    get center(): GlobalPoint {
+        return addP(this.topLeft, new Vector(this.w / 2, this.h / 2));
+    }
+
+    centerOn(centerPoint: GlobalPoint): BoundingRect {
         return new BoundingRect(toGP(centerPoint.x - this.w / 2, centerPoint.y - this.h / 2), this.w, this.h);
     }
 
@@ -136,7 +137,7 @@ export class BoundingRect implements SimpleShape {
     }
 
     rotateAround(point: GlobalPoint, angle: number): BoundingRect {
-        const center = this.center();
+        const center = this.center;
         const newCenter = rotateAroundPoint(center, point, angle);
 
         const bb = new BoundingRect(

--- a/client/src/game/shapes/variants/text.ts
+++ b/client/src/game/shapes/variants/text.ts
@@ -32,6 +32,7 @@ export class Text extends Shape {
         properties?: Partial<ShapeProperties>,
     ) {
         super(position, options, properties);
+        this._center = this.__center();
     }
 
     get isClosed(): boolean {
@@ -97,10 +98,15 @@ export class Text extends Shape {
         return this.getBoundingBox().contains(point);
     }
 
-    center(): GlobalPoint;
-    center(centerPoint: GlobalPoint): void;
-    center(centerPoint?: GlobalPoint): GlobalPoint | void {
-        if (centerPoint === undefined) return this.refPoint;
+    __center(): GlobalPoint {
+        return this._refPoint;
+    }
+
+    get center(): GlobalPoint {
+        return this._center;
+    }
+
+    set center(centerPoint: GlobalPoint) {
         this.refPoint = centerPoint;
     }
 
@@ -117,7 +123,7 @@ export class Text extends Shape {
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     resize(resizePoint: number, point: GlobalPoint): number {
-        point = rotateAroundPoint(point, this.center(), -this.angle);
+        point = rotateAroundPoint(point, this.center, -this.angle);
 
         const oldPoints = this.points;
 

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -132,9 +132,9 @@ export class ToggleComposite extends Shape {
 
         if (sync) {
             oldVariant.options.skipDraw = true;
-            const oldCenter = oldVariant.center();
+            const oldCenter = oldVariant.center;
             delete newVariant.options.skipDraw;
-            newVariant.center(oldCenter);
+            newVariant.center = oldCenter;
 
             sendShapePositionUpdate([newVariant], false);
             sendShapeSkipDraw({ shape: getGlobalId(oldVariant.id), value: true });
@@ -177,10 +177,15 @@ export class ToggleComposite extends Shape {
         return false;
     }
 
-    center(): GlobalPoint;
-    center(centerPoint: GlobalPoint): void;
-    center(centerPoint?: GlobalPoint): GlobalPoint | void {
-        if (centerPoint === undefined) return getShape(this.active_variant)!.center();
+    __center(): GlobalPoint {
+        return getShape(this.active_variant)!.center;
+    }
+
+    get center(): GlobalPoint {
+        return this.__center();
+    }
+
+    set center(centerPoint: GlobalPoint) {
         this.refPoint = centerPoint;
     }
 

--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -101,7 +101,7 @@ class ClientSystem implements System {
         if (dimensions === undefined) return;
         const { center, h, w } = dimensions;
         polygon.vertices = [toGP(0, 0), toGP(0, h), toGP(w, h), toGP(w, 0), toGP(0, 0)];
-        polygon.center(center);
+        polygon.center = center;
         polygon.invalidate(true);
     }
 
@@ -171,7 +171,7 @@ class ClientSystem implements System {
         if (dimensions === undefined) return;
         const { h, w } = dimensions;
 
-        const center = rect.center();
+        const center = rect.center;
         const newPosition = { ...locationData, pan_x: w / 2 - center.x - offset.x, pan_y: h / 2 - center.y - offset.y };
 
         sendMoveClientThrottled({

--- a/client/src/game/systems/logic/tp/core.ts
+++ b/client/src/game/systems/logic/tp/core.ts
@@ -22,7 +22,7 @@ export function getTpZoneShapes(fromZone: LocalId): LocalId[] {
         if (
             !getProperties(shape.id)!.isLocked &&
             accessSystem.hasAccessTo(shape.id, false, { movement: true }) &&
-            fromShape.contains(shape.center())
+            fromShape.contains(shape.center)
         ) {
             shapes.push(shape.id);
         }
@@ -38,7 +38,7 @@ export async function teleport(fromZone: LocalId, toZone: GlobalId, transfers?: 
     let targetLocation = activeLocation;
     const tpTargetId = getLocalId(toZone);
     const targetShape = tpTargetId === undefined ? undefined : getShape(tpTargetId);
-    let center: GlobalPoint | undefined = targetShape?.center();
+    let center: GlobalPoint | undefined = targetShape?.center;
     let floor: string | undefined = targetShape?.floor.name;
 
     if (targetShape === undefined) {
@@ -46,7 +46,7 @@ export async function teleport(fromZone: LocalId, toZone: GlobalId, transfers?: 
         targetLocation = location;
         const simpleShape = createSimpleShapeFromDict(shape);
         if (simpleShape === undefined) return;
-        center = simpleShape.center();
+        center = simpleShape.center;
         floor = shape.floor;
     }
     if (floor === undefined || center === undefined) return;

--- a/client/src/game/systems/logic/tp/index.ts
+++ b/client/src/game/systems/logic/tp/index.ts
@@ -183,7 +183,7 @@ class TeleportZoneSystem implements ShapeSystem {
                     (locationSettingsState.raw.spawnLocations.value.includes(shape.id) ?? false)
                 )
                     continue;
-                if (tpShape.floor.id === shape.floor.id && tpShape.contains(shape.center())) {
+                if (tpShape.floor.id === shape.floor.id && tpShape.contains(shape.center)) {
                     shapesToMove.push(shape.id);
                 }
             }

--- a/client/src/game/tools/variants/map.ts
+++ b/client/src/game/tools/variants/map.ts
@@ -168,7 +168,7 @@ class MapTool extends Tool {
             this.shape.h *= yFactor;
 
             const oldRefpoint = this.shape.refPoint;
-            const oldCenter = this.rect.center();
+            const oldCenter = this.rect.center;
 
             const delta = subtractP(oldCenter, oldRefpoint);
             const newCenter = addP(oldRefpoint, new Vector(xFactor * delta.x, yFactor * delta.y));

--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -99,8 +99,8 @@ class PingTool extends Tool {
             return;
         }
 
-        this.ping.center(gp);
-        this.border.center(gp);
+        this.ping.center = gp;
+        this.border.center = gp;
 
         sendShapePositionUpdate([this.ping, this.border], true);
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -483,7 +483,7 @@ class SelectTool extends Tool implements ISelectTool {
                 this.resizePoint = resizeShape(shape, targetPoint, this.resizePoint, ctrlOrCmdPressed(event), true);
                 this.updateCursor(gp, features);
             } else if (this.mode === SelectOperations.Rotate) {
-                const center = this.rotationBox!.center();
+                const center = this.rotationBox!.center;
                 const newAngle = -Math.atan2(center.y - gp.y, gp.x - center.x) + Math.PI / 2;
                 this.rotateSelection(newAngle, center, true);
             } else {
@@ -680,7 +680,7 @@ class SelectTool extends Tool implements ISelectTool {
                 }
             }
             if (this.mode === SelectOperations.Rotate) {
-                const rotationCenter = this.rotationBox!.center();
+                const rotationCenter = this.rotationBox!.center;
 
                 for (const [s, sel] of layerSelection.entries()) {
                     if (!accessSystem.hasAccessTo(sel.id, false, { movement: true })) continue;
@@ -830,8 +830,8 @@ class SelectTool extends Tool implements ISelectTool {
             const angle = layerSelection[0].angle;
             this.angle = angle;
             this.rotationBox.angle = angle;
-            this.rotationAnchor.rotateAround(bbox.center(), angle);
-            this.rotationEnd.rotateAround(bbox.center(), angle);
+            this.rotationAnchor.rotateAround(bbox.center, angle);
+            this.rotationEnd.rotateAround(bbox.center, angle);
         }
 
         this.rotationUiActive = true;

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -127,7 +127,7 @@ class SpellTool extends Tool {
 
         if (selectedSystem.hasSelection && (this.state.range === 0 || equalsP(startPosition, ogPoint))) {
             const selection = [...selectedSystem.$.value];
-            this.shape.center(getShape(selection[0])!.center());
+            this.shape.center = getShape(selection[0])!.center;
         }
 
         layer.addShape(
@@ -150,7 +150,7 @@ class SpellTool extends Tool {
 
         const selection = [...selectedSystem.$.value];
         this.rangeShape = new Circle(
-            getShape(selection[0])!.center(),
+            getShape(selection[0])!.center,
             getUnitDistance(this.state.range),
             {
                 isSnappable: false,
@@ -214,13 +214,13 @@ class SpellTool extends Tool {
 
         if (selectedSystem.hasSelection && this.state.range === 0) {
             if (this.state.selectedSpellShape === SpellShape.Cone) {
-                const center = g2l(this.shape.center());
+                const center = g2l(this.shape.center);
                 (this.shape as ICircle).angle = -Math.atan2(lp.y - center.y, center.x - lp.x) + Math.PI;
                 if (this.state.showPublic) sendShapePositionUpdate([this.shape], true);
                 layer.invalidate(true);
             }
         } else {
-            this.shape.center(endPoint);
+            this.shape.center = endPoint;
             if (this.state.showPublic) sendShapePositionUpdate([this.shape], true);
             layer.invalidate(true);
         }

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -267,7 +267,7 @@ class InitiativeStore extends Store<InitiativeState> {
             const actor = this.getDataSet()[this._state.turnCounter];
             if (accessSystem.hasAccessTo(actor.shape, false, { vision: true }) ?? false) {
                 const shape = getShape(actor.shape)!;
-                setCenterPosition(shape.center());
+                setCenterPosition(shape.center);
             }
         }
     }

--- a/client/src/game/ui/settings/shape/GroupSettings.vue
+++ b/client/src/game/ui/settings/shape/GroupSettings.vue
@@ -140,7 +140,7 @@ function updateToggles(checked: boolean): void {
 
 function centerMember(member: IShape): void {
     if (!owned.value) return;
-    setCenterPosition(member.center());
+    setCenterPosition(member.center);
 }
 
 function toggleHighlight(member: IShape, show: boolean): void {

--- a/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
+++ b/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
@@ -52,7 +52,7 @@ function showArea(): void {
     if (shape === undefined) return;
 
     shape.showHighlight = true;
-    setCenterPosition(shape.center());
+    setCenterPosition(shape.center);
 }
 </script>
 

--- a/client/src/store/game.ts
+++ b/client/src/store/game.ts
@@ -100,7 +100,7 @@ class GameStore {
     jumpToMarker(marker: LocalId): void {
         const shape = getShape(marker);
         if (shape == undefined) return;
-        setCenterPosition(shape.center());
+        setCenterPosition(shape.center);
     }
 
     removeMarker(marker: LocalId, sync: boolean): void {


### PR DESCRIPTION
The center point of shapes are being calculated on the fly.

Most shapes however don't actively move that often if at all, so we're kinda wasting CPU cycles on calculating the center whenever we need to render it. This PR changes that to instead keep the center in memory.

We're basically using more memory to gain more performance.

_The implementation is the same idea as the now closed #850 but that PR was no longer up to date with a lot of the recent changes, so I just decided to create a fresh PR._