### PR TITLE
bug(Vision): Fix vision not properly updating on shape floor change

### DIFF
--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -19,6 +19,7 @@ export interface IShape extends SimpleShape {
 
     get points(): [number, number][];
     invalidatePoints(): void;
+    resetVisionIteration(): void;
 
     contains(point: GlobalPoint, nearbyThreshold?: number): boolean;
 

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -241,6 +241,7 @@ export class Layer implements ILayer {
     pushShapes(...shapes: IShape[]): void {
         this.shapes.push(...shapes);
         for (const shape of shapes) {
+            shape.resetVisionIteration();
             this.addShapeToSectors(shape.id, shape.getAuraAABB());
         }
         this.updateView();
@@ -251,6 +252,7 @@ export class Layer implements ILayer {
         this.xSectors.clear();
         this.ySectors.clear();
         for (const shape of shapes) {
+            shape.resetVisionIteration();
             this.addShapeToSectors(shape.id, shape.getAuraAABB());
         }
         this.updateView();
@@ -392,11 +394,8 @@ export class Layer implements ILayer {
                 // Normal shape draw loop
                 for (const shape of this.shapesInSector) {
                     if (shape.options.skipDraw ?? false) continue;
-                    if (
-                        getProperties(shape.id)!.isInvisible &&
-                        !accessSystem.hasAccessTo(shape.id, true, { vision: true })
-                    )
-                        continue;
+                    const props = getProperties(shape.id)!;
+                    if (props.isInvisible && !accessSystem.hasAccessTo(shape.id, true, { vision: true })) continue;
                     if (shape.labels.length === 0 && gameState.filterNoLabel) continue;
                     if (
                         shape.labels.length &&

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -142,6 +142,10 @@ export abstract class Shape implements IShape {
         return props.isToken || props.blocksMovement || auraSystem.getAll(this.id, true).some((a) => a.visionSource);
     }
 
+    resetVisionIteration(): void {
+        this.visionIteration = -1;
+    }
+
     get visionPolygon(): Path2D {
         const floorIteration = floorState.readonly.iteration;
         const visionIteration = visionState.getVisionIteration(this._floor!);
@@ -179,7 +183,7 @@ export abstract class Shape implements IShape {
     set refPoint(point: GlobalPoint) {
         this._refPoint = point;
         this._center = this.__center();
-        this.visionIteration = -1;
+        this.resetVisionIteration();
         this.layer.updateSectors(this.id, this.getAuraAABB());
         this.invalidatePoints();
     }
@@ -207,7 +211,7 @@ export abstract class Shape implements IShape {
         this._refPoint = toGP(position.points[0]);
         this._center = this.__center();
         this.angle = position.angle;
-        this.visionIteration = -1;
+        this.resetVisionIteration();
         this.layer.updateSectors(this.id, this.getAuraAABB());
         this.updateShapeVision(false, false);
     }


### PR DESCRIPTION
When moving a shape to a different floor and visiting that floor, the vision would of that shape would not be recalculated until you move it or interact in another way that triggers vision recalculation.

This has been resolved.