### PR TITLE
bug(Variants): Fix variant layer/floor swapping

### DIFF
--- a/client/src/game/id.ts
+++ b/client/src/game/id.ts
@@ -17,6 +17,7 @@ let uuids: GlobalId[] = [];
 
 const idMap: Map<LocalId, IShape> = new Map();
 (window as any).idMap = idMap;
+(window as any).uuids = uuids;
 
 // we're not giving id 0 on purpose to prevent potential unsafe if checks against this
 // Usually our explicit undefined check catches this, but because of our LocalId typing

--- a/client/src/game/interfaces/shapes/toggleComposite.ts
+++ b/client/src/game/interfaces/shapes/toggleComposite.ts
@@ -3,7 +3,7 @@ import type { LocalId } from "../../id";
 import type { IShape } from "../shape";
 
 export interface IToggleComposite extends IShape {
-    get variants(): readonly { uuid: LocalId; name: string }[];
+    get variants(): readonly { id: LocalId; name: string }[];
 
     addVariant(uuid: LocalId, name: string, sync: boolean): void;
     removeVariant(id: LocalId, syncTo: Sync): void;

--- a/client/src/game/layers/state.ts
+++ b/client/src/game/layers/state.ts
@@ -19,12 +19,12 @@ class CompositeState {
         return undefined;
     }
 
-    addComposite(parent: LocalId, variant: { uuid: LocalId; name: string }, sync: boolean): void {
-        this.compositeMap.set(variant.uuid, parent);
+    addComposite(parent: LocalId, variant: { id: LocalId; name: string }, sync: boolean): void {
+        this.compositeMap.set(variant.id, parent);
         if (sync) {
             sendToggleCompositeAddVariant({
                 shape: getGlobalId(parent),
-                variant: getGlobalId(variant.uuid),
+                variant: getGlobalId(variant.id),
                 name: variant.name,
             });
         }
@@ -40,11 +40,11 @@ class CompositeState {
                 shapeUuids.add(parent.id);
                 allShapes.push(parent);
                 for (const variant of parent.variants) {
-                    if (shapeUuids.has(variant.uuid)) {
+                    if (shapeUuids.has(variant.id)) {
                         continue;
                     } else {
-                        shapeUuids.add(variant.uuid);
-                        allShapes.push(getShape(variant.uuid)!);
+                        shapeUuids.add(variant.id);
+                        allShapes.push(getShape(variant.id)!);
                     }
                 }
             }

--- a/client/src/game/shapes/create.ts
+++ b/client/src/game/shapes/create.ts
@@ -93,7 +93,7 @@ export function createShapeFromDict(shape: ServerShape): IShape | undefined {
         sh = new ToggleComposite(
             refPoint,
             getLocalId(toggleComposite.active_variant)!,
-            toggleComposite.variants.map((v) => ({ uuid: getLocalId(v.uuid)!, name: v.name })),
+            toggleComposite.variants.map((v) => ({ id: reserveLocalId(v.uuid), name: v.name })),
             {
                 uuid: toggleComposite.uuid,
             },

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -361,6 +361,7 @@ export abstract class Shape implements IShape {
         ctx.stroke();
 
         const points = this.points; // expensive call
+        if (points.length === 0) return; // can trigger mid-floor change
 
         // Draw vertices
         for (const p of points) {

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -157,6 +157,7 @@ export function pasteShapes(targetLayer?: LayerName): readonly IShape[] {
 }
 
 export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
+    if (shapes.length === 0) return;
     if (sync === SyncMode.FULL_SYNC) {
         addOperation({ type: "shaperemove", shapes: shapes.map((s) => s.asDict()) });
     }

--- a/client/src/game/ui/settings/shape/VariantSwitcher.vue
+++ b/client/src/game/ui/settings/shape/VariantSwitcher.vue
@@ -15,7 +15,7 @@ const modals = useModal();
 
 const vState = activeShapeStore.state;
 
-const currentIndex = computed(() => vState.variants.findIndex((v) => v.uuid === vState.id));
+const currentIndex = computed(() => vState.variants.findIndex((v) => v.id === vState.id));
 
 const previousVariant = computed(() => {
     if (currentIndex.value < 0) return { name: "No variant" };
@@ -43,14 +43,14 @@ function activateVariant(variant: LocalId): void {
 }
 
 function swapPrev(): void {
-    if ("uuid" in previousVariant.value) {
-        activateVariant(previousVariant.value.uuid);
+    if ("id" in previousVariant.value) {
+        activateVariant(previousVariant.value.id);
     }
 }
 
 function swapNext(): void {
-    if ("uuid" in nextVariant.value) {
-        activateVariant(nextVariant.value.uuid);
+    if ("id" in nextVariant.value) {
+        activateVariant(nextVariant.value.id);
     }
 }
 
@@ -71,7 +71,7 @@ async function addVariant(): Promise<void> {
 
     let parent = compositeParent.value;
     if (parent === undefined) {
-        parent = new ToggleComposite(cloneP(shape.refPoint), shape.id, [{ uuid: shape.id, name: "base variant" }]);
+        parent = new ToggleComposite(cloneP(shape.refPoint), shape.id, [{ id: shape.id, name: "base variant" }]);
         shape.layer.addShape(parent, SyncMode.FULL_SYNC, InvalidationMode.NO);
     }
     parent.addVariant(newShape.id, name, true);

--- a/client/src/store/activeShape.ts
+++ b/client/src/store/activeShape.ts
@@ -31,7 +31,7 @@ interface ActiveShapeState {
 
     groupId: string | undefined;
 
-    variants: { uuid: LocalId; name: string }[];
+    variants: { id: LocalId; name: string }[];
 
     labels: Label[];
 }
@@ -108,7 +108,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
     renameVariant(uuid: LocalId, name: string, syncTo: Sync): void {
         if (this._state.id === undefined || this._state.parentUuid === undefined) return;
 
-        const variant = this._state.variants.find((v) => v.uuid === uuid);
+        const variant = this._state.variants.find((v) => v.id === uuid);
         if (variant === undefined) return;
 
         variant.name = name;
@@ -122,7 +122,7 @@ export class ActiveShapeStore extends Store<ActiveShapeState> {
     removeVariant(uuid: LocalId, syncTo: Sync): void {
         if (this._state.id === undefined || this._state.parentUuid === undefined) return;
 
-        const index = this._state.variants.findIndex((v) => v.uuid === uuid);
+        const index = this._state.variants.findIndex((v) => v.id === uuid);
         if (index < 0) return;
 
         this._state.variants.splice(index, 1);

--- a/client/test/game/systems/auras/index.test.ts
+++ b/client/test/game/systems/auras/index.test.ts
@@ -61,7 +61,7 @@ describe("Aura System", () => {
             const id = generateTestLocalId(generateTestShape({ floor: "test" }));
             const id2 = generateTestLocalId();
             const aura = generateTestAura();
-            compositeState.addComposite(id, { uuid: id2, name: "variant" }, false);
+            compositeState.addComposite(id, { id: id2, name: "variant" }, false);
             auraSystem.inform(id, [aura]);
             // test
             expect(auraSystem.get(id2, aura.uuid, false)).toBeUndefined();
@@ -91,7 +91,7 @@ describe("Aura System", () => {
             // setup
             const id = generateTestLocalId(generateTestShape({ floor: "test" }));
             const id2 = generateTestLocalId();
-            compositeState.addComposite(id, { uuid: id2, name: "variant" }, false);
+            compositeState.addComposite(id, { id: id2, name: "variant" }, false);
             const aura = generateTestAura();
             auraSystem.inform(id, [aura]);
             const aura2 = generateTestAura({ visible: false, visionSource: false });


### PR DESCRIPTION
When changing a shape with variants to another layer or floor, depending on timing, it was possible for the variant system to be in an invalid state.

This PR fixes 2 small issues related to this problem as well as renaming a variable that contained a localId, but had a name implying a globalId