### PR TITLE
bug(TpZone): Fix floor change not causing player view to move along

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ tech changes will usually be stripped from release notes for the public
 -   Access: Changing access would not live update the edit shape UI if it was open by another client
 -   Access: Fix default access in UI not being up to date if shape has no access modifications until reload
 -   Access: Prevent DMs from having an explicit access rule
+-   TpZone: Fix tp zone moving a player to a different floor not moving their view along (if 'move players' configured)
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -459,6 +459,12 @@ export interface PlayersInfoSet {
   position?: ApiLocationUserOption;
   clients?: OptionalClientViewport[];
 }
+export interface PlayersPositionSet {
+  x: number;
+  y: number;
+  floor: string;
+  players: string[];
+}
 export interface PositionTuple {
   x: number;
   y: number;

--- a/client/src/game/api/emits/players.ts
+++ b/client/src/game/api/emits/players.ts
@@ -1,6 +1,7 @@
-import type { PlayerRoleSet, PlayerPosition } from "../../../apiTypes";
+import type { PlayerRoleSet, PlayerPosition, PlayersPositionSet } from "../../../apiTypes";
 import { wrapSocket } from "../helpers";
 
 export const sendBringPlayers = wrapSocket<PlayerPosition>("Players.Bring");
+export const sendSetPlayersPosition = wrapSocket<PlayersPositionSet>("Players.Position.Set");
 
 export const sendChangePlayerRole = wrapSocket<PlayerRoleSet>("Player.Role.Set");

--- a/client/src/game/systems/logic/tp/core.ts
+++ b/client/src/game/systems/logic/tp/core.ts
@@ -1,3 +1,4 @@
+import { sendSetPlayersPosition } from "../../../api/emits/players";
 import { requestShapeInfo, sendShapesMove } from "../../../api/emits/shape/core";
 import { getShape, getLocalId, getGlobalId } from "../../../id";
 import type { LocalId, GlobalId } from "../../../id";
@@ -65,14 +66,16 @@ export async function teleport(fromZone: LocalId, toZone: GlobalId, transfers?: 
     });
     const { location, ...position } = target;
     if (locationSettingsState.raw.movePlayerOnTokenChange.value) {
+        const players = new Set<string>();
+        for (const sh of shapes) {
+            for (const owner of accessSystem.getOwners(sh)) players.add(owner);
+        }
+
         if (location === activeLocation) {
             setCenterPosition(center);
+            sendSetPlayersPosition({ ...position, players: [...players] });
         } else {
-            const users = new Set<string>();
-            for (const sh of shapes) {
-                for (const owner of accessSystem.getOwners(sh)) users.add(owner);
-            }
-            playerSystem.updatePlayersLocation([...users], location, true, position);
+            playerSystem.updatePlayersLocation([...players], location, true, position);
         }
     }
 }

--- a/server/src/api/models/players/__init__.py
+++ b/server/src/api/models/players/__init__.py
@@ -6,3 +6,7 @@ from .role import *
 
 class PlayerPosition(PositionTuple):
     floor: str
+
+
+class PlayersPositionSet(PlayerPosition):
+    players: list[str]


### PR DESCRIPTION
If a player has the 'Move player(s) when a token they own changes location' setting enabled, when a shape the player owns is moved to a different floor due to a teleport zone, their view would not move along.

The wording of the setting specifically mentions a location change, which in PA terms is actually not happening, but the intent of the setting is to move the camera along if a token changes position suddenly as is the case here.

Fixes #1213