### PR TITLE
bug(Access): Fix various errors with access

### DIFF
--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union, cast
+from typing import Any, List, Optional, Union
 
 from peewee import Case
 
@@ -72,7 +72,7 @@ async def add_shape(sid: str, raw_data: Any):
             return
 
     for room_player in pr.room.players:
-        is_dm = cast(bool, room_player.role == Role.DM)
+        is_dm = room_player.role == Role.DM
         for psid in game_state.get_sids(
             player=room_player.player, active_location=pr.active_location
         ):

--- a/server/src/models/access.py
+++ b/server/src/models/access.py
@@ -20,4 +20,7 @@ def has_ownership(shape: Shape, pr: PlayerRoom, movement=False) -> bool:
     if movement and shape.default_movement_access:
         return True
 
-    return ShapeOwner.get_or_none(shape=shape, user=pr.player) is not None
+    so = ShapeOwner.get_or_none(shape=shape, user=pr.player)
+    if so is None:
+        return False
+    return so.edit_access or (movement and so.movement_access)

--- a/server/src/transform/shape.py
+++ b/server/src/transform/shape.py
@@ -1,34 +1,40 @@
+from ..api.models.shape.owner import ApiShapeOwner
 from ..api.models.shape.shape import ApiCoreShape
 from ..api.models.shape.subtypes import ApiShapeSubType
 from ..db.models.aura import Aura
 from ..db.models.label import Label
 from ..db.models.shape import Shape
+from ..db.models.shape_owner import ShapeOwner
 from ..db.models.tracker import Tracker
 from ..db.models.user import User
 
 
 # todo: Change this API to accept a PlayerRoom instead
 def transform_shape(shape: Shape, user: User, dm: bool) -> ApiShapeSubType:
-    owners = [owner.as_pydantic() for owner in shape.owners]
-    owned = (
-        dm
-        or shape.default_edit_access
-        or shape.default_vision_access
-        or any(user.name == o.user for o in owners)
-    )
+    owners: list[ApiShapeOwner] = []
+    user_owner: ShapeOwner | None = None
+    for owner in shape.owners:
+        owners.append(owner.as_pydantic())
+        if owner.user == user:
+            user_owner = owner
+
+    edit_access = shape.default_edit_access or (user_owner and user_owner.edit_access)
+
+    # Access checks
     tracker_query = shape.trackers
     aura_query = shape.auras
     label_query = shape.labels.join(Label)
-    annotation = shape.annotation
     name = shape.name
-    if not owned:
-        if not shape.annotation_visible:
-            annotation = ""
+    annotation = shape.annotation
+    if not edit_access:
         tracker_query = tracker_query.where(Tracker.visible)
         aura_query = aura_query.where(Aura.visible)
         label_query = label_query.where(Label.visible)
         if not shape.name_visible:
             name = "?"
+        if not shape.annotation_visible:
+            annotation = ""
+
     trackers = [t.as_pydantic() for t in tracker_query]
     auras = [a.as_pydantic() for a in aura_query]
     labels = [sh_label.label.as_pydantic() for sh_label in label_query]


### PR DESCRIPTION
As reported in #1187 some access was granted to people who had explicit access rules but no access set.
This was caused by some oversights into places where the presence of an access rule for a person was assumed to equal access, which is wrong.

Additionally modifying the access rights of a user who already had explicit access rules, would sometimes not properly update until a refresh.

This has been rectified.
Fixes #1187