### PR TITLE
bug(Assets): Fix asset default stroke colour being set wrongly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool: the 'is public' label was wrongly attached to the range input box
 -   Fake Player: showing DM layer
 -   DM settings: Fix last DM being able to demote themselves to a player
+-   Assets: default stroke colour wrongly set, causing badges to be transparent
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -22,7 +22,6 @@ export class Asset extends BaseRect implements IAsset {
     type: SHAPE_TYPE = "assetrect";
     img: HTMLImageElement;
     src = "";
-    strokeColour = ["white"];
     #loaded: boolean;
 
     svgData?: { svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }[];
@@ -34,7 +33,7 @@ export class Asset extends BaseRect implements IAsset {
         h: number,
         options?: { id?: LocalId; uuid?: GlobalId; assetId?: number; loaded?: boolean; isSnappable?: boolean },
     ) {
-        super(topleft, w, h, { isSnappable: false, ...options });
+        super(topleft, w, h, { isSnappable: false, ...options }, { strokeColour: ["white"] });
         this.img = img;
         this.#loaded = options?.loaded ?? true;
     }


### PR DESCRIPTION
The default colour for assets was no longer properly set since the introduction of the propertiesSystem.
This affected things like the badge background which uses this colour.

This fixes #1143