### PR TITLE
bug(Templates): Fix custom templates no longer working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ tech changes will usually be stripped from release notes for the public
 -   Token direction UI triggering when other UI is on top of it
 -   Floor detail UI not moving along if side menu is opened
 -   Unlocking shape could sometimes trigger the shape following your mouse
+-   Templates: only using the first character of the provided template name
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/core/components/modals/SelectionBox.vue
+++ b/client/src/core/components/modals/SelectionBox.vue
@@ -7,7 +7,7 @@ import type { SelectionBoxOptions } from "../../plugins/modals/selectionBox";
 
 import Modal from "./Modal.vue";
 
-const emit = defineEmits(["close", "submit"]);
+const emit = defineEmits<{ (e: "submit", choices: string[]): void; (e: "close"): void }>();
 const props = defineProps<{
     visible: boolean;
     title: string;
@@ -61,7 +61,7 @@ function create(): void {
     } else if (props.choices.includes(state.customName)) {
         state.error = t("core.components.selectionbox.already_exists_warning").toString();
     } else {
-        emit("submit", state.customName);
+        emit("submit", [state.customName]);
         close();
     }
 }
@@ -69,7 +69,7 @@ function create(): void {
 function submit(): void {
     emit(
         "submit",
-        [...state.activeSelection].map((i) => props.choices[i]),
+        [...state.activeSelection].map((i) => props.choices[i]!),
     );
 }
 </script>

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -195,12 +195,12 @@ async function setLocation(newLocation: number): Promise<void> {
             spawnLocation = spawnInfo[0]!;
             break;
         default: {
-            const choice = await modals.selectionBox(
+            const choices = await modals.selectionBox(
                 "Choose the desired spawn location",
                 spawnInfo.map((s) => s.name),
             );
-            if (choice === undefined) return;
-            const choiceShape = spawnInfo.find((s) => s.name === choice[0]);
+            if (choices === undefined) return;
+            const choiceShape = spawnInfo.find((s) => s.name === choices[0]);
             if (choiceShape === undefined) return;
             spawnLocation = choiceShape;
             break;
@@ -265,12 +265,12 @@ async function saveTemplate(): Promise<void> {
     }
     const choices = Object.keys(assetOptions.templates);
     try {
-        const choice = await modals.selectionBox(t("game.ui.templates.save"), choices, {
+        const selection = await modals.selectionBox(t("game.ui.templates.save"), choices, {
             defaultButton: t("game.ui.templates.overwrite"),
             customButton: t("game.ui.templates.create_new"),
         });
-        if (choice === undefined || choice.length > 0) return;
-        assetOptions.templates[choice[0]!] = toTemplate(shape.asDict());
+        if (selection === undefined || selection.length === 0) return;
+        assetOptions.templates[selection[0]!] = toTemplate(shape.asDict());
         sendAssetOptions(shape.assetId, assetOptions);
     } catch {
         // no-op ; action cancelled

--- a/client/src/game/ui/menu/LocationBar.vue
+++ b/client/src/game/ui/menu/LocationBar.vue
@@ -54,12 +54,12 @@ async function showArchivedLocations(): Promise<void> {
     const locations = locationStore.archivedLocations.value;
     if (locations.length === 0) return;
 
-    const choice = await modals.selectionBox(
+    const choices = await modals.selectionBox(
         "Select a location to restore",
         locations.map((l) => l.name),
     );
-    const location = locations.find((l) => l.name === choice?.[0]);
-    if (choice !== undefined && location !== undefined) {
+    const location = locations.find((l) => l.name === choices?.[0]);
+    if (choices !== undefined && location !== undefined) {
         locationStore.unarchiveLocation(location.id, true);
     }
 }

--- a/client/src/game/ui/settings/location/AdminSettings.vue
+++ b/client/src/game/ui/settings/location/AdminSettings.vue
@@ -56,11 +56,11 @@ async function onCloneClick(): Promise<void> {
         const data = (await response.json()) as { owned: RoomInfo[] };
         const owned = data.owned;
 
-        const choice = await modals.selectionBox(
+        const choices = await modals.selectionBox(
             t("game.ui.settings.LocationBar.LocationAdminSettings.choose_room"),
             owned.map((room: RoomInfo) => room.name),
         );
-        const chosenRoom = owned.find((room) => room.name === choice?.[0]);
+        const chosenRoom = owned.find((room) => room.name === choices?.[0]);
         if (!chosenRoom) return;
 
         const roomName = chosenRoom.name;

--- a/client/src/game/ui/settings/shape/LogicSettings.vue
+++ b/client/src/game/ui/settings/shape/LogicSettings.vue
@@ -103,7 +103,7 @@ async function chooseTarget(): Promise<void> {
         "Select target location",
         locations.map((l) => l.name),
     );
-    if (choices === undefined) return;
+    if (choices === undefined || choices.length === 0) return;
 
     // Select spawn point
 
@@ -123,12 +123,12 @@ async function chooseTarget(): Promise<void> {
             targetLocation = { id: location, spawnUuid: spawnInfo[0]!.uuid };
             break;
         default: {
-            const choice = await modals.selectionBox(
+            const choices = await modals.selectionBox(
                 "Choose the desired teleport target",
                 spawnInfo.map((s) => s.name),
             );
-            if (choice === undefined) return;
-            const choiceShape = spawnInfo.find((s) => s.name === choice[0]);
+            if (choices === undefined || choices.length === 0) return;
+            const choiceShape = spawnInfo.find((s) => s.name === choices[0]);
             if (choiceShape === undefined) return;
             targetLocation = { id: location, spawnUuid: choiceShape.uuid };
             break;


### PR DESCRIPTION
Changes to the selectionbox modal made it so that a bug happened when making new templates.
Depending on which branch of the code you run the bug differs in nature.

- Only the first letter of the new template name is being used (latest release)
- The template name is not being saved at all (dev)

This fixes #1156 