### PR TITLE
feat(Dice): Add min-height to dice tool UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool
     -   range property is removed as it was confusing to people and a bit fiddly
     -   a ruler is now automatically drawn between the spell shape and the selected shape
+-   Dice tool: Add min-height in dice tool UI where the dice to roll are being prepared
 -   [lang] The edit dialog for shapes now properly says "Edit shape" instead of "Edit asset"
 
 ### Fixed

--- a/client/src/game/ui/tools/DiceTool.vue
+++ b/client/src/game/ui/tools/DiceTool.vue
@@ -109,7 +109,7 @@ async function go(): Promise<void> {
             <div @click="add(6)">6</div>
             <div @click="add(4)">4</div>
         </div>
-        <div>{{ diceText }}</div>
+        <div style="min-height: 1.5rem">{{ diceText }}</div>
         <div id="dice-input">
             <button @click="diceArray = []">clear</button>
             <button ref="button" @click="go">GO</button>


### PR DESCRIPTION
The area in the dice tool UI where the dice to roll are being prepared (e.g. 2d20 + 1d10), was being implicitly sized (in height). Which causes a janky jump of the other dice controls when the first die is added, which is kinda annoying.

This PR fixes this by just setting a minimum height to that UI element.