### PR TITLE
bug(SpellTool): Fix spell tool no longer working for selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Fixed
+
+-   Spell tool: spell on selection bugged
+
 ## [2022.3.0] - 2022-12-12
 
 ### Added

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -133,8 +133,16 @@ class SpellTool extends Tool {
 
         if (selectedSystem.hasSelection && (this.state.range === 0 || equalsP(startPosition, ogPoint))) {
             const selection = selectedSystem.getFocus().value;
-            if (selection === undefined) console.error("HAHA");
-            else this.shape.center = getShape(selection)!.center;
+            if (selection === undefined) {
+                console.error("SpellTool: No selection found.");
+            } else {
+                const selectionShape = getShape(selection);
+                if (selectionShape === undefined) {
+                    console.error("SpellTool: Selected shape does not exist.");
+                } else {
+                    this.shape.center = selectionShape.center;
+                }
+            }
         }
 
         this.drawRangeShape();

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -125,16 +125,17 @@ class SpellTool extends Tool {
             UI_SYNC,
         );
 
-        if (selectedSystem.hasSelection && (this.state.range === 0 || equalsP(startPosition, ogPoint))) {
-            const selection = [...selectedSystem.$.value];
-            this.shape.center = getShape(selection[0])!.center;
-        }
-
         layer.addShape(
             this.shape,
             this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC,
             InvalidationMode.NORMAL,
         );
+
+        if (selectedSystem.hasSelection && (this.state.range === 0 || equalsP(startPosition, ogPoint))) {
+            const selection = selectedSystem.getFocus().value;
+            if (selection === undefined) console.error("HAHA");
+            else this.shape.center = getShape(selection)!.center;
+        }
 
         this.drawRangeShape();
     }


### PR DESCRIPTION
When a shape is selected, spell-tool shapes should originate from the selection center. This was broken for a bit and should now be resolved.