### PR TITLE
bug(SpellTool): Fix spell tool fill colour jank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ tech changes will usually be stripped from release notes for the public
 ### Fixed
 
 -   Spell tool: spell on selection bugged
+-   Spell tool: fill colour behaving janky when border colour has <1 opacity
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/tools/tools.ts
+++ b/client/src/game/tools/tools.ts
@@ -36,6 +36,7 @@ export const toolMap: Record<string, ITool> = {
     [ToolName.LastGameboard]: lastGameboardTool,
     [ToolName.Dice]: diceTool,
 };
+(window as any).toolMap = toolMap;
 
 const buildTools: [ToolName, ToolFeatures][] = [
     [ToolName.Select, {}],

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -1,3 +1,4 @@
+import tinycolor from "tinycolor2";
 import { reactive, watch, watchEffect } from "vue";
 
 import { g2l, getUnitDistance, l2g, toRadians } from "../../../core/conversions";
@@ -115,7 +116,9 @@ class SpellTool extends Tool {
 
         if (this.shape === undefined) return;
 
-        propertiesSystem.setFillColour(this.shape.id, this.state.colour.replace(")", ", 0.7)"), NO_SYNC);
+        const c = tinycolor(this.state.colour);
+        c.setAlpha(c.getAlpha() * 0.7);
+        propertiesSystem.setFillColour(this.shape.id, c.toRgbString(), NO_SYNC);
         propertiesSystem.setStrokeColour(this.shape.id, this.state.colour, NO_SYNC);
 
         accessSystem.addAccess(


### PR DESCRIPTION
The fill colour of the spell tool shape is supposed to be 70% opacity of the border colour (which is the main colour you define). If you modify the opacity of that colour picker however, the fill colour suddenly can be any random colour as something incorrect was going on in the code.

This has been rectified.