### PR TITLE
bug(DmSettings): Fix invite url not including subpath if configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ tech changes will usually be stripped from release notes for the public
 -   Spell tool: the 'is public' label was wrongly attached to the range input box
 -   Fake Player: showing DM layer
 -   DM settings: Fix last DM being able to demote themselves to a player
+-   DM settings: Fix invite URL not containing subpath if set
 -   Assets: default stroke colour wrongly set, causing badges to be transparent
 -   Trackers: Display on token not working for trackers that are shared across variants
 -   Some cases where a client could edit shape info without access

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -4,6 +4,7 @@ import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 
 import InputCopyElement from "../../../../core/components/InputCopyElement.vue";
+import { baseAdjust } from "../../../../core/http";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { coreStore } from "../../../../store/core";
 import { sendDeleteRoom, sendRefreshInviteCode } from "../../../api/emits/room";
@@ -31,7 +32,10 @@ watch(
 );
 
 const invitationUrl = computed(
-    () => `${window.location.protocol}//${gameState.reactive.publicName}/invite/${gameState.reactive.invitationCode}`,
+    () =>
+        `${window.location.protocol}//${gameState.reactive.publicName}${baseAdjust("/invite/")}${
+            gameState.reactive.invitationCode
+        }`,
 );
 
 const creator = computed(() => route.params.creator);


### PR DESCRIPTION
When using subpath based hosting, the subpath was not being included in the invite url.

Some of you might have fixed this by including the subpath in your `publicName` server config.
But this was not intended behaviour, and you'll thus have to update your `publicName` if relevant.