### PR TITLE
bug(Select: Resize): Fix polygon point move under rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ tech changes will usually be stripped from release notes for the public
 -   Vision not properly recalculating when removing blocking shapes on multifloor setups
 -   AssetPicker UI appearing too low
 -   Polygon edit UI being left behind when panning
+-   Moving polygon point when polyon is rotated
 -   [DM] Assets not being able to moved up to parent folder
 -   [DM] Assets not being removable if a shape with a link to the asset exists
 -   [DM] Annotations still being visible until refresh after removing player access

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -204,21 +204,8 @@ export class Polygon extends Shape {
     resizeToGrid(): void {}
 
     resize(resizePoint: number, point: GlobalPoint): number {
-        if (this.angle === 0) {
-            if (resizePoint === 0) this._refPoint = point;
-            else this._vertices[resizePoint - 1] = point;
-        } else {
-            const newPoints = this.points.map((p) => toGP(p));
-
-            newPoints[resizePoint] = point;
-
-            const newCenter = getPointsCenter(filterEqualPoints(newPoints));
-
-            this._refPoint = rotateAroundPoint(newPoints[0], newCenter, -this.angle);
-            for (let i = 0; i < this._vertices.length; i++) {
-                this._vertices[i] = rotateAroundPoint(newPoints[i + 1], newCenter, -this.angle);
-            }
-        }
+        if (resizePoint === 0) this._refPoint = rotateAroundPoint(point, this.center, -this.angle);
+        else this._vertices[resizePoint - 1] = rotateAroundPoint(point, this.center, -this.angle);
         this.invalidatePoints();
         return resizePoint;
     }


### PR DESCRIPTION
When moving a polygon point with the select tool, the entire shape would move funky if the shape had a rotation applied.