### PR TITLE
bug(UI): Fix dice area adding scrollbar

### DIFF
--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -220,6 +220,6 @@ svg {
     z-index: 11;
     pointer-events: none;
     width: 100%;
-    height: 100%;
+    height: 100vh;
 }
 </style>


### PR DESCRIPTION
Recent changes to the css made it so that the dice area could be slightly higher than the rest of the main game UI, causing a scrollbar to appear on some devices.