### PR TITLE
bug(OOB): Take preFogShapes into account for OOB

### DIFF
--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -170,6 +170,7 @@ export class FowLightingLayer extends FowLayer {
                 }
                 preShape.draw(this.ctx);
                 preShape.globalCompositeOperation = ogComposite;
+                this.isEmpty = false;
             }
 
             if (locationSettingsState.raw.fullFow.value && this.floor === activeFloor.id) {


### PR DESCRIPTION
Shapes drawn with the reveal/hide draw modifiers were not taken into account for the out-of-bounds checks