### PR TITLE
bug(Select): Fix shape removal not working if no initiative is present

### DIFF
--- a/server/src/api/socket/initiative.py
+++ b/server/src/api/socket/initiative.py
@@ -262,8 +262,18 @@ async def clear_initiatives(sid: str):
 
 
 async def remove_shape(pr: PlayerRoom, uuid: str, group: Optional[Group]):
-    location_data = Initiative.get(location=pr.active_location)
-    json_data = json.loads(location_data.data)
+    location_data = Initiative.get_or_none(location=pr.active_location)
+    if location_data is None:
+        return
+    try:
+        json_data = json.loads(location_data.data)
+    except json.JSONDecodeError:
+        logger.warning(
+            "Invalid initiative data found during shape removal",
+            pr.room.id,
+            pr.active_location.id,
+        )
+        return
 
     modified = False
     new_json_data = []


### PR DESCRIPTION
Recent initiative fixes were made to make sure that when removing a shape, the initiative entry is also removed. These checks however wrongly assumed that every location always has an initiative entry causing the call to fail.