### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ WORKDIR /usr/src/admin-client
 
 # Copy first package.json so changes in code dont require to reinstall all npm modules
 COPY admin-client/package.json admin-client/package-lock.json ./
-RUN npm i
+RUN npm i && npm cache clean --force;
 
 WORKDIR /usr/src/client
 
 # Copy first package.json so changes in code dont require to reinstall all npm modules
 COPY client/package.json client/package-lock.json ./
-RUN npm i
+RUN npm i && npm cache clean --force;
 
 ARG PA_BASEPATH="/"
 
@@ -53,7 +53,7 @@ VOLUME /planarally/static/assets
 
 ENV PA_GIT_INFO docker:${DOCKER_TAG}-${SOURCE_COMMIT}
 
-RUN apt-get update && apt-get install dumb-init curl libffi-dev libssl-dev gcc -y && \
+RUN apt-get update && apt-get install --no-install-recommends dumb-init curl libffi-dev libssl-dev gcc -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy first requirements.txt so changes in code dont require to reinstall python requirements


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size. I did not update the changelog since it does not change the software itself. I hope it is what is expected.

Summary of the changes:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.


Impact on the image size:
* Image size before repair: 342.55 MB
* Image size after repair: 311.48 MB
* Difference: 31.07 MB (9.07%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,