### PR TITLE
bug(UI: Menu): Fix Fake Player hiding menu entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ tech changes will usually be stripped from release notes for the public
 -   [DM] Assets not being removable if a shape with a link to the asset exists
 -   [DM] Annotations still being visible until refresh after removing player access
 -   [DM] Resetting location specific settings was not immediately synchronizing to clients until a refresh
+-   [DM] Enabling fake-player mode would hide the DM entries from the left sidebar
 -   [DM|server] The asset manager was no longer useable when using a subpath setup
 -   [server] Diceroller not working on subpath server
 

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -31,6 +31,7 @@ const assetSearch = ref("");
 const gameState = getGameState();
 
 const isDm = toRef(gameState, "isDm");
+const isFakePlayer = toRef(gameState, "isFakePlayer");
 const notes = toRef(gameState, "notes");
 const markers = toRef(gameState, "markers");
 
@@ -109,7 +110,7 @@ const openClientSettings = (): void => uiStore.showClientSettings(!uiStore.state
     <div id="menu" @click="settingsClick">
         <div style="width: 200px; overflow-y: auto; overflow-x: hidden">
             <!-- ASSETS -->
-            <template v-if="isDm">
+            <template v-if="isDm || isFakePlayer">
                 <button class="menu-accordion">{{ t("common.assets") }}</button>
                 <div id="menu-assets" class="menu-accordion-panel" style="position: relative">
                     <input id="asset-search" v-model="assetSearch" :placeholder="t('common.search')" />


### PR DESCRIPTION
When enabling "fake player" modus, the DM enters a mode where some of their DM abilities are stripped down to mimic players. The left menubar however would also listen to these changes and no longer show DM entries.

One of these entries, the DM Settings, however is pretty crucial as without access to the DM Settings you can't disable the fake player mode again.

The menu entries have now been granted an exception to still operate in DM mode while fake player mode is active.