### PR TITLE
feat(out-of-bounds): Add out-of-bounds checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ tech changes will usually be stripped from release notes for the public
     -   Clicking on a name, centers your screen on their current view (if on the same location)
 -   User configuration option to limit rendering to only the active floor
 -   User setting to change toolbar between icons and words (defaults to icons)
+-   Out-of-bounds check with visual UI element to help people get back to their content
 -   [server] option to specify alternative location for static files
 
 ### Changed

--- a/client/src/game/interfaces/layer.ts
+++ b/client/src/game/interfaces/layer.ts
@@ -15,6 +15,8 @@ export interface ILayer {
     playerEditable: boolean;
     points: Map<string, Set<LocalId>>;
     selectable: boolean;
+    shapeIdsInSector: Set<LocalId>;
+    shapesInSector: IShape[];
 
     get height(): number;
     get isActiveLayer(): boolean;

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -59,6 +59,7 @@ export interface IShape extends SimpleShape {
     onLayerAdd(): void;
 
     get visionPolygon(): Path2D;
+    _visionBbox: BoundingRect | undefined;
 
     // POSITION
 

--- a/client/src/game/layers/variants/fow.ts
+++ b/client/src/game/layers/variants/fow.ts
@@ -13,6 +13,7 @@ export class FowLayer extends Layer {
     preFogShapes: IShape[] = [];
     virtualCanvas: HTMLCanvasElement;
     vCtx: CanvasRenderingContext2D;
+    isEmpty = false;
 
     constructor(canvas: HTMLCanvasElement, public name: LayerName, public floor: FloorId, protected index: number) {
         super(canvas, name, floor, index);

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -21,6 +21,7 @@ export class FowVisionLayer extends FowLayer {
                 return;
             }
 
+            this.isEmpty = true;
             super._draw();
 
             // For the DM this is done at the end of this function.  TODO: why the split up ???
@@ -54,6 +55,11 @@ export class FowVisionLayer extends FowLayer {
                 this.ctx.fillStyle = gradient;
 
                 this.ctx.fill(token.visionPolygon);
+
+                // Out of Bounds check
+                if (token._visionBbox?.visibleInCanvas({ w: this.width, h: this.height }) ?? false) {
+                    this.isEmpty = false;
+                }
             }
 
             const activeFloor = floorState.currentFloor.value!.id;

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -59,11 +59,11 @@ export class Layer implements ILayer {
     // The collection of shapes that this layer contains.
     // These are ordered on a depth basis.
     protected shapes: IShape[] = [];
-    protected shapesInSector: IShape[] = [];
+    shapesInSector: IShape[] = [];
     protected xSectors: Map<number, Set<LocalId>> = new Map();
     protected ySectors: Map<number, Set<LocalId>> = new Map();
 
-    protected shapeIdsInSector: Set<LocalId> = new Set();
+    shapeIdsInSector: Set<LocalId> = new Set();
 
     points: Map<string, Set<LocalId>> = new Map();
 

--- a/client/src/game/shapes/variants/simple/boundingRect.ts
+++ b/client/src/game/shapes/variants/simple/boundingRect.ts
@@ -79,6 +79,14 @@ export class BoundingRect implements SimpleShape {
         return new BoundingRect(toGP(xmin, ymin), xmax - xmin, ymax - ymin);
     }
 
+    intersect(other: BoundingRect): BoundingRect {
+        const xmin = Math.max(this.topLeft.x, other.topLeft.x);
+        const xmax = Math.min(this.topRight.x, other.topRight.x);
+        const ymin = Math.max(this.topLeft.y, other.topLeft.y);
+        const ymax = Math.min(this.botLeft.y, other.botLeft.y);
+        return new BoundingRect(toGP(xmin, ymin), xmax - xmin, ymax - ymin);
+    }
+
     getDiagCorner(botright: boolean): GlobalPoint {
         return botright ? this.botRight : this.topLeft;
     }

--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -1,11 +1,20 @@
 import { registerSystem } from "..";
 import type { System } from "..";
 import { g2l, l2g, zoomDisplayToFactor } from "../../../core/conversions";
-import { addP, subtractP, toGP, Vector } from "../../../core/geometry";
+import { addP, getPointDistance, subtractP, toGP, Vector } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import { sendClientLocationOptions } from "../../api/emits/client";
+import { getAllShapes, getShape } from "../../id";
+import type { IShape } from "../../interfaces/shape";
+import type { FowLayer } from "../../layers/variants/fow";
+import { LayerName } from "../../models/floor";
+import { setCenterPosition } from "../../position";
+import { visionState } from "../../vision/state";
+import { accessState } from "../access/state";
 import { clientSystem } from "../client";
 import { floorSystem } from "../floors";
+import { floorState } from "../floors/state";
+import { locationSettingsState } from "../settings/location/state";
 import { playerSettingsState } from "../settings/players/state";
 
 import { DEFAULT_GRID_SIZE, positionState } from "./state";
@@ -34,6 +43,7 @@ class PositionSystem implements System {
         mutable.panY = y + readonly.gridOffset.y;
         if (options.updateSectors) {
             floorSystem.invalidateSectors();
+            this.checkOutOfBounds();
         }
         floorSystem.updateIteration();
     }
@@ -43,6 +53,7 @@ class PositionSystem implements System {
         mutable.panY += y;
         floorSystem.invalidateSectors();
         floorSystem.updateIteration();
+        this.checkOutOfBounds();
     }
 
     // OFFSET
@@ -58,7 +69,7 @@ class PositionSystem implements System {
 
     // ZOOM
 
-    setZoomFactor(zoomDisplay: number): void {
+    private setZoomFactor(zoomDisplay: number): void {
         const gf = playerSettingsState.gridSize.value / DEFAULT_GRID_SIZE;
         if (playerSettingsState.raw.useAsPhysicalBoard.value) {
             if (readonly.zoom !== gf) {
@@ -76,7 +87,10 @@ class PositionSystem implements System {
         if (zoom > 1) zoom = 1;
         $.zoomDisplay = zoom;
         this.setZoomFactor(zoom);
-        if (options.updateSectors) floorSystem.invalidateSectors();
+        if (options.updateSectors) {
+            floorSystem.invalidateSectors();
+            this.checkOutOfBounds();
+        }
         if (options.invalidate) floorSystem.invalidateAllFloors();
         if (options.sync) {
             sendClientLocationOptions(false);
@@ -94,6 +108,75 @@ class PositionSystem implements System {
         floorSystem.invalidateAllFloors();
         sendClientLocationOptions(false);
         clientSystem.updateZoomFactor();
+    }
+
+    // OOB
+
+    private checkOutOfBounds(): void {
+        $.outOfBounds = true;
+        if (locationSettingsState.raw.fullFow.value) {
+            for (const layer of floorState.raw.layers) {
+                if (locationSettingsState.raw.fowLos.value) {
+                    if (layer.name === LayerName.Vision && !(layer as FowLayer).isEmpty) {
+                        $.outOfBounds = false;
+                        return;
+                    }
+                } else {
+                    if (layer.name === LayerName.Lighting && !(layer as FowLayer).isEmpty) {
+                        $.outOfBounds = false;
+                        return;
+                    }
+                }
+            }
+            if ($.outOfBounds) return;
+        }
+        for (const layer of floorState.raw.layers) {
+            for (const sh of layer.shapesInSector) {
+                if (!(sh.options.skipDraw ?? false)) {
+                    $.outOfBounds = false;
+                    return;
+                }
+            }
+        }
+    }
+
+    returnToBounds(): void {
+        let nearest: GlobalPoint | undefined;
+        if (locationSettingsState.raw.fullFow.value) {
+            if (locationSettingsState.raw.fowLos.value) {
+                // find nearest token
+                nearest = this.findNearest(accessState.activeTokens.value, (i) => getShape(i));
+            } else {
+                // find nearest lightsource
+                nearest = this.findNearest(visionState.getAllVisionSources(), (s) => getShape(s.shape));
+            }
+        } else {
+            // find nearest shape
+            nearest = this.findNearest(getAllShapes(), (x) => x);
+        }
+
+        if (nearest !== undefined) {
+            setCenterPosition(nearest);
+            $.outOfBounds = false;
+        }
+    }
+
+    private findNearest<T>(shapes: Iterable<T>, fn: (x: T) => IShape | undefined): GlobalPoint | undefined {
+        let nearest: { position: GlobalPoint; distance: number } | null = null;
+        for (const sh of shapes) {
+            const shape = fn(sh);
+            if (
+                shape === undefined ||
+                (shape.options?.skipDraw ?? false) ||
+                shape.floor !== floorState.currentFloor.value
+            )
+                continue;
+            const distance = getPointDistance(this.screenCenter, shape.center);
+            if (nearest === null || distance < nearest.distance) {
+                nearest = { position: shape.center, distance };
+            }
+        }
+        return nearest?.position;
     }
 }
 

--- a/client/src/game/systems/position/state.ts
+++ b/client/src/game/systems/position/state.ts
@@ -4,6 +4,7 @@ export const DEFAULT_GRID_SIZE = 50;
 
 const state = buildState(
     {
+        outOfBounds: false,
         zoomDisplay: 0.5,
     },
     {

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -197,6 +197,9 @@ function setTempZoomDisplay(value: number): void {
         <DiceResults />
         <div id="teleport-modals"></div>
         <MarkdownModal v-if="showChangelog" :title="t('game.ui.ui.new_ver_msg')" :source="changelogText" />
+        <div id="oob" v-if="positionState.reactive.outOfBounds" @click="positionSystem.returnToBounds">
+            Click to return to content
+        </div>
         <!-- When updating zoom boundaries, also update store updateZoom function;
             should probably do this using a store variable-->
         <SliderComponent
@@ -280,6 +283,24 @@ function setTempZoomDisplay(value: number): void {
     top: 15px;
     right: 25px;
     grid-area: zoom;
+}
+
+#oob {
+    position: fixed;
+    bottom: 50px;
+    left: 50%;
+    transform: translateX(-50%);
+    pointer-events: auto;
+
+    background-color: white;
+    padding: 20px 50px;
+    border-radius: 15px;
+    border: solid 3px black;
+
+    &:hover {
+        font-weight: bold;
+        cursor: pointer;
+    }
 }
 
 #radialmenu {

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -340,6 +340,10 @@ class VisionState extends Store<State> {
         this.visionSourcesInView.set(floor, viv);
     }
 
+    getAllVisionSources(): readonly { shape: LocalId; aura: AuraId }[] {
+        return [...this.visionSources.values()].flat();
+    }
+
     private getVisionSources(floor: FloorId): readonly { shape: LocalId; aura: AuraId }[] {
         return this.visionSources.get(floor) ?? [];
     }


### PR DESCRIPTION
Sometimes you may find yourself somewhere on the infinite canvas with nothing familiar in sight. For power-users familiar with PA this is usually quickly resolved with a couple of methods. This is however not info easily figured out by novice players/dms. Additionally some of these methods can only be accessed with keyboard, excluding another batch of users.

This PR introduces a simple UI element that pops up on the bottom of the screen when your screen is no longer seeing something interesting. By clicking on the new UI element you will return to a place where you can see something and hopefully be able to figure out where you wanted to be.

Depending on the vision-modes enabled there are 3 different approaches that PA uses to return to content (as well as detect the out-of-bounds condition):

1) Fog of War & Line of Sight are enabled: return to the nearest token that you have access to
2) Fog of War enabled: return to the nearest vision-source that you have access to or is public
3) return to the nearest shape

_(nearest is currently decided based on distance to the center of the shape)_

_To minimise performance overhead, this is done with some simple bounding box checks. Auras are however radial, so there might be some edge-cases where the oob warning does not yet pop up because you're in a corner of an aura bbox. Panning a bit more around should make the oob element appear in this case_

This closes #1071