### PR TITLE
feat(Dice): Show individual die results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ tech changes will usually be stripped from release notes for the public
     -   Export now redirects to a separate page
     -   Both Import and Export now have a status prompt, giving more clarity that things are happening
     -   New game now offers a selection between an empty campaign or importing a campaign
+-   Individual die results are now also shown
 -   [DM] Players section in the left in-game dm sidebar
     -   Lists players connected to the session
     -   Clicking on a name, centers your screen on their current view (if on the same location)

--- a/client/src/game/ui/dice/DiceResults.vue
+++ b/client/src/game/ui/dice/DiceResults.vue
@@ -44,6 +44,9 @@ function sum(data: readonly number[]): number {
                             <div v-if="result[1].type === 'dice'">
                                 <div class="input">{{ result[1].input }}</div>
                                 <div class="value">{{ sum(result[1].output) }}</div>
+                                <div class="details">
+                                    <div v-for="res of result[1].output" :key="res">{{ res }}</div>
+                                </div>
                             </div>
                             <div v-else-if="result[1].type === 'op'">
                                 {{ result[1].value }}
@@ -94,7 +97,7 @@ function sum(data: readonly number[]): number {
     #breakdown {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        // align-items: center;
         max-width: 25vw;
         font-size: 20px;
         > div {
@@ -110,6 +113,23 @@ function sum(data: readonly number[]): number {
         }
         .value {
             font-weight: bold;
+        }
+
+        .details {
+            display: flex;
+            font-size: 0.8em;
+            flex-wrap: wrap;
+            margin-top: 0.5rem;
+            font-style: italic;
+            justify-content: center;
+
+            > div::after {
+                content: ",";
+            }
+
+            > div:last-child::after {
+                content: "";
+            }
         }
     }
 }


### PR DESCRIPTION
Currently PA shows the total + subtotal per die type when throwing dice (e.g. 6d6+2d4 will show you something like 13 (10 + 3)).

It can be important for various systems to see the individual die results instead (e.g. the 2d4 above subtotal to 3 because you rolled a 1 and a 2).