### PR TITLE
chore: Debug helpers

### DIFF
--- a/client/src/game/floor/server.ts
+++ b/client/src/game/floor/server.ts
@@ -42,7 +42,7 @@ export function addServerFloor(serverFloor: ServerFloor): void {
 }
 
 function addServerLayer(layerInfo: ServerLayer, floor: Floor): void {
-    const canvas = createCanvas();
+    const canvas = createCanvas(layerInfo.name);
 
     const layerName = layerInfo.name as LayerName;
 

--- a/client/src/game/layers/canvas.ts
+++ b/client/src/game/layers/canvas.ts
@@ -1,9 +1,10 @@
 import { playerSettingsState } from "../systems/settings/players/state";
 
-export function createCanvas(): HTMLCanvasElement {
+export function createCanvas(layerName?: string): HTMLCanvasElement {
     // Create canvas element
     const canvas = document.createElement("canvas");
     canvas.style.display = "none";
+    if (layerName !== undefined) canvas.classList.add(layerName);
     setCanvasDimensions(canvas, window.innerWidth, window.innerHeight);
     return canvas;
 }

--- a/client/src/game/rendering/basic.ts
+++ b/client/src/game/rendering/basic.ts
@@ -39,7 +39,7 @@ function drawPointL(point: number[], r: number, colour?: string): void {
 
 export function drawPolygon(
     polygon: number[][],
-    options?: { colour?: string; strokeWidth?: number; close?: boolean },
+    options?: { colour?: string; strokeWidth?: number; close?: boolean; debug?: boolean },
 ): void {
     const dl = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
     if (dl === undefined) return;
@@ -52,9 +52,15 @@ export function drawPolygon(
         options?.colour === undefined
             ? `rgb(${Math.random() * 255}, ${Math.random() * 255}, ${Math.random() * 255})`
             : options.colour;
-    ctx.moveTo(g2lx(polygon[0][0]), g2ly(polygon[0][1]));
+    const x = g2lx(polygon[0][0]);
+    const y = g2ly(polygon[0][1]);
+    ctx.moveTo(x, y);
+    if (options?.debug ?? false) console.log(x, y);
     for (const point of polygon) {
-        ctx.lineTo(g2lx(point[0]), g2ly(point[1]));
+        const x = g2lx(point[0]);
+        const y = g2ly(point[1]);
+        ctx.lineTo(x, y);
+        if (options?.debug ?? false) console.log(x, y);
     }
     if (options?.close ?? true) ctx.closePath();
     if (options?.strokeWidth !== undefined) ctx.lineWidth = options.strokeWidth;


### PR DESCRIPTION
This is a small PR adding two additions to help with debugging.

- setting the class name of the canvas elements to the corresponding layer
- Adding an optional log option to the drawPolygon function