### PR TITLE
feat(Performance): Add client option to limit floor rendering to active floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tech changes will usually be stripped from release notes for the public
 -   Players section in the left in-game dm sidebar
     -   Lists players connected to the session
     -   Clicking on a name, centers your screen on their current view (if on the same location)
+-   User configuration option to limit rendering to only the active floor
 -   [server] option to specify alternative location for static files
 
 ### Changed

--- a/client/src/game/api/events/player/options.ts
+++ b/client/src/game/api/events/player/options.ts
@@ -70,4 +70,11 @@ socket.on("Player.Options.Set", (options: ServerPlayerInfo) => {
         sync: false,
         default: defaultOptions.initiativeEffectVisibility,
     });
+
+    // Performance
+
+    playerSettingsSystem.setRenderAllFloors(roomOptions?.renderAllFloors, {
+        sync: false,
+        default: defaultOptions.renderAllFloors,
+    });
 });

--- a/client/src/game/layers/canvas.ts
+++ b/client/src/game/layers/canvas.ts
@@ -3,6 +3,7 @@ import { playerSettingsState } from "../systems/settings/players/state";
 export function createCanvas(): HTMLCanvasElement {
     // Create canvas element
     const canvas = document.createElement("canvas");
+    canvas.style.display = "none";
     setCanvasDimensions(canvas, window.innerWidth, window.innerHeight);
     return canvas;
 }

--- a/client/src/game/layers/variants/fow.ts
+++ b/client/src/game/layers/variants/fow.ts
@@ -3,6 +3,7 @@ import { LayerName } from "../../models/floor";
 import type { FloorId } from "../../models/floor";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
+import { playerSettingsState } from "../../systems/settings/players/state";
 import { createCanvas, setCanvasDimensions } from "../canvas";
 
 import { Layer } from "./layer";
