### PR TITLE
bug(Logic): Fix Request mode behaving as Enabled mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ tech changes will usually be stripped from release notes for the public
 -   Access: Fix default access in UI not being up to date if shape has no access modifications until reload
 -   Access: Prevent DMs from having an explicit access rule
 -   TpZone: Fix tp zone moving a player to a different floor not moving their view along (if 'move players' configured)
+-   Logic: Request mode not working as intended and behaving as Enabled mode instead
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -412,14 +412,14 @@ export interface LogicDoorRequest {
   door: GlobalId;
 }
 export interface LogicRequestInfo {
-  requester: string;
+  requester: PlayerId;
   request: LogicDoorRequest | LogicTeleportRequest;
 }
 export interface LogicTeleportRequest {
   logic: "tp";
   fromZone: GlobalId;
   toZone: GlobalId;
-  transfers: string[];
+  transfers: GlobalId[];
 }
 export interface NotificationShow {
   uuid: string;

--- a/client/src/game/api/emits/logic.ts
+++ b/client/src/game/api/emits/logic.ts
@@ -1,5 +1,6 @@
 import type { LogicDoorRequest, LogicTeleportRequest } from "../../../apiTypes";
+import type { PlayerId } from "../../systems/players/models";
 import { wrapSocket } from "../helpers";
 
 export const sendRequest = wrapSocket<LogicDoorRequest | LogicTeleportRequest>("Logic.Request");
-export const sendDeclineRequest = wrapSocket<string>("Logic.Request.Decline");
+export const sendDeclineRequest = wrapSocket<PlayerId>("Logic.Request.Decline");

--- a/client/src/game/api/events/logic.ts
+++ b/client/src/game/api/events/logic.ts
@@ -14,7 +14,7 @@ socket.on("Logic.Request", (data: LogicRequestInfo) => {
     if (data.request.logic === "door") {
         const doorId = getLocalId(data.request.door);
         if (doorId === undefined) return;
-        const canUse = doorSystem.canUse(doorId);
+        const canUse = doorSystem.canUse(doorId, data.requester);
         if (canUse === Access.Enabled) {
             doorSystem.toggleDoor(doorId);
             return;

--- a/client/src/game/id.ts
+++ b/client/src/game/id.ts
@@ -3,10 +3,6 @@ import { uuidv4 } from "../core/utils";
 import type { IShape } from "./interfaces/shape";
 import { dropFromSystems } from "./systems";
 
-export type Global<T> = {
-    [key in keyof T]: T[key] extends LocalId ? GlobalId : T[key] extends LocalId[] ? GlobalId[] : T[key];
-};
-
 export type NumberId<T extends string> = number & { __brand: T };
 export type StringId<T extends string> = string & { __brand: T };
 export type GlobalId = StringId<"globalId">;

--- a/client/src/game/systems/logic/door/index.ts
+++ b/client/src/game/systems/logic/door/index.ts
@@ -8,6 +8,7 @@ import type { Sync } from "../../../../core/models/types";
 import { getGlobalId } from "../../../id";
 import type { LocalId } from "../../../id";
 import { selectToolState } from "../../../tools/variants/select/state";
+import type { PlayerId } from "../../players/models";
 import { propertiesSystem } from "../../properties";
 import { getProperties } from "../../properties/state";
 import { canUse } from "../common";
@@ -146,8 +147,8 @@ class DoorSystem implements ShapeSystem {
         return props.blocksMovement ? "lock-open-solid" : "lock-solid";
     }
 
-    canUse(id: LocalId): Access {
-        return canUse(id, "door");
+    canUse(id: LocalId, playerId: PlayerId): Access {
+        return canUse(id, "door", playerId);
     }
 
     getDoors(): Readonly<IterableIterator<LocalId>> {

--- a/client/src/game/systems/logic/door/models.ts
+++ b/client/src/game/systems/logic/door/models.ts
@@ -1,10 +1,4 @@
-import type { LocalId } from "../../../id";
 import type { Permissions } from "../models";
-
-export interface DoorRequest {
-    logic: "door";
-    door: LocalId;
-}
 
 export type DOOR_TOGGLE_MODE = "movement" | "vision" | "both";
 export const DOOR_TOGGLE_MODES: DOOR_TOGGLE_MODE[] = ["vision", "movement", "both"];

--- a/client/src/game/systems/logic/models.ts
+++ b/client/src/game/systems/logic/models.ts
@@ -1,8 +1,3 @@
-import type { Global } from "../../id";
-
-import type { DoorRequest } from "./door/models";
-import type { TpRequest } from "./tp/models";
-
 export const DEFAULT_PERMISSIONS: () => Permissions = () => ({ enabled: [], request: [], disabled: ["default"] });
 export type LOGIC_TYPES = "door" | "tp";
 
@@ -11,9 +6,6 @@ export enum Access {
     Request,
     Disabled,
 }
-
-type RequestType = DoorRequest | TpRequest;
-export type RequestTypeResponse = Global<RequestType> & { requester: string };
 
 export interface Permissions {
     enabled: string[];

--- a/client/src/game/systems/logic/tp/index.ts
+++ b/client/src/game/systems/logic/tp/index.ts
@@ -11,6 +11,8 @@ import { sendRequest } from "../../../api/emits/logic";
 import { getGlobalId, getShape } from "../../../id";
 import type { LocalId } from "../../../id";
 import type { IShape } from "../../../interfaces/shape";
+import { playerSystem } from "../../players";
+import type { PlayerId } from "../../players/models";
 import { getProperties } from "../../properties/state";
 import { locationSettingsState } from "../../settings/location/state";
 import { canUse } from "../common";
@@ -157,8 +159,8 @@ class TeleportZoneSystem implements ShapeSystem {
         options.permissions = permissions;
     }
 
-    canUse(id: LocalId): Access {
-        return canUse(id, "tp");
+    canUse(id: LocalId, playerId: PlayerId): Access {
+        return canUse(id, "tp", playerId);
     }
 
     setTarget(id: LocalId, target: NonNullable<TeleportOptions["location"]>, syncTo: Sync): void {
@@ -183,7 +185,7 @@ class TeleportZoneSystem implements ShapeSystem {
             const tpShape = getShape(tp);
             if (tpShape === undefined || options.location === undefined) continue;
 
-            const access = this.canUse(tp);
+            const access = this.canUse(tp, playerSystem.getCurrentPlayerId()!);
             if (access === Access.Disabled) {
                 continue;
             }

--- a/client/src/game/systems/logic/tp/models.ts
+++ b/client/src/game/systems/logic/tp/models.ts
@@ -1,12 +1,5 @@
-import type { GlobalId, LocalId } from "../../../id";
+import type { GlobalId } from "../../../id";
 import type { Permissions } from "../models";
-
-export interface TpRequest {
-    logic: "tp";
-    fromZone: LocalId;
-    toZone: LocalId;
-    transfers: LocalId[];
-}
 
 export interface TeleportOptions {
     permissions: Permissions;

--- a/client/src/game/systems/players/index.ts
+++ b/client/src/game/systems/players/index.ts
@@ -105,6 +105,15 @@ class PlayerSystem implements System {
         return $.players.get(playerId);
     }
 
+    // the following 2 functions should be cached..
+    getCurrentPlayerId(): PlayerId | undefined {
+        for (const player of raw.players.values()) {
+            if (player.name === coreStore.state.username) {
+                return player.id;
+            }
+        }
+    }
+
     getCurrentPlayer(): Player | undefined {
         for (const player of raw.players.values()) {
             if (player.name === coreStore.state.username) {

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -219,7 +219,7 @@ class SelectTool extends Tool implements ISelectTool {
                 doorSystem.toggleDoor(_.hoveredDoor);
                 return;
             } else {
-                if (doorSystem.canUse(_.hoveredDoor) === Access.Request) {
+                if (doorSystem.canUse(_.hoveredDoor, playerSystem.getCurrentPlayerId()!) === Access.Request) {
                     toast.info("Request to open door sent", {
                         position: POSITION.TOP_RIGHT,
                     });
@@ -404,7 +404,7 @@ class SelectTool extends Tool implements ISelectTool {
                 if (shape === undefined) continue;
                 if (shape.floorId !== floorState.currentFloor.value!.id) continue;
                 if (!shape.contains(gp)) continue;
-                if (doorSystem.canUse(id) === Access.Disabled) continue;
+                if (doorSystem.canUse(id, playerSystem.getCurrentPlayerId()!) === Access.Disabled) continue;
 
                 foundDoor = true;
                 _.hoveredDoor = id;

--- a/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
+++ b/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
@@ -1,22 +1,25 @@
 <script lang="ts" setup>
 import { computed } from "vue";
 
+import type { LogicDoorRequest, LogicRequestInfo, LogicTeleportRequest } from "../../../apiTypes";
 import { sendDeclineRequest } from "../../api/emits/logic";
 import { getLocalId, getShapeFromGlobal } from "../../id";
-import type { Global } from "../../id";
 import { setCenterPosition } from "../../position";
 import { floorSystem } from "../../systems/floors";
 import { doorSystem } from "../../systems/logic/door";
-import type { DoorRequest } from "../../systems/logic/door/models";
-import type { RequestTypeResponse } from "../../systems/logic/models";
 import { teleport } from "../../systems/logic/tp/core";
-import type { TpRequest } from "../../systems/logic/tp/models";
+import { playerSystem } from "../../systems/players";
 
 const emit = defineEmits(["close-toast"]);
-const props = defineProps<{ data: RequestTypeResponse }>();
+const props = defineProps<{ data: LogicRequestInfo }>();
+
+const player = computed(() => playerSystem.getPlayer(props.data.requester));
 
 const text = computed(
-    () => `${props.data.requester} requests to use ${props.data.logic === "door" ? "door" : "teleport zone"}`,
+    () =>
+        `${player.value?.name ?? "unknown player"} requests to use ${
+            props.data.request.logic === "door" ? "door" : "teleport zone"
+        }`,
 );
 
 function reject(): void {
@@ -25,21 +28,21 @@ function reject(): void {
 }
 
 async function accept(): Promise<void> {
-    if (props.data.logic === "door") {
-        approveDoor(props.data);
-    } else if (props.data.logic === "tp") {
-        await approveTp(props.data);
+    if (props.data.request.logic === "door") {
+        approveDoor(props.data.request);
+    } else if (props.data.request.logic === "tp") {
+        await approveTp(props.data.request);
     }
     emit("close-toast");
 }
 
-function approveDoor(request: Global<DoorRequest> & { requester: string }): void {
+function approveDoor(request: LogicDoorRequest): void {
     const shape = getLocalId(request.door);
     if (shape === undefined) return;
     doorSystem.toggleDoor(shape);
 }
 
-async function approveTp(request: Global<TpRequest> & { requester: string }): Promise<void> {
+async function approveTp(request: LogicTeleportRequest): Promise<void> {
     await teleport(
         getLocalId(request.fromZone)!,
         request.toZone,
@@ -48,7 +51,7 @@ async function approveTp(request: Global<TpRequest> & { requester: string }): Pr
 }
 
 function showArea(): void {
-    const uuid = props.data.logic === "door" ? props.data.door : props.data.toZone;
+    const uuid = props.data.request.logic === "door" ? props.data.request.door : props.data.request.toZone;
     const shape = getShapeFromGlobal(uuid);
     if (shape?.floorId === undefined) return;
 

--- a/server/src/api/models/logic/request.py
+++ b/server/src/api/models/logic/request.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ..helpers import TypeIdModel
 
@@ -14,9 +14,9 @@ class LogicTeleportRequest(TypeIdModel):
     logic: Literal["tp"]
     fromZone: str = Field(typeId="GlobalId")
     toZone: str = Field(typeId="GlobalId")
-    transfers: list[str]
+    transfers: list[str] = Field(typeId="GlobalId")
 
 
-class LogicRequestInfo(BaseModel):
-    requester: str
+class LogicRequestInfo(TypeIdModel):
+    requester: int = Field(typeId="PlayerId")
     request: LogicDoorRequest | LogicTeleportRequest

--- a/server/src/api/socket/logic.py
+++ b/server/src/api/socket/logic.py
@@ -33,18 +33,18 @@ async def request(sid: str, raw_data: Dict):
         if game_state.get(psid).role == Role.DM:
             await _send_game(
                 "Logic.Request",
-                LogicRequestInfo(requester=pr.player.name, request=data),
+                LogicRequestInfo(requester=pr.player.id, request=data),
                 room=psid,
             )
 
 
 @sio.on("Logic.Request.Decline", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
-async def decline_request(sid: str, name: str):
+async def decline_request(sid: str, player_id: int):
     pr: PlayerRoom = game_state.get(sid)
 
     for psid in game_state.get_sids(room=pr.room):
-        if game_state.get(psid).player.name == name:
+        if game_state.get(psid).player.id == player_id:
             await sio.emit(
                 "Logic.Request.Declined",
                 room=psid,


### PR DESCRIPTION
The logic permission "Request" was not properly being validated and instead behaved as "Enabled" instead.

Logic requests coming from players are routed through the DM to make sure they are valid and the Request check was not checking the original requester but instead always validating against DM which resulted in the Enabled behaviour.

Fixes #1214