### PR TITLE
bug(Tools): Fix toolbar detail position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ tech changes will usually be stripped from release notes for the public
     -   Modification of the initiative should retain the current active actor under more circumstances
 -   In-game AssetPicker modal UI fixes
 -   Prompt modal not clearing error message properly
+-   Tool details not always being in the correct location (e.g. when changing mode)
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/ui/tools/DiceTool.vue
+++ b/client/src/game/ui/tools/DiceTool.vue
@@ -1,25 +1,12 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from "vue";
-import type { CSSProperties } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 
 import { coreStore } from "../../../store/core";
 import { sendDiceRollResult } from "../../api/emits/dice";
 import { diceTool } from "../../tools/variants/dice";
 
-import { useToolPosition } from "./toolPosition";
-
-// Common tool bootup logic
-
-const right = ref("0px");
-const arrow = ref("0px");
 const button = ref<HTMLButtonElement | null>(null);
 const historyDiv = ref<HTMLDivElement | null>(null);
-
-const toolStyle = computed(() => ({ "--detailRight": right.value, "--detailArrow": arrow.value } as CSSProperties));
-
-onMounted(() => {
-    ({ right: right.value, arrow: arrow.value } = useToolPosition(diceTool.toolName));
-});
 
 // Dice logic
 const diceArray = ref<{ die: number; amount: number }[]>([]);
@@ -87,7 +74,7 @@ async function go(): Promise<void> {
 </script>
 
 <template>
-    <div id="dice" class="tool-detail" :style="toolStyle">
+    <div id="dice" class="tool-detail">
         <div id="dice-history" ref="historyDiv">
             <template v-for="r of diceTool.state.history" :key="r.roll">
                 <div class="roll" :title="r.player" @click="reroll(r.roll)">{{ r.roll }}</div>

--- a/client/src/game/ui/tools/DrawTool.vue
+++ b/client/src/game/ui/tools/DrawTool.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref, toRef } from "vue";
-import type { CSSProperties } from "vue";
+import { computed, ref, toRef } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../core/components/ColourPicker.vue";
@@ -10,17 +9,10 @@ import { DOOR_TOGGLE_MODES } from "../../systems/logic/door/models";
 import { DrawCategory, DrawMode, DrawShape, drawTool } from "../../tools/variants/draw";
 import LogicPermissions from "../settings/shape/LogicPermissions.vue";
 
-import { useToolPosition } from "./toolPosition";
-
 const { t } = useI18n();
 const modals = useModal();
 
 drawTool.setPromptFunction(modals.prompt);
-
-const state = reactive({
-    arrow: "0px",
-    right: "0px",
-});
 
 const hasBrushSize = drawTool.hasBrushSize;
 const isDm = toRef(getGameState(), "isDm");
@@ -28,7 +20,6 @@ const modes = Object.values(DrawMode);
 const categories = Object.values(DrawCategory);
 const selected = drawTool.isActiveTool;
 const shapes = Object.values(DrawShape);
-const toolStyle = computed(() => ({ "--detailRight": state.right, "--detailArrow": state.arrow } as CSSProperties));
 
 const showPermissions = ref(false);
 
@@ -46,10 +37,6 @@ const translationMapping = {
     [DrawCategory.Vision]: t("game.ui.tools.DrawTool.vision-category"),
     [DrawCategory.Logic]: t("game.ui.tools.DrawTool.logic-category"),
 };
