### PR TITLE
bug(Floors): Fix initial load not showing lower floors

### DIFF
--- a/client/src/game/layers/floor.ts
+++ b/client/src/game/layers/floor.ts
@@ -10,6 +10,8 @@ export function recalculateZIndices(): void {
             i += 1;
         }
     }
+    floorSystem.updateLayerVisibility();
+    floorSystem.invalidateAllFloors();
 }
 
 export function getPattern(pattern: string): BackgroundPattern | undefined {


### PR DESCRIPTION
When loading a location that has floors, lower floors would not immediately be shown until you change floors once.

_This is a regression due to the renderAllFloors performance option_