### PR TITLE
bug(SpellTool): Fix "is public" label wrongly being attached to the range input box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool: fill colour behaving janky when border colour has <1 opacity
 -   Spell tool: right-click was opening the context-menu
 -   Spell tool: once used, the select tool was not being properly activated
+-   Spell tool: the 'is public' label was wrongly attached to the range input box
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/ui/tools/SpellTool.vue
+++ b/client/src/game/ui/tools/SpellTool.vue
@@ -74,8 +74,9 @@ function selectShape(shape: SpellShape): void {
                 v-model:colour="spellTool.state.colour"
                 :title="t('game.ui.tools.DrawTool.background_color')"
             />
-            <label for="range" style="flex: 5">{{ t("game.ui.selection.edit_dialog.dialog.show_annotation") }}</label>
+            <label for="public" style="flex: 5">{{ t("game.ui.selection.edit_dialog.dialog.show_annotation") }}</label>
             <button
+                id="public"
                 class="slider-checkbox"
                 :aria-pressed="spellTool.state.showPublic"
                 @click="spellTool.state.showPublic = !spellTool.state.showPublic"


### PR DESCRIPTION
The HTML label "is public" had a `for` value that links it to the range input box instead of the actual is public switch.