### PR TITLE
bug(FakePlayer): Hide DM layer when fake-player is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool: right-click was opening the context-menu
 -   Spell tool: once used, the select tool was not being properly activated
 -   Spell tool: the 'is public' label was wrongly attached to the range input box
+-   Fake Player: showing DM layer
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/floor/server.ts
+++ b/client/src/game/floor/server.ts
@@ -2,6 +2,7 @@ import { hasGroup, addNewGroup } from "../groups";
 import type { ILayer } from "../interfaces/layer";
 import { createCanvas } from "../layers/canvas";
 import { recalculateZIndices } from "../layers/floor";
+import { DmLayer } from "../layers/variants/dm";
 import { FowLightingLayer } from "../layers/variants/fowLighting";
 import { FowVisionLayer } from "../layers/variants/fowVision";
 import { GridLayer } from "../layers/variants/grid";
@@ -56,6 +57,8 @@ function addServerLayer(layerInfo: ServerLayer, floor: Floor): void {
         layer = new FowVisionLayer(canvas, layerName, floor.id, layerInfo.index);
     } else if (layerName === LayerName.Map) {
         layer = new MapLayer(canvas, layerName, floor.id, layerInfo.index);
+    } else if (layerName === LayerName.Dm) {
+        layer = new DmLayer(canvas, layerName, floor.id, layerInfo.index);
     } else {
         layer = new Layer(canvas, layerName, floor.id, layerInfo.index);
     }

--- a/client/src/game/layers/variants/dm.ts
+++ b/client/src/game/layers/variants/dm.ts
@@ -1,0 +1,13 @@
+import { getGameState } from "../../../store/_game";
+
+import { Layer } from "./layer";
+
+export class DmLayer extends Layer {
+    draw(doClear = true): void {
+        if (getGameState().isFakePlayer) {
+            if (doClear) this.clear();
+        } else {
+            super.draw(doClear);
+        }
+    }
+}


### PR DESCRIPTION
The goal of the fake-player view is to have a sense of what players would see.
The DM layer is obviously not part of that and is from now-on no longer shown while FP is active.