### PR TITLE
bug(FakePlayer): Fix auras and isToken rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ tech changes will usually be stripped from release notes for the public
 
 ### Fixed
 
--   No longer sending group info for each member (just once)
--   A logic error in the auth routing code - in some cases you had to manually go to the login page
--   Templates missing some settings when saved
+-   Group: No longer sending group info for each member (just once)
+-   Auth: A logic error in the auth routing code - in some cases you had to manually go to the login page
+-   Templates: Missing some settings when saved
+-   Fake player: no longer render auras and isToken vision
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -41,6 +41,8 @@ export class FowVisionLayer extends FowLayer {
             for (const tokenId of accessState.activeTokens.value) {
                 const token = getShape(tokenId);
                 if (token === undefined || token.floorId !== this.floor) continue;
+                if (token.layerName === LayerName.Dm && gameState.raw.isFakePlayer) continue;
+
                 const center = token.center;
                 const lcenter = g2l(center);
 

--- a/client/src/game/rendering/auras.ts
+++ b/client/src/game/rendering/auras.ts
@@ -13,7 +13,8 @@ export function drawAuras(shape: IShape, ctx: CanvasRenderingContext2D): void {
     const lCenter = g2l(center);
 
     for (const aura of auraSystem.getAll(shape.id, true)) {
-        if (!aura.active || (!aura.visionSource && shape.layerName === LayerName.Lighting)) continue;
+        if (!aura.active) continue;
+        if (!aura.visionSource && shape.layerName === LayerName.Lighting) continue;
 
         const value = aura.value > 0 && !isNaN(aura.value) ? aura.value : 0;
         const dim = aura.dim > 0 && !isNaN(aura.dim) ? aura.dim : 0;

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -8,7 +8,9 @@ import type { Sync } from "../../../core/models/types";
 import { getGlobalId, getShape } from "../../id";
 import type { LocalId } from "../../id";
 import { compositeState } from "../../layers/state";
+import { LayerName } from "../../models/floor";
 import { visionState } from "../../vision/state";
+import { gameState } from "../game/state";
 import { selectedSystem } from "../selected";
 
 import { aurasToServer, partialAuraToServer, toUiAuras } from "./conversion";
@@ -100,6 +102,12 @@ class AuraSystem implements ShapeSystem {
     }
 
     getAll(id: LocalId, includeParent: boolean): DeepReadonly<Aura[]> {
+        if (gameState.raw.isFakePlayer) {
+            const shape = getShape(id);
+            if (shape === undefined) return [];
+            if (shape.layerName === LayerName.Dm) return [];
+        }
+
         const auras: Aura[] = [];
         if (includeParent) {
             const parent = compositeState.getCompositeParent(id);


### PR DESCRIPTION
In the last release we  fixed shapes on the DM layer no longer being rendered when in fake player mode.
As pointed out by #1203 however, I forgot to take into account potential auras as well as the minimal vision that shapes with `isToken` receive.

This is now resolved.

Fixes #1203