### PR TITLE
bug(Initiative): Fix adding multiple shapes to initiative always prompting for group handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ tech changes will usually be stripped from release notes for the public
 -   Unlocking shape could sometimes trigger the shape following your mouse
 -   Templates: only using the first character of the provided template name
 -   Asset manager: close contextmenu when scrolling
+-   Adding multiple shapes to group always prompting group question even if no groups are present
 
 ## [2022.3.0] - 2022-12-12
 


### PR DESCRIPTION
When adding multiple shapes at once to initiative, regardless of the group setup, a prompt would appear to ask how to handle shapes that belong to the same groups.

When shapes that have no groups are added to initiative, this is irrelevant and an annoying extra step.

Fixes #1179