### PR TITLE
feat(Initiative): Add new Initiative "active" state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ tech changes will usually be stripped from release notes for the public
 -   Button to change the current asset for a shape to the shape property settings
 -   [DM] Quick access togglebar under the tool bar
     -   Fake Player
+    -   Initiative active state (see below)
+-   Initiative now has a specific "active" state
+    -   This streamlines some things and allows some further future things without relying on the initiative window being open
+    -   The Initiative vision lock setting now only triggers when initiative is active
+    -   The above setting now also properly reverts to the original vision lock when initiative is no longer active as was always intended
+    -   The initiative UI is automatically opened for everybody once initiative is started. (and automatically closed as well)
+    -   The above behaviour can be disabled by a new user setting.
 
 ### Changed
 

--- a/client/src/game/api/emits/initiative.ts
+++ b/client/src/game/api/emits/initiative.ts
@@ -3,6 +3,7 @@ import type { InitiativeEffect, InitiativeSort, RawInitiativeData } from "../../
 import { wrapSocket } from "../helpers";
 import { socket } from "../socket";
 
+export const sendInitiativeActive = wrapSocket<boolean>("Initiative.Active.Set");
 export const sendInitiativeAdd = wrapSocket<RawInitiativeData>("Initiative.Add");
 export const sendInitiativeRemove = wrapSocket<GlobalId>("Initiative.Remove");
 export const sendInitiativeSetValue = wrapSocket<{ shape: GlobalId; value: number }>("Initiative.Value.Set");

--- a/client/src/game/api/events/initiative.ts
+++ b/client/src/game/api/events/initiative.ts
@@ -4,6 +4,7 @@ import { initiativeStore } from "../../ui/initiative/state";
 import { socket } from "../socket";
 
 socket.on("Initiative.Set", (data: InitiativeSettings) => initiativeStore.setData(data));
+socket.on("Initiative.Active.Set", (isActive: boolean) => initiativeStore.setActive(isActive));
 socket.on("Initiative.Value.Set", (data: { shape: GlobalId; value: number }) =>
     initiativeStore.setInitiative(data.shape, data.value, false),
 );

--- a/client/src/game/api/events/player/options.ts
+++ b/client/src/game/api/events/player/options.ts
@@ -97,6 +97,10 @@ socket.on("Player.Options.Set", (options: ServerPlayerInfo) => {
         sync: false,
         default: defaultOptions.initiativeEffectVisibility,
     });
+    playerSettingsSystem.setInitiativeOpenOnActivate(roomOptions?.initiativeOpenOnActivate, {
+        sync: false,
+        default: defaultOptions.initiativeOpenOnActivate,
+    });
 
     // Performance
 

--- a/client/src/game/models/initiative.ts
+++ b/client/src/game/models/initiative.ts
@@ -33,6 +33,7 @@ export type InitiativeSettings = {
     turn: number;
     sort: InitiativeSort;
     data: RawInitiativeData[];
+    isActive: boolean;
 };
 
 export enum InitiativeEffectMode {

--- a/client/src/game/systems/settings/players/helpers.ts
+++ b/client/src/game/systems/settings/players/helpers.ts
@@ -24,6 +24,7 @@ export function playerOptionsToClient(options: Partial<ServerPlayerOptions>): Pa
         initiativeCameraLock: options.initiative_camera_lock,
         initiativeVisionLock: options.initiative_vision_lock,
         initiativeEffectVisibility: options.initiative_effect_visibility,
+        initiativeOpenOnActivate: options.initiative_open_on_activate,
 
         renderAllFloors: options.render_all_floors,
     };

--- a/client/src/game/systems/settings/players/index.ts
+++ b/client/src/game/systems/settings/players/index.ts
@@ -177,6 +177,17 @@ class PlayerSettingsSystem implements System {
             sendRoomClientOptions("initiative_effect_visibility", initiativeEffectVisibility, options.default);
     }
 
