### PR TITLE
bug(Prompt): Fix validation function cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ tech changes will usually be stripped from release notes for the public
 -   Trackers:
     -   some cases where a client could edit information for shapes they didn't have access to
         (The above was never accepted by the server or sent to other clients)
+-   Prompt modals sometimes still using a validation check from an earlier prompt
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/core/plugins/modals/prompt.ts
+++ b/client/src/core/plugins/modals/prompt.ts
@@ -27,9 +27,11 @@ export function usePrompt(): PromptModal {
         error: "",
     });
 
-    let validationFunction: validationFunc = (_value) => ({
+    const defaultValidationFunction: validationFunc = (_value) => ({
         valid: true,
     });
+
+    let validationFunction = defaultValidationFunction;
 
     let resolve: (value: string | undefined) => void = (_value: string | undefined) => {};
 
@@ -39,6 +41,7 @@ export function usePrompt(): PromptModal {
         data.title = title;
         data.error = "";
         if (validation) validationFunction = validation;
+        else validation = defaultValidationFunction;
         return new Promise((res) => (resolve = res));
     }
 

--- a/client/src/core/plugins/modals/prompt.ts
+++ b/client/src/core/plugins/modals/prompt.ts
@@ -41,7 +41,7 @@ export function usePrompt(): PromptModal {
         data.title = title;
         data.error = "";
         if (validation) validationFunction = validation;
-        else validation = defaultValidationFunction;
+        else validationFunction = defaultValidationFunction;
         return new Promise((res) => (resolve = res));
     }
 


### PR DESCRIPTION
The prompt modal is used to prompt for several info bits in PA.
An optional validation function can be passed along so that the prompt can stay open and show an error message if an invalid response is given.
When opening a prompt without a validation function, there was nothing resetting the validation function if one was assigned previously.