### PR TITLE
feat(Shape): Add change asset button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Added
+
+-   Button to change the current asset for a shape to the shape property settings
+
 ### Changed
 
 -   Spell tool

--- a/client/src/game/api/emits/shape/asset.ts
+++ b/client/src/game/api/emits/shape/asset.ts
@@ -1,0 +1,3 @@
+import { wrapSocket } from "../../helpers";
+
+export const sendAssetRectImageChange = wrapSocket<{ uuid: string; src: string }>("Shape.Asset.Image.Set");

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -18,6 +18,7 @@ import "./events/player/options";
 import "./events/player/player";
 import "./events/player/players";
 import "./events/room";
+import "./events/shape/asset";
 import "./events/shape/circularToken";
 import "./events/shape/core";
 import "./events/shape/options";

--- a/client/src/game/api/events/shape/asset.ts
+++ b/client/src/game/api/events/shape/asset.ts
@@ -1,0 +1,11 @@
+import { getShapeFromGlobal } from "../../../id";
+import type { GlobalId } from "../../../id";
+import type { Asset } from "../../../shapes/variants/asset";
+import { socket } from "../../socket";
+
+socket.on("Shape.Asset.Image.Set", (data: { uuid: GlobalId; src: string }) => {
+    const shape = getShapeFromGlobal(data.uuid) as Asset | undefined;
+    if (shape === undefined) return;
+
+    shape.setImage(data.src, false);
+});

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -2,6 +2,7 @@ import { g2l, g2lz } from "../../../core/conversions";
 import { toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import { InvalidationMode, SyncMode } from "../../../core/models/types";
+import { sendAssetRectImageChange } from "../../api/emits/shape/asset";
 import { FOG_COLOUR } from "../../colour";
 import { getGlobalId } from "../../id";
 import type { GlobalId, LocalId } from "../../id";
@@ -113,5 +114,15 @@ export class Asset extends BaseRect implements IAsset {
             }
         }
         super.drawPost(ctx);
+    }
+
+    setImage(url: string, sync: boolean): void {
+        this.#loaded = false;
+        this.src = url;
+        this.img.src = url;
+        this.img.onload = () => {
+            this.setLoaded();
+        };
+        if (sync) sendAssetRectImageChange({ uuid: getGlobalId(this.id), src: url });
     }
 }

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -32,6 +32,7 @@ from ..constants import GAME_NS
 from ..groups import remove_group_if_empty
 from .. import initiative
 from .data_models import (
+    AssetRectImageData,
     CircleSizeData,
     OptionUpdate,
     OptionUpdateList,
@@ -486,6 +487,25 @@ async def update_text_size(sid: str, data: TextSizeData):
 
     await sio.emit(
         "Shape.Text.Size.Update",
+        data,
+        room=pr.active_location.get_path(),
+        skip_sid=sid,
+        namespace=GAME_NS,
+    )
+
+
+@sio.on("Shape.Asset.Image.Set", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def change_asset_image(sid: str, data: AssetRectImageData):
+    pr: PlayerRoom = game_state.get(sid)
+
+    shape = AssetRect.get_by_id(data["uuid"])
+
+    shape.src = data["src"]
+    shape.save()
+
+    await sio.emit(
+        "Shape.Asset.Image.Set",
         data,
         room=pr.active_location.get_path(),
         skip_sid=sid,

--- a/server/src/api/socket/shape/data_models.py
+++ b/server/src/api/socket/shape/data_models.py
@@ -162,6 +162,11 @@ class TextSizeData(TypedDict):
     temporary: bool
 
 
+class AssetRectImageData(TypedDict):
+    uuid: str
+    src: str
+
+
 class OptionUpdate(TypedDict):
     uuid: str
     option: str

--- a/server/src/models/shape/__init__.py
+++ b/server/src/models/shape/__init__.py
@@ -336,7 +336,7 @@ class BaseRect(ShapeType):
 
 
 class AssetRect(BaseRect):
-    src = TextField()
+    src = cast(str, TextField())
 
 
 class Circle(ShapeType):


### PR DESCRIPTION
Sometimes you just want to change the current character art for something else. PA offers some fancy things like variants to swap between art, but this is all very overkill if the sole purpose is to change the art without the desire to change back in the near future.

A simple button has been added to the Shape property settings to change the asset currently used. (This is thus only available to shapes that were made from assets in the first place)