@@ -36,7 +37,11 @@ export class FowLayer extends Layer {
             this.canvas.style.removeProperty("display");
         else if (this.floor !== activeFloor && this.canvas.style.display !== "none") this.canvas.style.display = "none";
 
-        if (this.floor === activeFloor && floorState.raw.floors.length > 1) {
+        if (
+            playerSettingsState.raw.renderAllFloors.value &&
+            this.floor === activeFloor &&
+            floorState.raw.floors.length > 1
+        ) {
             for (const floor of floorState.raw.floors) {
                 if (floor.name !== floorState.raw.floors[0].name) {
                     const mapl = floorSystem.getLayer(floor, LayerName.Map);

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -6,6 +6,7 @@ import { accessState } from "../../systems/access/state";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
 import { locationSettingsState } from "../../systems/settings/location/state";
+import { playerSettingsState } from "../../systems/settings/players/state";
 import { TriangulationTarget } from "../../vision/state";
 import { computeVisibility } from "../../vision/te";
 
@@ -67,7 +68,11 @@ export class FowVisionLayer extends FowLayer {
             }
 
             const activeFloor = floorState.currentFloor.value!.id;
-            if (this.floor === activeFloor && floorState.raw.floors.length > 1) {
+            if (
+                playerSettingsState.raw.renderAllFloors.value &&
+                this.floor === activeFloor &&
+                floorState.raw.floors.length > 1
+            ) {
                 for (let f = floorState.raw.floors.length - 1; f > floorState.raw.floorIndex; f--) {
                     const floor = floorState.raw.floors[f];
                     if (floor.id === activeFloor) break;

--- a/client/src/game/rendering/core.ts
+++ b/client/src/game/rendering/core.ts
@@ -1,6 +1,7 @@
 import type { Floor } from "../models/floor";
 import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
+import { playerSettingsState } from "../systems/settings/players/state";
 
 let _animationFrameId = 0;
 
@@ -14,27 +15,25 @@ export function stopDrawLoop(): void {
 
 function drawLoop(): void {
     const state = floorState.raw;
+
     // First process all other floors
-    for (const [f, floor] of state.floors.entries()) {
-        if (f === state.floorIndex) continue;
-        drawFloor(floor);
+    if (playerSettingsState.raw.renderAllFloors.value) {
+        for (const [f, floor] of state.floors.entries()) {
+            if (f === state.floorIndex) continue;
+            drawFloor(floor);
+        }
     }
+
     // Then process the current floor
     if (floorState.currentFloor !== undefined) {
         drawFloor(floorState.currentFloor.value!);
     }
-    for (let i = state.floorIndex; i >= 0; i--) {
-        const floor = state.floors[i];
-        for (const layer of floorSystem.getLayers(floor)) {
-            if (i === state.floorIndex || !layer.isVisionLayer) layer.show();
-        }
-    }
+
     _animationFrameId = requestAnimationFrame(drawLoop);
 }
 
 function drawFloor(floor: Floor): void {
     for (const layer of floorSystem.getLayers(floor)) {
-        layer.hide();
         layer.draw();
     }
 }

--- a/client/src/game/systems/settings/players/helpers.ts
+++ b/client/src/game/systems/settings/players/helpers.ts
@@ -20,5 +20,7 @@ export function playerOptionsToClient(options: Partial<ServerPlayerOptions>): Pa
         initiativeCameraLock: options.initiative_camera_lock,
         initiativeVisionLock: options.initiative_vision_lock,
         initiativeEffectVisibility: options.initiative_effect_visibility,
+
+        renderAllFloors: options.render_all_floors,
     };
 }

--- a/client/src/game/systems/settings/players/index.ts
+++ b/client/src/game/systems/settings/players/index.ts
@@ -139,6 +139,19 @@ class PlayerSettingsSystem implements System {
         if (options.sync)
             sendRoomClientOptions("initiative_effect_visibility", initiativeEffectVisibility, options.default);
     }
+
+    // PERFORMANCE
+
+    setRenderAllFloors(renderAllFloors: boolean | undefined, options: { sync: boolean; default?: boolean }): void {
+        $.renderAllFloors.override = renderAllFloors;
+        if (options.default !== undefined) $.renderAllFloors.default = options.default;
+        $.renderAllFloors.value = renderAllFloors ?? $.renderAllFloors.default;
+
+        floorSystem.updateLayerVisibility();
+        floorSystem.invalidateAllFloors();
+
+        if (options.sync) sendRoomClientOptions("render_all_floors", renderAllFloors, options.default);
+    }
 }
 
 export const playerSettingsSystem = new PlayerSettingsSystem();

--- a/client/src/game/systems/settings/players/models.ts
+++ b/client/src/game/systems/settings/players/models.ts
@@ -21,6 +21,9 @@ export interface PlayerOptions {
     initiativeCameraLock: boolean;
     initiativeVisionLock: boolean;
     initiativeEffectVisibility: InitiativeEffectMode;
+
+    // Performance
+    renderAllFloors: boolean;
 }
 
 export interface ServerPlayerOptions {
@@ -40,6 +43,8 @@ export interface ServerPlayerOptions {
     initiative_camera_lock: boolean;
     initiative_vision_lock: boolean;
     initiative_effect_visibility: InitiativeEffectMode;
+
+    render_all_floors: boolean;
 }
 
 export interface ServerPlayerInfo {

--- a/client/src/game/systems/settings/players/state.ts
+++ b/client/src/game/systems/settings/players/state.ts
@@ -28,6 +28,8 @@ const state = buildState<PlayerState, "gridSize">({
     initiativeCameraLock: init(false),
     initiativeVisionLock: init(false),
     initiativeEffectVisibility: init(InitiativeEffectMode.ActiveAndHover),
+
+    renderAllFloors: init(true),
 });
 
 const devicePixelRatio = computed(() => {

--- a/client/src/game/ui/settings/client/ClientSettings.vue
+++ b/client/src/game/ui/settings/client/ClientSettings.vue
@@ -10,6 +10,7 @@ import BehaviourSettings from "./BehaviourSettings.vue";
 import { ClientSettingCategory } from "./categories";
 import DisplaySettings from "./DisplaySettings.vue";
 import InitiativeSettings from "./InitiativeSettings.vue";
+import PerformanceSettings from "./PerformanceSettings.vue";
 
 const { t } = useI18n();
 
@@ -27,6 +28,7 @@ const categoryNames = [
     ClientSettingCategory.Behaviour,
     ClientSettingCategory.Display,
     ClientSettingCategory.Initiative,
+    ClientSettingCategory.Performance,
 ];
 
 const activeClientTab = toRef(uiStore.state, "clientSettingsTab");
@@ -40,6 +42,7 @@ const activeClientTab = toRef(uiStore.state, "clientSettingsTab");
             <DisplaySettings v-show="selection === ClientSettingCategory.Display" />
             <BehaviourSettings v-show="selection === ClientSettingCategory.Behaviour" />
             <InitiativeSettings v-show="selection === ClientSettingCategory.Initiative" />
+            <PerformanceSettings v-show="selection === ClientSettingCategory.Performance" />
         </template>
     </PanelModal>
 </template>

--- a/client/src/game/ui/settings/client/PerformanceSettings.vue
+++ b/client/src/game/ui/settings/client/PerformanceSettings.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+import { playerSettingsSystem } from "../../../systems/settings/players";
+import { playerSettingsState } from "../../../systems/settings/players/state";
+
+const { t } = useI18n();
+
+const { reactive: $ } = playerSettingsState;
+const pss = playerSettingsSystem;
+
+const onlyRenderActiveFloor = computed({
+    get() {
+        return !$.renderAllFloors.value;
+    },
+    set(onlyRenderActiveFloor: boolean | undefined) {
+        const renderAllFloors = onlyRenderActiveFloor === undefined ? undefined : !onlyRenderActiveFloor;
+        pss.setRenderAllFloors(renderAllFloors, { sync: true });
+    },
+});
+</script>
+
+<template>
+    <div class="panel restore-panel">
+        <div class="spanrow header">Rendering</div>
+        <div class="row">
+            <label for="renderAllFloors">
+                {{ t("game.ui.settings.client.PerformanceSettings.only_render_active_floor") }}
+            </label>
+            <div><input id="renderAllFloors" type="checkbox" v-model="onlyRenderActiveFloor" /></div>
+            <template v-if="$.renderAllFloors.override !== undefined">
+                <div :title="t('game.ui.settings.common.reset_default')" @click="onlyRenderActiveFloor = undefined">
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div
+                    :title="t('game.ui.settings.common.sync_default')"
+                    @click="pss.setRenderAllFloors(undefined, { sync: true, default: $.renderAllFloors.override })"
+                >
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+/* Force higher specificity without !important abuse */
+.panel.restore-panel {
+    min-width: 20vw;
+    column-gap: 15px;
+    grid-template-columns: [setting] 1fr [value] auto [restore] 30px [sync] 30px [end];
+}
+
+label {
+    grid-column-start: setting;
+}
+
+.overwritten,
+.restore-panel .row.overwritten * {
+    color: #7c253e;
+    font-weight: bold;
+}
+
+.panel input[type="number"] {
+    width: 50px;
+}
+</style>

--- a/client/src/game/ui/settings/client/categories.ts
+++ b/client/src/game/ui/settings/client/categories.ts
@@ -3,4 +3,5 @@ export enum ClientSettingCategory {
     Behaviour = "Behaviour",
     Display = "Display",
     Initiative = "Initiative",
+    Performance = "Performance",
 }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -245,6 +245,9 @@
                         "effect_visibility": "When to show effects",
                         "effect_always": "Always",
                         "effect_active": "Active and on-hover"
+                    },
+                    "PerformanceSettings": {
+                        "only_render_active_floor": "Only render active floor"
                     }
                 },
                 "dm": {

--- a/server/src/models/user.py
+++ b/server/src/models/user.py
@@ -42,6 +42,8 @@ class UserOptions(BaseModel):
     initiative_vision_lock = BooleanField(default=False, null=True)
     initiative_effect_visibility = TextField(default="active", null=True)
 
+    render_all_floors = BooleanField(default=True, null=True)
+
     @classmethod
     def create_empty(cls):
         return UserOptions.create(
@@ -58,6 +60,7 @@ class UserOptions(BaseModel):
             initiative_camera_lock=None,
             initiative_vision_lock=None,
             initiative_effect_visibility=None,
+            render_all_floors=None,
         )
 
     def as_dict(self):

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -13,7 +13,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 76
+SAVE_VERSION = 77
 
 import json
 import logging
@@ -237,6 +237,12 @@ def upgrade(db: SqliteExtDatabase, version: int):
             )
             db.execute_sql(
                 "UPDATE location_options SET underground_map_background = 'none' WHERE id IN (SELECT default_options_id FROM room) AND (underground_map_background IS NULL OR underground_map_background = 'rgba(0, 0, 0, 0)')"
+            )
+    elif version == 76:
+        # Add UserOptions.render_all_floors
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE user_options ADD COLUMN render_all_floors INTEGER DEFAULT 1"
             )
     else:
         raise UnknownVersionException(


### PR DESCRIPTION
The floor system adds a lot of fun immersive options. This comes at the cost of performance however, which depending on the player's hardware can be an issue.

This PR adds a first Performance oriented client option to disable rendering of all other floors.