### PR TITLE
bug(Vision): Fix vision bug when removing shapes in multi-floor setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ tech changes will usually be stripped from release notes for the public
 -   Jump to marker not changing floors
 -   Moving composite/variant shape to other floor and following would show extra selection boxes
 -   Draw layer being rendered below the fog (e.g. rulers/ping etc)
+-   Vision not properly recalculating when removing blocking shapes on multifloor setups
 -   [DM] Assets not being able to moved up to parent folder
 -   [DM] Assets not being removable if a shape with a link to the asset exists
 -   [DM] Annotations still being visible until refresh after removing player access

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -177,10 +177,9 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
     }
     if (sync !== SyncMode.NO_SYNC) sendRemoveShapes({ uuids: removed, temporary: sync === SyncMode.TEMP_SYNC });
     if (!recalculateIterative) {
-        if (recalculateMovement)
-            visionState.recalculate({ target: TriangulationTarget.MOVEMENT, floor: floorState.raw.floorIndex });
-        if (recalculateVision)
-            visionState.recalculate({ target: TriangulationTarget.VISION, floor: floorState.raw.floorIndex });
+        const floor = shapes[0].floor.id;
+        if (recalculateMovement) visionState.recalculate({ target: TriangulationTarget.MOVEMENT, floor });
+        if (recalculateVision) visionState.recalculate({ target: TriangulationTarget.VISION, floor });
         floorSystem.invalidateVisibleFloors();
     }
 }


### PR DESCRIPTION
Another bug that has been here for at least 2 years O_O.

When removing a shape on a floor that is not the lowest floor, the vision system would receive a call to refresh the wrong floor, _if_ the lowest floor was _not_ the initial floor loaded upon loading the campaign.