### PR TITLE
bug(Auth): Fix a logic error in the auth routing flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ tech changes will usually be stripped from release notes for the public
 ### Fixed
 
 -   No longer sending group info for each member (just once)
+-   A logic error in the auth routing code - in some cases you had to manually go to the login page
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHistory, type NavigationGuardNext } from "vue-router";
 
 import { http } from "../core/http";
 import { handleNotifications } from "../notifications";
@@ -35,24 +35,32 @@ router.beforeEach(async (to, _from, next) => {
         if (authResponse!.ok && versionResponse!.ok) {
             const authData = (await authResponse!.json()) as { auth: boolean; username: string; email: string };
             const versionData = (await versionResponse!.json()) as { release: string; env: string };
-            if (authData.auth) {
-                coreStore.setAuthenticated(true);
-                coreStore.setUsername(authData.username);
-                coreStore.setEmail(authData.email);
-            }
+
+            coreStore.setAuthenticated(authData.auth);
             coreStore.setVersion(versionData);
             coreStore.setInitialized(true);
-            await router.push(to.path);
-            next();
+
+            if (authData.auth) {
+                coreStore.setUsername(authData.username);
+                coreStore.setEmail(authData.email);
+                next();
+            } else {
+                forceLogin(next, to.path);
+            }
         } else {
             console.error("Authentication check could not be fulfilled.");
+            forceLogin(next, to.path);
         }
-    } else if (to.matched.some((record) => record.meta.auth) && !coreStore.state.authenticated) {
-        next({ path: "/auth/login", query: { redirect: to.path } });
+    } else if (to.meta.auth === true && !coreStore.state.authenticated) {
+        forceLogin(next, to.path);
     } else {
         next();
     }
 });
+
+function forceLogin(next: NavigationGuardNext, redirect: string): void {
+    next({ name: "login", query: { redirect } });
+}
 
 router.afterEach((_to, _from) => {
     coreStore.setLoading(false);


### PR DESCRIPTION
This PR fixes an error in the client-side auth routing flow. The error has no impact on security, but is purely a UX issue.

In some cases when visiting a page that requires the user to be logged in, the client was not properly redirecting to the login view, but instead would show the target page but without any data (e.g. the game listing would be empty) as the server side would reject all client requests.

This meant the user had to manually visit the login page in these cases.