### PR TITLE
bug(Initiative): Make initiative id handling more robust

### DIFF
--- a/client/src/game/api/emits/initiative.ts
+++ b/client/src/game/api/emits/initiative.ts
@@ -1,9 +1,9 @@
 import type { GlobalId } from "../../id";
-import type { InitiativeData, InitiativeEffect, InitiativeSort } from "../../models/initiative";
+import type { InitiativeEffect, InitiativeSort, RawInitiativeData } from "../../models/initiative";
 import { wrapSocket } from "../helpers";
 import { socket } from "../socket";
 
-export const sendInitiativeAdd = wrapSocket<InitiativeData<GlobalId>>("Initiative.Add");
+export const sendInitiativeAdd = wrapSocket<RawInitiativeData>("Initiative.Add");
 export const sendInitiativeRemove = wrapSocket<GlobalId>("Initiative.Remove");
 export const sendInitiativeSetValue = wrapSocket<{ shape: GlobalId; value: number }>("Initiative.Value.Set");
 export const sendInitiativeTurnUpdate = wrapSocket<number>("Initiative.Turn.Update");

--- a/client/src/game/api/events/initiative.ts
+++ b/client/src/game/api/events/initiative.ts
@@ -1,4 +1,3 @@
-import { getLocalId } from "../../id";
 import type { GlobalId } from "../../id";
 import type { InitiativeEffect, InitiativeSettings, InitiativeSort } from "../../models/initiative";
 import { initiativeStore } from "../../ui/initiative/state";
@@ -6,26 +5,26 @@ import { socket } from "../socket";
 
 socket.on("Initiative.Set", (data: InitiativeSettings) => initiativeStore.setData(data));
 socket.on("Initiative.Value.Set", (data: { shape: GlobalId; value: number }) =>
-    initiativeStore.setInitiative(getLocalId(data.shape)!, data.value, false),
+    initiativeStore.setInitiative(data.shape, data.value, false),
 );
-socket.on("Initiative.Remove", (data: GlobalId) => initiativeStore.removeInitiative(getLocalId(data)!, false));
+socket.on("Initiative.Remove", (data: GlobalId) => initiativeStore.removeInitiative(data, false));
 
 socket.on("Initiative.Turn.Update", (turn: number) => initiativeStore.setTurnCounter(turn, false));
 socket.on("Initiative.Round.Update", (round: number) => initiativeStore.setRoundCounter(round, false));
 socket.on("Initiative.Effect.New", (data: { actor: GlobalId; effect: InitiativeEffect }) => {
-    initiativeStore.createEffect(getLocalId(data.actor)!, data.effect, false);
+    initiativeStore.createEffect(data.actor, data.effect, false);
 });
 socket.on("Initiative.Effect.Rename", (data: { shape: GlobalId; index: number; name: string }) => {
-    initiativeStore.setEffectName(getLocalId(data.shape)!, data.index, data.name, false);
+    initiativeStore.setEffectName(data.shape, data.index, data.name, false);
 });
 socket.on("Initiative.Effect.Turns", (data: { shape: GlobalId; index: number; turns: string }) => {
-    initiativeStore.setEffectTurns(getLocalId(data.shape)!, data.index, data.turns, false);
+    initiativeStore.setEffectTurns(data.shape, data.index, data.turns, false);
 });
 socket.on("Initiative.Effect.Remove", (data: { shape: GlobalId; index: number }) =>
-    initiativeStore.removeEffect(getLocalId(data.shape)!, data.index, false),
+    initiativeStore.removeEffect(data.shape, data.index, false),
 );
 socket.on("Initiative.Option.Set", (data: { shape: GlobalId; option: "isVisible" | "isGroup"; value: boolean }) =>
-    initiativeStore.setOption(getLocalId(data.shape)!, data.option, data.value),
+    initiativeStore.setOption(data.shape, data.option, data.value),
 );
 socket.on("Initiative.Clear", () => initiativeStore.clearValues(false));
 socket.on("Initiative.Sort.Set", (sort: InitiativeSort) => initiativeStore.changeSort(sort, false));

--- a/client/src/game/models/initiative.ts
+++ b/client/src/game/models/initiative.ts
@@ -1,11 +1,18 @@
 import type { GlobalId, LocalId } from "../id";
 
-export interface InitiativeData<T = LocalId> {
-    shape: T;
+interface CommonInitiativeData {
     initiative?: number;
     isVisible: boolean;
     isGroup: boolean;
     effects: InitiativeEffect[];
+}
+
+export interface RawInitiativeData extends CommonInitiativeData {
+    shape: GlobalId;
+}
+export interface InitiativeData extends CommonInitiativeData {
+    globalId: GlobalId;
+    localId?: LocalId;
 }
 
 export interface InitiativeEffect {
@@ -25,7 +32,7 @@ export type InitiativeSettings = {
     round: number;
     turn: number;
     sort: InitiativeSort;
-    data: InitiativeData<GlobalId>[];
+    data: RawInitiativeData[];
 };
 
 export enum InitiativeEffectMode {

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -109,11 +109,11 @@ async function addToInitiative(): Promise<void> {
 function getInitiativeWord(): string {
     const selection = selectedSystem.$.value;
     if (selection.size === 1) {
-        return initiativeStore.state.locationData.some((i) => i.shape === [...selection][0])
+        return initiativeStore.state.locationData.some((i) => i.localId === [...selection][0])
             ? t("game.ui.selection.ShapeContext.show_initiative")
             : t("game.ui.selection.ShapeContext.add_initiative");
     } else {
-        return [...selection].every((shape) => initiativeStore.state.locationData.some((i) => i.shape === shape))
+        return [...selection].every((shape) => initiativeStore.state.locationData.some((i) => i.localId === shape))
             ? t("game.ui.selection.ShapeContext.show_initiative")
             : t("game.ui.selection.ShapeContext.add_all_initiative");
     }

--- a/client/src/game/ui/tools/toolPosition.ts
+++ b/client/src/game/ui/tools/toolPosition.ts
@@ -1,5 +1,6 @@
 export function useToolPosition(name: string): { right: string; arrow: string } {
-    const rect = document.getElementById(`${name}-selector`)!.getBoundingClientRect();
+    const rect = document.getElementById(`${name}-selector`)?.getBoundingClientRect();
+    if (rect === undefined) return { right: "0", arrow: "0" };
     const mid = rect.left + rect.width / 2;
 
     const right = Math.min(window.innerWidth - 25, mid + 75);


### PR DESCRIPTION
Since the introduction of the `LocalId` vs `GlobalId` concept, initiative has had a bunch of issues.

I thought most of these issues were resolved, but recently I hit some bugs again making me inspect the initiative code again. And I don't know what past me was thinking.

The initiative client state has been rewritten slightly to handle ids more robustly in the case of unknown shapes, which should make everything work correctly again.

That said:
- a hacky fix that was made previously hid entries that were unknown, these will re-appear as a `?`, but now should actually be properly removable by the DM, which was a problem in the past.
- I may have overlooked something, so small fixes here and there may still be necessary, but the overall structure is in a much better shape now