### PR TITLE
bug(UI): Fix token direction UI rendering

### DIFF
--- a/client/src/game/ui/TokenDirections.vue
+++ b/client/src/game/ui/TokenDirections.vue
@@ -43,8 +43,6 @@ function center(token: LocalId): void {
         border-radius: 1.875rem;
         border: solid 1px transparent;
 
-        background-color: red;
-
         &:hover {
             cursor: pointer;
         }


### PR DESCRIPTION
A recent change from #1165 unintentionally caused the token direction UI to render as all red rather than displaying a preview of the token. This change reverts that side effect.

result of #1165:
![2023-02-11_08-19](https://user-images.githubusercontent.com/2442544/218269754-733c0cd4-769a-4cc2-a41f-8c3e7086825a.png) 

after this fix:
![image](https://user-images.githubusercontent.com/2442544/218269775-8cac7b3a-a324-4967-8282-89ef13996bd4.png)
