### PR TITLE
feat(UI): Close modals with escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ tech changes will usually be stripped from release notes for the public
     -   The initiative UI is automatically opened for everybody once initiative is started. (and automatically closed as well)
     -   The above behaviour can be disabled by a new user setting.
 -   Most modals will now move to the front when interacted with
+-   Most modals can be closed with escape
 
 ### Changed
 

--- a/client/src/core/components/modals/Modal.vue
+++ b/client/src/core/components/modals/Modal.vue
@@ -22,6 +22,7 @@ let containerX = 0;
 let containerY = 0;
 
 function close(): void {
+    console.log(9);
     emit("close");
 }
 

--- a/client/src/core/components/modals/Modal.vue
+++ b/client/src/core/components/modals/Modal.vue
@@ -22,7 +22,6 @@ let containerX = 0;
 let containerY = 0;
 
 function close(): void {
-    console.log(9);
     emit("close");
 }
 

--- a/client/src/core/components/modals/PanelModal.vue
+++ b/client/src/core/components/modals/PanelModal.vue
@@ -11,6 +11,7 @@ const props = withDefaults(
 const emit = defineEmits<{
     (e: "update:visible", visible: boolean): void;
     (e: "update:selection", selection: string): void;
+    (e: "close"): void;
 }>();
 
 const { t } = useI18n();
@@ -30,6 +31,7 @@ function setSelection(category: string): void {
 
 function hideModal(): void {
     emit("update:visible", false);
+    emit("close");
 }
 </script>
 
@@ -38,7 +40,7 @@ function hideModal(): void {
         <template v-slot:header="m">
             <div class="modal-header" draggable="true" @dragstart="m.dragStart" @dragend="m.dragEnd">
                 <div><slot name="title"></slot></div>
-                <div class="header-close" @click="hideModal" :title="t('common.close')">
+                <div class="header-close" @click.stop="hideModal" :title="t('common.close')">
                     <font-awesome-icon :icon="['far', 'window-close']" />
                 </div>
             </div>

--- a/client/src/game/ui/LabelManager.vue
+++ b/client/src/game/ui/LabelManager.vue
@@ -83,7 +83,7 @@ function deleteLabel(uuid: string): void {
         <template v-slot:header="m">
             <div class="modal-header" draggable="true" @dragstart="m.dragStart" @dragend="m.dragEnd">
                 <div>{{ t("game.ui.LabelManager.title") }}</div>
-                <div class="header-close" @click="close" :title="t('common.close')">
+                <div class="header-close" @click.stop="close" :title="t('common.close')">
                     <font-awesome-icon :icon="['far', 'window-close']" />
                 </div>
             </div>

--- a/client/src/game/ui/ModalStack.vue
+++ b/client/src/game/ui/ModalStack.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+/**
+ * This component is responsible for management of general modal windows
+ * that require no immediate interaction.
+ *
+ * This component takes care of which modal is on top of which modal as well as
+ * closing the top-most modal with the escape-key.
+ *
+ * Any Modal component that is used here, _should_ expose a close function
+ * that can be get/set, as well as emit the following events:
+ * - `focus`: when the modal is interacted with
+ * - `close`: when the modal is closed
+ */
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import type { Component, ComputedRef } from "vue";
 
 import { getGameState } from "../../store/_game";
@@ -8,18 +20,18 @@ import { clientState } from "../systems/client/state";
 
 import DiceResults from "./dice/DiceResults.vue";
 import Initiative from "./initiative/Initiative.vue";
-import LgGridId from "./lg/GridId.vue";
-import SelectionInfo from "./SelectionInfo.vue";
 import ClientSettings from "./settings/client/ClientSettings.vue";
 import DmSettings from "./settings/dm/DmSettings.vue";
 import FloorSettings from "./settings/FloorSettings.vue";
 import LgSettings from "./settings/lg/LgSettings.vue";
 import LocationSettings from "./settings/location/LocationSettings.vue";
 import ShapeSettings from "./settings/shape/ShapeSettings.vue";
-import CreateTokenDialog from "./tokendialog/CreateTokenDialog.vue";
 
 const hasGameboard = coreStore.state.boardId !== undefined;
 const hasGameboardClients = computed(() => clientState.reactive.clientBoards.size > 0);
+
+const refs: Record<number, { close: () => void }> = {};
+(window as any).refs = refs;
 
 const dmOrFake = computed(() => {
     const state = getGameState();
@@ -28,27 +40,41 @@ const dmOrFake = computed(() => {
 
 const modals: (Component | { component: Component; condition: ComputedRef<boolean> })[] = [
     ClientSettings,
-    CreateTokenDialog,
-    DiceResults,
     { component: DmSettings, condition: dmOrFake },
     { component: FloorSettings, condition: dmOrFake },
     Initiative,
     { component: LgSettings, condition: computed(() => hasGameboardClients.value && dmOrFake.value) },
     { component: LocationSettings, condition: dmOrFake },
-    SelectionInfo,
     ShapeSettings,
 ];
-if (hasGameboard) {
-    modals.push(LgGridId, DiceResults);
+if (!hasGameboard) {
+    modals.push(DiceResults);
 }
 const modalOrder = ref(Array.from({ length: modals.length }, (_, i) => i));
+const openModals = new Set<number>();
+(window as any).openModals = openModals;
+
+onMounted(() => {
+    window.addEventListener("keydown", checkEscape);
+});
+onUnmounted(() => window.removeEventListener("keydown", checkEscape));
 
 function focus(index: number): void {
-    modalOrder.value.push(modalOrder.value.splice(index, 1)[0]);
+    const idx = modalOrder.value.splice(index, 1)[0];
+    modalOrder.value.push(idx);
+    openModals.add(idx);
+}
+
+function close(index: number): void {
+    openModals.delete(modalOrder.value[index]);
 }
 
 function isComponent(x: Component | { component: Component }): x is Component {
     return !("component" in x);
+}
+
+function isReffable(x: Component): x is { close: () => void } {
+    return "close" in x;
 }
 
 const visibleModals = computed(() => {
@@ -63,13 +89,42 @@ const visibleModals = computed(() => {
     }
     return _modals;
 });
+
+function checkEscape(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+        for (let i = modalOrder.value.length - 1; i--; i >= 0) {
+            if (openModals.has(i)) {
+                refs[i].close();
+                openModals.delete(i);
+                if (!event.ctrlKey) break;
+            }
+        }
+    }
+}
+
+function getComponentName(index: number): string {
+    const modal = modals[index];
+    const component = (isComponent(modal) ? modal : modal.component) as { __name: string };
+    return component.__name;
+}
+
+function setModalRef(m: Component | null, index: number): void {
+    if (m === null) return;
+    if (isReffable(m)) refs[index] = m;
+    else console.warn(`Modal without exposed close function found. (${getComponentName(index)})`);
+}
 </script>
 
 <template>
-    <component
-        v-for="modal of visibleModals"
-        :is="modal.component"
-        :key="modal.component"
-        @focus="focus(modal.index)"
-    />
+    <div>
+        <component
+            v-for="modal of visibleModals"
+            :ref="(m: Component | null) => setModalRef(m, modal.index)"
+            :is="modal.component"
+            :key="modal.component"
+            @focus="focus(modal.index)"
+            @close="close(modal.index)"
+            @update:visible="close(modal.index)"
+        />
+    </div>
 </template>

--- a/client/src/game/ui/NoteDialog.vue
+++ b/client/src/game/ui/NoteDialog.vue
@@ -54,7 +54,7 @@ function close(): void {
                     <font-awesome-icon icon="pencil-alt" />
                 </span>
                 <input :value="note.title" ref="title" @change="setTitle" />
-                <div class="header-close" @click="close" :title="t('common.close')">
+                <div class="header-close" @click.stop="close" :title="t('common.close')">
                     <font-awesome-icon :icon="['far', 'window-close']" />
                 </div>
             </div>

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -18,9 +18,12 @@ import { showDefaultContextMenu, showShapeContextMenu } from "./contextmenu/stat
 import LgDiceResults from "./dice/LgDiceResults.vue";
 import Floors from "./Floors.vue";
 import { initiativeStore } from "./initiative/state";
+import LgGridId from "./lg/GridId.vue";
 import LocationBar from "./menu/LocationBar.vue";
 import MenuBar from "./menu/MenuBar.vue";
 import ModalStack from "./ModalStack.vue";
+import SelectionInfo from "./SelectionInfo.vue";
+import CreateTokenDialog from "./tokendialog/CreateTokenDialog.vue";
 import { tokenDialogVisible } from "./tokendialog/state";
 import TokenDirections from "./TokenDirections.vue";
 import Tools from "./tools/Tools.vue";
@@ -176,6 +179,7 @@ function setTempZoomDisplay(value: number): void {
                 <span class="rm-topper"></span>
             </div>
         </div>
+        <!-- Core overlays -->
         <MenuBar />
         <Tools />
         <LocationBar v-if="getGameState().isDm" :active="visible.locations" :menuActive="visible.settings" />
@@ -183,10 +187,16 @@ function setTempZoomDisplay(value: number): void {
         <DefaultContext />
         <ShapeContext />
         <Annotation />
+        <LgGridId v-if="hasGameboard" />
+        <SelectionInfo />
         <template v-if="hasGameboard"><LgDiceResults /></template>
+        <!-- Modals that can be rearranged -->
         <ModalStack />
+        <!-- Modals that require immediate attention -->
+        <CreateTokenDialog />
         <div id="teleport-modals"></div>
         <MarkdownModal v-if="showChangelog" :title="t('game.ui.ui.new_ver_msg')" :source="changelogText" />
+        <!-- end of main modals -->
         <div id="oob" v-if="positionState.reactive.outOfBounds" @click="positionSystem.returnToBounds">
             Click to return to content
         </div>

--- a/client/src/game/ui/dice/DiceResults.vue
+++ b/client/src/game/ui/dice/DiceResults.vue
@@ -17,6 +17,8 @@ function close(): void {
     diceStore.setShowDiceResults(undefined);
 }
 
+defineExpose({ close });
+
 function sum(data: readonly number[]): number {
     return data.reduce((acc, val) => acc + val);
 }

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -26,9 +26,16 @@ import { initiativeStore } from "./state";
 const { t } = useI18n();
 const modals = useModal();
 
+const emit = defineEmits(["close"]);
+
 const isDm = toRef(getGameState(), "isDm");
 
-const close = (): void => initiativeStore.show(false, false);
+const close = (): void => {
+    initiativeStore.show(false, false);
+    emit("close");
+};
+defineExpose({ close });
+
 const clearValues = (): void => initiativeStore.clearValues(true);
 const nextTurn = (): void => initiativeStore.nextTurn();
 const previousTurn = (): void => initiativeStore.previousTurn();
@@ -172,7 +179,7 @@ function n(e: any): number {
         <template v-slot:header="m">
             <div class="modal-header" draggable="true" @dragstart="m.dragStart" @dragend="m.dragEnd">
                 <div>{{ t("common.initiative") }}</div>
-                <div class="header-close" @click="close" :title="t('common.close')">
+                <div class="header-close" @click.stop="close" :title="t('common.close')">
                     <font-awesome-icon :icon="['far', 'window-close']" />
                 </div>
             </div>

--- a/client/src/game/ui/settings/FloorSettings.vue
+++ b/client/src/game/ui/settings/FloorSettings.vue
@@ -24,6 +24,7 @@ const modals = useModal();
 
 const visible = toRef(uiStore.state, "showFloorSettings");
 const close = uiStore.hideFloorSettings.bind(uiStore);
+defineExpose({ close });
 
 const floor = computed(() => floorSystem.getFloor({ id: uiStore.state.selectedFloor }));
 

--- a/client/src/game/ui/settings/client/ClientSettings.vue
+++ b/client/src/game/ui/settings/client/ClientSettings.vue
@@ -23,6 +23,11 @@ const visible = computed({
     },
 });
 
+function close(): void {
+    visible.value = false;
+}
+
+defineExpose({ close });
 const categoryNames = [
     ClientSettingCategory.Appearance,
     ClientSettingCategory.Behaviour,

--- a/client/src/game/ui/settings/dm/DmSettings.vue
+++ b/client/src/game/ui/settings/dm/DmSettings.vue
@@ -23,6 +23,11 @@ const visible = computed({
     },
 });
 
+function close(): void {
+    visible.value = false;
+}
+defineExpose({ close });
+
 const categoryNames = computed(() => {
     return [
         DmSettingCategory.Admin,

--- a/client/src/game/ui/settings/lg/LgSettings.vue
+++ b/client/src/game/ui/settings/lg/LgSettings.vue
@@ -19,6 +19,11 @@ const visible = computed({
     },
 });
 
+function close(): void {
+    visible.value = false;
+}
+defineExpose({ close });
+
 const categoryNames = [LgSettingCategory.Grid];
 </script>
 

--- a/client/src/game/ui/settings/location/LocationSettings.vue
+++ b/client/src/game/ui/settings/location/LocationSettings.vue
@@ -26,6 +26,11 @@ const visible = computed({
     },
 });
 
+function close(): void {
+    visible.value = false;
+}
+defineExpose({ close });
+
 const locationName = computed(
     () => locationStore.activeLocations.value.find((l) => l.id === location.value)?.name ?? "",
 );

--- a/client/src/game/ui/settings/shape/LogicPermissions.vue
+++ b/client/src/game/ui/settings/shape/LogicPermissions.vue
@@ -100,7 +100,7 @@ function hideModal(): void {
         <template v-slot:header="m">
             <div class="modal-header" draggable="true" @dragstart="m.dragStart" @dragend="m.dragEnd">
                 Configure logic permissions
-                <div class="header-close" @click="hideModal" :title="t('common.close')">
+                <div class="header-close" @click.stop="hideModal" :title="t('common.close')">
                     <font-awesome-icon :icon="['far', 'window-close']" />
                 </div>
             </div>

--- a/client/src/game/ui/settings/shape/ShapeSettings.vue
+++ b/client/src/game/ui/settings/shape/ShapeSettings.vue
@@ -26,6 +26,11 @@ const visible = computed({
     },
 });
 
+function close(): void {
+    visible.value = false;
+}
+defineExpose({ close });
+
 const hasShape = computed(() => activeShapeStore.state.id !== undefined);
 
 const categoryNames = computed(() => {


### PR DESCRIPTION
With the addition of #1135 there now is a concept of topmost modal.

This PR adds the ability to close the topmost modal by pressing the escape key.

This closes #1062. Although that request wanted to close all open modals, I personally see more value in more fine-grained close mechanics. Definitely given that there aren't that many modals you probably have open anyway, so pressing escape once or twice more shouldn't be a huge deal.