### PR TITLE
bug(UI): Fix token direction UI trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ tech changes will usually be stripped from release notes for the public
         (The above was never accepted by the server or sent to other clients)
 -   Prompt modals sometimes still using a validation check from an earlier prompt
 -   Resizing the botright corner of a rectangle-based shape while rotated was moving the shape
+-   Token direction UI triggering when other UI is on top of it
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/ui/TokenDirections.vue
+++ b/client/src/game/ui/TokenDirections.vue
@@ -32,16 +32,22 @@ function center(token: LocalId): void {
 </template>
 
 <style lang="scss">
-#token-directions > div {
-    pointer-events: auto;
-    position: absolute;
-    width: 3.75rem;
-    height: 3.75rem;
-    border-radius: 1.875rem;
-    border: solid 1px transparent;
+#token-directions {
+    position: relative;
 
-    &:hover {
-        cursor: pointer;
+    > div {
+        pointer-events: auto;
+        position: absolute;
+        width: 3.75rem;
+        height: 3.75rem;
+        border-radius: 1.875rem;
+        border: solid 1px transparent;
+
+        background-color: red;
+
+        &:hover {
+            cursor: pointer;
+        }
     }
 }
 </style>

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -180,6 +180,10 @@ function setTempZoomDisplay(value: number): void {
                 <span class="rm-topper"></span>
             </div>
         </div>
+        <div v-if="positionState.reactive.outOfBounds" id="oob" @click="positionSystem.returnToBounds">
+            Click to return to content
+        </div>
+        <TokenDirections />
         <!-- Core overlays -->
         <MenuBar />
         <Tools />
@@ -198,10 +202,6 @@ function setTempZoomDisplay(value: number): void {
         <div id="teleport-modals"></div>
         <MarkdownModal v-if="showChangelog" :title="t('game.ui.ui.new_ver_msg')" :source="changelogText" />
         <!-- end of main modals -->
-        <div v-if="positionState.reactive.outOfBounds" id="oob" @click="positionSystem.returnToBounds">
-            Click to return to content
-        </div>
-        <TokenDirections />
         <!-- When updating zoom boundaries, also update store updateZoom function;
             should probably do this using a store variable-->
         <SliderComponent

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -246,24 +246,19 @@ DIRECTORY.CSS changes
     display: block;
 }
 
-#menuContainer {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    pointer-events: none;
-}
-
 #menu {
-    grid-area: menu;
     display: flex;
+    position: relative;
+    grid-area: menu;
+
+    max-width: 12.5rem;
+
     flex-direction: column;
     justify-content: space-between;
+
     background-color: #fa5a5a;
     overflow: auto;
     pointer-events: auto;
-    max-width: 12.5rem;
 }
 
 .actionButton {


### PR DESCRIPTION
The token direction UI (showing the direction of tokens that are offscreen) was getting priority over all other UI elements causing sometimes a jump to a token to happen instead of a UI element to open.

The behaviour has now changed so that the token direction UI should always have the last priority.

This fixes #1165