### PR TITLE
bug(Grid): Fix grid offset updating

### DIFF
--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -49,8 +49,10 @@ class PositionSystem implements System {
 
     setGridOffset(offset: { x: number; y: number }): void {
         console.log("Setting offset", offset);
+        const deltaX = offset.x - readonly.gridOffset.x;
+        const deltaY = offset.y - readonly.gridOffset.y;
         mutable.gridOffset = offset;
-        this.increasePan(offset.x, offset.y);
+        this.increasePan(deltaX, deltaY);
         floorSystem.invalidateAllFloors();
     }
 


### PR DESCRIPTION
When updating the grid offset, the current viewport would be wrongly positioned if there was previously already an offset configured.

The screen will now pan correctly to the expected location