### PR TITLE
bug(UI): Fix floor detail positioning when menu is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ tech changes will usually be stripped from release notes for the public
 -   Prompt modals sometimes still using a validation check from an earlier prompt
 -   Resizing the botright corner of a rectangle-based shape while rotated was moving the shape
 -   Token direction UI triggering when other UI is on top of it
+-   Floor detail UI not moving along if side menu is opened
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/ui/Floors.vue
+++ b/client/src/game/ui/Floors.vue
@@ -138,6 +138,7 @@ const selectedLayer = computed(() => {
 
 <style scoped lang="scss">
 #floor-layer {
+    position: relative;
     grid-area: layer;
     display: flex;
     list-style: none;
@@ -197,8 +198,7 @@ a {
 #floor-detail {
     pointer-events: auto;
     position: absolute;
-    left: 1.5rem;
-    bottom: 6.25rem;
+    bottom: 4.75rem;
     border: solid 1px #2b2b2b;
     background-color: white;
     padding: 0.625rem;


### PR DESCRIPTION
The floor details would stay in the same place if the side menu was opened.

This fixes #1166