### PR TITLE
feat(ClientSettings): Add setting to set mouse pan behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ tech changes will usually be stripped from release notes for the public
 
 ### Added
 
--   Pan with rightclick drag
+-   Pan with right-click drag
 -   User configuration option to limit rendering to only the active floor
 -   User setting to change toolbar between icons and words (defaults to icons)
 -   Out-of-bounds check with visual UI element to help people get back to their content

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -14,17 +14,7 @@ import { clearUndoStacks } from "./operations/undo";
 import { floorSystem } from "./systems/floors";
 import { playerSettingsState } from "./systems/settings/players/state";
 import { setSelectionBoxFunction } from "./temp";
-import {
-    contextMenu,
-    keyUp,
-    mouseDown,
-    mouseLeave,
-    mouseMove,
-    mouseUp,
-    touchEnd,
-    touchMove,
-    touchStart,
-} from "./tools/events";
+import { keyUp, mouseDown, mouseLeave, mouseMove, mouseUp, touchEnd, touchMove, touchStart } from "./tools/events";
 // import DebugInfo from "./ui/DebugInfo.vue";
 import { handleDrop } from "./ui/firefox";
 import UI from "./ui/UI.vue";
@@ -131,7 +121,6 @@ export default defineComponent({
         }
 
         return {
-            contextMenu,
             drop,
             isConnected: toRef(gameState, "isConnected"),
             mouseDown,

--- a/client/src/game/api/events/player/options.ts
+++ b/client/src/game/api/events/player/options.ts
@@ -46,6 +46,10 @@ socket.on("Player.Options.Set", (options: ServerPlayerInfo) => {
         sync: false,
         default: defaultOptions.defaultTrackerMode,
     });
+    playerSettingsSystem.setMousePanMode(roomOptions?.mousePanMode, {
+        sync: false,
+        default: defaultOptions.mousePanMode,
+    });
 
     // Display
     playerSettingsSystem.setUseHighDpi(roomOptions?.useHighDpi, {

--- a/client/src/game/systems/settings/players/helpers.ts
+++ b/client/src/game/systems/settings/players/helpers.ts
@@ -13,6 +13,7 @@ export function playerOptionsToClient(options: Partial<ServerPlayerOptions>): Pa
         invertAlt: options.invert_alt,
         disableScrollToZoom: options.disable_scroll_to_zoom,
         defaultTrackerMode: options.default_tracker_mode,
+        mousePanMode: options.mouse_pan_mode,
 
         useHighDpi: options.use_high_dpi,
         gridSize: options.grid_size,

--- a/client/src/game/systems/settings/players/index.ts
+++ b/client/src/game/systems/settings/players/index.ts
@@ -92,6 +92,13 @@ class PlayerSettingsSystem implements System {
         if (options.sync) sendRoomClientOptions("default_tracker_mode", defaultTrackerMode, options.default);
     }
 
+    setMousePanMode(mousePanMode: number | undefined, options: { sync: boolean; default?: number }): void {
+        $.mousePanMode.override = mousePanMode;
+        if (options.default !== undefined) $.mousePanMode.default = options.default;
+        $.mousePanMode.value = mousePanMode ?? $.mousePanMode.default;
+        if (options.sync) sendRoomClientOptions("mouse_pan_mode", mousePanMode, options.default);
+    }
+
     // DISPLAY
 
     setUseHighDpi(useHighDpi: boolean | undefined, options: { sync: boolean; default?: boolean }): void {

--- a/client/src/game/systems/settings/players/models.ts
+++ b/client/src/game/systems/settings/players/models.ts
@@ -12,6 +12,7 @@ export interface PlayerOptions {
     invertAlt: boolean;
     disableScrollToZoom: boolean;
     defaultTrackerMode: boolean;
+    mousePanMode: number;
 
     // Display
     useHighDpi: boolean;
@@ -39,6 +40,7 @@ export interface ServerPlayerOptions {
     invert_alt: boolean;
     disable_scroll_to_zoom: boolean;
     default_tracker_mode: boolean;
+    mouse_pan_mode: number;
 
     use_high_dpi: boolean;
     grid_size: number;

--- a/client/src/game/systems/settings/players/state.ts
+++ b/client/src/game/systems/settings/players/state.ts
@@ -22,6 +22,7 @@ const state = buildState<PlayerState, "gridSize">({
     invertAlt: init(false),
     disableScrollToZoom: init(false),
     defaultTrackerMode: init(false),
+    mousePanMode: init(3),
 
     useHighDpi: init(true),
     gridSize: init(DEFAULT_GRID_SIZE),

--- a/client/src/game/tools/events.ts
+++ b/client/src/game/tools/events.ts
@@ -7,17 +7,35 @@ import { ToolName } from "../models/tools";
 import { annotationState } from "../systems/annotations/state";
 import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
+import { playerSettingsState } from "../systems/settings/players/state";
 
 import { activeTool, getActiveTool, getFeatures, toolMap } from "./tools";
+
+function isPanModeButton(button: number): boolean {
+    const mode = playerSettingsState.raw.mousePanMode.value;
+    if (mode === 3) return [1, 2].includes(button);
+    else if (mode === 0) return false;
+    return button === mode;
+}
+
+function isPanModeButtons(buttons: number): boolean {
+    const mode = playerSettingsState.raw.mousePanMode.value;
+    const middle = (buttons & 4) !== 0;
+    const right = (buttons & 2) !== 0;
+    if (mode === 3) return middle || right;
+    else if (mode === 2) return right;
+    else if (mode === 1) return middle;
+    return false;
+}
 
 export function mouseDown(event: MouseEvent): void {
     if ((event.target as HTMLElement).tagName !== "CANVAS") return;
 
     let targetTool = activeTool.value;
-    if (event.button === 1 || event.button === 2) {
+    if (isPanModeButton(event.button)) {
         toolMap[targetTool].onPanStart();
         targetTool = ToolName.Pan;
-        uiStore.preventContextMenu(false);
+        if (event.button === 2) uiStore.preventContextMenu(false);
     } else if (event.button !== 0) {
         return;
     }
@@ -42,9 +60,10 @@ export async function mouseMove(event: MouseEvent): Promise<void> {
 
     let targetTool = activeTool.value;
     // force targetTool to pan if hitting mouse wheel
-    if ((event.buttons & 4) !== 0 || (event.buttons & 2) !== 0) {
+    // if ((event.buttons & 4) !== 0 || (event.buttons & 2) !== 0) {
+    if (isPanModeButtons(event.buttons)) {
         targetTool = ToolName.Pan;
-        uiStore.preventContextMenu(true);
+        if ((event.buttons & 2) !== 0) uiStore.preventContextMenu(true);
     } else if ((event.button & 1) > 1) {
         return;
     }
@@ -85,7 +104,7 @@ export async function mouseUp(event: MouseEvent): Promise<void> {
     if ((event.target as HTMLElement).tagName !== "CANVAS") return;
 
     let targetTool = activeTool.value;
-    if (event.button === 1 || event.button === 2) {
+    if (isPanModeButton(event.button)) {
         if (event.button === 2) {
             if (!uiStore.state.preventContextMenu) {
                 return contextMenu(event);
@@ -93,6 +112,9 @@ export async function mouseUp(event: MouseEvent): Promise<void> {
         }
         toolMap[targetTool].onPanEnd();
         targetTool = ToolName.Pan;
+    } else if (event.button === 2) {
+        uiStore.preventContextMenu(false);
+        return contextMenu(event);
     } else if (event.button !== 0) {
         return;
     }

--- a/client/src/game/tools/events.ts
+++ b/client/src/game/tools/events.ts
@@ -150,7 +150,7 @@ export async function mouseLeave(event: MouseEvent): Promise<void> {
     }
 }
 
-export function contextMenu(event: MouseEvent): void {
+function contextMenu(event: MouseEvent): void {
     if ((event.target as HTMLElement).tagName !== "CANVAS") return;
     if (uiStore.state.preventContextMenu) return;
     if (event.button !== 2) return;

--- a/client/src/game/ui/settings/client/BehaviourSettings.vue
+++ b/client/src/game/ui/settings/client/BehaviourSettings.vue
@@ -48,6 +48,15 @@ function setDefaultTrackerMode(event: Event): void {
     const mode = (event.target as HTMLSelectElement).value as TrackerMode;
     defaultTrackerMode.value = mode !== TrackerMode.Absolute;
 }
+
+const mousePanMode = computed({
+    get() {
+        return $.mousePanMode.value;
+    },
+    set(mousePanMode: number | undefined) {
+        pss.setMousePanMode(mousePanMode, { sync: true });
+    },
+});
 </script>
 
 <template>
@@ -87,13 +96,37 @@ function setDefaultTrackerMode(event: Event): void {
                     <font-awesome-icon icon="sync-alt" />
                 </div>
             </template>
+            <label for="mousePanMode">
+                {{ t("game.ui.settings.client.BehaviourSettings.mouse_pan_mode") }}
+            </label>
+            <div>
+                <select v-model="mousePanMode">
+                    <option
+                        v-for="option in [0, 1, 2, 3]"
+                        :key="option"
+                        :value="option"
+                        :label="t('game.ui.settings.client.BehaviourSettings.mouse_pan_mode_' + option)"
+                        :selected="option === mousePanMode"
+                    ></option>
+                </select>
+            </div>
+            <template v-if="$.mousePanMode.override !== undefined">
+                <div :title="t('game.ui.settings.common.reset_default')" @click="mousePanMode = undefined">
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div
+                    :title="t('game.ui.settings.common.sync_default')"
+                    @click="pss.setMousePanMode(undefined, { sync: true, default: $.mousePanMode.override })"
+                >
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
         </div>
         <div class="spanrow header">Selection Info</div>
         <div class="row">
             <label for="defaultTrackerMode">
                 {{ t("game.ui.settings.client.BehaviourSettings.selection_info_tracker_mode") }}
             </label>
-            <!-- <div><input id="defaultTrackerMode" type="checkbox" v-model="defaultTrackerMode" /></div> -->
             <div>
                 <select @change="setDefaultTrackerMode">
                     <option

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -246,7 +246,12 @@
                         "disable_scroll_to_zoom": "Disable scroll to zoom",
                         "selection_info_tracker_mode": "Default tracker mode",
                         "selection_info_tracker_mode_absolute": "Absolute",
-                        "selection_info_tracker_mode_relative": "Relative"
+                        "selection_info_tracker_mode_relative": "Relative",
+                        "mouse_pan_mode": "Mouse pan mode",
+                        "mouse_pan_mode_0": "None",
+                        "mouse_pan_mode_1": "Middle click",
+                        "mouse_pan_mode_2": "Right click",
+                        "mouse_pan_mode_3": "Both"
                     },
                     "InitiativeSettings": {
                         "camera_lock": "Lock camera to active (owned) tokens",

--- a/server/src/models/user.py
+++ b/server/src/models/user.py
@@ -35,6 +35,8 @@ class UserOptions(BaseModel):
     disable_scroll_to_zoom = BooleanField(default=False, null=True)
     # false = use absolute mode ; true = use relative mode
     default_tracker_mode = BooleanField(default=False, null=True)
+    # 0 = no pan  1 = middle mouse only  2 = right mouse only 3 = both
+    mouse_pan_mode = IntegerField(default=3, null=True)
 
     use_high_dpi = BooleanField(default=False, null=True)
     grid_size = IntegerField(default=50, null=True)
@@ -55,8 +57,11 @@ class UserOptions(BaseModel):
             grid_colour=None,
             ruler_colour=None,
             use_tool_icons=None,
+            show_token_directions=None,
             invert_alt=None,
             disable_scroll_to_zoom=None,
+            default_tracker_mode=None,
+            mouse_pan_mode=None,
             use_high_dpi=None,
             grid_size=None,
             use_as_physical_board=None,

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -13,7 +13,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 80
+SAVE_VERSION = 81
 
 import json
 import logging
@@ -273,6 +273,15 @@ def upgrade(db: SqliteExtDatabase, version: int):
             )
             db.execute_sql(
                 "UPDATE user_options SET show_token_directions = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
+            )
+    elif version == 80:
+        # Add UserOptions.mouse_pan_mode
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE user_options ADD COLUMN mouse_pan_mode INTEGER DEFAULT 3"
+            )
+            db.execute_sql(
+                "UPDATE user_options SET mouse_pan_mode = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
             )
     else:
         raise UnknownVersionException(


### PR DESCRIPTION
This PR adds a ClientSetting to decide which mouse buttons initiate pan mode.
It defaults to middle & right, but can be modified to either or none.

It can be found under the behaviour->mouse gestures section.

This closes #1104.