### PR TITLE
bug(Tool UI): Fix visible tools on first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ tech changes will usually be stripped from release notes for the public
 -   Templates: Missing some settings when saved
 -   Fake player: no longer render auras and isToken vision
 -   Labels: Fix removal not working
+-   Toolbar: Fix vision and filter tools not immediately being available when relevant
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -37,7 +37,12 @@ const visibleTools = computed(() => {
         const tools = [];
         for (const [toolName] of activeModeTools.value) {
             if (dmTools.includes(toolName) && !gameState.reactive.isDm) continue;
-            if (!isToolVisible(toolName)) continue;
+
+            if (toolName === ToolName.Filter) {
+                if (labelState.reactive.labels.size === 0) continue;
+            } else if (toolName === ToolName.Vision) {
+                if (accessState.reactive.ownedTokens.size <= 1) continue;
+            }
 
             const tool = toolMap[toolName];
             tools.push({
@@ -62,15 +67,6 @@ function updateDetails(): void {
     const pos = useToolPosition(activeTool.value);
     detailRight.value = pos.right;
     detailArrow.value = pos.arrow;
-}
-
-function isToolVisible(tool: ToolName): boolean {
-    if (tool === ToolName.Filter) {
-        return labelState.raw.labels.size > 0;
-    } else if (tool === ToolName.Vision) {
-        return accessState.raw.ownedTokens.size > 1;
-    }
-    return true;
 }
 
 function getStyle(tool: ToolMode): CSSProperties {


### PR DESCRIPTION
The vision and filter tools are only shown if there is some extra condition relevant. This condition was only evaluated when changing tool mode. This meant that upon opening these tools were not visible in play mode even when they should have been until you swapped to build mode and back.

Fixes #1201