### PR TITLE
bug(UI): Fix some DM elements being visible to players

### DIFF
--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -113,7 +113,7 @@ const openLgSettings = (): void => uiSystem.showLgSettings(!uiState.raw.showLgSe
     <div id="menu" @click="settingsClick">
         <div style="width: 12.5rem; overflow-y: auto; overflow-x: hidden">
             <!-- ASSETS -->
-            <template v-if="gameState.isDmOrFake">
+            <template v-if="gameState.isDmOrFake.value">
                 <button class="menu-accordion">{{ t("common.assets") }}</button>
                 <div id="menu-assets" class="menu-accordion-panel" style="position: relative">
                     <input id="asset-search" v-model="assetSearch" :placeholder="t('common.search')" />

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -127,7 +127,7 @@ function toggleFakePlayer(): void {
                 <li id="tool-mode"></li>
             </ul>
             <div v-if="!hasGameboard" id="tool-status">
-                <div v-if="gameState.isDmOrFake" id="tool-status-toggles">
+                <div v-if="gameState.isDmOrFake.value" id="tool-status-toggles">
                     <div
                         :class="{ active: gameState.reactive.isFakePlayer }"
                         title="Toggle fake-player"


### PR DESCRIPTION
A recent refactor to reason about `dm` and `fakePlayer` mode, was incorrectly checking this value in 2 components causing them to be visible to players.

this fixes #1152