### PR TITLE
bug(Css): Some weird firefox css change fix

### DIFF
--- a/client/src/core/components/slider/SliderComponent.vue
+++ b/client/src/core/components/slider/SliderComponent.vue
@@ -64,7 +64,7 @@ function setValueByPos(pos: number): void {
 <template>
     <div
         class="vue-slider"
-        :style="{ width, height, padding: `${dotSize[1] / scale}px 0` }"
+        :style="{ width, height, padding: `${dotSize[1] / scale}px 1rem` }"
         @click="onClick"
         @mousedown="dragging = true"
         @mousemove="dragMove"


### PR DESCRIPTION
Firefox must have changed something to their css engine as it was adding some extra whitespace causing scrollbars to appear were it didn't before. The element in question hasn't been touched for at least 18 months either so ¯\\\_(ツ)\_/¯.

I've added some extra padding to the zoom slider, which seems to resolve it.