### PR TITLE
Fix typo in location menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ tech changes will usually be stripped from release notes for the public
 -   The asset manager was no longer useable when using a subpath setup
 -   Player state clearing on location change
 -   Zoom sensitivity on touchpad
+-   Typo in location menu
 -   Multiple Initiative bugs
     -   Server should detect client errors in initiative listings better and reject wrong data
     -   Modification of the initiative should retain the current active actor under more circumstances

--- a/client/src/game/ui/menu/LocationBar.vue
+++ b/client/src/game/ui/menu/LocationBar.vue
@@ -57,7 +57,7 @@ async function showArchivedLocations(): Promise<void> {
     if (locations.length === 0) return;
 
     const choice = await modals.selectionBox(
-        "Select a location to retore",
+        "Select a location to restore",
         locations.map((l) => l.name),
     );
     const location = locations.find((l) => l.name === choice?.[0]);


### PR DESCRIPTION
Location menu has a typo in the archived locations section.