### PR TITLE
bug(UI: Out-of-Bounds): Don't do OOB check when there is nothing

### DIFF
--- a/client/src/game/id.ts
+++ b/client/src/game/id.ts
@@ -101,3 +101,7 @@ export function getShapeFromGlobal(global: GlobalId): IShape | undefined {
 export function getAllShapes(): IterableIterator<IShape> {
     return idMap.values();
 }
+
+export function getShapeCount(): number {
+    return idMap.size;
+}


### PR DESCRIPTION
When there are no shapes at all, it is pretty silly to show a "return to content" box.