### PR TITLE
bug(Camera): Fix multiple center-on-shape calls not checking for floor change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ tech changes will usually be stripped from release notes for the public
 -   Tool details not always being in the correct location (e.g. when changing mode)
 -   Diceroller not working on subpath server
 -   Trim down noisy whitespace in selection info
+-   Initiative camera-lock not changing floors
+-   Door/Tp area preview not changing floors
+-   Jump to marker not changing floors
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -23,6 +23,7 @@ import type { InitiativeData, InitiativeEffect, InitiativeSettings } from "../..
 import { setCenterPosition } from "../../position";
 import { accessSystem } from "../../systems/access";
 import { accessState } from "../../systems/access/state";
+import { floorSystem } from "../../systems/floors";
 import { playerSettingsState } from "../../systems/settings/players/state";
 
 let activeTokensBackup: Set<LocalId> | undefined = undefined;
@@ -266,8 +267,10 @@ class InitiativeStore extends Store<InitiativeState> {
         if (playerSettingsState.raw.initiativeCameraLock.value) {
             const actor = this.getDataSet()[this._state.turnCounter];
             if (accessSystem.hasAccessTo(actor.shape, false, { vision: true }) ?? false) {
-                const shape = getShape(actor.shape)!;
+                const shape = getShape(actor.shape);
+                if (shape === undefined) return;
                 setCenterPosition(shape.center);
+                floorSystem.selectFloor({ name: shape.floor.name }, true);
             }
         }
     }

--- a/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
+++ b/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
@@ -5,6 +5,7 @@ import { sendDeclineRequest } from "../../api/emits/logic";
 import { getLocalId, getShapeFromGlobal } from "../../id";
 import type { Global } from "../../id";
 import { setCenterPosition } from "../../position";
+import { floorSystem } from "../../systems/floors";
 import { doorSystem } from "../../systems/logic/door";
 import type { DoorRequest } from "../../systems/logic/door/models";
 import type { RequestTypeResponse } from "../../systems/logic/models";
@@ -53,6 +54,7 @@ function showArea(): void {
 
     shape.showHighlight = true;
     setCenterPosition(shape.center);
+    floorSystem.selectFloor({ name: shape.floor.name }, true);
 }
 </script>
 

--- a/client/src/store/game.ts
+++ b/client/src/store/game.ts
@@ -101,6 +101,7 @@ class GameStore {
         const shape = getShape(marker);
         if (shape == undefined) return;
         setCenterPosition(shape.center);
+        floorSystem.selectFloor({ name: shape.floor.name }, true);
     }
 
     removeMarker(marker: LocalId, sync: boolean): void {


### PR DESCRIPTION
When using initiative camera-lock to automatically center the camera on the next character, the logic would not check if that character was on a different floor.

Similar logic errors were fixed for 'jump to marker' and 'preview area' for logic doors/tp.