### PR TITLE
bug(UI): Fix AssetPicker UI problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ tech changes will usually be stripped from release notes for the public
 -   Multiple Initiative bugs
     -   Server should detect client errors in initiative listings better and reject wrong data
     -   Modification of the initiative should retain the current active actor under more circumstances
+-   In-game AssetPicker modal UI fixes
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/core/components/modals/AssetPicker.vue
+++ b/client/src/core/components/modals/AssetPicker.vue
@@ -109,22 +109,20 @@ function select(event: MouseEvent, inode: number): void {
 .modal-body {
     max-width: 30vw;
     padding: 10px;
+    padding-top: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
 }
 
 #assets {
+    display: flex;
     max-height: 50vh;
     width: 30vw;
     flex-grow: 1;
     background-color: white;
-    border: solid 1px black;
-    margin: 10px;
     position: relative;
     padding-top: 45px;
-    padding-bottom: 45px;
-    box-shadow: 3px 3px gray;
 
     #breadcrumbs {
         position: absolute;


### PR DESCRIPTION
The in-game asset picker modal had some UI "bugs" like content overflowing into areas where it shouldn't be visible etc.

This PR is a simple cleanup of some of these issues.