### PR TITLE
bug(Access): Fix edit shape UI not live updating to access changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ tech changes will usually be stripped from release notes for the public
 -   Fake player: no longer render auras and isToken vision
 -   Labels: Fix removal not working
 -   Toolbar: Fix vision and filter tools not immediately being available when relevant
+-   Access: Fix players with specific access rules, having edit access at all times
+-   Access: Changing access would not live update the edit shape UI if it was open by another client
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/ui/settings/shape/AccessSettings.vue
+++ b/client/src/game/ui/settings/shape/AccessSettings.vue
@@ -1,31 +1,28 @@
 <script setup lang="ts">
-import { computed, ref, toRef, watch } from "vue";
+import { computed, ref, toRef, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { SERVER_SYNC } from "../../../../core/models/types";
 import type { PartialPick } from "../../../../core/types";
-import { activeShapeStore } from "../../../../store/activeShape";
 import { Role } from "../../../models/role";
 import { accessSystem } from "../../../systems/access";
 import { DEFAULT_ACCESS, DEFAULT_ACCESS_SYMBOL } from "../../../systems/access/models";
 import type { ACCESS_KEY, ShapeAccess } from "../../../systems/access/models";
 import { accessState } from "../../../systems/access/state";
 import { playerState } from "../../../systems/players/state";
+import { selectedSystem } from "../../../systems/selected";
 
 const { t } = useI18n();
 defineProps<{ activeSelection: boolean }>();
 
-watch(
-    () => activeShapeStore.state.id,
-    (newId, oldId) => {
-        if (newId !== undefined && oldId !== newId) {
-            accessSystem.loadState(newId);
-        } else if (newId === undefined) {
-            accessSystem.dropState();
-        }
-    },
-    { immediate: true },
-);
+watchEffect(() => {
+    const id = selectedSystem.getFocus().value;
+    if (id !== undefined) {
+        accessSystem.loadState(id);
+    } else {
+        accessSystem.dropState();
+    }
+});
 
 const accessDropdown = ref<HTMLSelectElement | null>(null);
 

--- a/client/src/game/ui/settings/shape/ExtraSettings.vue
+++ b/client/src/game/ui/settings/shape/ExtraSettings.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import tinycolor from "tinycolor2";
-import { computed, ref, toRef, watch } from "vue";
+import { computed, ref, toRef, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { l2gz } from "../../../../core/conversions";
@@ -37,19 +37,16 @@ import LabelManager from "../../LabelManager.vue";
 const { t } = useI18n();
 const modals = useModal();
 
-watch(
-    () => selectedSystem.getFocus().value,
-    (newId, oldId) => {
-        if (newId !== undefined && oldId !== newId) {
-            annotationSystem.loadState(newId);
-            labelSystem.loadState(newId);
-        } else if (newId === undefined) {
-            annotationSystem.dropState();
-            labelSystem.dropState();
-        }
-    },
-    { immediate: true },
-);
+watchEffect(() => {
+    const id = selectedSystem.getFocus().value;
+    if (id) {
+        annotationSystem.loadState(id);
+        labelSystem.loadState(id);
+    } else {
+        annotationSystem.dropState();
+        labelSystem.dropState();
+    }
+});
 
 const textarea = ref<HTMLTextAreaElement | null>(null);
 


### PR DESCRIPTION
When you have a shape's edit UI open and someone alters the access rights you have for that shape, the UI would not update accordingly until you deselected and then reselected the shape in some cases.