### PR TITLE
feat(Initiative): Limit movement during initiative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ tech changes will usually be stripped from release notes for the public
     -   The above setting now also properly reverts to the original vision lock when initiative is no longer active as was always intended
     -   The initiative UI is automatically opened for everybody once initiative is started. (and automatically closed as well)
     -   The above behaviour can be disabled by a new user setting.
+    -   A new DM setting (under Varia) can be enabled to limit (non-DM) initiated movement only to the active initiative shape.
 -   Most modals will now move to the front when interacted with
 -   Most modals can be closed with escape
 

--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -88,6 +88,8 @@ function setLocationOptions(
 
     if (overwrite_all || options.move_player_on_token_change !== undefined)
         locationSettingsSystem.setMovePlayerOnTokenChange(options.move_player_on_token_change, id, false);
+    if (overwrite_all || options.limit_movement_during_initiative !== undefined)
+        locationSettingsSystem.setLimitMovementDuringInitiative(options.limit_movement_during_initiative, id, false);
 
     // SPAWN LOCATIONS
 

--- a/client/src/game/systems/settings/location/index.ts
+++ b/client/src/game/systems/settings/location/index.ts
@@ -180,6 +180,16 @@ class LocationSettingsSystem implements System {
         if (sync) sendLocationOption("move_player_on_token_change", movePlayerOnTokenChange, location);
     }
 
+    setLimitMovementDuringInitiative(
+        limitMovementDuringInitiative: boolean | undefined,
+        location: number | undefined,
+        sync: boolean,
+    ): void {
+        if (!this.setValue($.limitMovementDuringInitiative, limitMovementDuringInitiative, location)) return;
+
+        if (sync) sendLocationOption("limit_movement_during_initiative", limitMovementDuringInitiative, location);
+    }
+
     // SPAWN LOCATIONS
 
     setSpawnLocations(spawnLocations: GlobalId[], location: number, sync: boolean): void {

--- a/client/src/game/systems/settings/location/models.ts
+++ b/client/src/game/systems/settings/location/models.ts
@@ -16,6 +16,7 @@ export interface ServerLocationOptions {
     vision_max_range: number;
     spawn_locations: string;
     move_player_on_token_change: boolean;
+    limit_movement_during_initiative: boolean;
 
     air_map_background: string;
     ground_map_background: string;
@@ -37,6 +38,7 @@ export interface LocationOptions {
     // when switching locations this can be completely wrong
     spawnLocations: GlobalId[];
     movePlayerOnTokenChange: boolean;
+    limitMovementDuringInitiative: boolean;
 
     airMapBackground: string;
     groundMapBackground: string;

--- a/client/src/game/systems/settings/location/state.ts
+++ b/client/src/game/systems/settings/location/state.ts
@@ -22,6 +22,7 @@ function getInitState(): State {
         visionMaxRange: init(0),
         visionMinRange: init(0),
         visionMode: init(""),
+        limitMovementDuringInitiative: init(false),
 
         airMapBackground: init("none"),
         groundMapBackground: init("none"),

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -322,6 +322,10 @@ class InitiativeStore extends Store<InitiativeState> {
 
     // EXTRA
 
+    getActor(): InitiativeData | undefined {
+        return this._state.locationData[this._state.turnCounter];
+    }
+
     getDataSet(): InitiativeData[] {
         return this._state[this._state.editLock === undefined ? "locationData" : "newData"];
     }

--- a/client/src/game/ui/settings/location/VariaSettings.vue
+++ b/client/src/game/ui/settings/location/VariaSettings.vue
@@ -24,6 +24,15 @@ const movePlayerOnTokenChange = computed({
     },
 });
 
+const limitMovementDuringInitiative = computed({
+    get() {
+        return getOption($.limitMovementDuringInitiative, location.value).value;
+    },
+    set(limitMovementDuringInitiative: boolean | undefined) {
+        lss.setLimitMovementDuringInitiative(limitMovementDuringInitiative, location.value, true);
+    },
+});
+
 function o(k: any): boolean {
     return getOption(k, location.value).override !== undefined;
 }
@@ -57,6 +66,26 @@ function o(k: any): boolean {
             <div
                 v-if="!isGlobal && o($.movePlayerOnTokenChange)"
                 @click="movePlayerOnTokenChange = undefined"
+                :title="t('game.ui.settings.common.reset_default')"
+            >
+                <font-awesome-icon icon="times-circle" />
+            </div>
+            <div v-else></div>
+        </div>
+        <div class="row" :class="{ overwritten: !isGlobal && o($.limitMovementDuringInitiative) }">
+            <label :for="'limitMovementDuringInitiativeInput-' + location">
+                {{ t("game.ui.settings.VariaSettings.limitMovementDuringInitiative") }}
+            </label>
+            <div>
+                <input
+                    :id="'limitMovementDuringInitiativeInput-' + location"
+                    type="checkbox"
+                    v-model="limitMovementDuringInitiative"
+                />
+            </div>
+            <div
+                v-if="!isGlobal && o($.limitMovementDuringInitiative)"
+                @click="limitMovementDuringInitiative = undefined"
                 :title="t('game.ui.settings.common.reset_default')"
             >
                 <font-awesome-icon icon="times-circle" />

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -314,7 +314,8 @@
                     "underground_background": "Underground floor(s)"
                 },
                 "VariaSettings": {
-                    "movePlayerOnTokenChange": "Move player(s) when a token they own changes location"
+                    "movePlayerOnTokenChange": "Move player(s) when a token they own changes location",
+                    "limitMovementDuringInitiative": "Limit movement during initiative to active shape"
                 },
                 "LocationBar": {
                     "LocationAdminSettings": {

--- a/server/src/models/campaign.py
+++ b/server/src/models/campaign.py
@@ -55,6 +55,7 @@ class LocationOptions(BaseModel):
     air_map_background = TextField(default="none", null=True)
     ground_map_background = TextField(default="none", null=True)
     underground_map_background = TextField(default="none", null=True)
+    limit_movement_during_initiative = BooleanField(default=False, null=True)
 
     @classmethod
     def create_empty(cls):
@@ -73,6 +74,7 @@ class LocationOptions(BaseModel):
             air_map_background=None,
             ground_map_background=None,
             underground_map_background=None,
+            limit_movement_during_initiative=None,
         )
 
     def as_dict(self):

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 84
+SAVE_VERSION = 85
 
 import json
 import logging
@@ -376,6 +376,15 @@ def upgrade(db: SqliteExtDatabase, version: int):
             )
             db.execute_sql(
                 "UPDATE user_options SET initiative_open_on_activate = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
+            )
+    elif version == 84:
+        # Add LocationOptions.limit_movement_during_initiative
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE location_options ADD COLUMN limit_movement_during_initiative INTEGER DEFAULT 0"
+            )
+            db.execute_sql(
+                "UPDATE location_options SET limit_movement_during_initiative = NULL WHERE id NOT IN (SELECT default_options_id FROM room)"
             )
     else:
         raise UnknownVersionException(


### PR DESCRIPTION
This PR adds a new optional DM setting to limit movement during initiative.

The setting can be found in the `Varia` category.
When enabled, only the shape that is currently acting in the initiative tracker can be moved.

This rule is intended to keep some players in check who might move around too much when they aren't supposed to.

Do note that DMs themselves are not restricted by this rule.

Also important to note is that this rule only applies when "initiative is active". (see #1132)