### PR TITLE
bug(TpZone): Fix non-immediate player initiated teleports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ tech changes will usually be stripped from release notes for the public
 -   Access: Fix default access in UI not being up to date if shape has no access modifications until reload
 -   Access: Prevent DMs from having an explicit access rule
 -   TpZone: Fix tp zone moving a player to a different floor not moving their view along (if 'move players' configured)
+-   TpZone: Fix non-immediate player initiated teleports not working correctly
+-   TpZone: Fix teleports initiated in build-mode not working correctly for players
 -   Logic: Request mode not working as intended and behaving as Enabled mode instead
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -526,7 +526,6 @@ export interface ShapeLayerChange {
 export interface ShapeLocationMove {
   shapes: GlobalId[];
   target: ShapeLocationMoveTarget;
-  tp_zone: boolean;
 }
 export interface ShapeLocationMoveTarget {
   x: number;

--- a/client/src/game/systems/logic/tp/core.ts
+++ b/client/src/game/systems/logic/tp/core.ts
@@ -1,16 +1,24 @@
+import { POSITION, useToast } from "vue-toastification";
+
+import { sendRequest } from "../../../api/emits/logic";
 import { sendSetPlayersPosition } from "../../../api/emits/players";
 import { requestShapeInfo, sendShapesMove } from "../../../api/emits/shape/core";
 import { getShape, getLocalId, getGlobalId } from "../../../id";
 import type { LocalId, GlobalId } from "../../../id";
 import { LayerName } from "../../../models/floor";
-import { setCenterPosition } from "../../../position";
+import { Role } from "../../../models/role";
 import { createSimpleShapeFromDict } from "../../../shapes/simple";
 import { accessSystem } from "../../access";
 import { floorSystem } from "../../floors";
 import { floorState } from "../../floors/state";
+import { gameState } from "../../game/state";
 import { playerSystem } from "../../players";
+import { playerState } from "../../players/state";
 import { getProperties } from "../../properties/state";
 import { locationSettingsState } from "../../settings/location/state";
+import { Access } from "../models";
+
+const toast = useToast();
 
 export function getTpZoneShapes(fromZone: LocalId): LocalId[] {
     const tokenLayer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Tokens)!;
@@ -31,7 +39,36 @@ export function getTpZoneShapes(fromZone: LocalId): LocalId[] {
     return shapes;
 }
 
+export async function validateTeleport(
+    access: Access,
+    tp: LocalId,
+    toZone: GlobalId,
+    shapesToMove: LocalId[],
+): Promise<void> {
+    if (access === Access.Request) {
+        toast.info("Request to use teleport zone sent", {
+            position: POSITION.TOP_RIGHT,
+        });
+        const gId = getGlobalId(tp);
+        if (gId) {
+            sendRequest({
+                fromZone: gId,
+                toZone,
+                transfers: shapesToMove.map((s) => getGlobalId(s)!),
+                logic: "tp",
+            });
+        }
+    } else if (access === Access.Enabled) {
+        await teleport(tp, toZone, shapesToMove);
+    }
+}
+
 export async function teleport(fromZone: LocalId, toZone: GlobalId, transfers?: readonly LocalId[]): Promise<void> {
+    if (!gameState.isDmOrFake.value) {
+        console.error("Attempted TP as non-DM");
+        return;
+    }
+
     const shapes = transfers ? transfers : getTpZoneShapes(fromZone);
     if (shapes.length === 0) return;
 
@@ -62,17 +99,18 @@ export async function teleport(fromZone: LocalId, toZone: GlobalId, transfers?: 
     sendShapesMove({
         shapes: shapes.map((s) => getGlobalId(s)!),
         target,
-        tp_zone: true,
     });
     const { location, ...position } = target;
     if (locationSettingsState.raw.movePlayerOnTokenChange.value) {
         const players = new Set<string>();
+        for (const player of playerState.raw.players.values()) {
+            if (player.role === Role.DM) players.add(player.name);
+        }
         for (const sh of shapes) {
             for (const owner of accessSystem.getOwners(sh)) players.add(owner);
         }
 
         if (location === activeLocation) {
-            setCenterPosition(center);
             sendSetPlayersPosition({ ...position, players: [...players] });
         } else {
             playerSystem.updatePlayersLocation([...players], location, true, position);

--- a/client/src/game/systems/logic/tp/index.ts
+++ b/client/src/game/systems/logic/tp/index.ts
@@ -7,7 +7,6 @@ import { registerSystem } from "../..";
 import type { ShapeSystem } from "../..";
 import SingleButtonToast from "../../../../core/components/toasts/SingleButtonToast.vue";
 import type { Sync } from "../../../../core/models/types";
-import { sendRequest } from "../../../api/emits/logic";
 import { getGlobalId, getShape } from "../../../id";
 import type { LocalId } from "../../../id";
 import type { IShape } from "../../../interfaces/shape";
@@ -19,7 +18,7 @@ import { canUse } from "../common";
 import { Access, DEFAULT_PERMISSIONS } from "../models";
 import type { Permissions } from "../models";
 
-import { getTpZoneShapes, teleport } from "./core";
+import { getTpZoneShapes, validateTeleport } from "./core";
 import {
     sendShapeIsImmediateTeleportZone,
     sendShapeIsTeleportZone,
@@ -206,28 +205,14 @@ class TeleportZoneSystem implements ShapeSystem {
                 const toZone = options.location.spawnUuid;
 
                 if (options.immediate) {
-                    if (access === Access.Request) {
-                        toast.info("Request to use teleport zone sent", {
-                            position: POSITION.TOP_RIGHT,
-                        });
-                        const gId = getGlobalId(tp);
-                        if (gId)
-                            sendRequest({
-                                fromZone: gId,
-                                toZone,
-                                transfers: shapesToMove.map((s) => getGlobalId(s)!),
-                                logic: "tp",
-                            });
-                    } else {
-                        await teleport(tp, toZone, shapesToMove);
-                    }
+                    await validateTeleport(access, tp, toZone, shapesToMove);
                 } else if (options.toastId === undefined) {
                     options.toastId = toast.info(
                         {
                             component: SingleButtonToast,
                             props: {
                                 text: "Teleport Zone",
-                                onClick: async () => await teleport(tp, toZone),
+                                onClick: async () => await validateTeleport(access, tp, toZone, shapesToMove),
                             },
                         },
                         {

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -226,7 +226,6 @@ async function setLocation(newLocation: number): Promise<void> {
     sendShapesMove({
         shapes: shapes.map((s) => getGlobalId(s.id)!),
         target: { location: newLocation, ...targetPosition },
-        tp_zone: false,
     });
     if (locationSettingsState.raw.movePlayerOnTokenChange.value) {
         const users = new Set<string>();

--- a/server/src/api/models/shape/__init__.py
+++ b/server/src/api/models/shape/__init__.py
@@ -50,7 +50,6 @@ class ShapeLocationMoveTarget(PositionTuple):
 class ShapeLocationMove(TypeIdModel):
     shapes: list[str] = Field(typeId="GlobalId")
     target: ShapeLocationMoveTarget
-    tp_zone: bool
 
 
 class ShapeTextValueSet(TypeIdModel):

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -319,7 +319,7 @@ async def move_shapes(sid: str, raw_data: Any):
 
     pr: PlayerRoom = game_state.get(sid)
 
-    if pr.role != Role.DM and not data.tp_zone:
+    if pr.role != Role.DM:
         logger.warning(f"{pr.player.name} attempted to move shape locations")
         return
 


### PR DESCRIPTION
Teleports give players some agency to do things that they normally cannot do.  For this reason these requests are usually relayed through the DM to ensure that the request is valid and that the request will not be rejected by the server due to permission errors.

For some reason I decided to not do this for teleports that are not in 'immediate' mode. Causing some funky bugs to appear.

This also seems to fix #1216 