### PR TITLE
chore: Cleanup sync tool calls

### DIFF
--- a/client/src/game/tools/tool.ts
+++ b/client/src/game/tools/tool.ts
@@ -58,11 +58,19 @@ export abstract class Tool implements ITool {
     onPinchEnd(_event: TouchEvent, _features: ToolFeatures): void {}
     onContextMenu(_event: MouseEvent, _features: ToolFeatures): void {}
 
-    async onSelect(): Promise<void> {}
+    onSelect(): Promise<void> {
+        return Promise.resolve();
+    }
     onDeselect(): void {}
-    async onDown(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {}
-    async onUp(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {}
-    async onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {}
+    onDown(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {
+        return Promise.resolve();
+    }
+    onUp(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {
+        return Promise.resolve();
+    }
+    onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {
+        return Promise.resolve();
+    }
 
     onToolsModeChange(_mode: ToolMode, _features: ToolFeatures): void {}
     onPanStart(): void {}

--- a/client/src/game/tools/variants/map.ts
+++ b/client/src/game/tools/variants/map.ts
@@ -91,10 +91,9 @@ class MapTool extends Tool {
         this.state.manualDrag = true;
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onDown(lp: LocalPoint): Promise<void> {
-        if (!this.state.manualDrag) return;
-        if (this.rect !== undefined || !selectedSystem.hasSelection) return;
+    onDown(lp: LocalPoint): Promise<void> {
+        if (!this.state.manualDrag) return Promise.resolve();
+        if (this.rect !== undefined || !selectedSystem.hasSelection) return Promise.resolve();
 
         const startPoint = l2g(lp);
 
@@ -116,11 +115,11 @@ class MapTool extends Tool {
         this.rect.preventSync = true;
         layer.addShape(this.rect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
         selectedSystem.set(this.rect.id);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onMove(lp: LocalPoint): Promise<void> {
-        if (!this.active.value || this.rect === undefined || this.startPoint === undefined) return;
+    onMove(lp: LocalPoint): Promise<void> {
+        if (!this.active.value || this.rect === undefined || this.startPoint === undefined) return Promise.resolve();
 
         const endPoint = l2g(lp);
 
@@ -130,22 +129,23 @@ class MapTool extends Tool {
         this.rect.h = Math.abs(endPoint.y - this.startPoint.y);
         this.rect.refPoint = toGP(Math.min(this.startPoint.x, endPoint.x), Math.min(this.startPoint.y, endPoint.y));
         layer.invalidate(false);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onUp(): Promise<void> {
-        if (!this.active.value || this.rect === undefined) return;
+    onUp(): Promise<void> {
+        if (!this.active.value || this.rect === undefined) return Promise.resolve();
 
         this.active.value = false;
 
         if (selectedSystem.$.value.size !== 1) {
             this.removeRect();
-            return;
+            return Promise.resolve();
         }
 
         this.permittedTools_ = [
             { name: ToolName.Select, features: { enabled: [SelectFeatures.Drag, SelectFeatures.Resize] } },
         ];
+        return Promise.resolve();
     }
 
     preview(temporary: boolean): void {

--- a/client/src/game/tools/variants/pan.ts
+++ b/client/src/game/tools/variants/pan.ts
@@ -30,23 +30,22 @@ class PanTool extends Tool {
         sendClientLocationOptions(!full);
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onDown(lp: LocalPoint): Promise<void> {
+    onDown(lp: LocalPoint): Promise<void> {
         this.panStart = lp;
         this.active.value = true;
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onMove(lp: LocalPoint): Promise<void> {
-        if (!this.active.value) return;
-        this.panScreen(lp, false);
+    onMove(lp: LocalPoint): Promise<void> {
+        if (this.active.value) this.panScreen(lp, false);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onUp(lp: LocalPoint): Promise<void> {
-        if (!this.active.value) return;
+    onUp(lp: LocalPoint): Promise<void> {
+        if (!this.active.value) return Promise.resolve();
         this.active.value = false;
         this.panScreen(lp, true);
+        return Promise.resolve();
     }
 }
 

--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -42,15 +42,14 @@ class PingTool extends Tool {
         this.cleanup();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onDown(lp: LocalPoint): Promise<void> {
+    onDown(lp: LocalPoint): Promise<void> {
         this.cleanup();
         this.startPoint = l2g(lp);
         const layer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
 
         if (layer === undefined) {
             console.log("No draw layer!");
-            return;
+            return Promise.resolve();
         }
 
         this.active.value = true;
@@ -84,19 +83,19 @@ class PingTool extends Tool {
         );
         layer.addShape(this.ping, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
         layer.addShape(this.border, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onMove(lp: LocalPoint): Promise<void> {
+    onMove(lp: LocalPoint): Promise<void> {
         if (!this.active.value || this.ping === undefined || this.border === undefined || this.startPoint === undefined)
-            return;
+            return Promise.resolve();
 
         const gp = l2g(lp);
 
         const layer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
         if (layer === undefined) {
             console.log("No draw layer!");
-            return;
+            return Promise.resolve();
         }
 
         this.ping.center = gp;
@@ -105,11 +104,12 @@ class PingTool extends Tool {
         sendShapePositionUpdate([this.ping, this.border], true);
 
         layer.invalidate(true);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onUp(): Promise<void> {
+    onUp(): Promise<void> {
         this.cleanup();
+        return Promise.resolve();
     }
 }
 

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -81,8 +81,7 @@ class RulerTool extends Tool {
 
     // EVENT HANDLERS
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onDown(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
+    onDown(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
         this.cleanup();
         this.startPoint = l2g(lp);
 
@@ -91,7 +90,7 @@ class RulerTool extends Tool {
         const layer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
         if (layer === undefined) {
             console.log("No draw layer!");
-            return;
+            return Promise.resolve();
         }
         this.active.value = true;
         this.createNewRuler(cloneP(this.startPoint), cloneP(this.startPoint));
@@ -112,18 +111,18 @@ class RulerTool extends Tool {
             NO_SYNC,
         );
         layer.addShape(this.text, this.syncMode, InvalidationMode.NORMAL);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onMove(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
+    onMove(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
         let endPoint = l2g(lp);
         if (!this.active.value || this.rulers.length === 0 || this.startPoint === undefined || this.text === undefined)
-            return;
+            return Promise.resolve();
 
         const layer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
         if (layer === undefined) {
             console.log("No draw layer!");
-            return;
+            return Promise.resolve();
         }
 
         if (playerSettingsState.useSnapping(event)) [endPoint] = snapToGridPoint(endPoint);
@@ -154,11 +153,12 @@ class RulerTool extends Tool {
         this.text.angle = angle;
         sendShapePositionUpdate([this.text], true);
         layer.invalidate(true);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onUp(): Promise<void> {
+    onUp(): Promise<void> {
         this.cleanup();
+        return Promise.resolve();
     }
 
     onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -187,38 +187,33 @@ class SelectTool extends Tool implements ISelectTool {
         this.removePolygonEditUi();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onSelect(): Promise<void> {
+    onSelect(): Promise<void> {
         const features = getFeatures(this.toolName);
         if (this.hasFeature(SelectFeatures.PolygonEdit, features)) {
             this.createPolygonEditUi();
             _$.polygonUiVisible = "hidden";
         }
+        return Promise.resolve();
     }
 
     // INPUT HANDLERS
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onDown(
-        lp: LocalPoint,
-        event: MouseEvent | TouchEvent,
-        features: ToolFeatures<SelectFeatures>,
-    ): Promise<void> {
+    onDown(lp: LocalPoint, event: MouseEvent | TouchEvent, features: ToolFeatures<SelectFeatures>): Promise<void> {
         // if we only have context capabilities, immediately skip
-        if (features.enabled?.length === 1 && features.enabled[0] === SelectFeatures.Context) return;
+        if (features.enabled?.length === 1 && features.enabled[0] === SelectFeatures.Context) return Promise.resolve();
 
         const gp = l2g(lp);
         const layer = floorState.currentLayer.value;
         if (layer === undefined) {
             console.log("No active layer!");
-            return;
+            return Promise.resolve();
         }
 
         // Logic Door Check
         if (_.hoveredDoor !== undefined && activeToolMode.value === ToolMode.Play) {
             if (getGameState().isDm) {
                 doorSystem.toggleDoor(_.hoveredDoor);
-                return;
+                return Promise.resolve();
             } else {
                 if (doorSystem.canUse(_.hoveredDoor) === Access.Request) {
                     toast.info("Request to open door sent", {
@@ -226,7 +221,7 @@ class SelectTool extends Tool implements ISelectTool {
                     });
                 }
                 sendRequest({ door: getGlobalId(_.hoveredDoor), logic: "door" });
-                return;
+                return Promise.resolve();
             }
         }
 
@@ -334,8 +329,8 @@ class SelectTool extends Tool implements ISelectTool {
 
         // GroupSelect case, draw a selection box to select multiple shapes
         if (!hit) {
-            if (!this.hasFeature(SelectFeatures.ChangeSelection, features)) return;
-            if (!this.hasFeature(SelectFeatures.GroupSelect, features)) return;
+            if (!this.hasFeature(SelectFeatures.ChangeSelection, features)) return Promise.resolve();
+            if (!this.hasFeature(SelectFeatures.GroupSelect, features)) return Promise.resolve();
             this.mode = SelectOperations.GroupSelect;
 
             this.selectionStartPoint = gp;
@@ -379,6 +374,7 @@ class SelectTool extends Tool implements ISelectTool {
             rulerTool.onDown(lp, event);
         }
         if (this.mode !== SelectOperations.Noop) this.active.value = true;
+        return Promise.resolve();
     }
 
     async onMove(

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -169,12 +169,12 @@ class SpellTool extends Tool {
         layer.addShape(this.rangeShape, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onSelect(): Promise<void> {
+    onSelect(): Promise<void> {
         if (!selectedSystem.hasSelection && this.state.selectedSpellShape === SpellShape.Cone) {
             this.state.selectedSpellShape = SpellShape.Circle;
         }
         this.drawShape();
+        return Promise.resolve();
     }
 
     onDeselect(): void {
@@ -198,9 +198,8 @@ class SpellTool extends Tool {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onDown(): Promise<void> {
-        if (this.shape === undefined) return;
+    onDown(): Promise<void> {
+        if (this.shape === undefined) return Promise.resolve();
         const layer = floorState.currentLayer.value!;
 
         layer.removeShape(this.shape, {
@@ -212,11 +211,11 @@ class SpellTool extends Tool {
         layer.addShape(this.shape, SyncMode.FULL_SYNC, InvalidationMode.NORMAL);
         this.shape = undefined;
         activateTool(ToolName.Select);
+        return Promise.resolve();
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async onMove(lp: LocalPoint): Promise<void> {
-        if (this.shape === undefined) return;
+    onMove(lp: LocalPoint): Promise<void> {
+        if (this.shape === undefined) return Promise.resolve();
 
         const endPoint = l2g(lp);
         const layer = floorState.currentLayer.value!;
@@ -233,6 +232,7 @@ class SpellTool extends Tool {
             if (this.state.showPublic) sendShapePositionUpdate([this.shape], true);
             layer.invalidate(true);
         }
+        return Promise.resolve();
     }
 
     onContextMenu(): void {


### PR DESCRIPTION
Tools all share a same interface. Some of the tools require these methods to be async, whereas others don't care.

In the past I used some eslint ignores, but I've restructured it to return `Promise.resolve()` in that case.