### PR TITLE
feat(SpellTool): Rework range concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Changed
+
+-   Spell tool
+    -   range property is removed as it was confusing to people and a bit fiddly
+    -   a ruler is now automatically drawn between the spell shape and the selected shape
+
 ### Fixed
 
 -   Spell tool: spell on selection bugged

--- a/client/src/game/models/tools.ts
+++ b/client/src/game/models/tools.ts
@@ -1,5 +1,7 @@
 import type { Ref } from "vue";
 
+import type { LocalPoint } from "../../core/geometry";
+
 export enum ToolName {
     Select = "Select",
     Pan = "Pan",
@@ -55,6 +57,10 @@ export interface ITool {
     onPinchEnd(event: TouchEvent, features: ToolFeatures): void;
 
     onContextMenu(event: MouseEvent, features: ToolFeatures): boolean;
+
+    onDown(_lp: LocalPoint, _event: MouseEvent | TouchEvent | undefined, _features: ToolFeatures): Promise<void>;
+    onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent | undefined, _features: ToolFeatures): Promise<void>;
+    onUp(_lp: LocalPoint, _event: MouseEvent | TouchEvent | undefined, _features: ToolFeatures): Promise<void>;
 }
 
 export interface ISelectTool extends ITool {

--- a/client/src/game/tools/tool.ts
+++ b/client/src/game/tools/tool.ts
@@ -64,13 +64,13 @@ export abstract class Tool implements ITool {
         return Promise.resolve();
     }
     onDeselect(): void {}
-    onDown(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {
+    onDown(_lp: LocalPoint, _event: MouseEvent | TouchEvent | undefined, _features: ToolFeatures): Promise<void> {
         return Promise.resolve();
     }
-    onUp(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {
+    onUp(_lp: LocalPoint, _event: MouseEvent | TouchEvent | undefined, _features: ToolFeatures): Promise<void> {
         return Promise.resolve();
     }
-    onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent, _features: ToolFeatures): Promise<void> {
+    onMove(_lp: LocalPoint, _event: MouseEvent | TouchEvent | undefined, _features: ToolFeatures): Promise<void> {
         return Promise.resolve();
     }
 

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -81,11 +81,11 @@ class RulerTool extends Tool {
 
     // EVENT HANDLERS
 
-    onDown(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
+    onDown(lp: LocalPoint, event: MouseEvent | TouchEvent | undefined): Promise<void> {
         this.cleanup();
         this.startPoint = l2g(lp);
 
-        if (playerSettingsState.useSnapping(event)) [this.startPoint] = snapToGridPoint(this.startPoint);
+        if (event && playerSettingsState.useSnapping(event)) [this.startPoint] = snapToGridPoint(this.startPoint);
 
         const layer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
         if (layer === undefined) {
@@ -114,7 +114,7 @@ class RulerTool extends Tool {
         return Promise.resolve();
     }
 
-    onMove(lp: LocalPoint, event: MouseEvent | TouchEvent): Promise<void> {
+    onMove(lp: LocalPoint, event: MouseEvent | TouchEvent | undefined): Promise<void> {
         let endPoint = l2g(lp);
         if (!this.active.value || this.rulers.length === 0 || this.startPoint === undefined || this.text === undefined)
             return Promise.resolve();
@@ -125,7 +125,7 @@ class RulerTool extends Tool {
             return Promise.resolve();
         }
 
-        if (playerSettingsState.useSnapping(event)) [endPoint] = snapToGridPoint(endPoint);
+        if (event && playerSettingsState.useSnapping(event)) [endPoint] = snapToGridPoint(endPoint);
 
         const ruler = this.rulers.at(-1)!;
         ruler.endPoint = endPoint;

--- a/client/src/game/ui/tools/SpellTool.vue
+++ b/client/src/game/ui/tools/SpellTool.vue
@@ -13,7 +13,7 @@ const selected = spellTool.isActiveTool;
 const selection = selectedSystem.$;
 const shapes = Object.values(SpellShape);
 
-const canConeBeCast = computed(() => selection.value.size > 0 && spellTool.state.range === 0);
+const canConeBeCast = computed(() => selection.value.size > 0);
 
 const translationMapping = {
     [SpellShape.Square]: t("game.ui.tools.DrawTool.square"),
@@ -54,19 +54,6 @@ function selectShape(shape: SpellShape): void {
                 v-model.number="spellTool.state.size"
                 min="0"
                 step="5"
-            />
-            <label for="range" style="flex: 5" :class="{ disabled: selection.size === 0 }">
-                {{ t("game.ui.tools.SpellTool.range") }}
-            </label>
-            <input
-                type="number"
-                id="range"
-                style="flex: 1; align-self: center"
-                min="0"
-                step="5"
-                v-model.number="spellTool.state.range"
-                :disabled="selection.size === 0"
-                :class="{ disabled: selection.size === 0 }"
             />
             <label for="colour" style="flex: 5">{{ t("common.fill_color") }}</label>
             <ColourPicker


### PR DESCRIPTION
The spell-tool has had a size and a range property since the beginning. The latter only being available when you have a shape selected.

From experience however players tend to be confused by which value is meant to represent what and in most cases it's a bit of a hassle to configure the range in advance.

So this PR removes the range from the spell tool UI and instead shows a ruler between your selected shape and the spell you're drawing. This conveys the same information with less effort!