-
-onMounted(() => {
-    ({ right: state.right, arrow: state.arrow } = useToolPosition(drawTool.toolName));
-});
 
 const showBorderColour = computed(() => {
     if (drawTool.state.selectedShape === DrawShape.Brush) return false;
@@ -70,7 +57,7 @@ const alerts = computed(() => {
 </script>
 
 <template>
-    <div class="tool-detail" v-if="selected" :style="toolStyle">
+    <div class="tool-detail" v-if="selected">
         <div id="draw-tool-categories">
             <div
                 v-for="category in categories"

--- a/client/src/game/ui/tools/FilterTool.vue
+++ b/client/src/game/ui/tools/FilterTool.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { CSSProperties } from "vue";
-import { computed, onMounted, reactive } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import Accordion from "../../../core/components/Accordion.vue";
@@ -9,21 +8,9 @@ import { gameStore } from "../../../store/game";
 import type { Label } from "../../interfaces/label";
 import { filterTool } from "../../tools/variants/filter";
 
-import { useToolPosition } from "./toolPosition";
-
 const { t } = useI18n();
 
-const state = reactive({
-    arrow: "0px",
-    right: "0px",
-});
-
 const selected = filterTool.isActiveTool;
-const toolStyle = computed(() => ({ "--detailRight": state.right, "--detailArrow": state.arrow } as CSSProperties));
-
-onMounted(() => {
-    ({ right: state.right, arrow: state.arrow } = useToolPosition(filterTool.toolName));
-});
 
 const categories = computed(() => {
     const cat: Map<string, Label[]> = new Map();
@@ -72,7 +59,7 @@ function getCategoryInitValues(category: string): string[] {
 </script>
 
 <template>
-    <div class="tool-detail" v-if="selected" :style="toolStyle">
+    <div class="tool-detail" v-if="selected">
         <div id="accordion-container">
             <Accordion
                 v-for="[category, labels] of categories"

--- a/client/src/game/ui/tools/MapTool.vue
+++ b/client/src/game/ui/tools/MapTool.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
-import type { CSSProperties } from "vue";
-import { computed, onMounted, reactive, watchEffect } from "vue";
+import { reactive, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { getShape } from "../../id";
 import { DEFAULT_GRID_SIZE } from "../../systems/position/state";
 import { selectedSystem } from "../../systems/selected";
 import { mapTool } from "../../tools/variants/map";
-
-import { useToolPosition } from "./toolPosition";
 
 const { t } = useI18n();
 
@@ -22,11 +19,6 @@ const state = reactive({
 const selected = mapTool.isActiveTool;
 const removeRect = (): void => mapTool.removeRect();
 const skipManualDrag = (): void => mapTool.skipManualDrag();
-const toolStyle = computed(() => ({ "--detailRight": state.right, "--detailArrow": state.arrow } as CSSProperties));
-
-onMounted(() => {
-    ({ right: state.right, arrow: state.arrow } = useToolPosition(mapTool.toolName));
-});
 
 watchEffect(() => {
     if (state.lock) {
@@ -89,7 +81,7 @@ function updateSizeY(): void {
 }
 </script>
 <template>
-    <div class="tool-detail map" v-if="selected" :style="toolStyle">
+    <div class="tool-detail map" v-if="selected">
         <template v-if="mapTool.state.hasShape">
             <div class="row">{{ mapTool.state.error }}</div>
             <template v-if="!mapTool.state.hasRect && mapTool.state.manualDrag === true">

--- a/client/src/game/ui/tools/RulerTool.vue
+++ b/client/src/game/ui/tools/RulerTool.vue
@@ -1,23 +1,12 @@
 <script setup lang="ts">
-import type { CSSProperties } from "vue";
-import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { rulerTool } from "../../tools/variants/ruler";
 
-import { useToolPosition } from "./toolPosition";
-
 const { t } = useI18n();
-const right = ref("0px");
-const arrow = ref("0px");
 
 const selected = rulerTool.isActiveTool;
 const showPublic = rulerTool.showPublic;
-const toolStyle = computed(() => ({ "--detailRight": right.value, "--detailArrow": arrow.value } as CSSProperties));
-
-onMounted(() => {
-    ({ right: right.value, arrow: arrow.value } = useToolPosition(rulerTool.toolName));
-});
 
 function toggle(event: MouseEvent): void {
     const state = (event.target as HTMLButtonElement).getAttribute("aria-pressed") ?? "false";
@@ -26,7 +15,7 @@ function toggle(event: MouseEvent): void {
 </script>
 
 <template>
-    <div id="ruler" class="tool-detail" v-if="selected" :style="toolStyle">
+    <div id="ruler" class="tool-detail" v-if="selected">
         <button @click="toggle" :aria-pressed="showPublic">{{ t("game.ui.tools.RulerTool.share") }}</button>
     </div>
 </template>

--- a/client/src/game/ui/tools/SelectTool.vue
+++ b/client/src/game/ui/tools/SelectTool.vue
@@ -1,21 +1,14 @@
 <script setup lang="ts">
-import type { CSSProperties } from "vue";
-import { computed, onMounted, ref, watch } from "vue";
+import { onMounted, watch } from "vue";
 
 import type { Polygon } from "../../shapes/variants/polygon";
 import { selectedSystem } from "../../systems/selected";
 import { selectTool } from "../../tools/variants/select";
 import { selectToolState } from "../../tools/variants/select/state";
 
-import { useToolPosition } from "./toolPosition";
-
-const right = ref("0px");
-const arrow = ref("0px");
-
 const { $, _$ } = selectToolState;
 
 const selected = selectTool.isActiveTool;
-const toolStyle = computed(() => ({ "--detailRight": right.value, "--detailArrow": arrow.value } as CSSProperties));
 
 const polygonUiLeft = $.polygonUiLeft;
 const polygonUiTop = $.polygonUiTop;
@@ -25,7 +18,6 @@ const polygonUiSizeX = $.polygonUiSizeX;
 const polygonUiSizeY = $.polygonUiSizeY;
 
 onMounted(() => {
-    ({ right: right.value, arrow: arrow.value } = useToolPosition(selectTool.toolName));
     selectTool.checkRuler();
     watch(selectedSystem.$, () => {
         selectTool.resetRotationHelper();
@@ -61,7 +53,7 @@ function removePoint(): void {
         <div @click="cutPolygon"><font-awesome-icon icon="cut" /></div>
     </div>
 
-    <div id="ruler" class="tool-detail" v-if="selected && $.hasSelection" :style="toolStyle">
+    <div id="ruler" class="tool-detail" v-if="selected && $.hasSelection">
         <button @click="toggleShowRuler" :aria-pressed="$.showRuler">Show ruler</button>
     </div>
 </template>

--- a/client/src/game/ui/tools/SpellTool.vue
+++ b/client/src/game/ui/tools/SpellTool.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { CSSProperties } from "vue";
-import { computed, onMounted, reactive } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../core/components/ColourPicker.vue";
@@ -8,23 +7,11 @@ import { baseAdjust } from "../../../core/http";
 import { selectedSystem } from "../../systems/selected";
 import { SpellShape, spellTool } from "../../tools/variants/spell";
 
-import { useToolPosition } from "./toolPosition";
-
 const { t } = useI18n();
-
-const state = reactive({
-    arrow: "0px",
-    right: "0px",
-});
 
 const selected = spellTool.isActiveTool;
 const selection = selectedSystem.$;
 const shapes = Object.values(SpellShape);
-const toolStyle = computed(() => ({ "--detailRight": state.right, "--detailArrow": state.arrow } as CSSProperties));
-
-onMounted(() => {
-    ({ right: state.right, arrow: state.arrow } = useToolPosition(spellTool.toolName));
-});
 
 const canConeBeCast = computed(() => selection.value.size > 0 && spellTool.state.range === 0);
 
@@ -41,7 +28,7 @@ function selectShape(shape: SpellShape): void {
 </script>
 
 <template>
-    <div class="tool-detail" v-if="selected" :style="toolStyle">
+    <div class="tool-detail" v-if="selected">
         <div class="selectgroup">
             <div
                 v-for="shape in shapes"

--- a/client/src/game/ui/tools/VisionTool.vue
+++ b/client/src/game/ui/tools/VisionTool.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { CSSProperties } from "vue";
-import { computed, onMounted, ref } from "vue";
+import { computed } from "vue";
 
 import { getShape } from "../../id";
 import type { LocalId } from "../../id";
@@ -11,17 +10,7 @@ import { accessState } from "../../systems/access/state";
 import { getProperties } from "../../systems/properties/state";
 import { visionTool } from "../../tools/variants/vision";
 
-import { useToolPosition } from "./toolPosition";
-
-const right = ref("0px");
-const arrow = ref("0px");
-
 const selected = visionTool.isActiveTool;
-const toolStyle = computed(() => ({ "--detailRight": right.value, "--detailArrow": arrow.value } as CSSProperties));
-
-onMounted(() => {
-    ({ right: right.value, arrow: arrow.value } = useToolPosition(visionTool.toolName));
-});
 
 const tokens = computed(() => [...accessState.reactive.ownedTokens].map((t) => getShape(t)!));
 const selection = computed(() => {
@@ -43,7 +32,7 @@ function getImageSrc(token: IShape): string {
 </script>
 
 <template>
-    <div class="tool-detail" v-if="selected" :style="toolStyle">
+    <div class="tool-detail" v-if="selected">
         <div
             v-for="token in tokens"
             :key="token.id"


### PR DESCRIPTION
The detail panel for specific tools (e.g. colour selection etc) was not properly positioned on the y-axis when using the new icons. This is now fixed.

Additionally I also simplified/cleaned the css logic for this detail panel and it should now also no longer be in the wrong location. This could happen in the past when changing tool mode or when another tool would be enabled/disabled.