### PR TITLE
bug(Tracker): Fix shared for all variants tracker not being able to use display on token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ tech changes will usually be stripped from release notes for the public
 -   Trackers:
     -   some cases where a client could edit information for shapes they didn't have access to
         (The above was never accepted by the server or sent to other clients)
+    -   Display on token not working for trackers that are shared across variants
 -   Prompt modals sometimes still using a validation check from an earlier prompt
 -   Resizing the botright corner of a rectangle-based shape while rotated was moving the shape
 -   Token direction UI triggering when other UI is on top of it

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -361,7 +361,7 @@ export abstract class Shape implements IShape {
         }
         // Draw tracker bars
         let barOffset = 0;
-        for (const tracker of trackerSystem.getAll(this.id, false)) {
+        for (const tracker of trackerSystem.getAll(this.id, true)) {
             if (tracker.draw && (tracker.visible || accessSystem.hasAccessTo(this.id, false, { vision: true }))) {
                 if (bbox === undefined) bbox = this.getBoundingBox();
                 ctx.strokeStyle = "black";


### PR DESCRIPTION
Trackers have a `display on token` property to show the tracker visually above the token in a rectangular bar.

This bar was not showing up if the tracker happened to be shared among all variants.

This fixes #1167