### PR TITLE
feat(BringPlayers): No longer adjust players' zoom to DM zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ tech changes will usually be stripped from release notes for the public
 ### Changed
 
 -   Templates no longer save certain settings
+-   Bring players no longer changes the zoom level of the players
 
 ### Fixed
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -445,15 +445,14 @@ export interface PlayerOptionsSet {
   default_user_options: ApiUserOptions;
   room_user_options: ApiOptionalUserOptions | null;
 }
-export interface PlayerRoleSet {
-  player: PlayerId;
-  role: number;
-}
-export interface PlayersBring {
+export interface PlayerPosition {
   x: number;
   y: number;
   floor: string;
-  zoom: number;
+}
+export interface PlayerRoleSet {
+  player: PlayerId;
+  role: number;
 }
 export interface PlayersInfoSet {
   core: PlayerInfoCore;

--- a/client/src/game/api/emits/players.ts
+++ b/client/src/game/api/emits/players.ts
@@ -1,6 +1,6 @@
-import type { PlayerRoleSet, PlayersBring } from "../../../apiTypes";
+import type { PlayerRoleSet, PlayerPosition } from "../../../apiTypes";
 import { wrapSocket } from "../helpers";
 
-export const sendBringPlayers = wrapSocket<PlayersBring>("Players.Bring");
+export const sendBringPlayers = wrapSocket<PlayerPosition>("Players.Bring");
 
 export const sendChangePlayerRole = wrapSocket<PlayerRoleSet>("Player.Role.Set");

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -29,7 +29,7 @@ import "./events/user";
 
 import "./gbsocket"; // Start tuio listener
 
-import type { ApiFloor, ApiLocationCore, PlayersBring, PositionTuple } from "../../apiTypes";
+import type { ApiFloor, ApiLocationCore, PlayerPosition } from "../../apiTypes";
 import { toGP } from "../../core/geometry";
 import { SyncMode } from "../../core/models/types";
 import type { AssetList } from "../../core/models/types";
@@ -48,7 +48,6 @@ import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
 import { gameSystem } from "../systems/game";
 import { playerSystem } from "../systems/players";
-import { positionSystem } from "../systems/position";
 
 import { socket } from "./socket";
 
@@ -117,10 +116,8 @@ socket.on("Board.Floor.Set", (floor: ApiFloor) => {
 
 // Varia
 
-socket.on("Position.Set", (data: PositionTuple & Partial<PlayersBring>) => {
+socket.on("Position.Set", (data: PlayerPosition) => {
     if (data.floor !== undefined) floorSystem.selectFloor({ name: data.floor }, true);
-    if (data.zoom !== undefined)
-        positionSystem.setZoomDisplay(data.zoom, { invalidate: false, updateSectors: false, sync: false });
     setCenterPosition(toGP(data.x, data.y));
 });
 

--- a/client/src/game/ui/contextmenu/DefaultContext.vue
+++ b/client/src/game/ui/contextmenu/DefaultContext.vue
@@ -15,7 +15,6 @@ import { Asset } from "../../shapes/variants/asset";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
 import { gameState } from "../../systems/game/state";
-import { positionState } from "../../systems/position/state";
 import { propertiesSystem } from "../../systems/properties";
 import { getProperties } from "../../systems/properties/state";
 import { locationSettingsSystem } from "../../systems/settings/location";
@@ -38,9 +37,7 @@ function bringPlayers(): void {
     sendBringPlayers({
         floor: floorState.currentFloor.value!.name,
         x: l2gx(defaultContextLeft.value),
-        // eslint-disable-next-line no-undef
         y: l2gy(defaultContextTop.value),
-        zoom: positionState.raw.zoomDisplay,
     });
     close();
 }

--- a/server/src/api/models/players/__init__.py
+++ b/server/src/api/models/players/__init__.py
@@ -4,6 +4,5 @@ from .options import *
 from .role import *
 
 
-class PlayersBring(PositionTuple):
+class PlayerPosition(PositionTuple):
     floor: str
-    zoom: int

--- a/server/src/api/socket/player.py
+++ b/server/src/api/socket/player.py
@@ -9,14 +9,14 @@ from ...logs import logger
 from ...models.role import Role
 from ...state.game import game_state
 from ..helpers import _send_game
-from ..models.players import PlayersBring
+from ..models.players import PlayerPosition
 from ..models.players.role import PlayerRoleSet
 
 
 @sio.on("Players.Bring", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def bring_players(sid: str, raw_data: Any):
-    data = PlayersBring(**raw_data)
+    data = PlayerPosition(**raw_data)
 
     pr = game_state.get(sid)
 


### PR DESCRIPTION
The "Bring Players" feature has always changed the receiving players' zoom level to that of the DM.

Since its introduction I've actually felt it to be more of a pain than a boon so I'm changing this behaviour to just change the position and not touch the zoom level.

Players might be zoomed out or in depending on their monitor setup, and the zoom drastically changing to some arbitrary vision that the DM happens to be using, makes little sense.