### PR TITLE
bug(Access): Fix keybinds not checking access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,11 @@ tech changes will usually be stripped from release notes for the public
 -   Fake Player: showing DM layer
 -   DM settings: Fix last DM being able to demote themselves to a player
 -   Assets: default stroke colour wrongly set, causing badges to be transparent
--   Trackers:
-    -   some cases where a client could edit information for shapes they didn't have access to
-        (The above was never accepted by the server or sent to other clients)
-    -   Display on token not working for trackers that are shared across variants
+-   Trackers: Display on token not working for trackers that are shared across variants
+-   Some cases where a client could edit shape info without access
+    -   _this was always rejected by the server and never synced_
+    -   most tracker properties
+    -   defeated and locked state using keybinds
 -   Prompt modals sometimes still using a validation check from an earlier prompt
 -   Resizing the botright corner of a rectangle-based shape while rotated was moving the shape
 -   Token direction UI triggering when other UI is on top of it

--- a/client/src/game/input/keyboard/down.ts
+++ b/client/src/game/input/keyboard/down.ts
@@ -9,6 +9,7 @@ import { moveShapes } from "../../operations/movement";
 import { redoOperation, undoOperation } from "../../operations/undo";
 import { setCenterPosition } from "../../position";
 import { copyShapes, pasteShapes } from "../../shapes/utils";
+import { accessSystem } from "../../systems/access";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
 import { gameState } from "../../systems/game/state";
@@ -109,18 +110,22 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
             // x - Mark Defeated
             const selection = selectedSystem.get({ includeComposites: true });
             for (const shape of selection) {
-                const isDefeated = getProperties(shape.id)!.isDefeated;
-                propertiesSystem.setIsDefeated(shape.id, !isDefeated, FULL_SYNC);
+                if (accessSystem.hasAccessTo(shape.id, false, { edit: true })) {
+                    const isDefeated = getProperties(shape.id)!.isDefeated;
+                    propertiesSystem.setIsDefeated(shape.id, !isDefeated, FULL_SYNC);
+                }
             }
             event.preventDefault();
             event.stopPropagation();
         } else if (event.key === "l" && ctrlOrCmdPressed(event)) {
             const selection = selectedSystem.get({ includeComposites: true });
             for (const shape of selection) {
-                // This and GroupSettings are the only places currently where we would need to update both UI and Server.
-                // Might need to introduce a SyncTo.BOTH
-                const isLocked = getProperties(shape.id)!.isLocked;
-                propertiesSystem.setLocked(shape.id, !isLocked, FULL_SYNC);
+                if (accessSystem.hasAccessTo(shape.id, false, { edit: true })) {
+                    // This and GroupSettings are the only places currently where we would need to update both UI and Server.
+                    // Might need to introduce a SyncTo.BOTH
+                    const isLocked = getProperties(shape.id)!.isLocked;
+                    propertiesSystem.setLocked(shape.id, !isLocked, FULL_SYNC);
+                }
             }
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
The `x` keybind (to set defeated state) and `ctrl+l` keybind (to toggle the locked state) where not checking for access at the client-side.

They were checked and rejected at the server side, so no other players would ever see the changes, but for the client attempting the change it would seem like it worked.