### PR TITLE
feat(UI: Tokens): Add off-screen token directionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tech changes will usually be stripped from release notes for the public
 -   User configuration option to limit rendering to only the active floor
 -   User setting to change toolbar between icons and words (defaults to icons)
 -   Out-of-bounds check with visual UI element to help people get back to their content
+-   Show off-screen token directions
 -   [DM] Players section in the left in-game dm sidebar
     -   Lists players connected to the session
     -   Clicking on a name, centers your screen on their current view (if on the same location)

--- a/client/src/core/geometry.ts
+++ b/client/src/core/geometry.ts
@@ -1,3 +1,5 @@
+import { l2g } from "./conversions";
+
 /*
 This module defines some Point classes.
 A strong focus is made to ensure that at no time a global and a local point are mixed up with each other.
@@ -135,6 +137,11 @@ export class Ray<T extends Point> {
         else maxT = (p2.y - p1.y) / vec.y;
         return new Ray(p1, vec, maxT);
     }
+
+    static toGlobalRay(ray: Ray<LocalPoint>): Ray<GlobalPoint> {
+        return new Ray(l2g(ray.origin), ray.direction, ray.tMax);
+    }
+
     get(t: number): T {
         return { x: this.origin.x + t * this.direction.x, y: this.origin.y + t * this.direction.y } as T;
     }
@@ -143,6 +150,9 @@ export class Ray<T extends Point> {
     }
     getT(t1: number, distance: number): number {
         return t1 + Math.sqrt(Math.pow(distance, 2) / (Math.pow(this.direction.x, 2) + Math.pow(this.direction.y, 2)));
+    }
+    getPointAtDistance(distance: number, startT = 0): T {
+        return addP(this.get(startT), this.direction.normalize().multiply(distance));
     }
 }
 

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -81,7 +81,7 @@ export interface IShape extends SimpleShape {
 
     // DRAWING
 
-    draw(ctx: CanvasRenderingContext2D): void;
+    draw(ctx: CanvasRenderingContext2D, customScale?: { center: GlobalPoint; width: number; height: number }): void;
     drawPost(ctx: CanvasRenderingContext2D): void;
     drawSelection(ctx: CanvasRenderingContext2D): void;
 

--- a/client/src/game/rendering/basic.ts
+++ b/client/src/game/rendering/basic.ts
@@ -1,4 +1,6 @@
-import { g2lx, g2ly } from "../../core/conversions";
+import { g2lx, g2ly, toRadians } from "../../core/conversions";
+import { toArrayP } from "../../core/geometry";
+import type { LocalPoint, Ray } from "../../core/geometry";
 import { LayerName } from "../models/floor";
 import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
@@ -115,6 +117,42 @@ export function drawLine(from: number[], to: number[], constrained: boolean, loc
     ctx.lineTo(x(to[0], local), y(to[1], local));
     ctx.closePath();
     ctx.stroke();
+}
+
+export function drawTear(ray: Ray<LocalPoint>, options?: { fillColour?: string }): void {
+    const dl = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
+    if (dl === undefined) return;
+    const ctx = dl.ctx;
+
+    // const ray = Ray.fromPoints(toLP(120, 20), toLP(175, 100));
+    // const ray = Ray.fromPoints(toLP(120, 20), toLP(120, 88));
+    const angleRay = ray.direction.angle();
+    const a = toArrayP(ray.get(0));
+    const b = toArrayP(ray.getPointAtDistance(68));
+
+    const r = 34.5;
+    const angleA = angleRay - Math.PI / 2 - toRadians(30);
+    const angleB = angleA + Math.PI + toRadians(60);
+    const c = [b[0] + r * Math.cos(angleA), b[1] + r * Math.sin(angleA)];
+
+    ctx.beginPath();
+    ctx.lineJoin = "miter";
+    ctx.moveTo(a[0], a[1]);
+    ctx.lineTo(c[0], c[1]);
+    ctx.arc(b[0], b[1], r, angleA, angleB, false);
+    ctx.lineTo(a[0], a[1]);
+    ctx.closePath();
+    ctx.strokeStyle = "#000";
+    ctx.lineWidth = 2;
+    ctx.fillStyle = options?.fillColour ?? "#77CCEE";
+    ctx.stroke();
+    ctx.fill();
+
+    // drawPointL([117.5, 30], 5, "red");
+    // drawPointL([117.5, 35], 5, "orange");
+    // drawPointL(a, 5, "blue");
+    // drawPointL(b, 5, "brown");
+    // drawPointL(c, 5, "green");
 }
 
 function drawEdge(edge: Edge, colour: string, local = false): void {

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -17,7 +17,8 @@ import type { GlobalId, LocalId } from "../id";
 import type { Label } from "../interfaces/label";
 import type { ILayer } from "../interfaces/layer";
 import type { IShape } from "../interfaces/shape";
-import type { Floor, FloorId, LayerName } from "../models/floor";
+import { LayerName } from "../models/floor";
+import type { Floor, FloorId } from "../models/floor";
 import type { ServerShape, ServerShapeOptions, ShapeOptions } from "../models/shapes";
 import { accessSystem } from "../systems/access";
 import { ownerToClient, ownerToServer } from "../systems/access/helpers";
@@ -210,6 +211,8 @@ export abstract class Shape implements IShape {
         this._center = this.__center();
         this.resetVisionIteration();
         this.invalidatePoints();
+        if (getProperties(this.id)?.isToken === true)
+            floorSystem.getLayer(this.floor, LayerName.Draw)?.invalidate(true);
     }
 
     get angle(): number {
@@ -236,6 +239,8 @@ export abstract class Shape implements IShape {
         this.angle = position.angle;
         this.resetVisionIteration();
         this.updateShapeVision(false, false);
+        if (getProperties(this.id)?.isToken === true)
+            floorSystem.getLayer(this.floor, LayerName.Draw)?.invalidate(true);
     }
 
     invalidate(skipLightUpdate: boolean): void {
@@ -291,11 +296,11 @@ export abstract class Shape implements IShape {
 
     // DRAWING
 
-    draw(ctx: CanvasRenderingContext2D): void {
+    draw(ctx: CanvasRenderingContext2D, customScale?: { center: GlobalPoint; width: number; height: number }): void {
         if (this.globalCompositeOperation !== undefined) ctx.globalCompositeOperation = this.globalCompositeOperation;
         else ctx.globalCompositeOperation = "source-over";
 
-        const center = g2l(this.center);
+        const center = g2l(customScale?.center ?? this.center);
         const pixelRatio = playerSettingsState.devicePixelRatio.value;
 
         ctx.setTransform(pixelRatio, 0, 0, pixelRatio, center.x * pixelRatio, center.y * pixelRatio);

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -1,10 +1,11 @@
-import { g2l, g2lx, g2ly, g2lz } from "../../../core/conversions";
+import { g2l, g2lz } from "../../../core/conversions";
 import { toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import { FOG_COLOUR } from "../../colour";
 import { getGlobalId } from "../../id";
 import type { GlobalId, LocalId } from "../../id";
+import { LayerName } from "../../models/floor";
 import type { ServerAsset } from "../../models/shapes";
 import { loadSvgData } from "../../svg";
 import { floorSystem } from "../../systems/floors";
@@ -54,6 +55,8 @@ export class Asset extends BaseRect {
     setLoaded(): void {
         // Late image loading affects floor lighting
         this.layer.invalidate(true);
+        if (getProperties(this.id)?.isToken === true)
+            floorSystem.getLayer(this.floor, LayerName.Draw)?.invalidate(true);
         floorSystem.invalidateLightAllFloors();
         this.#loaded = true;
     }
@@ -88,26 +91,22 @@ export class Asset extends BaseRect {
         }
     }
 
-    draw(ctx: CanvasRenderingContext2D): void {
-        super.draw(ctx);
+    draw(ctx: CanvasRenderingContext2D, customScale?: { center: GlobalPoint; width: number; height: number }): void {
+        super.draw(ctx, customScale);
         const center = g2l(this.center);
+        const rp = g2l(this.refPoint);
+        const ogH = g2lz(this.h);
+        const ogW = g2lz(this.w);
+        const h = customScale ? customScale.height : ogH;
+        const w = customScale ? customScale.width : ogW;
+        const deltaH = (ogH - h) / 2;
+        const deltaW = (ogW - w) / 2;
         if (!this.#loaded) {
             ctx.fillStyle = FOG_COLOUR;
-            ctx.fillRect(
-                g2lx(this.refPoint.x) - center.x,
-                g2ly(this.refPoint.y) - center.y,
-                g2lz(this.w),
-                g2lz(this.h),
-            );
+            ctx.fillRect(rp.x - center.x, rp.y - center.y, w, h);
         } else {
             try {
-                ctx.drawImage(
-                    this.img,
-                    g2lx(this.refPoint.x) - center.x,
-                    g2ly(this.refPoint.y) - center.y,
-                    g2lz(this.w),
-                    g2lz(this.h),
-                );
+                ctx.drawImage(this.img, rp.x - center.x + deltaW, rp.y - center.y + deltaH, w, h);
             } catch (error) {
                 console.warn(`Shape ${getGlobalId(this.id)} could not load the image ${this.src}`);
             }

--- a/client/src/game/systems/access/state.ts
+++ b/client/src/game/systems/access/state.ts
@@ -2,6 +2,9 @@ import { computed } from "vue";
 
 import { getGameState } from "../../../store/_game";
 import type { LocalId } from "../../id";
+import { LayerName } from "../../models/floor";
+import { floorSystem } from "../floors";
+import { floorState } from "../floors/state";
 import { playerSystem } from "../players";
 import { buildState } from "../state";
 
@@ -27,6 +30,8 @@ const state = buildState<AccessState>({
 });
 
 const activeTokens = computed(() => {
+    const floor = floorState.currentFloor.value;
+    if (floor !== undefined) floorSystem.getLayer(floor, LayerName.Draw)?.invalidate(true);
     if (state.reactive.activeTokenFilters !== undefined) return state.reactive.activeTokenFilters;
     return state.reactive.ownedTokens;
 });

--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -2,10 +2,11 @@ import { registerSystem } from "..";
 import type { System } from "..";
 import { g2l, l2g, zoomDisplayToFactor } from "../../../core/conversions";
 import { addP, getPointDistance, subtractP, toGP, Vector } from "../../../core/geometry";
-import type { GlobalPoint } from "../../../core/geometry";
+import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
 import { getGameState } from "../../../store/_game";
 import { sendClientLocationOptions } from "../../api/emits/client";
 import { getAllShapes, getShape, getShapeCount } from "../../id";
+import type { LocalId } from "../../id";
 import type { IShape } from "../../interfaces/shape";
 import type { FowLayer } from "../../layers/variants/fow";
 import { LayerName } from "../../models/floor";
@@ -196,6 +197,12 @@ class PositionSystem implements System {
             }
         }
         return nearest?.position;
+    }
+
+    // TOKEN DIRECTIONS
+
+    setTokenDirection(token: LocalId, direction: LocalPoint | undefined): void {
+        $.tokenDirections.set(token, direction);
     }
 }
 

--- a/client/src/game/systems/position/state.ts
+++ b/client/src/game/systems/position/state.ts
@@ -1,3 +1,5 @@
+import type { LocalPoint } from "../../../core/geometry";
+import type { LocalId } from "../../id";
 import { buildState } from "../state";
 
 export const DEFAULT_GRID_SIZE = 50;
@@ -6,6 +8,7 @@ const state = buildState(
     {
         outOfBounds: false,
         zoomDisplay: 0.5,
+        tokenDirections: new Map<LocalId, LocalPoint | undefined>(),
     },
     {
         gridOffset: { x: 0, y: 0 },

--- a/client/src/game/ui/TokenDirections.vue
+++ b/client/src/game/ui/TokenDirections.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { toRef } from "vue";
+
+import { getShape } from "../id";
+import type { LocalId } from "../id";
+import { setCenterPosition } from "../position";
+import { positionState } from "../systems/position/state";
+
+const tokens = toRef(positionState.reactive, "tokenDirections");
+
+function center(token: LocalId): void {
+    const shape = getShape(token);
+    if (shape === undefined) return;
+
+    setCenterPosition(shape.center);
+}
+</script>
+
+<template>
+    <div id="token-directions">
+        <div
+            v-for="token of tokens"
+            :key="token[0]"
+            :style="{
+                visibility: token[1] === undefined ? 'hidden' : 'visible',
+                left: `${(token[1]?.x ?? 0) - 30}px`,
+                top: `${(token[1]?.y ?? 0) - 30}px`,
+            }"
+            @click="center(token[0])"
+        ></div>
+    </div>
+</template>
+
+<style lang="scss">
+#token-directions > div {
+    pointer-events: auto;
+    position: absolute;
+    width: 60px;
+    height: 60px;
+    border-radius: 30px;
+    border: solid 1px transparent;
+
+    &:hover {
+        cursor: pointer;
+    }
+}
+</style>

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -29,6 +29,7 @@ import LocationSettings from "./settings/location/LocationSettings.vue";
 import ShapeSettings from "./settings/shape/ShapeSettings.vue";
 import CreateTokenDialog from "./tokendialog/CreateTokenDialog.vue";
 import { tokenDialogVisible } from "./tokendialog/state";
+import TokenDirections from "./TokenDirections.vue";
 import Tools from "./tools/Tools.vue";
 
 const uiEl = ref<HTMLDivElement | null>(null);
@@ -200,6 +201,7 @@ function setTempZoomDisplay(value: number): void {
         <div id="oob" v-if="positionState.reactive.outOfBounds" @click="positionSystem.returnToBounds">
             Click to return to content
         </div>
+        <TokenDirections />
         <!-- When updating zoom boundaries, also update store updateZoom function;
             should probably do this using a store variable-->
         <SliderComponent


### PR DESCRIPTION
This PR adds direction info for tokens that are off-screen, by showing a small icon of the off-screen token and a 'teardrop' to give a sense of direction.

You can click on these to immediately center on the given shape.

The teardrop takes the colour of your ruler.

![Token direction info](https://cdn.discordapp.com/attachments/280427908730847232/1042459641101168670/image.png)