+    setInitiativeOpenOnActivate(
+        initiativeOpenOnActivate: boolean | undefined,
+        options: { sync: boolean; default?: boolean },
+    ): void {
+        $.initiativeOpenOnActivate.override = initiativeOpenOnActivate;
+        if (options.default !== undefined) $.initiativeOpenOnActivate.default = options.default;
+        $.initiativeOpenOnActivate.value = initiativeOpenOnActivate ?? $.initiativeOpenOnActivate.default;
+        if (options.sync)
+            sendRoomClientOptions("initiative_open_on_activate", initiativeOpenOnActivate, options.default);
+    }
+
     // PERFORMANCE
 
     setRenderAllFloors(renderAllFloors: boolean | undefined, options: { sync: boolean; default?: boolean }): void {

--- a/client/src/game/systems/settings/players/models.ts
+++ b/client/src/game/systems/settings/players/models.ts
@@ -25,6 +25,7 @@ export interface PlayerOptions {
     initiativeCameraLock: boolean;
     initiativeVisionLock: boolean;
     initiativeEffectVisibility: InitiativeEffectMode;
+    initiativeOpenOnActivate: boolean;
 
     // Performance
     renderAllFloors: boolean;
@@ -51,6 +52,7 @@ export interface ServerPlayerOptions {
     initiative_camera_lock: boolean;
     initiative_vision_lock: boolean;
     initiative_effect_visibility: InitiativeEffectMode;
+    initiative_open_on_activate: boolean;
 
     render_all_floors: boolean;
 }

--- a/client/src/game/systems/settings/players/state.ts
+++ b/client/src/game/systems/settings/players/state.ts
@@ -33,6 +33,7 @@ const state = buildState<PlayerState, "gridSize">({
     initiativeCameraLock: init(false),
     initiativeVisionLock: init(false),
     initiativeEffectVisibility: init(InitiativeEffectMode.ActiveAndHover),
+    initiativeOpenOnActivate: init(true),
 
     renderAllFloors: init(true),
 });

--- a/client/src/game/ui/settings/client/InitiativeSettings.vue
+++ b/client/src/game/ui/settings/client/InitiativeSettings.vue
@@ -13,6 +13,15 @@ const pss = playerSettingsSystem;
 
 const effectVisibilityOptions = Object.values(InitiativeEffectMode);
 
+const openOnActivate = computed({
+    get() {
+        return $.initiativeOpenOnActivate.value;
+    },
+    set(openOnActivate: boolean | undefined) {
+        pss.setInitiativeOpenOnActivate(openOnActivate, { sync: true });
+    },
+});
+
 const cameraLock = computed({
     get() {
         return $.initiativeCameraLock.value;
@@ -47,6 +56,26 @@ function setEffectVisibility(event: Event): void {
 
 <template>
     <div class="panel restore-panel">
+        <div class="row">
+            <label for="openOnActivate">{{ t("game.ui.settings.client.InitiativeSettings.open_on_activate") }}</label>
+            <div><input id="openOnActivate" type="checkbox" v-model="openOnActivate" /></div>
+            <template v-if="$.initiativeOpenOnActivate.override !== undefined">
+                <div :title="t('game.ui.settings.common.reset_default')" @click="openOnActivate = undefined">
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div
+                    :title="t('game.ui.settings.common.sync_default')"
+                    @click="
+                        pss.setInitiativeOpenOnActivate(undefined, {
+                            sync: true,
+                            default: $.initiativeOpenOnActivate.override,
+                        })
+                    "
+                >
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
         <div class="row">
             <label for="cameraLock">{{ t("game.ui.settings.client.InitiativeSettings.camera_lock") }}</label>
             <div><input id="cameraLock" type="checkbox" v-model="cameraLock" /></div>

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -11,6 +11,7 @@ import { ToolMode, ToolName } from "../../models/tools";
 import { accessState } from "../../systems/access/state";
 import { playerSettingsState } from "../../systems/settings/players/state";
 import { activeModeTools, activeTool, activeToolMode, dmTools, toggleActiveMode, toolMap } from "../../tools/tools";
+import { initiativeStore } from "../initiative/state";
 
 import DiceTool from "./DiceTool.vue";
 import DrawTool from "./DrawTool.vue";
@@ -128,7 +129,16 @@ function toggleFakePlayer(): void {
             </ul>
             <div v-if="!hasGameboard" id="tool-status">
                 <div id="tool-status-toggles" v-if="getGameState().isDm || getGameState().isFakePlayer">
-                    <div :class="{ active: fakePlayerActive }" @click="toggleFakePlayer">FP</div>
+                    <div :class="{ active: fakePlayerActive }" @click="toggleFakePlayer" title="Toggle fake-player">
+                        FP
+                    </div>
+                    <div
+                        :class="{ active: initiativeStore.state.isActive }"
+                        @click="initiativeStore.toggleActive"
+                        title="Toggle Initiative State"
+                    >
+                        INI
+                    </div>
                 </div>
                 <div style="flex-grow: 1"></div>
                 <div id="tool-status-modes" @click="toggleActiveMode" :title="t('game.ui.tools.tools.change_mode')">

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -255,6 +255,7 @@
                         "mouse_pan_mode_3": "Both"
                     },
                     "InitiativeSettings": {
+                        "open_on_activate": "Open automatically when initiative is started",
                         "camera_lock": "Lock camera to active (owned) tokens",
                         "vision_lock": "Lock vision to active (owned) tokens",
                         "effect_visibility": "When to show effects",

--- a/server/src/models/initiative.py
+++ b/server/src/models/initiative.py
@@ -1,7 +1,7 @@
 import json
 from typing import cast
 
-from peewee import ForeignKeyField, IntegerField, TextField
+from peewee import BooleanField, ForeignKeyField, IntegerField, TextField
 from playhouse.shortcuts import model_to_dict
 
 from . import Location
@@ -19,8 +19,12 @@ class Initiative(BaseModel):
     turn = cast(int, IntegerField())
     sort = cast(int, IntegerField(default=0))
     data = cast(str, TextField())
+    is_active = cast(bool, BooleanField(default=False))
 
     def as_dict(self):
-        initiative = model_to_dict(self, recurse=False, exclude=[Initiative.id])
+        initiative = model_to_dict(
+            self, recurse=False, exclude=[Initiative.id, Initiative.is_active]
+        )
         initiative["data"] = json.loads(initiative["data"])
+        initiative["isActive"] = self.is_active
         return initiative

--- a/server/src/models/user.py
+++ b/server/src/models/user.py
@@ -47,6 +47,7 @@ class UserOptions(BaseModel):
     initiative_camera_lock = BooleanField(default=False, null=True)
     initiative_vision_lock = BooleanField(default=False, null=True)
     initiative_effect_visibility = TextField(default="active", null=True)
+    initiative_open_on_activate = cast(bool, BooleanField(default=True, null=True))
 
     render_all_floors = BooleanField(default=True, null=True)
 
@@ -70,6 +71,7 @@ class UserOptions(BaseModel):
             initiative_camera_lock=None,
             initiative_vision_lock=None,
             initiative_effect_visibility=None,
+            initiative_open_on_activate=None,
             render_all_floors=None,
         )
 


### PR DESCRIPTION
Initiative never had a real concept of "active". You could have the initiative UI open or closed regardless of whether something is actually happening with initiative.

This hampers some things (e.g. the Initiative setting "lock vision" is in a semi-broken state due to this), so I'm adding it in this PR.

I considered regarding whether the initiative UI is open to be an implicit representation of whether initiative is active, but felt that that was not adequate from my own experience in how I use this UI.

#### How to activate initiative

This toggle will join the recently added status toggle bar and join the "Fake Player" toggle.

This also makes it a bit easier to access initiative instead of going through a right click.

The active state is saved on the server, so this is remembered when you refresh the page.

It is currently tracked on a per location basis.

#### I don't like this

It's worth noting that this addition is not something you have to use. You'll be able to use the initiative UI pretty much exactly as it was without touching this new "active" thing, but some features will interact with it going forward.

#### Vision lock

A first such feature is the aforementioned "vision lock" initiative setting.

The goal of this setting is that when initiative starts your current vision filters are set aside. Instead the vision filter will adapt to whoever is currently acting in initiative. If this is a shape you own, then your vision will be limited to that shape, otherwise you'll revert to no filters.
This setting makes it easy to quickly immerse yourself in what your character can actually see on the moment it is their turn.

The main problem with this feature was that there was no set time to revert to the original set of vision filters as there was no official end to initiative. This also meant that if your character happens to be the last actor in initiative, the vision will be locked to your character and you have to manually reset the vision tool to your desired values.

From now on this setting will only be regarded if initiative is active and will properly revert to your original vision filters when initiative ends.

#### Automatically opening/closing initiative UI

By default when toggling the initiative active state, the initiative UI will also toggle for all players.

This can be disabled in your user settings if this is something you don't like.

#### Related features coming up

Vision lock was already a setting so has immediately been streamlined to use this "new" system.
I mentioned some other features that would work depending on the activate context and these are two things in my mind at this point in time.

##### Movement lock

As an optional DM setting, you'll be able to lock movement only to the active actor.

##### Spell tool integration

From a recent discussion on discord I got convinced to add something to the spell tool so that shapes drawn when initiative is active and it is your turn, can automatically be added as a initiative event and disappear when the timer runs out.