### PR TITLE
bug(CI: Windows Build): Change PyInstaller for Nuitka

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
 
             - run:
                   name: Compile bootloader
-                  command: cd .\pyinstaller-5.6.2\bootloader; if ($?) { python .\waf all --target-arch=64bit }
+                  command: cd .\pyinstaller-5.6.2\bootloader; if ($?) { python .\waf all }
 
             - run: cd .\pyinstaller-5.6.2; if ($?) {python .\setup.py install}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,29 @@ jobs:
                   name: Install python dependencies
                   command: python -m pip install -r requirements.txt
 
+            - command: python -m pip install wheel
+
+            # - run:
+            #       name: Install pyinstaller
+            #       command: python -m pip install pyinstaller
+
             - run:
-                  name: Install pyinstaller
-                  command: python -m pip install pyinstaller
+                  name: Download PyInstaller
+                  command: Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip
+
+            - command: unzip.exe .\pyinstaller.exe
+
+            - command: cd .\pyinstaller-5.6.2\bootloader
+
+            - run:
+                  name: Compile bootloader
+                  command: python .\waf all --target-arch=64bit
+
+            - command: cd ..
+
+            - command: python .\setup.py install
+
+            - command: cd ..
 
             - run:
                   name: Run pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
 
             - when:
                   condition:
-                      equals: [ci-test, << pipeline.git.branch >>]
+                      not: [ci-test, << pipeline.git.branch >>]
                   steps:
                       - run:
                             name: "Publish release on github"
@@ -119,7 +119,7 @@ jobs:
 
             - when:
                   condition:
-                      equals: [ci-test, << pipeline.git.branch >>]
+                      not: [ci-test, << pipeline.git.branch >>]
                   steps:
                       - run:
                             name: Publish release on github

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
             #       name: Run pyinstaller
             #       command: pyinstaller --clean -y --dist C:\Users\circleci\dist\ PA.spec
 
-            - run: python -m nuitka --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates --windows-icon-from-ico=static/favicon.ico
+            - run: python -m nuitka --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates --windows-icon-from-ico=static/favicon.ico ./planarally.py
 
             - run:
                   name: Zip artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
                   name: Zip artifacts
                   command: |
                       $VERSION=$(Get-Content -TotalCount 1 VERSION)
-                      Compress-Archive -Path .\planarally.dist -DestinationPath C:\Users\circleci\archives\planarally-windows-${VERSION}-temp.zip
+                      Compress-Archive -Path .\planarally.dist -DestinationPath C:\Users\circleci\archives\planarally-windows-${VERSION}.zip
 
             - run:
                   name: Install ghr
@@ -160,14 +160,14 @@ workflows:
                       - build-client
                   filters:
                       branches:
-                          only: ci-test
+                          #   only: ci-test  # MAKE SURE TO CONDITION OR RENAME UPLOADED FILES TO GITHUB!!
                           ignore: /.*/
                       tags:
                           only: /^\d+\.\d+\.\d+[-a-zA-Z0-9]*$/
             - build-client:
                   filters:
                       branches:
-                          only: ci-test
+                          #   only: ci-test  # MAKE SURE TO CONDITION OR RENAME UPLOADED FILES TO GITHUB!!
                           ignore: /.*/
                       tags:
                           only: /^\d+\.\d+\.\d+[-a-zA-Z0-9]*$/
@@ -176,7 +176,7 @@ workflows:
                       - build-client
                   filters:
                       branches:
