### PR TITLE
bug(Access): Prevent DMs from having explicit access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ tech changes will usually be stripped from release notes for the public
 -   Access: Fix players with specific access rules, having edit access at all times
 -   Access: Changing access would not live update the edit shape UI if it was open by another client
 -   Access: Fix default access in UI not being up to date if shape has no access modifications until reload
+-   Access: Prevent DMs from having an explicit access rule
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -4,6 +4,7 @@ import { registerSystem } from "..";
 import type { ShapeSystem } from "..";
 import { NO_SYNC } from "../../../core/models/types";
 import type { Sync } from "../../../core/models/types";
+import { coreStore } from "../../../store/core";
 import { getGlobalId } from "../../id";
 import type { LocalId } from "../../id";
 import { initiativeStore } from "../../ui/initiative/state";
@@ -156,6 +157,7 @@ class AccessSystem implements ShapeSystem {
             console.error("[ACCESS] Attempt to add access for user with access");
             return;
         }
+        if (gameState.isDmOrFake.value && coreStore.state.username === user) return;
 
         const userAccess = { ...DEFAULT_ACCESS, ...access };
 
@@ -215,6 +217,9 @@ class AccessSystem implements ShapeSystem {
 
         // Commit to state
         const newAccess = { ...oldAccess, ...access };
+        if (!this.access.has(shapeId)) {
+            this.access.set(shapeId, new Map());
+        }
         this.access.get(shapeId)!.set(user, newAccess);
 
         if ($.id === shapeId) {


### PR DESCRIPTION
DMs have implicit edit access to all shapes. It is not possible to add explicit access for DMs using the access UI as this could potentially be confusing if you try to revoke certain access rights from a DM.

During the creation of some shapes(e.g. basic tokens) DMs would still be explicitly granted access and thus show up in the access UI.

This PR now actively prevents any `addAccess` call to work for DMs.