### PR TITLE
bug(UI: Polygon Edit): Fix polygon edit UI during panning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ tech changes will usually be stripped from release notes for the public
 -   Draw layer being rendered below the fog (e.g. rulers/ping etc)
 -   Vision not properly recalculating when removing blocking shapes on multifloor setups
 -   AssetPicker UI appearing too low
+-   Polygon edit UI being left behind when panning
 -   [DM] Assets not being able to moved up to parent folder
 -   [DM] Assets not being removable if a shape with a link to the asset exists
 -   [DM] Annotations still being visible until refresh after removing player access

--- a/client/src/game/models/tools.ts
+++ b/client/src/game/models/tools.ts
@@ -32,6 +32,8 @@ export interface ITool {
     permittedTools: ToolPermission[];
 
     onToolsModeChange(mode: ToolMode, features: ToolFeatures): void;
+    onPanStart(): void;
+    onPanEnd(): void;
 
     onSelect(): void;
     onDeselect(): void;

--- a/client/src/game/tools/events.ts
+++ b/client/src/game/tools/events.ts
@@ -15,6 +15,7 @@ export function mouseDown(event: MouseEvent): void {
 
     let targetTool = activeTool.value;
     if (event.button === 1 || event.button === 2) {
+        toolMap[targetTool].onPanStart();
         targetTool = ToolName.Pan;
         uiStore.preventContextMenu(false);
     } else if (event.button !== 0) {
@@ -90,6 +91,7 @@ export async function mouseUp(event: MouseEvent): Promise<void> {
                 return contextMenu(event);
             }
         }
+        toolMap[targetTool].onPanEnd();
         targetTool = ToolName.Pan;
     } else if (event.button !== 0) {
         return;

--- a/client/src/game/tools/tool.ts
+++ b/client/src/game/tools/tool.ts
@@ -65,4 +65,6 @@ export abstract class Tool implements ITool {
     async onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {}
 
     onToolsModeChange(_mode: ToolMode, _features: ToolFeatures): void {}
+    onPanStart(): void {}
+    onPanEnd(): void {}
 }

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -172,6 +172,17 @@ class SelectTool extends Tool implements ISelectTool {
         }
     }
 
+    onPanStart(): void {
+        if (this.polygonTracer !== null) _$.polygonUiVisible = "hidden";
+    }
+
+    onPanEnd(): void {
+        if (this.polygonTracer !== null) {
+            this.updatePolygonEditUi(this.polygonTracer!.refPoint);
+            _$.polygonUiVisible = "visible";
+        }
+    }
+
     onDeselect(): void {
         this.removePolygonEditUi();
     }


### PR DESCRIPTION
The polygon edit UI is part of the select tool in build mode. When you use a panning shortcut while the polygon edit UI is visible, parts of the UI would stay on the same (x,y) location on the screen while the shape is being moved around.

This is visually not very pleasing. This PR solves the issue by hiding the polygon UI during pan and show it again when the panning stops.

We could go the extra mile and update the polygon UI position continuously during the pan, but given that it can't be interacted with anyway during a pan, it only adds clutter.