### PR TITLE
bug(Variants): Fix variant floor change selection issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ tech changes will usually be stripped from release notes for the public
 -   Initiative camera-lock not changing floors
 -   Door/Tp area preview not changing floors
 -   Jump to marker not changing floors
+-   Moving composite/variant shape to other floor and following would show extra selection boxes
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/input/keyboard/down.ts
+++ b/client/src/game/input/keyboard/down.ts
@@ -192,11 +192,11 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
 
 function changeFloor(event: KeyboardEvent, targetFloor: number): void {
     if (targetFloor < 0 || targetFloor > floorState.raw.floors.length - 1) return;
-    const selection = selectedSystem.get({ includeComposites: true });
+    const selection = selectedSystem.get({ includeComposites: false });
     const newFloor = floorState.raw.floors[targetFloor];
 
     if (event.altKey) {
-        moveFloor([...selection], newFloor, true);
+        moveFloor([...selectedSystem.get({ includeComposites: true })], newFloor, true);
     }
     selectedSystem.clear();
     floorState.currentLayer.value!.invalidate(true);

--- a/client/src/game/layers/state.ts
+++ b/client/src/game/layers/state.ts
@@ -35,7 +35,11 @@ class CompositeState {
         const allShapes = [...shapes];
         for (const shape of this.compositeMap.keys()) {
             if (shapes.some((s) => s.id === shape)) {
-                const parent = this.getCompositeParent(shape)!;
+                const parent = this.getCompositeParent(shape);
+                if (parent === undefined) {
+                    console.warn("Missing composite parent");
+                    continue;
+                }
                 if (shapeUuids.has(parent.id)) continue;
                 shapeUuids.add(parent.id);
                 allShapes.push(parent);


### PR DESCRIPTION
When changing a composite/variant shape to a different floor and following along, extra selection boxes would appear.

These boxes are related to the other composite shapes, but shouldn't be visible. This has been resolved.