### PR TITLE
bug(AssetManager): Fix asset path handling

### DIFF
--- a/client/src/assetManager/socket.ts
+++ b/client/src/assetManager/socket.ts
@@ -28,7 +28,7 @@ socket.on("Folder.Set", async (data: { folder: Asset; path?: number[] }) => {
     assetStore.clear();
     assetStore.setFolderData(data.folder.id, data.folder);
     if (!assetStore.state.modalActive) {
-        if (data.path) assetStore.setPath(data.path);
+        if (data.path && data.path.length > 0) assetStore.setPath(data.path);
         const path = `/assets${assetStore.currentFilePath.value}/`;
         if (path !== router.currentRoute.value.path) {
             await router.push({ path });

--- a/client/src/assetManager/socket.ts
+++ b/client/src/assetManager/socket.ts
@@ -28,7 +28,7 @@ socket.on("Folder.Set", async (data: { folder: Asset; path?: number[] }) => {
     assetStore.clear();
     assetStore.setFolderData(data.folder.id, data.folder);
     if (!assetStore.state.modalActive) {
-        if (data.path && data.path.length > 0) assetStore.setPath(data.path);
+        if (data.path) assetStore.setPath(data.path);
         const path = `/assets${assetStore.currentFilePath.value}/`;
         if (path !== router.currentRoute.value.path) {
             await router.push({ path });

--- a/client/src/assetManager/state.ts
+++ b/client/src/assetManager/state.ts
@@ -80,7 +80,11 @@ class AssetStore extends Store<AssetState> {
 
     setPath(path: number[]): void {
         this._state.folderPath = path;
-        for (const [index, part] of router.currentRoute.value.path.slice("/assets/".length).split("/").entries()) {
+        let assetPath = router.currentRoute.value.path.slice("/assets/".length);
+        if (assetPath.at(-1) === "/") assetPath = assetPath.slice(0, -1);
+        if (assetPath.length === 0) return;
+
+        for (const [index, part] of assetPath.split("/").entries()) {
             const pathId = path[index];
             if (pathId === undefined) {
                 console.error("Incorrect PathIndex encountered.");


### PR DESCRIPTION
This is a fix for an innocent bug that caused an error log to appear in the console when using the asset manager.

An additional iteration of some code was being done due to an extra "/" at the end that was not being handled. The extra iteration however would always fail due to an index error and there was nothing else to do after the iteration so in practice nothing terrible happened.