### PR TITLE
bug(Prompt): Fix prompt modal not clearing error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ tech changes will usually be stripped from release notes for the public
     -   Server should detect client errors in initiative listings better and reject wrong data
     -   Modification of the initiative should retain the current active actor under more circumstances
 -   In-game AssetPicker modal UI fixes
+-   Prompt modal not clearing error message properly
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/core/plugins/modals/prompt.ts
+++ b/client/src/core/plugins/modals/prompt.ts
@@ -37,6 +37,7 @@ export function usePrompt(): PromptModal {
         data.visible = true;
         data.question = question;
         data.title = title;
+        data.error = "";
         if (validation) validationFunction = validation;
         return new Promise((res) => (resolve = res));
     }


### PR DESCRIPTION
When the last prompt modal you opened had an error message, this message will appear in any following prompt you open instead of being properly cleared.