### PR TITLE
bug(AssetManager): Close contextmenu on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ tech changes will usually be stripped from release notes for the public
 -   Floor detail UI not moving along if side menu is opened
 -   Unlocking shape could sometimes trigger the shape following your mouse
 -   Templates: only using the first character of the provided template name
+-   Asset manager: close contextmenu when scrolling
 
 ## [2022.3.0] - 2022-12-12
 

--- a/client/src/assetManager/AssetContext.vue
+++ b/client/src/assetManager/AssetContext.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from "vue";
+import { nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ContextMenu from "../core/components/ContextMenu.vue";
@@ -11,6 +11,14 @@ import { assetStore } from "./state";
 const cm = ref<{ $el: HTMLDivElement } | null>(null);
 const modals = useModal();
 const { t } = useI18n();
+
+onMounted(() => {
+    window.addEventListener("scroll", close);
+});
+
+onUnmounted(() => {
+    window.removeEventListener("scroll", close);
+});
 
 watch(showAssetContextMenu, async () => {
     if (showAssetContextMenu.value) {


### PR DESCRIPTION
Scrolling after opening the context-menu (right click) on an item in the asset manager was not moving the context-menu along with the rest of the content.

This PR resolves this visual annoyance by closing the context-menu if a scroll action is done.

Fixes #1169 