### PR TITLE
bug(SpellTool): Fix contextmenu opening on right-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Spell tool: spell on selection bugged
 -   Spell tool: fill colour behaving janky when border colour has <1 opacity
+-   Spell tool: right-click was opening the context-menu
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/models/tools.ts
+++ b/client/src/game/models/tools.ts
@@ -54,7 +54,7 @@ export interface ITool {
     onPinchMove(event: TouchEvent, features: ToolFeatures): void;
     onPinchEnd(event: TouchEvent, features: ToolFeatures): void;
 
-    onContextMenu(event: MouseEvent, features: ToolFeatures): void;
+    onContextMenu(event: MouseEvent, features: ToolFeatures): boolean;
 }
 
 export interface ISelectTool extends ITool {

--- a/client/src/game/tools/events.ts
+++ b/client/src/game/tools/events.ts
@@ -160,7 +160,8 @@ function contextMenu(event: MouseEvent): void {
         toolMap[permitted.name].onContextMenu(event, permitted.features);
     }
 
-    tool.onContextMenu(event, getFeatures(activeTool.value));
+    const done = !tool.onContextMenu(event, getFeatures(activeTool.value));
+    if (done) return;
 
     for (const permitted of tool.permittedTools) {
         if (permitted.early ?? false) continue;

--- a/client/src/game/tools/tool.ts
+++ b/client/src/game/tools/tool.ts
@@ -56,7 +56,9 @@ export abstract class Tool implements ITool {
     onPinchStart(_event: TouchEvent, _features: ToolFeatures): void {}
     onPinchMove(_event: TouchEvent, _features: ToolFeatures): void {}
     onPinchEnd(_event: TouchEvent, _features: ToolFeatures): void {}
-    onContextMenu(_event: MouseEvent, _features: ToolFeatures): void {}
+    onContextMenu(_event: MouseEvent, _features: ToolFeatures): boolean {
+        return true;
+    }
 
     onSelect(): Promise<void> {
         return Promise.resolve();

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -599,7 +599,7 @@ class DrawTool extends Tool {
         return Promise.resolve();
     }
 
-    onContextMenu(event: MouseEvent): void {
+    onContextMenu(event: MouseEvent): boolean {
         if (
             this.active.value &&
             this.shape !== undefined &&
@@ -609,7 +609,7 @@ class DrawTool extends Tool {
             const layer = this.getLayer();
             if (layer === undefined) {
                 console.log("No active layer!");
-                return;
+                return true;
             }
             layer.removeShape(this.ruler!, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.ruler = undefined;
@@ -625,6 +625,7 @@ class DrawTool extends Tool {
         } else if (!this.active.value) {
             openDefaultContextMenu(event);
         }
+        return true;
     }
 
     onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -726,11 +726,11 @@ class SelectTool extends Tool implements ISelectTool {
         this.mode = SelectOperations.Noop;
     }
 
-    onContextMenu(event: MouseEvent, features: ToolFeatures<SelectFeatures>): void {
-        if (!this.hasFeature(SelectFeatures.Context, features)) return;
+    onContextMenu(event: MouseEvent, features: ToolFeatures<SelectFeatures>): boolean {
+        if (!this.hasFeature(SelectFeatures.Context, features)) return true;
         if (floorState.currentLayer.value === undefined) {
             console.log("No active layer!");
-            return;
+            return true;
         }
         const layer = floorState.currentLayer.value!;
         const layerSelection = selectedSystem.get({ includeComposites: false });
@@ -740,7 +740,7 @@ class SelectTool extends Tool implements ISelectTool {
             if (shape.contains(globalMouse)) {
                 layer.invalidate(true);
                 openShapeContextMenu(event);
-                return;
+                return true;
             }
         }
 
@@ -751,11 +751,12 @@ class SelectTool extends Tool implements ISelectTool {
                 selectedSystem.set(shape.id);
                 layer.invalidate(true);
                 openShapeContextMenu(event);
-                return;
+                return true;
             }
         }
         // Fallback to default context menu
         openDefaultContextMenu(event);
+        return true;
     }
 
     onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -238,7 +238,7 @@ class SpellTool extends Tool {
         return Promise.resolve();
     }
 
-    onContextMenu(): void {
+    onContextMenu(): boolean {
         if (this.shape !== undefined) {
             const layer = floorState.currentLayer.value!;
 
@@ -250,6 +250,7 @@ class SpellTool extends Tool {
             this.shape = undefined;
         }
         activateTool(ToolName.Select);
+        return false;
     }
 }
 


### PR DESCRIPTION
The SpellTool on right-click cancels the current draw operation and that's all it's supposed to do.

It was however also triggering the context menu on opening. This has been resolved.