### PR TITLE
bug(UI: AssetPicker): Fix asset picker appearing too low

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ tech changes will usually be stripped from release notes for the public
 -   Moving composite/variant shape to other floor and following would show extra selection boxes
 -   Draw layer being rendered below the fog (e.g. rulers/ping etc)
 -   Vision not properly recalculating when removing blocking shapes on multifloor setups
+-   AssetPicker UI appearing too low
 -   [DM] Assets not being able to moved up to parent folder
 -   [DM] Assets not being removable if a shape with a link to the asset exists
 -   [DM] Annotations still being visible until refresh after removing player access

--- a/client/src/core/components/modals/AssetPicker.vue
+++ b/client/src/core/components/modals/AssetPicker.vue
@@ -117,7 +117,7 @@ function select(event: MouseEvent, inode: number): void {
 
 #assets {
     display: flex;
-    max-height: 50vh;
+    height: 40vh;
     width: 30vw;
     flex-grow: 1;
     background-color: white;
@@ -176,6 +176,7 @@ function select(event: MouseEvent, inode: number): void {
         left: 0;
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(105px, 1fr));
+        grid-auto-rows: 105px;
         max-width: 100%;
         max-height: 54vh;
         overflow: auto;


### PR DESCRIPTION
The AssetPicker is a Modal window that appears when selecting assets. (e.g. campaign logo selection, shape variants, ...)

Modals are centered on the screen the moment they appear based on their current height, which for the AssetPicker was very tiny as the data still had to be fetched. Causing the final visual appearance of the modal to be way too low, with the buttons potentially off-screen.

This has now been fixed.