### PR TITLE
bug(Resize): Fix botright resize while rotated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ tech changes will usually be stripped from release notes for the public
     -   some cases where a client could edit information for shapes they didn't have access to
         (The above was never accepted by the server or sent to other clients)
 -   Prompt modals sometimes still using a validation check from an earlier prompt
+-   Resizing the botright corner of a rectangle-based shape while rotated was moving the shape
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/shapes/variants/baseRect.ts
+++ b/client/src/game/shapes/variants/baseRect.ts
@@ -1,5 +1,5 @@
 import { clampGridLine, clampToGrid, g2lx, g2ly } from "../../../core/conversions";
-import { addP, toGP, Vector } from "../../../core/geometry";
+import { addP, cloneP, toGP, Vector } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import { rotateAroundPoint } from "../../../core/math";
 import { calculateDelta } from "../../drag";
@@ -195,6 +195,7 @@ export abstract class BaseRect extends Shape implements IShape {
             case 2: {
                 this.w = point.x - this.refPoint.x;
                 this.h = point.y - this.refPoint.y;
+                this.refPoint = cloneP(this.refPoint); // required to recalculate center!!
                 break;
             }
             case 3: {


### PR DESCRIPTION
When a rotated rectangle shape is resized with its bottom-right corner, the shape does funky things.

This fixes #1160.