### PR TITLE
lang: Change edit dialog header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 [server] denotes changes only useful for the server owner\
 [tech] denotes internal changes that are only useful for code contributors\
 tech changes will usually be stripped from release notes for the public
+[lang] this is a change to some translation string
 
 ## Unreleased
 
@@ -18,6 +19,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool
     -   range property is removed as it was confusing to people and a bit fiddly
     -   a ruler is now automatically drawn between the spell shape and the selected shape
+-   [lang] The edit dialog for shapes now properly says "Edit shape" instead of "Edit asset"
 
 ### Fixed
 

--- a/client/src/game/ui/settings/shape/ShapeSettings.vue
+++ b/client/src/game/ui/settings/shape/ShapeSettings.vue
@@ -48,7 +48,7 @@ const SSC = ShapeSettingCategory;
 
 <template>
     <PanelModal v-model:visible="visible" :categories="categoryNames">
-        <template v-slot:title>{{ t("game.ui.selection.edit_dialog.dialog.edit_asset") }}</template>
+        <template v-slot:title>{{ t("game.ui.selection.edit_dialog.dialog.edit_shape") }}</template>
         <template v-slot:default="{ selection }">
             <div v-if="hasShape" style="display: flex; flex-direction: column">
                 <PropertySettings v-show="selection === SSC.Properties" />

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -180,7 +180,6 @@
                         "dim_value": "Wert diffus",
                         "toggle_light_source": "Lichtquelle umschalten",
                         "delete_aura": "Aura löschen",
-                        "edit_asset": "Asset bearbeiten",
                         "is_a_token": "Ist ein Spielstein",
                         "is_invisible": "Ist unsichtbar",
                         "is_defeated": "Ist besiegt",

--- a/client/src/locales/dk.json
+++ b/client/src/locales/dk.json
@@ -164,7 +164,6 @@
                         "dim_value": "Dim værdi",
                         "toggle_light_source": "Skift lyskilde",
                         "delete_aura": "Slet aura",
-                        "edit_asset": "Rediger materiale",
                         "is_a_token": "Er en polet",
                         "is_invisible": "Er usynlig",
                         "is_locked": "Er låst",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -191,7 +191,7 @@
                         "dim_value": "Dim value",
                         "toggle_light_source": "Toggle light source",
                         "delete_aura": "Delete aura",
-                        "edit_asset": "Edit asset",
+                        "edit_shape": "Edit shape",
                         "is_a_token": "Is a token",
                         "is_invisible": "Is invisible",
                         "is_defeated": "Is defeated",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -177,7 +177,6 @@
                         "dim_value": "Dim value",
                         "toggle_light_source": "Activar/Desactivar fuente de luz",
                         "delete_aura": "Borrar aura",
-                        "edit_asset": "Editar material",
                         "is_a_token": "Es un token",
                         "is_invisible": "Es invisible",
                         "is_locked": "Esta bloqueado",

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -176,7 +176,6 @@
                         "dim_value": "Valore di diminuzione",
                         "toggle_light_source": "Attiva/disattiva la sorgente di luce",
                         "delete_aura": "Elimina aura",
-                        "edit_asset": "Modifica asset",
                         "is_a_token": "È un segnalino",
                         "is_invisible": "È invisibile",
                         "is_locked": "È bloccato",

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -164,7 +164,6 @@
                         "dim_value": "Dim value",
                         "toggle_light_source": "Переключить источник света",
                         "delete_aura": "Удалить ауру",
-                        "edit_asset": "Редактировать объект",
                         "is_a_token": "Это токен",
                         "is_invisible": "Невидимо",
                         "is_locked": "Заблокировано",

--- a/client/src/locales/tw.json
+++ b/client/src/locales/tw.json
@@ -170,7 +170,6 @@
                         "dim_value": "模糊值",
                         "toggle_light_source": "切換光源",
                         "delete_aura": "移除光暈",
-                        "edit_asset": "編輯素材",
                         "is_a_token": "指示物屬性",
                         "is_invisible": "不可見狀態",
                         "is_locked": "鎖定狀態",

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -184,7 +184,6 @@
                         "dim_value": "模糊值",
                         "toggle_light_source": "切换光源",
                         "delete_aura": "移除光晕",
-                        "edit_asset": "编辑素材",
                         "is_a_token": "指示物属性",
                         "is_invisible": "不可见状态",
                         "is_locked": "锁定状态",


### PR DESCRIPTION
The edit dialog header has been saying "Edit asset" for ages. Which is incorrect use of the terminology established in the docs.

This has been rectified and now properly says "Edit shape".

The language keys in translated languages has been reset for this property and should thus be adjusted separately. (Translations is something I need to look back into some time as well)