-                          only: ci-test
+                          #   only: ci-test  # MAKE SURE TO CONDITION OR RENAME UPLOADED FILES TO GITHUB!!
                           ignore: /.*/
                       tags:
                           only: /^\d+\.\d+\.\d+[-a-zA-Z0-9]*$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,15 +64,15 @@ jobs:
                       VERSION=$(head -1 server/VERSION)
                       tar -czf /tmp/archives/planarally-bin-${VERSION}.tar.gz server/*
 
-            - run:
-                  name: "Publish release on github"
-                  when:
-                      condition:
-                          equals: [ci-test, << pipeline.git.branch >>]
-                      steps:
-                          command: |
-                              VERSION=$(head -1 server/VERSION)
-                              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} /tmp/archives
+            - when:
+                  condition:
+                      equals: [ci-test, << pipeline.git.branch >>]
+                  steps:
+                      - run:
+                            name: "Publish release on github"
+                            command: |
+                                VERSION=$(head -1 server/VERSION)
+                                ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} /tmp/archives
 
     build-windows:
         executor: win/server-2022
@@ -117,15 +117,15 @@ jobs:
                   name: Install ghr
                   command: go get -u github.com/tcnksm/ghr
 
-            - run:
-                  name: Publish release on github
-                  when:
-                      condition:
-                          equals: [ci-test, << pipeline.git.branch >>]
-                      steps:
-                          command: |
-                              $VERSION=$(Get-Content -TotalCount 1 VERSION)
-                              C:\Users\circleci\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
+            - when:
+                  condition:
+                      equals: [ci-test, << pipeline.git.branch >>]
+                  steps:
+                      - run:
+                            name: Publish release on github
+                            command: |
+                                $VERSION=$(Get-Content -TotalCount 1 VERSION)
+                                C:\Users\circleci\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,13 @@ jobs:
 
             - run:
                   name: "Publish release on github"
-                  command: |
-                      VERSION=$(head -1 server/VERSION)
-                      ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} /tmp/archives
+                  when:
+                      condition:
+                          equals: [ci-test, << pipeline.git.branch >>]
+                      steps:
+                          command: |
+                              VERSION=$(head -1 server/VERSION)
+                              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} /tmp/archives
 
     build-windows:
         executor: win/server-2022
@@ -81,11 +85,11 @@ jobs:
 
             - run:
                   name: Create archives folder
-                  command: mkdir ~/archives
+                  command: mkdir C:\Users\circleci\archives
 
             - run:
                   name: Create dist folder
-                  command: mkdir ~/dist
+                  command: mkdir C:\Users\circleci\dist
 
             - run:
                   name: Upgrade pip
@@ -101,7 +105,7 @@ jobs:
 
             - run:
                   name: Run pyinstaller
-                  command: pyinstaller --clean -y --dist ~/dist/ PA.spec
+                  command: pyinstaller --clean -y --dist C:\Users\circleci\dist\ PA.spec
 
             - run:
                   name: Zip artifacts
@@ -115,9 +119,13 @@ jobs:
 
             - run:
                   name: Publish release on github
-                  command: |
-                      $VERSION=$(Get-Content -TotalCount 1 VERSION)
-                      C:\Users\circleci\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
+                  when:
+                      condition:
+                          equals: [ci-test, << pipeline.git.branch >>]
+                      steps:
+                          command: |
+                              $VERSION=$(Get-Content -TotalCount 1 VERSION)
+                              C:\Users\circleci\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
                   name: Download PyInstaller
                   command: Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip
 
-            - run: unzip.exe .\pyinstaller.exe
+            - run: unzip.exe .\pyinstaller.zip
 
             - run: cd .\pyinstaller-5.6.2\bootloader
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,21 +108,18 @@ jobs:
 
             - run:
                   name: Download PyInstaller
-                  command: Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip
-
-            - command: unzip.exe .\pyinstaller.exe
-
-            - command: cd .\pyinstaller-5.6.2\bootloader
+                  command: >-
+                      Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip &&
+                      unzip.exe .\pyinstaller.exe &&
+                      cd .\pyinstaller-5.6.2\bootloader
 
             - run:
                   name: Compile bootloader
-                  command: python .\waf all --target-arch=64bit
-
-            - command: cd ..
-
-            - command: python .\setup.py install
-
-            - command: cd ..
+                  command: >-
+                      python .\waf all --target-arch=64bit &&
+                      cd .. &&
+                      python .\setup.py install &&
+                      cd ..
 
             - run:
                   name: Run pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
             #       name: Run pyinstaller
             #       command: pyinstaller --clean -y --dist C:\Users\circleci\dist\ PA.spec
 
-            - run: python -m nuitka --standalone --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates --windows-icon-from-ico=static/favicon.ico ./planarally.py
+            - run: python -m nuitka --standalone --assume-yes-for-downloads --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates --windows-icon-from-ico=static/favicon.ico ./planarally.py
 
             - run:
                   name: Zip artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
     build-windows:
         executor: win/server-2022
 
-        working_directory: C:\Users\circleci\PlanarAlly\server
+        working_directory: ~/PlanarAlly/server
 
         steps:
             - attach_workspace:
@@ -141,7 +141,7 @@ jobs:
                   name: Publish release on github
                   command: |
                       $VERSION=$(Get-Content -TotalCount 1 VERSION)
-                      C:\Users\circleci\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
+                      ~\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,8 @@ jobs:
 
             - when:
                   condition:
-                      not: [ci-test, << pipeline.git.branch >>]
+                      not:
+                          equal: [ci-test, << pipeline.git.branch >>]
                   steps:
                       - run:
                             name: "Publish release on github"
@@ -119,7 +120,8 @@ jobs:
 
             - when:
                   condition:
-                      not: [ci-test, << pipeline.git.branch >>]
+                      not:
+                          equal: [ci-test, << pipeline.git.branch >>]
                   steps:
                       - run:
                             name: Publish release on github

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,10 @@ orbs:
 jobs:
     build-client:
         docker:
-            - image: circleci/node:16
+            - image: cimg/node:16
 
         working_directory: ~/PlanarAlly/client
+        resource_class: large
 
         steps:
             - checkout:
@@ -41,6 +42,7 @@ jobs:
             - image: cibuilds/github:0.13.0
 
         working_directory: ~/PlanarAlly
+        resource_class: large
 
         steps:
             - attach_workspace:
@@ -72,6 +74,7 @@ jobs:
         executor: win/server-2022
 
         working_directory: ~/PlanarAlly/server
+        resource_class: large
 
         steps:
             - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
     build-windows:
         executor: win/server-2022
 
-        working_directory: ~/PlanarAlly/server
+        working_directory: C:\Users\circleci\PlanarAlly\server
 
         steps:
             - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,9 @@ jobs:
 
             - run:
                   name: Compile bootloader
-                  command: cd .\pyinstaller-5.6.2\bootloader && python .\waf all --target-arch=64bit
+                  command: (cd .\pyinstaller-5.6.2\bootloader) -and (python .\waf all --target-arch=64bit)
 
-            - run: cd .\pyinstaller-5.6.2 && python .\setup.py install
+            - run: (cd .\pyinstaller-5.6.2) -and (python .\setup.py install)
 
             - run:
                   name: Run pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
             #       name: Run pyinstaller
             #       command: pyinstaller --clean -y --dist C:\Users\circleci\dist\ PA.spec
 
-            - run: python -m nuitka --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates ./planarally.py
+            - run: python -m nuitka --standalone --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates --windows-icon-from-ico=static/favicon.ico ./planarally.py
 
             - run:
                   name: Zip artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,17 +112,11 @@ jobs:
 
             - run: unzip.exe .\pyinstaller.zip
 
-            - run: cd .\pyinstaller-5.6.2\bootloader
-
             - run:
                   name: Compile bootloader
-                  command: python .\waf all --target-arch=64bit
+                  command: cd .\pyinstaller-5.6.2\bootloader && python .\waf all --target-arch=64bit
 
-            - run: cd ..
-
-            - run: python .\setup.py install
-
-            - run: cd ..
+            - run: cd .\pyinstaller-5.6.2 && python .\setup.py install
 
             - run:
                   name: Run pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,9 @@ jobs:
 
             - run:
                   name: Install python dependencies
-                  command: >-
-                      python -m pip install -r requirements.txt &&
-                      python -m pip install wheel
+                  command: python -m pip install -r requirements.txt
+
+            - run: python -m pip install wheel
 
             # - run:
             #       name: Install pyinstaller
@@ -108,18 +108,21 @@ jobs:
 
             - run:
                   name: Download PyInstaller
-                  command: >-
-                      Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip &&
-                      unzip.exe .\pyinstaller.exe &&
-                      cd .\pyinstaller-5.6.2\bootloader
+                  command: Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip
+
+            - run: unzip.exe .\pyinstaller.exe
+
+            - run: cd .\pyinstaller-5.6.2\bootloader
 
             - run:
                   name: Compile bootloader
-                  command: >-
-                      python .\waf all --target-arch=64bit &&
-                      cd .. &&
-                      python .\setup.py install &&
-                      cd ..
+                  command: python .\waf all --target-arch=64bit
+
+            - run: cd ..
+
+            - run: python .\setup.py install
+
+            - run: cd ..
 
             - run:
                   name: Run pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,9 @@ jobs:
                                 ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} /tmp/archives
 
     build-windows:
-        executor: win/server-2022
+        executor:
+            name: win/server-2022
+            size: large
 
         working_directory: ~/PlanarAlly/server
 
@@ -102,31 +104,37 @@ jobs:
 
             - run: python -m pip install wheel
 
+            - run: python -m pip install orderedset
+
+            - run: python -m pip install nuitka
+
             # - run:
             #       name: Install pyinstaller
             #       command: python -m pip install pyinstaller
 
-            - run:
-                  name: Download PyInstaller
-                  command: Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip
+            # - run:
+            #       name: Download PyInstaller
+            #       command: Invoke-WebRequest https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.6.2.zip -OutFile .\pyinstaller.zip
 
-            - run: unzip.exe .\pyinstaller.zip
+            # - run: unzip.exe .\pyinstaller.zip
 
-            - run:
-                  name: Compile bootloader
-                  command: cd .\pyinstaller-5.6.2\bootloader; if ($?) { python .\waf all }
+            # - run:
+            #       name: Compile bootloader
+            #       command: cd .\pyinstaller-5.6.2\bootloader; if ($?) { python .\waf all }
 
-            - run: cd .\pyinstaller-5.6.2; if ($?) {python .\setup.py install}
+            # - run: cd .\pyinstaller-5.6.2; if ($?) {python .\setup.py install}
 
-            - run:
-                  name: Run pyinstaller
-                  command: pyinstaller --clean -y --dist C:\Users\circleci\dist\ PA.spec
+            # - run:
+            #       name: Run pyinstaller
+            #       command: pyinstaller --clean -y --dist C:\Users\circleci\dist\ PA.spec
+
+            - run: python -m nuitka --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates --windows-icon-from-ico=static/favicon.ico
 
             - run:
                   name: Zip artifacts
                   command: |
                       $VERSION=$(Get-Content -TotalCount 1 VERSION)
-                      Compress-Archive -Path C:\Users\circleci\dist -DestinationPath C:\Users\circleci\archives\planarally-windows-${VERSION}-temp.zip
+                      Compress-Archive -Path .\planarally.dist -DestinationPath C:\Users\circleci\archives\planarally-windows-${VERSION}-temp.zip
 
             - run:
                   name: Install ghr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
 
             - run:
                   name: Install ghr
-                  command: go get -u github.com/tcnksm/ghr
+                  command: go install -u github.com/tcnksm/ghr@latest
 
             - when:
                   condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 orbs:
-    windows: circleci/windows@2.4.0
+    win: circleci/windows@5.0
 
 jobs:
     build-client:
         docker:
-            - image: circleci/node:12
+            - image: circleci/node:16
 
         working_directory: ~/PlanarAlly/client
 
@@ -69,7 +69,7 @@ jobs:
                       ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -replace ${VERSION} /tmp/archives
 
     build-windows:
-        executor: windows/default
+        executor: win/server-2022
 
         working_directory: ~/PlanarAlly/server
 
@@ -126,12 +126,14 @@ workflows:
                       - build-client
                   filters:
                       branches:
+                          only: ci-test
                           ignore: /.*/
                       tags:
                           only: /^\d+\.\d+\.\d+[-a-zA-Z0-9]*$/
             - build-client:
                   filters:
                       branches:
