### PR TITLE
bug(Select): Fix locked shape snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ tech changes will usually be stripped from release notes for the public
 -   Resizing the botright corner of a rectangle-based shape while rotated was moving the shape
 -   Token direction UI triggering when other UI is on top of it
 -   Floor detail UI not moving along if side menu is opened
+-   Unlocking shape could sometimes trigger the shape following your mouse
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -309,7 +309,7 @@ class SelectTool extends Tool implements ISelectTool {
                     }
                 }
                 // Drag case, a shape is selected
-                if (this.hasFeature(SelectFeatures.Drag, features)) {
+                if (!props.isLocked && this.hasFeature(SelectFeatures.Drag, features)) {
                     this.mode = SelectOperations.Drag;
                     const localRefPoint = g2l(shape.refPoint);
                     this.dragRay = Ray.fromPoints(localRefPoint, lp);


### PR DESCRIPTION
When unlocking a shape, after having attempted to move it, the shape snaps to your cursor and follows it as if you had started dragging it.

This fixes #1168