### PR TITLE
bug(Dice): Reposition dice going offscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ tech changes will usually be stripped from release notes for the public
 -   Polygon edit UI being left behind when panning
 -   Moving polygon point when polyon is rotated
 -   Normal shapes sometimes wrongly being identified as spawn locations
+-   Dice sometimes going offscreen
 -   [DM] Assets not being able to moved up to parent folder
 -   [DM] Assets not being removable if a shape with a link to the asset exists
 -   [DM] Annotations still being visible until refresh after removing player access

--- a/client/src/game/dice/environment.ts
+++ b/client/src/game/dice/environment.ts
@@ -53,13 +53,28 @@ export async function loadDiceEnv(): Promise<DiceThrower> {
     light.intensity = 1;
 
     scene.registerBeforeRender(() => {
-        const meshes = scene.getActiveMeshes();
+        const meshes = scene.getActiveMeshCandidates();
         for (let j = 0; j < meshes.length; j++) {
             const i = meshes.data[j].getPhysicsImpostor();
             if (i === null || i === undefined) continue;
-            if (meshes.data[j].position.y > 3) continue;
-            i.setLinearVelocity(i.getLinearVelocity()!.multiplyByFloats(0.99, 0.99, 0.99));
-            i.setAngularVelocity(i.getAngularVelocity()!.multiplyByFloats(0.99, 0.99, 0.99));
+            const pos = meshes.data[j].position;
+            if (pos.y > 3) continue;
+            const linVel = i.getLinearVelocity()!;
+            const linVelZero = linVel.x === 0 && linVel.y === 0 && linVel.z === 0;
+            if (!linVelZero) i.setLinearVelocity(i.getLinearVelocity()!.multiplyByFloats(0.99, 0.99, 0.99));
+            const angVel = i.getAngularVelocity()!;
+            const angVelZero = angVel.x === 0 && angVel.y === 0 && angVel.z === 0;
+            if (!angVelZero) i.setAngularVelocity(i.getAngularVelocity()!.multiplyByFloats(0.99, 0.99, 0.99));
+
+            if (!(linVelZero && angVelZero)) {
+                const dim = diceStore.state.dimensions;
+                if (pos.y < 0) pos.y = 19;
+                else if (pos.y > 20) pos.y = 1;
+                if (pos.x < -dim.width / 2) pos.x = 0.9 * (dim.width / 2);
+                else if (pos.x > dim.width / 2) pos.x = 0.9 * (-dim.width / 2);
+                if (pos.z < -dim.height / 2) pos.z = 0.9 * (dim.height / 2);
+                else if (pos.z > dim.height / 2) pos.z = 0.9 * (-dim.height / 2);
+            }
         }
     });
 


### PR DESCRIPTION
Sometimes the virtual dice clip through the cage. I don't really know why, but I'm fixing it by detecting when they go offscreen and moving them inside the cage :V