### PR TITLE
bug(AdminSettings): Fix removing last DM being possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool: once used, the select tool was not being properly activated
 -   Spell tool: the 'is public' label was wrongly attached to the range input box
 -   Fake Player: showing DM layer
+-   DM settings: Fix last DM being able to demote themselves to a player
 
 ## [2022.3.0] - 2022-12-12
 

--- a/server/src/api/socket/player.py
+++ b/server/src/api/socket/player.py
@@ -60,6 +60,16 @@ async def set_player_role(sid: str, data: PlayerRoleChange):
         )
         return
 
+    if pr.role == Role.DM and new_role != Role.DM:
+        dm_players = PlayerRoom.filter(room=pr.room, role=Role.DM).where(
+            PlayerRoom.player != data["player"]
+        )
+        if dm_players.count() == 0:
+            logger.warning(
+                f"{pr.player.name} attempted to change the role of the last dm in the campaign"
+            )
+            return
+
     player_pr.role = new_role
     player_pr.save()
 


### PR DESCRIPTION
This closes #1144

The last DM was able to demote themselves to player, causing the campaign to become unmanageable.