### PR TITLE
bug(Access): Fix default access UI not always accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ tech changes will usually be stripped from release notes for the public
 -   Toolbar: Fix vision and filter tools not immediately being available when relevant
 -   Access: Fix players with specific access rules, having edit access at all times
 -   Access: Changing access would not live update the edit shape UI if it was open by another client
+-   Access: Fix default access in UI not being up to date if shape has no access modifications until reload
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -36,13 +36,18 @@ class AccessSystem implements ShapeSystem {
 
     loadState(id: LocalId): void {
         $.id = id;
-        $.id = id;
+        $.defaultAccess = { ...DEFAULT_ACCESS };
         $.playerAccess.clear();
-        for (const [user, access] of this.access.get(id) ?? []) {
-            if (user === DEFAULT_ACCESS_SYMBOL) {
-                $.defaultAccess = { ...access };
-            } else {
-                $.playerAccess.set(user, { ...access });
+
+        const accessMap = this.access.get(id);
+
+        if (accessMap !== undefined) {
+            for (const [user, access] of accessMap) {
+                if (user === DEFAULT_ACCESS_SYMBOL) {
+                    $.defaultAccess = { ...access };
+                } else {
+                    $.playerAccess.set(user, { ...access });
+                }
             }
         }
     }


### PR DESCRIPTION
For shapes that have no alterations to the access state, the default access values could be wrongly displayed in the edit shape access UI if a shape has previously been selected that differed from the default values for default access.