### PR TITLE
bug(LocationSettings): Fix location settings not being sent to players

### DIFF
--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -27,7 +27,7 @@ socket.on("Client.Move", (data: { player: PlayerId; client: ClientId } & ServerU
 });
 
 socket.on("Client.Viewport.Set", (data: { client: ClientId; viewport: Viewport }) => {
-    clientSystem.setClientViewport(data.client, data.viewport);
+    clientSystem.setClientViewport(data.client, data.viewport, true);
 });
 
 socket.on("Client.Offset.Set", (data: { client: ClientId } & { x?: number; y?: number }) => {

--- a/client/src/game/api/events/player/players.ts
+++ b/client/src/game/api/events/player/players.ts
@@ -39,7 +39,7 @@ socket.on(
         for (const player of data) {
             for (const client of player.clients ?? []) {
                 clientSystem.addClient(player.core.id, client.sid);
-                if (client.viewport) clientSystem.setClientViewport(client.sid, client.viewport);
+                if (client.viewport) clientSystem.setClientViewport(client.sid, client.viewport, false);
             }
         }
     },

--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -151,9 +151,9 @@ class ClientSystem implements System {
         return polygon;
     }
 
-    setClientViewport(client: ClientId, viewport: Viewport): void {
+    setClientViewport(client: ClientId, viewport: Viewport, update: boolean): void {
         $.clientViewports.set(client, viewport);
-        this.updateClientRect(client);
+        if (update) this.updateClientRect(client);
     }
 
     moveClient(rectUuid: LocalId): void {

--- a/client/src/game/systems/settings/location/index.ts
+++ b/client/src/game/systems/settings/location/index.ts
@@ -11,11 +11,11 @@ import { isDefaultWrapper } from "./helpers";
 import type { WithLocationDefault } from "./models";
 import { locationSettingsState } from "./state";
 
-const { mutableReactive: $, raw } = locationSettingsState;
+const { mutableReactive: $, raw, reset } = locationSettingsState;
 
 class LocationSettingsSystem implements System {
     clear(partial: boolean): void {
-        //
+        if (!partial) reset();
     }
 
     private resetValue(setting: WithLocationDefault<unknown>): void {

--- a/client/src/game/systems/settings/location/state.ts
+++ b/client/src/game/systems/settings/location/state.ts
@@ -4,28 +4,32 @@ import type { LocationOptions, WithDefault, WithLocationDefault } from "./models
 
 const init = <T>(x: T): WithLocationDefault<T> => ({ default: x, location: {}, value: x });
 
-const state = buildState<
-    { activeLocation: number } & { [key in keyof LocationOptions]: WithLocationDefault<LocationOptions[key]> }
->({
-    activeLocation: 0,
+type State = { activeLocation: number } & { [key in keyof LocationOptions]: WithLocationDefault<LocationOptions[key]> };
 
-    fowLos: init(false),
-    fowOpacity: init(0),
-    gridType: init("SQUARE"),
-    fullFow: init(false),
-    movePlayerOnTokenChange: init(false),
-    spawnLocations: init([]),
-    useGrid: init(false),
-    unitSize: init(5), // gridSize computed is not triggering on setDefault for some reason
-    unitSizeUnit: init("ft"),
-    visionMaxRange: init(0),
-    visionMinRange: init(0),
-    visionMode: init(""),
+function getInitState(): State {
+    return {
+        activeLocation: 0,
 
-    airMapBackground: init("none"),
-    groundMapBackground: init("none"),
-    undergroundMapBackground: init("none"),
-});
+        fowLos: init(false),
+        fowOpacity: init(0),
+        gridType: init("SQUARE"),
+        fullFow: init(false),
+        movePlayerOnTokenChange: init(false),
+        spawnLocations: init([]),
+        useGrid: init(false),
+        unitSize: init(5), // gridSize computed is not triggering on setDefault for some reason
+        unitSizeUnit: init("ft"),
+        visionMaxRange: init(0),
+        visionMinRange: init(0),
+        visionMode: init(""),
+
+        airMapBackground: init("none"),
+        groundMapBackground: init("none"),
+        undergroundMapBackground: init("none"),
+    };
+}
+
+const state = buildState<State>(getInitState());
 
 function getOption<T>(key: WithLocationDefault<T>, location: number | undefined): WithDefault<T> {
     if (location === undefined) return { value: key.default, default: key.default };
@@ -36,4 +40,11 @@ function getOption<T>(key: WithLocationDefault<T>, location: number | undefined)
 export const locationSettingsState = {
     ...state,
     getOption,
+    reset: () => {
+        const i = getInitState();
+        for (const key of Object.keys(i)) {
+            const a = key as keyof State;
+            state.mutableReactive[a] = i[a] as any; // typing cannot infer Key<>Value relation per key
+        }
+    },
 };

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -168,7 +168,7 @@ async def load_location(sid: str, location: Location, *, complete=False):
 
     await sio.emit("Location.Set", location_data, room=sid, namespace=GAME_NS)
 
-    # 4. Load all location settings (DM)
+    # 4. Load location settings
 
     if complete and IS_DM:
         await sio.emit(
@@ -179,6 +179,20 @@ async def load_location(sid: str, location: Location, *, complete=False):
                 "locations": {
                     l.id: {} if l.options is None else l.options.as_dict()
                     for l in pr.room.locations
+                },
+            },
+            room=sid,
+            namespace=GAME_NS,
+        )
+    elif not IS_DM:
+        loc = pr.active_location
+        await sio.emit(
+            "Locations.Settings.Set",
+            {
+                "default": pr.room.default_options.as_dict(),
+                "active": location_data["id"],
+                "locations": {
+                    loc.id: {} if loc.options is None else loc.options.as_dict()
                 },
             },
             room=sid,


### PR DESCRIPTION
Due to an oversight during a recent refactor, the settings of the active location were not properly being sent to players causing things like fog of war suddenly disappearing at the player side but not the DM side.