### PR TITLE
bug(Layers): Fix Draw layer order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ tech changes will usually be stripped from release notes for the public
 -   Door/Tp area preview not changing floors
 -   Jump to marker not changing floors
 -   Moving composite/variant shape to other floor and following would show extra selection boxes
+-   Draw layer being rendered below the fog (e.g. rulers/ping etc)
 
 ## [2022.2.3] - 2022-07-13
 

--- a/client/src/game/floor/server.ts
+++ b/client/src/game/floor/server.ts
@@ -32,8 +32,8 @@ export function addServerFloor(serverFloor: ServerFloor): void {
     for (const layer of serverFloor.layers) {
         if (layer.name === LayerName.Lighting) fowLayer = layer;
         else addServerLayer(layer, floor);
+        if (layer.name === LayerName.Vision) addServerLayer(fowLayer!, floor);
     }
-    if (fowLayer) addServerLayer(fowLayer, floor);
 
     visionState.recalculateVision(floorId);
     visionState.recalculateMovement(floorId);


### PR DESCRIPTION
A while ago (>2 years) I changed the direction in which the layers are drawn. As the lighting layer depends on the vision layer, I had to do a small modification to make sure they were still drawn in the correct order.

The way this was implemented was by moving the vision layer to the end of the draw stack. Which caused the draw layer to now be below the fog layer which in turn means that things like the ruler or ping tool would appear below the fog and thus are currently not visible.

I'm slightly confused how this has flown below my radar for so long. So if this was reported and I somehow ignored it, it was not on purpose!