### PR TITLE
bug(Initiative): Fix initiative UI immediately closing when not active in certain cases

### DIFF
--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -73,7 +73,7 @@ const showChangelog = computed(() => {
 onMounted(() => {
     // hide all UI elements that were previously open
     activeShapeStore.setShowEditDialog(false);
-    initiativeStore.show(false);
+    initiativeStore.show(false, false);
     showDefaultContextMenu.value = false;
     showShapeContextMenu.value = false;
     tokenDialogVisible.value = false;

--- a/client/src/game/ui/contextmenu/DefaultContext.vue
+++ b/client/src/game/ui/contextmenu/DefaultContext.vue
@@ -92,7 +92,7 @@ async function createSpawnLocation(): Promise<void> {
 }
 
 function showInitiativeDialog(): void {
-    initiativeStore.show(true);
+    initiativeStore.show(true, true);
     close();
 }
 

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -100,11 +100,11 @@ async function addToInitiative(): Promise<void> {
     const groupsProcessed = new Set();
     for (const shape of selection) {
         if (!groupInitiatives || shape.groupId === undefined || !groupsProcessed.has(shape.groupId)) {
-            initiativeStore.addInitiative(shape.id, undefined, groupInitiatives && shape.groupId !== undefined);
+            initiativeStore.addInitiative(shape.id, groupInitiatives && shape.groupId !== undefined);
             groupsProcessed.add(shape.groupId);
         }
     }
-    initiativeStore.show(true);
+    initiativeStore.show(true, true);
     close();
 }
 

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -28,7 +28,7 @@ const modals = useModal();
 
 const isDm = toRef(getGameState(), "isDm");
 
-const close = (): void => initiativeStore.show(false);
+const close = (): void => initiativeStore.show(false, false);
 const clearValues = (): void => initiativeStore.clearValues(true);
 const nextTurn = (): void => initiativeStore.nextTurn();
 const previousTurn = (): void => initiativeStore.previousTurn();
@@ -36,7 +36,7 @@ const owns = (actorId?: GlobalId): boolean => initiativeStore.owns(actorId);
 const toggleOption = (index: number, option: "isVisible" | "isGroup"): void =>
     initiativeStore.toggleOption(index, option);
 
-onMounted(() => initiativeStore.show(false));
+onMounted(() => initiativeStore.show(false, false));
 
 const alwaysShowEffects = computed(
     () => playerSettingsState.reactive.initiativeEffectVisibility.value === InitiativeEffectMode.Always,


### PR DESCRIPTION
When a player adds initiative, the server sends a request back which also contains the active state of the initiative and based on that info was setting the initiative UI visibility. If the initiative state was not active, this could cause a funky experience if you tried to interact with the initiative UI while the initiative state was not active.

As mentioned in the PR for the initiative state, this is not the intention and has been rectified.