### PR TITLE
chore: Remove skipUiHelpers

### DIFF
--- a/client/src/game/interfaces/layer.ts
+++ b/client/src/game/interfaces/layer.ts
@@ -23,11 +23,7 @@ export interface ILayer {
     addShape(shape: IShape, sync: SyncMode, invalidate: InvalidationMode): void;
     clear(): void;
     draw(doClear?: boolean): void;
-    getShapes(options: {
-        skipUiHelpers?: boolean;
-        onlyInView?: boolean;
-        includeComposites: boolean;
-    }): readonly IShape[];
+    getShapes(options: { onlyInView?: boolean; includeComposites: boolean }): readonly IShape[];
     hide(): void;
     invalidate(skipLightUpdate: boolean): void;
     updateView(): void;
@@ -39,6 +35,6 @@ export interface ILayer {
     setServerShapes(shapes: ServerShape[]): void;
     setShapes(...shapes: IShape[]): void;
     show(): void;
-    size(options: { skipUiHelpers?: boolean; includeComposites: boolean }): number;
+    size(options: { includeComposites: boolean }): number;
     updateSectors(shapeId: LocalId, aabb: BoundingRect): void;
 }

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -161,7 +161,7 @@ export class Layer implements ILayer {
     /**
      * Returns the number of shapes on this layer
      */
-    size(options: { skipUiHelpers?: boolean; includeComposites: boolean }): number {
+    size(options: { includeComposites: boolean }): number {
         return this.getShapes(options).length;
     }
 
@@ -230,14 +230,8 @@ export class Layer implements ILayer {
 
     // UI helpers are objects that are created for UI reaons but that are not pertinent to the actual state
     // They are often not desired unless in specific circumstances
-    getShapes(options: {
-        includeComposites: boolean;
-        skipUiHelpers?: boolean;
-        onlyInView?: boolean;
-    }): readonly IShape[] {
-        const skipUiHelpers = options.skipUiHelpers ?? true;
-        const target = options?.onlyInView ?? false ? this.shapesInSector : this.shapes;
-        let shapes: readonly IShape[] = skipUiHelpers ? target.filter((s) => !(s.options.UiHelper ?? false)) : target;
+    getShapes(options: { includeComposites: boolean; onlyInView?: boolean }): readonly IShape[] {
+        let shapes: readonly IShape[] = options?.onlyInView ?? false ? this.shapesInSector : this.shapes;
         if (options.includeComposites) {
             shapes = compositeState.addAllCompositeShapes(shapes);
         }


### PR DESCRIPTION
`skipUiHelpers` is an older filter on `layer.getShapes` and `layer.size` which is no longer used.