### PR TITLE
feat(UI): Add modal stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ tech changes will usually be stripped from release notes for the public
     -   The above setting now also properly reverts to the original vision lock when initiative is no longer active as was always intended
     -   The initiative UI is automatically opened for everybody once initiative is started. (and automatically closed as well)
     -   The above behaviour can be disabled by a new user setting.
+-   Most modals will now move to the front when interacted with
 
 ### Changed
 

--- a/client/src/core/components/modals/Modal.vue
+++ b/client/src/core/components/modals/Modal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import { nextTick, onMounted, onUnmounted, ref, watch, watchEffect } from "vue";
 
 import { clearDropCallback, registerDropCallback } from "../../../game/ui/firefox";
 
@@ -7,7 +7,7 @@ const props = withDefaults(defineProps<{ colour?: string; mask?: boolean; visibl
     colour: "white",
     mask: true,
 });
-const emit = defineEmits(["close"]);
+const emit = defineEmits(["close", "focus", "modalClick"]);
 
 const container = ref<HTMLDivElement | null>(null);
 
@@ -51,9 +51,14 @@ watch(
     () => props.visible,
     () => positionCheck(),
 );
+watchEffect(() => {
+    if (props.visible) {
+        emit("focus");
+    }
+});
 
 function updatePosition(): void {
-    if (container.value === undefined) return;
+    if (container.value === null) return;
     if (!positioned) {
         if (container.value!.offsetWidth === 0 && container.value!.offsetHeight === 0) return;
         containerX = (window.innerWidth - container.value!.offsetWidth) / 2;
@@ -104,7 +109,6 @@ function dragOver(_event: DragEvent): void {
 </script>
 
 <template>
-    <div ref="test"></div>
     <transition name="modal">
         <div
             class="mask"
@@ -113,7 +117,12 @@ function dragOver(_event: DragEvent): void {
             v-show="visible"
             @dragover.prevent="dragOver"
         >
-            <div class="modal-container" @click.stop ref="container" :style="{ backgroundColor: colour }">
+            <div
+                class="modal-container"
+                @click.stop="emit('modalClick')"
+                ref="container"
+                :style="{ backgroundColor: colour }"
+            >
                 <slot name="header" :dragStart="dragStart" :dragEnd="dragEnd"></slot>
                 <slot></slot>
             </div>

--- a/client/src/game/ui/ModalStack.vue
+++ b/client/src/game/ui/ModalStack.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type { Component, ComputedRef } from "vue";
+
+import { getGameState } from "../../store/_game";
+import { coreStore } from "../../store/core";
+import { clientState } from "../systems/client/state";
+
+import DiceResults from "./dice/DiceResults.vue";
+import Initiative from "./initiative/Initiative.vue";
+import LgGridId from "./lg/GridId.vue";
+import SelectionInfo from "./SelectionInfo.vue";
+import ClientSettings from "./settings/client/ClientSettings.vue";
+import DmSettings from "./settings/dm/DmSettings.vue";
+import FloorSettings from "./settings/FloorSettings.vue";
+import LgSettings from "./settings/lg/LgSettings.vue";
+import LocationSettings from "./settings/location/LocationSettings.vue";
+import ShapeSettings from "./settings/shape/ShapeSettings.vue";
+import CreateTokenDialog from "./tokendialog/CreateTokenDialog.vue";
+
+const hasGameboard = coreStore.state.boardId !== undefined;
+const hasGameboardClients = computed(() => clientState.reactive.clientBoards.size > 0);
+
+const dmOrFake = computed(() => {
+    const state = getGameState();
+    return state.isDm || state.isFakePlayer;
+});
+
+const modals: (Component | { component: Component; condition: ComputedRef<boolean> })[] = [
+    ClientSettings,
+    CreateTokenDialog,
+    DiceResults,
+    { component: DmSettings, condition: dmOrFake },
+    { component: FloorSettings, condition: dmOrFake },
+    Initiative,
+    { component: LgSettings, condition: computed(() => hasGameboardClients.value && dmOrFake.value) },
+    { component: LocationSettings, condition: dmOrFake },
+    SelectionInfo,
+    ShapeSettings,
+];
+if (hasGameboard) {
+    modals.push(LgGridId, DiceResults);
+}
+const modalOrder = ref(Array.from({ length: modals.length }, (_, i) => i));
+
+function focus(index: number): void {
+    modalOrder.value.push(modalOrder.value.splice(index, 1)[0]);
+}
+
+function isComponent(x: Component | { component: Component }): x is Component {
+    return !("component" in x);
+}
+
+const visibleModals = computed(() => {
+    const _modals: { index: number; component: Component }[] = [];
+    for (let i = 0; i < modalOrder.value.length; i++) {
+        const modal = modals[modalOrder.value[i]];
+        if (isComponent(modal)) {
+            _modals.push({ index: i, component: modal });
+        } else if (modal.condition.value) {
+            _modals.push({ index: i, component: modal.component });
+        }
+    }
+    return _modals;
+});
+</script>
+
+<template>
+    <component
+        v-for="modal of visibleModals"
+        :is="modal.component"
+        :key="modal.component"
+        @modalClick="focus(modal.index)"
+        @focus="focus(modal.index)"
+    />
+</template>

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -8,7 +8,6 @@ import { baseAdjust } from "../../core/http";
 import { getGameState } from "../../store/_game";
 import { activeShapeStore } from "../../store/activeShape";
 import { coreStore } from "../../store/core";
-import { clientState } from "../systems/client/state";
 import { positionSystem } from "../systems/position";
 import { positionState } from "../systems/position/state";
 
@@ -16,22 +15,12 @@ import Annotation from "./Annotation.vue";
 import DefaultContext from "./contextmenu/DefaultContext.vue";
 import ShapeContext from "./contextmenu/ShapeContext.vue";
 import { showDefaultContextMenu, showShapeContextMenu } from "./contextmenu/state";
-import DiceResults from "./dice/DiceResults.vue";
 import LgDiceResults from "./dice/LgDiceResults.vue";
 import Floors from "./Floors.vue";
-import Initiative from "./initiative/Initiative.vue";
 import { initiativeStore } from "./initiative/state";
-import LgGridId from "./lg/GridId.vue";
 import LocationBar from "./menu/LocationBar.vue";
 import MenuBar from "./menu/MenuBar.vue";
-import SelectionInfo from "./SelectionInfo.vue";
-import ClientSettings from "./settings/client/ClientSettings.vue";
-import DmSettings from "./settings/dm/DmSettings.vue";
-import FloorSettings from "./settings/FloorSettings.vue";
-import LgSettings from "./settings/lg/LgSettings.vue";
-import LocationSettings from "./settings/location/LocationSettings.vue";
-import ShapeSettings from "./settings/shape/ShapeSettings.vue";
-import CreateTokenDialog from "./tokendialog/CreateTokenDialog.vue";
+import ModalStack from "./ModalStack.vue";
 import { tokenDialogVisible } from "./tokendialog/state";
 import TokenDirections from "./TokenDirections.vue";
 import Tools from "./tools/Tools.vue";
@@ -48,8 +37,6 @@ const visible = reactive({
     settings: false,
 });
 const topLeft = computed(() => visible.locations && visible.settings);
-
-const hasGameboardClients = computed(() => clientState.reactive.clientBoards.size > 0);
 
 const changelogText = computed(() =>
     t("game.ui.ui.changelog_RELEASE_LOG", {
@@ -193,21 +180,11 @@ function setTempZoomDisplay(value: number): void {
         <Tools />
         <LocationBar v-if="getGameState().isDm" :active="visible.locations" :menuActive="visible.settings" />
         <Floors />
-        <CreateTokenDialog />
-        <Initiative />
         <DefaultContext />
         <ShapeContext />
-        <ShapeSettings />
-        <DmSettings v-if="getGameState().isDm || getGameState().isFakePlayer" />
-        <LgSettings v-if="hasGameboardClients && (getGameState().isDm || getGameState().isFakePlayer)" />
-        <LgGridId v-if="hasGameboard" />
-        <FloorSettings v-if="getGameState().isDm || getGameState().isFakePlayer" />
-        <LocationSettings v-if="getGameState().isDm || getGameState().isFakePlayer" />
-        <ClientSettings />
-        <SelectionInfo />
         <Annotation />
-        <template v-if="!hasGameboard"><DiceResults /></template>
-        <template v-else><LgDiceResults /></template>
+        <template v-if="hasGameboard"><LgDiceResults /></template>
+        <ModalStack />
         <div id="teleport-modals"></div>
         <MarkdownModal v-if="showChangelog" :title="t('game.ui.ui.new_ver_msg')" :source="changelogText" />
         <div id="oob" v-if="positionState.reactive.outOfBounds" @click="positionSystem.returnToBounds">


### PR DESCRIPTION
There has been a longstanding pending PR #422 to handle the stacking of modals, but it has been stuck in a draft phase for about 2 years now.

I decided to throw in my own attempt and here it is.

Most modals will now move to the front when opened/interacted with.
I say "most", because some modals should be interacted with immediately (e.g. confirm dialogs etc).