### PR TITLE
bug(Draw): drawing no longer working if vision or movement is blocked

### DIFF
--- a/client/src/game/api/events/shape/circularToken.ts
+++ b/client/src/game/api/events/shape/circularToken.ts
@@ -8,5 +8,5 @@ socket.on("Shape.CircularToken.Value.Set", (data: { uuid: GlobalId; text: string
     if (shape === undefined) return;
 
     shape.text = data.text;
-    shape.layer.invalidate(true);
+    shape.layer?.invalidate(true);
 });

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -20,7 +20,7 @@ socket.on("Shape.Set", (data: ServerShape) => {
     const old = getShapeFromGlobal(data.uuid);
     const isActive = activeShapeStore.state.id === getLocalId(data.uuid);
     const hasEditDialogOpen = isActive && activeShapeStore.state.showEditDialog;
-    if (old) old.layer.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
+    if (old) old.layer?.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
     const shape = addShape(data, SyncMode.NO_SYNC);
 
     if (shape && isActive) {
@@ -67,7 +67,7 @@ socket.on("Shape.Order.Set", (data: { uuid: GlobalId; index: number }) => {
         console.log(`Attempted to move the shape order of an unknown shape`);
         return;
     }
-    shape.layer.moveShapeOrder(shape, data.index, SyncMode.NO_SYNC);
+    shape.layer?.moveShapeOrder(shape, data.index, SyncMode.NO_SYNC);
 });
 
 socket.on("Shapes.Floor.Change", (data: { uuids: GlobalId[]; floor: string }) => {
@@ -91,7 +91,7 @@ socket.on("Shape.Rect.Size.Update", (data: { uuid: GlobalId; w: number; h: numbe
 
     shape.w = data.w;
     shape.h = data.h;
-    shape.layer.invalidate(!shape.triggersVisionRecalc);
+    shape.layer?.invalidate(!shape.triggersVisionRecalc);
 });
 
 socket.on("Shape.Circle.Size.Update", (data: { uuid: GlobalId; r: number }) => {
@@ -99,5 +99,5 @@ socket.on("Shape.Circle.Size.Update", (data: { uuid: GlobalId; r: number }) => {
     if (shape === undefined) return;
 
     shape.r = data.r;
-    shape.layer.invalidate(!shape.triggersVisionRecalc);
+    shape.layer?.invalidate(!shape.triggersVisionRecalc);
 });

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -116,8 +116,11 @@ socket.on("Shape.Options.SvgAsset.Set", async (data: { shape: GlobalId; value: s
         delete shape.options.svgHeight;
         delete shape.options.svgPaths;
         delete shape.options.svgWidth;
-        visionState.recalculateVision(shape.floor.id);
-        floorSystem.invalidate({ id: shape.floor.id });
+        const floorId = shape.floorId;
+        if (floorId !== undefined) {
+            visionState.recalculateVision(floorId);
+            floorSystem.invalidate({ id: floorId });
+        }
     } else {
         shape.options.svgAsset = data.value;
         await (shape as IAsset).loadSvgs();

--- a/client/src/game/api/events/shape/text.ts
+++ b/client/src/game/api/events/shape/text.ts
@@ -8,7 +8,7 @@ socket.on("Shape.Text.Value.Set", (data: { uuid: GlobalId; text: string }) => {
     if (shape === undefined) return;
 
     shape.text = data.text;
-    shape.layer.invalidate(true);
+    shape.layer?.invalidate(true);
 });
 
 socket.on("Shape.Text.Size.Update", (data: { uuid: GlobalId; font_size: number }) => {
@@ -16,5 +16,5 @@ socket.on("Shape.Text.Size.Update", (data: { uuid: GlobalId; font_size: number }
     if (shape === undefined) return;
 
     shape.fontSize = data.font_size;
-    shape.layer.invalidate(!shape.triggersVisionRecalc);
+    shape.layer?.invalidate(!shape.triggersVisionRecalc);
 });

--- a/client/src/game/drag.ts
+++ b/client/src/game/drag.ts
@@ -12,12 +12,15 @@ import { cw, ccw, intersection, orientation } from "./vision/triag";
 export function calculateDelta(delta: Vector, sel: IShape, shrink = false): Vector {
     if (delta.x === 0 && delta.y === 0) return delta;
     const center = toArrayP(sel.center);
-    const centerTriangle = visionState.getCDT(TriangulationTarget.MOVEMENT, sel.floor.id).locate(center, null).loc;
+
+    if (sel.floorId === undefined) return delta;
+
+    const centerTriangle = visionState.getCDT(TriangulationTarget.MOVEMENT, sel.floorId).locate(center, null).loc;
     for (let point of sel.points) {
         if (shrink) {
             point = [point[0] - (point[0] - center[0]) * 0.75, point[1] - (point[1] - center[1]) * 0.75];
         }
-        const lt = visionState.getCDT(TriangulationTarget.MOVEMENT, sel.floor.id).locate(point, centerTriangle);
+        const lt = visionState.getCDT(TriangulationTarget.MOVEMENT, sel.floorId).locate(point, centerTriangle);
         const triangle = lt.loc;
         if (triangle === null) continue;
         delta = checkTriangle(point, triangle, delta);

--- a/client/src/game/input/keyboard/up.ts
+++ b/client/src/game/input/keyboard/up.ts
@@ -26,7 +26,7 @@ export function onKeyUp(event: KeyboardEvent): void {
             const i = tokens.findIndex((o) => equalsP(o.center, positionSystem.screenCenter));
             const token = tokens[(i + 1) % tokens.length]!;
             setCenterPosition(token.center);
-            floorSystem.selectFloor({ name: token.floor.name }, true);
+            if (token.floorId !== undefined) floorSystem.selectFloor({ id: token.floorId }, true);
         }
         if (event.key === "Enter") {
             if (selectedSystem.hasSelection) {

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -56,8 +56,10 @@ export interface IShape extends SimpleShape {
 
     // POSITION
 
-    get floor(): Floor;
-    get layer(): ILayer;
+    readonly floorId: FloorId | undefined;
+    readonly layerName: LayerName | undefined;
+    get floor(): Floor | undefined;
+    get layer(): ILayer | undefined;
     get refPoint(): GlobalPoint;
     set refPoint(point: GlobalPoint);
     get angle(): number;

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -53,7 +53,7 @@ export class FowLightingLayer extends FowLayer {
                     const shape = getShape(sh);
                     if (shape === undefined) continue;
                     if (shape.options.skipDraw ?? false) continue;
-                    if (shape.floor.id !== activeFloor.id) continue;
+                    if (shape.floorId !== activeFloor.id) continue;
                     const bb = shape.getBoundingBox();
                     const lcenter = g2l(shape.center);
                     const alm = 0.8 * g2lz(bb.w);

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -40,7 +40,7 @@ export class FowVisionLayer extends FowLayer {
 
             for (const tokenId of accessState.activeTokens.value) {
                 const token = getShape(tokenId);
-                if (token === undefined || token.floor.id !== this.floor) continue;
+                if (token === undefined || token.floorId !== this.floor) continue;
                 const center = token.center;
                 const lcenter = g2l(center);
 

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -441,7 +441,7 @@ export class Layer implements ILayer {
                     for (const token of accessState.activeTokens.value) {
                         let found = false;
                         const shape = getShape(token);
-                        if (shape !== undefined && shape.floor.id === this.floor && shape.type === "assetrect") {
+                        if (shape !== undefined && shape.floorId === this.floor && shape.type === "assetrect") {
                             if (!shape.visibleInCanvas({ w: this.width, h: this.height }, { includeAuras: false })) {
                                 const ray = Ray.fromPoints(shape.center, bboxCenter);
                                 const { hit, min } = bbox.containsRay(ray);

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -83,10 +83,12 @@ export async function moveShapes(shapes: readonly IShape[], delta: Vector, tempo
         await teleportZoneSystem.checkTeleport(selectedSystem.get({ includeComposites: true }));
     }
 
-    const floorId = shapes[0]!.floor.id;
-    if (recalculateVision) visionState.recalculateVision(floorId);
-    if (recalculateMovement) visionState.recalculateMovement(floorId);
-    shapes[0]!.layer.invalidate(false);
+    const layer = shapes[0]?.layer;
+    if (layer !== undefined) {
+        if (recalculateVision) visionState.recalculateVision(layer.floor);
+        if (recalculateMovement) visionState.recalculateMovement(layer.floor);
+        layer.invalidate(false);
+    }
 }
 
 function canMove(shapeId: LocalId): boolean {

--- a/client/src/game/operations/resize.ts
+++ b/client/src/game/operations/resize.ts
@@ -40,9 +40,12 @@ export function resizeShape(
 
     if (!shape.preventSync) sendShapeSizeUpdate({ shape, temporary });
 
-    if (recalculateMovement) visionState.recalculateMovement(shape.floor.id);
-    if (recalculateVision) visionState.recalculateVision(shape.floor.id);
-    shape.layer.invalidate(false);
+    const layer = shape.layer;
+    if (layer !== undefined) {
+        if (recalculateMovement) visionState.recalculateMovement(layer.floor);
+        if (recalculateVision) visionState.recalculateVision(layer.floor);
+        layer.invalidate(false);
+    }
 
     return newResizePoint;
 }

--- a/client/src/game/operations/rotation.ts
+++ b/client/src/game/operations/rotation.ts
@@ -41,8 +41,10 @@ export function rotateShapes(
         if (!shape.preventSync) sendShapePositionUpdate([shape], temporary);
     }
 
-    const firstShape = shapes[0]!;
-    if (recalculateMovement) visionState.recalculateMovement(firstShape.floor.id);
-    if (recalculateVision) visionState.recalculateVision(firstShape.floor.id);
-    firstShape.layer.invalidate(false);
+    const layer = shapes[0]?.layer;
+    if (layer !== undefined) {
+        if (recalculateMovement) visionState.recalculateMovement(layer.floor);
+        if (recalculateVision) visionState.recalculateVision(layer.floor);
+        layer.invalidate(false);
+    }
 }

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -133,9 +133,12 @@ function handleLayerMove(shapes: LocalId[], from: LayerName, to: LayerName, dire
     const fullShapes = shapes.map((s) => getShape(s)!);
     let layerName = from;
     if (direction === "redo") layerName = to;
-    const floor = floorSystem.getFloor({ id: fullShapes[0]!.floor.id })!;
-    const layer = floorSystem.getLayer(floor, layerName)!;
-    moveLayer(fullShapes, layer, true);
+
+    const floor = fullShapes[0]?.floor;
+    if (floor !== undefined) {
+        const layer = floorSystem.getLayer(floor, layerName);
+        if (layer !== undefined) moveLayer(fullShapes, layer, true);
+    }
 }
 
 function handleShapeRemove(shapes: ServerShape[], direction: "undo" | "redo"): void {

--- a/client/src/game/rendering/auras.ts
+++ b/client/src/game/rendering/auras.ts
@@ -13,7 +13,7 @@ export function drawAuras(shape: IShape, ctx: CanvasRenderingContext2D): void {
     const lCenter = g2l(center);
 
     for (const aura of auraSystem.getAll(shape.id, true)) {
-        if (!aura.active || (!aura.visionSource && shape.layer.name === LayerName.Lighting)) continue;
+        if (!aura.active || (!aura.visionSource && shape.layerName === LayerName.Lighting)) continue;
 
         const value = aura.value > 0 && !isNaN(aura.value) ? aura.value : 0;
         const dim = aura.dim > 0 && !isNaN(aura.dim) ? aura.dim : 0;

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -174,13 +174,15 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
         const props = getProperties(sel.id)!;
         if (props.blocksVision) recalculateVision = true;
         if (props.blocksMovement) recalculateMovement = true;
-        sel.layer.removeShape(sel, { sync: SyncMode.NO_SYNC, recalculate: recalculateIterative, dropShapeId: true });
+        sel.layer?.removeShape(sel, { sync: SyncMode.NO_SYNC, recalculate: recalculateIterative, dropShapeId: true });
     }
     if (sync !== SyncMode.NO_SYNC) sendRemoveShapes({ uuids: removed, temporary: sync === SyncMode.TEMP_SYNC });
     if (!recalculateIterative) {
-        const floor = shapes[0]!.floor.id;
-        if (recalculateMovement) visionState.recalculate({ target: TriangulationTarget.MOVEMENT, floor });
-        if (recalculateVision) visionState.recalculate({ target: TriangulationTarget.VISION, floor });
-        floorSystem.invalidateVisibleFloors();
+        const floor = shapes[0]?.floorId;
+        if (floor !== undefined) {
+            if (recalculateMovement) visionState.recalculate({ target: TriangulationTarget.MOVEMENT, floor });
+            if (recalculateVision) visionState.recalculate({ target: TriangulationTarget.VISION, floor });
+            floorSystem.invalidateVisibleFloors();
+        }
     }
 }

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -53,9 +53,14 @@ export class Asset extends BaseRect implements IAsset {
 
     setLoaded(): void {
         // Late image loading affects floor lighting
-        this.layer.invalidate(true);
-        if (getProperties(this.id)?.isToken === true)
-            floorSystem.getLayer(this.floor, LayerName.Draw)?.invalidate(true);
+        this.layer?.invalidate(true);
+
+        // invalidate token directions
+        if (getProperties(this.id)?.isToken === true) {
+            const floor = this.floor;
+            if (floor !== undefined) floorSystem.getLayer(floor, LayerName.Draw)?.invalidate(true);
+        }
+
         floorSystem.invalidateLightAllFloors();
         this.#loaded = true;
     }
@@ -73,19 +78,19 @@ export class Asset extends BaseRect implements IAsset {
                 this.points.slice(1).map((p) => toGP(p)),
                 { openPolygon: false, isSnappable: false },
             );
-            this.layer.addShape(cover, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+            this.layer?.addShape(cover, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
             const svgs = await loadSvgData(`/static/assets/${this.options.svgAsset}`);
             this.svgData = [...svgs.values()].map((svg) => ({ svg, rp: this.refPoint, paths: undefined }));
             const props = getProperties(this.id)!;
             if (props.blocksVision) {
-                visionState.recalculateVision(this._floor!);
+                if (this.floorId !== undefined) visionState.recalculateVision(this.floorId);
                 visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: this.id });
             }
             if (props.blocksMovement) {
-                visionState.recalculateMovement(this._floor!);
+                if (this.floorId !== undefined) visionState.recalculateMovement(this.floorId);
                 visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: this.id });
             }
-            this.layer.removeShape(cover, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
+            this.layer?.removeShape(cover, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
             this.invalidate(false);
         }
     }

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -253,7 +253,7 @@ export class Polygon extends Shape implements IShape {
 
             const props = getProperties(this.id)!;
 
-            this.layer.addShape(
+            this.layer?.addShape(
                 newPolygon,
                 SyncMode.FULL_SYNC,
                 props.blocksVision ? InvalidationMode.WITH_LIGHT : InvalidationMode.NORMAL,
@@ -271,7 +271,7 @@ export class Polygon extends Shape implements IShape {
     pushPoint(point: GlobalPoint): void {
         this._vertices.push(point);
         this._points.push(this.invalidatePoint(point, this.center));
-        this.layer.updateSectors(this.id, this.getAuraAABB());
+        this.layer?.updateSectors(this.id, this.getAuraAABB());
         if (this.isSnappable) this.updateLayerPoints();
     }
 
@@ -313,8 +313,10 @@ export class Polygon extends Shape implements IShape {
 
         if (invalidate) {
             const props = getProperties(this.id)!;
-            if (props.blocksVision) visionState.recalculateVision(this.floor.id);
-            if (props.blocksMovement) visionState.recalculateMovement(this.floor.id);
+            if (this.floorId !== undefined) {
+                if (props.blocksVision) visionState.recalculateVision(this.floorId);
+                if (props.blocksMovement) visionState.recalculateMovement(this.floorId);
+            }
             if (!this.preventSync) sendShapePositionUpdate([this], false);
 
             this.invalidatePoints();

--- a/client/src/game/shapes/variants/text.ts
+++ b/client/src/game/shapes/variants/text.ts
@@ -170,7 +170,7 @@ export class Text extends Shape implements IText {
     private getLines(ctx: CanvasRenderingContext2D): { text: string; x: number; y: number }[] {
         const lines = this.text.split("\n");
         const allLines: { text: string; x: number; y: number }[] = [];
-        const maxWidth = this.layer.width;
+        const maxWidth = this.layer?.width ?? 0;
         const lineHeight = 30;
         const x = 0; // this.refPoint.x;
         let y = 0; // this.refPoint.y;

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -125,8 +125,8 @@ class AuraSystem implements ShapeSystem {
             const shape = getShape(id);
 
             if (shape && aura.visionSource) {
-                const floor = shape.floor;
-                visionState.addVisionSource({ aura: aura.uuid, shape: id }, floor.id);
+                if (shape.floorId !== undefined)
+                    visionState.addVisionSource({ aura: aura.uuid, shape: id }, shape.floorId);
             }
 
             shape?.invalidate(false);
@@ -157,14 +157,18 @@ class AuraSystem implements ShapeSystem {
 
         Object.assign(aura, delta);
 
-        if (oldAuraVisionSource && !aura.visionSource && aura.active) {
-            visionState.removeVisionSource(shape.floor.id, aura.uuid);
-        } else if (!oldAuraVisionSource && aura.visionSource && aura.active) {
-            visionState.addVisionSource({ aura: aura.uuid, shape: id }, shape.floor.id);
-        } else if (oldAuraActive && !aura.active && aura.visionSource) {
-            visionState.removeVisionSource(shape.floor.id, aura.uuid);
-        } else if (!oldAuraActive && aura.active && aura.visionSource) {
-            visionState.addVisionSource({ aura: aura.uuid, shape: id }, shape.floor.id);
+        const floorId = shape.floorId;
+
+        if (floorId !== undefined) {
+            if (oldAuraVisionSource && !aura.visionSource && aura.active) {
+                visionState.removeVisionSource(floorId, aura.uuid);
+            } else if (!oldAuraVisionSource && aura.visionSource && aura.active) {
+                visionState.addVisionSource({ aura: aura.uuid, shape: id }, floorId);
+            } else if (oldAuraActive && !aura.active && aura.visionSource) {
+                visionState.removeVisionSource(floorId, aura.uuid);
+            } else if (!oldAuraActive && aura.active && aura.visionSource) {
+                visionState.addVisionSource({ aura: aura.uuid, shape: id }, floorId);
+            }
         }
 
         if (id === this._state.id || id === this._state.parentId) this.updateAuraState();
@@ -187,7 +191,7 @@ class AuraSystem implements ShapeSystem {
         if (oldAura?.active === true) {
             const shape = getShape(id);
             if (shape && oldAura.visionSource) {
-                visionState.removeVisionSource(shape.floor.id, auraId);
+                if (shape.floorId !== undefined) visionState.removeVisionSource(shape.floorId, auraId);
             }
             shape?.invalidate(false);
         }

--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -90,7 +90,7 @@ class ClientSystem implements System {
         if (rect !== undefined) {
             const shape = getShape(rect);
             if (shape !== undefined) {
-                shape.layer.removeShape(shape, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
+                shape.layer?.removeShape(shape, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
             }
             $.clientRectIds.delete(client);
         }
@@ -191,7 +191,7 @@ class ClientSystem implements System {
         if (rect === undefined) return;
 
         rect.options.skipDraw = !show;
-        rect.layer.invalidate(true);
+        rect.layer?.invalidate(true);
     }
 
     getClientLocation(client: ClientId): GlobalPoint | undefined {

--- a/client/src/game/systems/groups/index.ts
+++ b/client/src/game/systems/groups/index.ts
@@ -254,7 +254,7 @@ class GroupSystem implements ShapeSystem {
         const group = groupToClient(serverGroup);
         mutable.groups.set(group.uuid, group);
         for (const member of this.getGroupMembers(group.uuid)) {
-            getShape(member)?.layer.invalidate(true);
+            getShape(member)?.layer?.invalidate(true);
         }
     }
 }

--- a/client/src/game/systems/labels/index.ts
+++ b/client/src/game/systems/labels/index.ts
@@ -102,7 +102,7 @@ export class LabelSystem implements ShapeSystem {
         if (!$.labels.has(uuid)) return;
         for (const [shapeId, labels] of $.shapeLabels.entries()) {
             labels.delete(uuid);
-            getShape(shapeId)?.layer.invalidate(false);
+            getShape(shapeId)?.layer?.invalidate(false);
         }
         $.labels.delete(uuid);
 

--- a/client/src/game/systems/logic/tp/core.ts
+++ b/client/src/game/systems/logic/tp/core.ts
@@ -1,4 +1,3 @@
-import type { GlobalPoint } from "../../../../core/geometry";
 import { requestShapeInfo, sendShapesMove } from "../../../api/emits/shape/core";
 import { getShape, getLocalId, getGlobalId } from "../../../id";
 import type { LocalId, GlobalId } from "../../../id";
@@ -39,8 +38,8 @@ export async function teleport(fromZone: LocalId, toZone: GlobalId, transfers?: 
     let targetLocation = activeLocation;
     const tpTargetId = getLocalId(toZone);
     const targetShape = tpTargetId === undefined ? undefined : getShape(tpTargetId);
-    let center: GlobalPoint | undefined = targetShape?.center;
-    let floor: string | undefined = targetShape?.floor.name;
+    let center = targetShape?.center;
+    let floor = targetShape?.floor?.name;
 
     if (targetShape === undefined) {
         const { location, shape } = await requestShapeInfo(toZone);

--- a/client/src/game/systems/logic/tp/index.ts
+++ b/client/src/game/systems/logic/tp/index.ts
@@ -195,7 +195,7 @@ class TeleportZoneSystem implements ShapeSystem {
                     locationSettingsState.raw.spawnLocations.value.includes(getGlobalId(shape.id)!)
                 )
                     continue;
-                if (tpShape.floor.id === shape.floor.id && tpShape.contains(shape.center)) {
+                if (tpShape.floor?.id === shape.floorId && tpShape.contains(shape.center)) {
                     shapesToMove.push(shape.id);
                 }
             }

--- a/client/src/game/systems/markers/index.ts
+++ b/client/src/game/systems/markers/index.ts
@@ -29,7 +29,7 @@ class MarkerSystem implements System {
         const shape = getShape(marker);
         if (shape == undefined) return;
         setCenterPosition(shape.center);
-        floorSystem.selectFloor({ name: shape.floor.name }, true);
+        if (shape.floorId !== undefined) floorSystem.selectFloor({ id: shape.floorId }, true);
     }
 
     removeMarker(marker: LocalId, sync: boolean): void {

--- a/client/src/game/systems/properties/movement.ts
+++ b/client/src/game/systems/properties/movement.ts
@@ -4,7 +4,7 @@ import { TriangulationTarget, visionState } from "../../vision/state";
 import { floorState } from "../floors/state";
 
 export function checkMovementSources(id: LocalId, blocksMovement: boolean, recalculate = true): boolean {
-    const floor = getShape(id)?.floor.id ?? floorState.currentFloor.value!.id;
+    const floor = getShape(id)?.floorId ?? floorState.currentFloor.value!.id;
 
     let alteredMovement = false;
     const movementBlockers = visionState.getBlockers(TriangulationTarget.MOVEMENT, floor);

--- a/client/src/game/systems/properties/vision.ts
+++ b/client/src/game/systems/properties/vision.ts
@@ -4,7 +4,7 @@ import { TriangulationTarget, visionState } from "../../vision/state";
 import { floorState } from "../floors/state";
 
 export function checkVisionSources(id: LocalId, blocksVision: boolean, recalculate = true): boolean {
-    const floor = getShape(id)?.floor.id ?? floorState.currentFloor.value!.id;
+    const floor = getShape(id)?.floorId ?? floorState.currentFloor.value!.id;
 
     let alteredVision = false;
     const visionBlockers = visionState.getBlockers(TriangulationTarget.VISION, floor);

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -20,6 +20,11 @@ export function moveFloor(shapes: IShape[], newFloor: Floor, sync: boolean): voi
     const firstShape = shapes[0]!;
     const oldLayer = firstShape.layer;
     const oldFloor = firstShape.floor;
+
+    if (oldLayer === undefined || oldFloor === undefined) {
+        throw new Error("No layer information available for shape move");
+    }
+
     if (shapes.some((s) => s.layer !== oldLayer)) {
         throw new Error("Mixing shapes from different floors in shape move");
     }
@@ -42,7 +47,11 @@ export function moveFloor(shapes: IShape[], newFloor: Floor, sync: boolean): voi
 
 export function moveLayer(shapes: readonly IShape[], newLayer: ILayer, sync: boolean): void {
     if (shapes.length === 0) return;
-    const oldLayer = shapes[0]!.layer;
+    const oldLayer = shapes[0]?.layer;
+
+    if (oldLayer === undefined) {
+        throw new Error("No layer information available for shape move");
+    }
 
     if (shapes.some((s) => s.layer !== oldLayer)) {
         throw new Error("Mixing shapes from different floors in shape move");

--- a/client/src/game/tools/events.ts
+++ b/client/src/game/tools/events.ts
@@ -89,7 +89,7 @@ export async function mouseMove(event: MouseEvent): Promise<void> {
     for (const [uuid, annotation] of annotationState.readonly.annotations.entries()) {
         if (floorSystem.hasLayer(floorState.currentFloor.value!, LayerName.Draw)) {
             const shape = getShape(uuid);
-            if (shape && shape.floor.id === floorState.currentFloor.value!.id && shape.contains(eventPoint)) {
+            if (shape && shape.floorId === floorState.currentFloor.value!.id && shape.contains(eventPoint)) {
                 foundAnnotation = true;
                 uiSystem.setAnnotationText(annotation);
             }
@@ -251,7 +251,7 @@ export async function touchMove(event: TouchEvent): Promise<void> {
             const shape = getShape(uuid);
             if (
                 shape &&
-                shape.floor.id === floorState.currentFloor.value!.id &&
+                shape.floorId === floorState.currentFloor.value!.id &&
                 shape.contains(l2g(getLocalPointFromEvent(event)))
             ) {
                 found = true;

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -187,8 +187,11 @@ class DrawTool extends Tool implements ITool {
         } else {
             this.shape.updateLayerPoints();
             const props = getProperties(this.shape.id)!;
-            if (props.blocksVision) visionState.recalculateVision(this.shape.floor.id);
-            if (props.blocksMovement) visionState.recalculateMovement(this.shape.floor.id);
+
+            if (this.shape.floorId !== undefined) {
+                if (props.blocksVision) visionState.recalculateVision(this.shape.floorId);
+                if (props.blocksMovement) visionState.recalculateMovement(this.shape.floorId);
+            }
             if (!this.shape.preventSync) sendShapeSizeUpdate({ shape: this.shape, temporary: false });
             if (this.state.isDoor) {
                 doorSystem.inform(
@@ -545,17 +548,19 @@ class DrawTool extends Tool implements ITool {
             const props = getProperties(this.shape.id)!;
             if (!this.shape.preventSync) sendShapeSizeUpdate({ shape: this.shape, temporary: true });
             if (props.blocksVision) {
-                if (
-                    visionState
-                        .getCDT(TriangulationTarget.VISION, this.shape.floor.id)
-                        .tds.getTriagVertices(this.shape.id).length > 1
-                )
-                    visionState.deleteFromTriangulation({
-                        target: TriangulationTarget.VISION,
-                        shape: this.shape.id,
-                    });
-                visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: this.shape.id });
-                visionState.recalculateVision(this.shape.floor.id);
+                if (this.shape.floorId !== undefined) {
+                    const vertices = visionState
+                        .getCDT(TriangulationTarget.VISION, this.shape.floorId)
+                        .tds.getTriagVertices(this.shape.id);
+                    if (vertices.length > 1) {
+                        visionState.deleteFromTriangulation({
+                            target: TriangulationTarget.VISION,
+                            shape: this.shape.id,
+                        });
+                    }
+                    visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: this.shape.id });
+                    visionState.recalculateVision(this.shape.floorId);
+                }
             }
         }
         layer.invalidate(false);
@@ -592,11 +597,11 @@ class DrawTool extends Tool implements ITool {
             this.shape.resizeToGrid(this.shape.getPointIndex(endPoint, l2gz(5)), ctrlOrCmdPressed(event));
             if (props.blocksVision) {
                 visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: this.shape.id });
-                visionState.recalculateVision(this.shape.floor.id);
+                if (this.shape.floorId !== undefined) visionState.recalculateVision(this.shape.floorId);
             }
             if (props.blocksMovement) {
                 visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: this.shape.id });
-                visionState.recalculateMovement(this.shape.floor.id);
+                if (this.shape.floorId !== undefined) visionState.recalculateMovement(this.shape.floorId);
             }
         }
 

--- a/client/src/game/ui/contextmenu/DefaultContext.vue
+++ b/client/src/game/ui/contextmenu/DefaultContext.vue
@@ -78,7 +78,7 @@ async function createSpawnLocation(): Promise<void> {
     floorSystem
         .getLayer(floorState.currentFloor.value!, LayerName.Dm)!
         .addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO);
-    img.onload = () => (gameState.raw.boardInitialized ? shape.layer.invalidate(true) : undefined);
+    img.onload = () => (gameState.raw.boardInitialized ? shape.layer?.invalidate(true) : undefined);
 
     const gId = getGlobalId(shape.id);
 

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -95,11 +95,11 @@ function toggleHighlight(actorId: LocalId | undefined, show: boolean): void {
         if (shape === undefined) return;
         shapeArray = [shape];
     } else {
-        shapeArray = [...groupSystem.getGroupMembers(groupId)].map(m => getShape(m)!);
+        shapeArray = [...groupSystem.getGroupMembers(groupId)].map((m) => getShape(m)!);
     }
     for (const sh of shapeArray) {
         sh.showHighlight = show;
-        sh.layer.invalidate(true);
+        sh.layer?.invalidate(true);
     }
 }
 

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -168,7 +168,7 @@ class InitiativeStore extends Store<InitiativeState> {
         if (shape === undefined) return;
         if (shape.showHighlight) {
             shape.showHighlight = false;
-            shape.layer.invalidate(true);
+            shape.layer?.invalidate(true);
         }
     }
 
@@ -305,7 +305,7 @@ class InitiativeStore extends Store<InitiativeState> {
                 const shape = getShape(actor.localId);
                 if (shape === undefined) return;
                 setCenterPosition(shape.center);
-                floorSystem.selectFloor({ name: shape.floor.name }, true);
+                if (shape.floorId !== undefined) floorSystem.selectFloor({ id: shape.floorId }, true);
             }
         }
     }

--- a/client/src/game/ui/settings/shape/ExtraSettings.vue
+++ b/client/src/game/ui/settings/shape/ExtraSettings.vue
@@ -210,10 +210,13 @@ function applyDDraft(): void {
         );
     }
 
-    visionState.recalculateVision(realShape.floor.id);
-    visionState.recalculateMovement(realShape.floor.id);
-    fowLayer.invalidate(false);
-    realShape.layer.invalidate(false);
+    const layer = realShape.layer;
+    if (layer !== undefined) {
+        visionState.recalculateVision(layer.floor);
+        visionState.recalculateMovement(layer.floor);
+        fowLayer.invalidate(false);
+        layer.invalidate(false);
+    }
 }
 </script>
 

--- a/client/src/game/ui/settings/shape/GroupSettings.vue
+++ b/client/src/game/ui/settings/shape/GroupSettings.vue
@@ -132,7 +132,7 @@ function toggleHighlight(member: LocalId, show: boolean): void {
     const shape = getShape(member);
     if (shape) {
         shape.showHighlight = show;
-        shape.layer.invalidate(true);
+        shape.layer?.invalidate(true);
     }
 }
 

--- a/client/src/game/ui/settings/shape/VariantSwitcher.vue
+++ b/client/src/game/ui/settings/shape/VariantSwitcher.vue
@@ -77,7 +77,7 @@ async function addVariant(): Promise<void> {
     let parent = compositeParent.value;
     if (parent === undefined) {
         parent = new ToggleComposite(cloneP(shape.refPoint), shape.id, [{ id: shape.id, name: "base variant" }]);
-        shape.layer.addShape(parent, SyncMode.FULL_SYNC, InvalidationMode.NO);
+        shape.layer?.addShape(parent, SyncMode.FULL_SYNC, InvalidationMode.NO);
     }
     parent.addVariant(newShape.id, name, true);
     parent.setActiveVariant(newShape.id, true);

--- a/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
+++ b/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
@@ -50,11 +50,11 @@ async function approveTp(request: Global<TpRequest> & { requester: string }): Pr
 function showArea(): void {
     const uuid = props.data.logic === "door" ? props.data.door : props.data.toZone;
     const shape = getShapeFromGlobal(uuid);
-    if (shape === undefined) return;
+    if (shape?.floorId === undefined) return;
 
     shape.showHighlight = true;
     setCenterPosition(shape.center);
-    floorSystem.selectFloor({ name: shape.floor.name }, true);
+    floorSystem.selectFloor({ id: shape.floorId }, true);
 }
 </script>
 

--- a/client/src/game/vision/iterative.ts
+++ b/client/src/game/vision/iterative.ts
@@ -67,7 +67,10 @@ export class IterativeDelete {
         this.handledPoints = [];
         this.finalConstraints = [];
 
-        this.cdt = visionState.getCDT(target, shape.floor.id);
+        if (shape.floorId === undefined) {
+            throw new Error("Shape without floor passed");
+        }
+        this.cdt = visionState.getCDT(target, shape.floorId);
         this.shape = shape;
 
         this.deleteVertices();

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -141,7 +141,7 @@ class VisionState extends Store<State> {
 
         for (const sh of shapes) {
             const shape = getShape(sh);
-            if (shape === undefined || shape.floor.id !== floor) continue;
+            if (shape === undefined || shape.floorId !== floor) continue;
 
             this.triangulateShape(target, shape);
         }
@@ -237,11 +237,13 @@ class VisionState extends Store<State> {
     }
 
     insertConstraint(target: TriangulationTarget, shape: IShape, pa: [number, number], pb: [number, number]): void {
-        const cdt = this.getCDT(target, shape.floor.id);
-        const { va, vb } = cdt.insertConstraint(pa, pb);
-        va.shapes.add(shape);
-        vb.shapes.add(shape);
-        cdt.tds.addTriagVertices(shape.id, va, vb);
+        if (shape.floorId !== undefined) {
+            const cdt = this.getCDT(target, shape.floorId);
+            const { va, vb } = cdt.insertConstraint(pa, pb);
+            va.shapes.add(shape);
+            vb.shapes.add(shape);
+            cdt.tds.addTriagVertices(shape.id, va, vb);
+        }
     }
 
     addToTriangulation(data: { target: TriangulationTarget; shape: LocalId }): void {
@@ -249,7 +251,9 @@ class VisionState extends Store<State> {
             const shape = getShape(data.shape);
             if (shape) {
                 this.triangulateShape(data.target, shape);
-                if (data.target === TriangulationTarget.VISION) this.increaseVisionIteration(shape.floor.id);
+                if (data.target === TriangulationTarget.VISION) {
+                    if (shape.floorId !== undefined) this.increaseVisionIteration(shape.floorId);
+                }
             }
         }
     }
@@ -259,7 +263,9 @@ class VisionState extends Store<State> {
             const shape = getShape(data.shape);
             if (shape) {
                 this.deleteShapesFromTriangulation(data.target, shape);
-                if (data.target === TriangulationTarget.VISION) this.increaseVisionIteration(shape.floor.id);
+                if (data.target === TriangulationTarget.VISION) {
+                    if (shape.floorId !== undefined) this.increaseVisionIteration(shape.floorId);
+                }
             }
         }
     }
@@ -303,7 +309,7 @@ class VisionState extends Store<State> {
             const source = sources[i]!;
             const shape = getShape(source.shape);
             if (shape === undefined) continue;
-            if (shape.layer.name === layer) {
+            if (shape.layerName === layer) {
                 if (shapeIds.has(shape.id)) {
                     found.add(shape.id);
                 } else {

--- a/client/src/store/activeShape.ts
+++ b/client/src/store/activeShape.ts
@@ -46,7 +46,7 @@ class ActiveShapeStore extends Store<ActiveShapeState> {
 
     constructor() {
         super();
-        this.floor = computed(() => (this._state.id !== undefined ? getShape(this._state.id)?.floor.id : undefined));
+        this.floor = computed(() => (this._state.id !== undefined ? getShape(this._state.id)?.floorId : undefined));
         this.isComposite = computed(() => this._state.parentUuid !== undefined);
 
         watchEffect(() => {

--- a/client/src/store/lastGameboard.ts
+++ b/client/src/store/lastGameboard.ts
@@ -107,7 +107,7 @@ class LastGameboardStore extends Store<LastGameboardState> {
             this.contourHistory.delete(typeId);
             this.contourShapes.delete(typeId);
             if (shape === undefined) return;
-            shape.layer.removeShape(shape, { sync: SyncMode.FULL_SYNC, recalculate: true, dropShapeId: true });
+            shape.layer?.removeShape(shape, { sync: SyncMode.FULL_SYNC, recalculate: true, dropShapeId: true });
         }
     }
 


### PR DESCRIPTION
This PR fixes #1158.

The `Shape` interface had the `floor` and `layer` getters typed as if they always exist.
In practice they should be set for most shapes at most times, there is however a short time while a shape is being created where these are not yet set, which could lead to subtle bugs as the one reported above.

The typing of these getters has now been properly changed to include the possibility that they are not yet set, which is the reason that this PR  touches a bunch of files.