### PR TITLE
bug(Groups): Fix group creation not immediately adding members

### DIFF
--- a/client/src/game/systems/groups/index.ts
+++ b/client/src/game/systems/groups/index.ts
@@ -120,13 +120,13 @@ class GroupSystem implements ShapeSystem {
             if (groupId !== memberGroupId) {
                 if (memberGroupId !== undefined) {
                     mutable.groupMembers.get(memberGroupId)?.delete(member.uuid);
-                    if (!mutable.shapeData.has(member.uuid)) {
-                        this.inform(member.uuid, { groupId, badge: 0 });
-                    } else {
-                        mutable.shapeData.set(member.uuid, { groupId, badge: member.badge });
-                    }
-                    // todo: invalidate(true) shape
                 }
+                if (!mutable.shapeData.has(member.uuid)) {
+                    this.inform(member.uuid, { groupId, badge: 0 });
+                } else {
+                    mutable.shapeData.set(member.uuid, { groupId, badge: member.badge });
+                }
+                // todo: invalidate(true) shape
             }
             mutable.groupMembers.get(groupId)?.add(member.uuid);
         }


### PR DESCRIPTION
When creating a new group, most UI elements would report the shapes as not being in a group until you refreshed.

This fixes #1164 