+                          only: ci-test
                           ignore: /.*/
                       tags:
                           only: /^\d+\.\d+\.\d+[-a-zA-Z0-9]*$/
@@ -140,6 +142,7 @@ workflows:
                       - build-client
                   filters:
                       branches:
+                          only: ci-test
                           ignore: /.*/
                       tags:
                           only: /^\d+\.\d+\.\d+[-a-zA-Z0-9]*$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
 
             - run:
                   name: Install ghr
-                  command: go install -u github.com/tcnksm/ghr@latest
+                  command: go install github.com/tcnksm/ghr@latest
 
             - when:
                   condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,9 @@ jobs:
 
             - run:
                   name: Compile bootloader
-                  command: (cd .\pyinstaller-5.6.2\bootloader) -and (python .\waf all --target-arch=64bit)
+                  command: cd .\pyinstaller-5.6.2\bootloader; if ($?) { python .\waf all --target-arch=64bit }
 
-            - run: (cd .\pyinstaller-5.6.2) -and (python .\setup.py install)
+            - run: cd .\pyinstaller-5.6.2; if ($?) {python .\setup.py install}
 
             - run:
                   name: Run pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,9 @@ jobs:
 
             - run:
                   name: Install python dependencies
-                  command: python -m pip install -r requirements.txt
-
-            - command: python -m pip install wheel
+                  command: >-
+                      python -m pip install -r requirements.txt &&
+                      python -m pip install wheel
 
             # - run:
             #       name: Install pyinstaller

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
     build-client:
         docker:
