### PR TITLE
bug(Dice): Fix diceroller not working on subpath server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ tech changes will usually be stripped from release notes for the public
 -   In-game AssetPicker modal UI fixes
 -   Prompt modal not clearing error message properly
 -   Tool details not always being in the correct location (e.g. when changing mode)
+-   Diceroller not working on subpath server
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/dice/environment.ts
+++ b/client/src/game/dice/environment.ts
@@ -15,6 +15,8 @@ import { ShadowOnlyMaterial } from "@babylonjs/materials/shadowOnly";
 import { Dice, DiceThrower, DndParser } from "@planarally/dice";
 import type { DieOptions } from "@planarally/dice";
 
+import { baseAdjust } from "../../core/http";
+
 import { loadAmmoModule } from "./ammo";
 import { diceStore } from "./state";
 
@@ -32,7 +34,7 @@ export async function loadDiceEnv(): Promise<DiceThrower> {
     const Ammo = (window as any).Ammo;
 
     diceThrower = new DiceThrower({ canvas, tresholds: { linear: 0.05, angular: 0.1 } });
-    await diceThrower.load("/static/babylon_test6.babylon", Ammo());
+    await diceThrower.load(baseAdjust("/static/babylon_test6.babylon"), Ammo());
 
     /*
      * Currently the camera looks in such a way that the x-axis goes from negative right to positive left


### PR DESCRIPTION
As reported in #1044, the diceroller was not working when the server is using subpath serving.