### PR TITLE
bug(Templates): Fix missing settings + remove some settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Changed
+
+-   Templates no longer save certain settings
+
 ### Fixed
 
 -   No longer sending group info for each member (just once)
 -   A logic error in the auth routing code - in some cases you had to manually go to the login page
+-   Templates missing some settings when saved
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/models/templates.ts
+++ b/client/src/game/models/templates.ts
@@ -13,27 +13,46 @@ export const BaseTemplateStrings = [
     "name",
     "name_visible",
     "annotation",
+    "annotation_visible",
     "is_token",
-    "is_invisible",
-    "is_defeated",
-    "show_badge",
-    "is_locked",
     "default_edit_access",
     "default_movement_access",
     "default_vision_access",
     "asset",
 ] as const;
-export const BaseAuraStrings = ["vision_source", "visible", "name", "value", "dim", "colour"] as const;
-export const BaseTrackerStrings = ["visible", "name", "value", "maxvalue"] as const;
-export type BaseAuraTemplate = Pick<ApiAura, typeof BaseAuraStrings[number]>;
-export type BaseTrackerTemplate = Pick<ApiTracker, typeof BaseTrackerStrings[number]>;
-type BasePropertyTemplate = Pick<ApiShape, typeof BaseTemplateStrings[number]>;
+// Some properties are not desirable by default:
+// is_door, is_teleport_zone, is_locked, is_defeated, show_badge, is_invisible
+// ideally we have an advanced option where you can decide which template options are saved including the above by default deselected
+export const BaseAuraStrings = [
+    "vision_source",
+    "visible",
+    "name",
+    "value",
+    "dim",
+    "colour",
+    "active",
+    "border_colour",
+    "angle",
+    "direction",
+] as const;
+export const BaseTrackerStrings = [
+    "visible",
+    "name",
+    "value",
+    "maxvalue",
+    "draw",
+    "primary_color",
+    "secondary_color",
+] as const;
+export type BaseAuraTemplate = Pick<ApiAura, (typeof BaseAuraStrings)[number]>;
+export type BaseTrackerTemplate = Pick<ApiTracker, (typeof BaseTrackerStrings)[number]>;
+type BasePropertyTemplate = Pick<ApiShape, (typeof BaseTemplateStrings)[number]>;
 export type BaseTemplate = Partial<
     BasePropertyTemplate & { auras: Partial<BaseAuraTemplate>[] } & { trackers: Partial<BaseTrackerTemplate>[] }
 >;
 
+// Why do these exist, templates only work for Assets at the moment?
 const PolygonTemplateStrings = ["x", "y", "vertices", "open_polygon", "line_width"] as const;
-
 const TextTemplateStrings = ["text", "font"] as const;
 
 const AssetTemplateStrings = ["width", "height", "src"] as const;
@@ -55,5 +74,8 @@ const TEMPLATE_TYPES: Record<SHAPE_TYPE, SpecifcShapeTemplateStrings> = {
 };
 
 export function getTemplateKeys(shapeType: SHAPE_TYPE): SpecifcShapeTemplateStrings {
+    if (shapeType !== "assetrect") {
+        console.error("Template keys requested for non-assetrect");
+    }
     return TEMPLATE_TYPES[shapeType];
 }


### PR DESCRIPTION
Templates are a way to save a shape with some settings pre-filled for later re-use. Since introducing templates, they haven't been updated to match new features and are thus missing some data that one would expect to be saved.

The following data is now also saved:

- Annotation public visibility
- Trackers:
  - Display on token
  - Colors for display on token
- Auras:
  - Whether the aura is enabled
  - The stroke colour
  - The angle and direction

While revisiting these keys, I've also removed some settings that are **no longer** saved.
The settings I've removed felt too situational to be saved as a general setting.
Ideally at some point while saving a template, you would get the option to choose which things are saved on a more fine-grained level, allowing you to save these after all for specific cases. But alas we're not there yet.

The following data is no longer saved:

- invisible state
- defeated state
- locked state
- 'show badge'

If you frequently save templates with one of these specifically in mind, feel free to mention something here or on discord and we'll see if I want to adjust my vision or prioritise the aforementioned granular saving implementation.

Fixes #1204