-            - image: cimg/node:16
+            - image: cimg/node:16.18.1
 
         working_directory: ~/PlanarAlly/client
         resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,22 +126,22 @@ jobs:
                   name: Zip artifacts
                   command: |
                       $VERSION=$(Get-Content -TotalCount 1 VERSION)
-                      Compress-Archive -Path C:\Users\circleci\dist -DestinationPath C:\Users\circleci\archives\planarally-windows-${VERSION}.zip
+                      Compress-Archive -Path C:\Users\circleci\dist -DestinationPath C:\Users\circleci\archives\planarally-windows-${VERSION}-temp.zip
 
             - run:
                   name: Install ghr
                   command: go install github.com/tcnksm/ghr@latest
 
-            - when:
-                  condition:
-                      not:
-                          equal: [ci-test, << pipeline.git.branch >>]
-                  steps:
-                      - run:
-                            name: Publish release on github
-                            command: |
-                                $VERSION=$(Get-Content -TotalCount 1 VERSION)
-                                C:\Users\circleci\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
+            # - when:
+            #       condition:
+            #           not:
+            #               equal: [ci-test, << pipeline.git.branch >>]
+            #       steps:
+            - run:
+                  name: Publish release on github
+                  command: |
+                      $VERSION=$(Get-Content -TotalCount 1 VERSION)
+                      C:\Users\circleci\go\bin\ghr.exe -t $env:GITHUB_TOKEN -u $env:CIRCLE_PROJECT_USERNAME -r $env:CIRCLE_PROJECT_REPONAME -c $env:CIRCLE_SHA1 -replace $VERSION C:\Users\circleci\archives
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
 
             - run: python -m pip install wheel
 
