### PR TITLE
bug(Trackers): Fix some missing client-side access checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ tech changes will usually be stripped from release notes for the public
 -   Fake Player: showing DM layer
 -   DM settings: Fix last DM being able to demote themselves to a player
 -   Assets: default stroke colour wrongly set, causing badges to be transparent
+-   Trackers:
+    -   some cases where a client could edit information for shapes they didn't have access to
+        (The above was never accepted by the server or sent to other clients)
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/core/components/ColourPicker.vue
+++ b/client/src/core/components/ColourPicker.vue
@@ -14,11 +14,15 @@ enum InputMode {
     Rgba,
 }
 
-const props = withDefaults(defineProps<{ colour?: string; showAlpha?: boolean; vShow?: boolean }>(), {
-    colour: "rgba(0, 0, 0, 1)",
-    showAlpha: true,
-    vShow: true,
-});
+const props = withDefaults(
+    defineProps<{ colour?: string; showAlpha?: boolean; vShow?: boolean; disabled?: boolean }>(),
+    {
+        colour: "rgba(0, 0, 0, 1)",
+        showAlpha: true,
+        vShow: true,
+        disabled: false,
+    },
+);
 const emit = defineEmits<(e: "input:colour" | "update:colour", c: string) => void>();
 
 const alpha = ref<HTMLDivElement | null>(null);
@@ -79,6 +83,7 @@ function setPosition(): void {
 }
 
 async function open(event: Event): Promise<void> {
+    if (props.disabled) return;
     originalColor = tc.value.toRgbString();
     setPosition();
     visible.value = true;
@@ -250,7 +255,7 @@ function setHex(hex: string): void {
 </script>
 
 <template>
-    <div v-show="vShow" v-bind="$attrs" ref="picker" class="outer" @click="open">
+    <div v-show="vShow" v-bind="$attrs" ref="picker" class="outer" :class="{ noAccess: disabled }" @click="open">
         <div
             class="current-color"
             :style="
@@ -436,6 +441,10 @@ function setHex(hex: string): void {
         height: 13px;
         background-color: #000;
         border: solid 1px black;
+    }
+
+    &.noAccess:hover {
+        cursor: not-allowed;
     }
 }
 

--- a/client/src/core/components/RotationSlider.vue
+++ b/client/src/core/components/RotationSlider.vue
@@ -7,6 +7,7 @@ const props = withDefaults(
     defineProps<{
         angle: number;
         showNumberInput?: boolean;
+        disabled: boolean;
     }>(),
     { showNumberInput: false },
 );
@@ -36,6 +37,7 @@ onMounted(() => {
 });
 
 function mouseDown(): void {
+    if (props.disabled) return;
     active = true;
 }
 
@@ -75,7 +77,9 @@ function mouseMove(event: MouseEvent): void {
         >
             <div class="slider" :style="{ left: `${left}px`, top: `${top}px` }"></div>
         </div>
-        <div v-if="showNumberInput"><input v-model.number="degreeAngle" type="number" @change="syncDegreeAngle" /></div>
+        <div v-if="showNumberInput">
+            <input v-model.number="degreeAngle" type="number" :disabled="disabled" @change="syncDegreeAngle" />
+        </div>
     </div>
 </template>
 

--- a/client/src/game/ui/SelectionInfo.vue
+++ b/client/src/game/ui/SelectionInfo.vue
@@ -37,7 +37,7 @@ function openEditDialog(): void {
 }
 
 function changeValue(tracker: Tracker | Aura): void {
-    if (shapeId.value === undefined) return;
+    if (shapeId.value === undefined || !accessState.hasEditAccess.value) return;
 
     activeTracker.value = tracker;
 }
@@ -76,7 +76,7 @@ function setValue(data: { solution: number; relativeMode: boolean }): void {
                     <font-awesome-icon icon="edit" />
                 </div>
                 <div id="selection-name">{{ propertiesState.reactive.name }}</div>
-                <div id="selection-values">
+                <div id="selection-values" :class="{ noAccess: !accessState.hasEditAccess.value }">
                     <template v-for="tracker in trackers" :key="tracker.uuid">
                         <div>{{ tracker.name }}</div>
                         <div
@@ -130,41 +130,44 @@ function setValue(data: { solution: number; relativeMode: boolean }): void {
         background-color: #82c8a0;
         opacity: 1;
     }
-}
 
-#selection-lock-button {
-    position: absolute;
-    right: 13px;
-    top: 30px;
-    cursor: pointer;
-}
-
-#selection-edit-button {
-    position: absolute;
-    right: 10px;
-    top: 10px;
-    cursor: pointer;
-}
-
-#selection-values {
-    display: grid;
-    grid-template-columns: [name] 1fr [value] max-content;
-}
-
-.selection-tracker-value,
-.selection-aura-value {
-    justify-self: center;
-    padding: 2px;
-
-    &:hover {
+    #selection-lock-button {
+        position: absolute;
+        right: 13px;
+        top: 30px;
         cursor: pointer;
-        background-color: rgba(20, 20, 20, 0.2);
     }
-}
 
-#selection-name {
-    font-size: 20px;
-    font-weight: bold;
-    margin-bottom: 10px;
+    #selection-edit-button {
+        position: absolute;
+        right: 10px;
+        top: 10px;
+        cursor: pointer;
+    }
+
+    #selection-values {
+        display: grid;
+        grid-template-columns: [name] 1fr [value] max-content;
+
+        .selection-tracker-value {
+            justify-self: center;
+            padding: 2px;
+
+            &:hover {
+                cursor: pointer;
+                background-color: rgba(20, 20, 20, 0.2);
+            }
+        }
+
+        &.noAccess .selection-tracker-value:hover {
+            cursor: not-allowed;
+        }
+    }
+
+    #selection-name {
+        font-size: 20px;
+        font-weight: bold;
+        margin-bottom: 10px;
+    }
 }
 </style>

--- a/client/src/game/ui/settings/shape/TrackerSettings.vue
+++ b/client/src/game/ui/settings/shape/TrackerSettings.vue
@@ -281,6 +281,7 @@ function toggleCompositeAura(shape: LocalId, auraId: AuraId): void {
                         <input
                             type="number"
                             :value="aura.angle"
+                            :disabled="!owned"
                             min="1"
                             max="360"
                             @change="updateAura(aura, { angle: parseFloat(getValue($event)) })"
@@ -288,6 +289,7 @@ function toggleCompositeAura(shape: LocalId, auraId: AuraId): void {
                         <RotationSlider
                             :angle="aura.direction"
                             :show-number-input="true"
+                            :disabled="!owned"
                             @input="
                                 (direction) => {
                                     updateAura(aura, { direction }, false);


### PR DESCRIPTION
This fixes #1150.

Some tracker/aura related settings did not do proper access checks on the client side, allowing players to edit some public tracker/aura information for shapes they otherwise don't have access to.

These changes however were always rejected by the server and thus never reached other players.