### PR TITLE
bug(OOB): Wait with OOB check until layer draw

### DIFF
--- a/client/src/game/rendering/core.ts
+++ b/client/src/game/rendering/core.ts
@@ -1,6 +1,8 @@
 import type { Floor } from "../models/floor";
 import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
+import { positionSystem } from "../systems/position";
+import { positionState } from "../systems/position/state";
 import { playerSettingsState } from "../systems/settings/players/state";
 
 let _animationFrameId = 0;
@@ -27,6 +29,10 @@ function drawLoop(): void {
     // Then process the current floor
     if (floorState.currentFloor !== undefined) {
         drawFloor(floorState.currentFloor.value!);
+    }
+
+    if (positionState.readonly.performOobCheck) {
+        positionSystem.checkOutOfBounds();
     }
 
     _animationFrameId = requestAnimationFrame(drawLoop);

--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -45,7 +45,7 @@ class PositionSystem implements System {
         mutable.panY = y + readonly.gridOffset.y;
         if (options.updateSectors) {
             floorSystem.invalidateSectors();
-            this.checkOutOfBounds();
+            mutable.performOobCheck = true;
         }
         floorSystem.updateIteration();
     }
@@ -55,7 +55,7 @@ class PositionSystem implements System {
         mutable.panY += y;
         floorSystem.invalidateSectors();
         floorSystem.updateIteration();
-        this.checkOutOfBounds();
+        mutable.performOobCheck = true;
     }
 
     // OFFSET
@@ -91,7 +91,7 @@ class PositionSystem implements System {
         this.setZoomFactor(zoom);
         if (options.updateSectors) {
             floorSystem.invalidateSectors();
-            this.checkOutOfBounds();
+            mutable.performOobCheck = true;
         }
         if (options.invalidate) floorSystem.invalidateAllFloors();
         if (options.sync) {
@@ -114,7 +114,8 @@ class PositionSystem implements System {
 
     // OOB
 
-    private checkOutOfBounds(): void {
+    checkOutOfBounds(): void {
+        mutable.performOobCheck = false;
         // First check if there are any shapes at all
         // Displaying a "return to content" when there is no content is pretty silly.
         // We however don't want to iterate over _all_ shapes if there are a lot

--- a/client/src/game/systems/position/state.ts
+++ b/client/src/game/systems/position/state.ts
@@ -15,6 +15,7 @@ const state = buildState(
         zoom: NaN,
         panX: 0,
         panY: 0,
+        performOobCheck: false,
     },
 );
 

--- a/client/src/game/ui/TokenDirections.vue
+++ b/client/src/game/ui/TokenDirections.vue
@@ -35,9 +35,9 @@ function center(token: LocalId): void {
 #token-directions > div {
     pointer-events: auto;
     position: absolute;
-    width: 60px;
-    height: 60px;
-    border-radius: 30px;
+    width: 3.75rem;
+    height: 3.75rem;
+    border-radius: 1.875rem;
     border: solid 1px transparent;
 
     &:hover {


### PR DESCRIPTION
Out of bound checks were being ran a bit too early, possibly still showing a "return to content" button after already having returned to said content.

(they were fired after layer invalidation, but not explicitly waiting on the layers to actually be re-drawn)