-            # - run: python -m pip install orderedset  # not supported in 3.10??
+            - run: python -m pip install ordered-set
 
             - run: python -m pip install nuitka
 
@@ -128,7 +128,7 @@ jobs:
             #       name: Run pyinstaller
             #       command: pyinstaller --clean -y --dist C:\Users\circleci\dist\ PA.spec
 
-            - run: python -m nuitka --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates --windows-icon-from-ico=static/favicon.ico ./planarally.py
+            - run: python -m nuitka --include-data-files=VERSION=VERSION --include-data-files=server_config.cfg=server_config.cfg --include-data-dir=static=static --include-data-dir=templates=templates ./planarally.py
 
             - run:
                   name: Zip artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
         executor: win/server-2022
 
         working_directory: ~/PlanarAlly/server
-        resource_class: large
 
         steps:
             - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
 
             - run: python -m pip install wheel
 
-            - run: python -m pip install orderedset
+            # - run: python -m pip install orderedset  # not supported in 3.10??
 
             - run: python -m pip install nuitka
 

--- a/server/PA.spec
+++ b/server/PA.spec
@@ -14,7 +14,7 @@ block_cipher = None
 
 
 a = Analysis([_('planarally.py')],
-             pathex=[pa_dir]],
+             pathex=[pa_dir],
              datas=[
     (_('VERSION'), '.'),
     (_('server_config.cfg'), '.'),


### PR DESCRIPTION
PyInstaller has been our trusty goto tool to create the windows builds (.exe files) for those people out there that are less technical.

I sadly recently got a handful of people complaining that kaspersky flags it as a virus.

This is extremely likely a false positive, but well I took some time to investigate it an couldn't get anything else to work, until I tried nuitka, which virustotal gives 0 detections for.

Nuitka is pretty slow compared to PyInstaller (~15 minutes compared to 1), but we only need it for release builds, so that doesn't happen that often anyway.

I'll have to monitor people using the new exes (starting with 2022.3) to see if there is any noticeable difference with the previous versions.