### PR TITLE
bug(SpellTool): Fix spell->select activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool: spell on selection bugged
 -   Spell tool: fill colour behaving janky when border colour has <1 opacity
 -   Spell tool: right-click was opening the context-menu
+-   Spell tool: once used, the select tool was not being properly activated
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/tools/tools.ts
+++ b/client/src/game/tools/tools.ts
@@ -106,5 +106,5 @@ export function getFeatures(tool: ToolName): ToolFeatures {
 }
 
 export function activateTool(tool: ToolName): void {
-    toolMap[tool].onSelect();
+    activeTool.value = tool;
 }


### PR DESCRIPTION
Once the spell tool has been used (either by left or right click), the select tool should be activated.

This however was no longer happening properly.