### PR TITLE
bug(AssetManager): Fix context menu appearing in wrong location when scrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ tech changes will usually be stripped from release notes for the public
 -   Floor detail UI not moving along if side menu is opened
 -   Unlocking shape could sometimes trigger the shape following your mouse
 -   Templates: only using the first character of the provided template name
--   Asset manager: close contextmenu when scrolling
+-   Asset Manager: close contextmenu when scrolling
+-   Asset Manager: contextmenu appearing in the wrong location when scrolled
 -   Adding multiple shapes to group always prompting group question even if no groups are present
 
 ## [2022.3.0] - 2022-12-12

--- a/client/src/assetManager/context.ts
+++ b/client/src/assetManager/context.ts
@@ -6,6 +6,6 @@ export const assetContextTop = ref(0);
 
 export function openAssetContextMenu(event: MouseEvent): void {
     showAssetContextMenu.value = true;
-    assetContextLeft.value = event.pageX;
-    assetContextTop.value = event.pageY;
+    assetContextLeft.value = event.clientX;
+    assetContextTop.value = event.clientY;
 }


### PR DESCRIPTION
If you're scrolled down in the asset manager and try to open the context-menu on an item, it appears in the wrong location.

Fixes #1169