### PR TITLE
bug(Subpath): Fix two issues with image rendering on subpath setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ tech changes will usually be stripped from release notes for the public
 -   TpZone: Fix non-immediate player initiated teleports not working correctly
 -   TpZone: Fix teleports initiated in build-mode not working correctly for players
 -   Logic: Request mode not working as intended and behaving as Enabled mode instead
+-   Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -2,6 +2,7 @@ import type { ApiAssetRectShape } from "../../../apiTypes";
 import { g2l, g2lz } from "../../../core/conversions";
 import { toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
+import { baseAdjust } from "../../../core/http";
 import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import { sendAssetRectImageChange } from "../../api/emits/shape/asset";
 import { FOG_COLOUR } from "../../colour";
@@ -122,7 +123,7 @@ export class Asset extends BaseRect implements IAsset {
     setImage(url: string, sync: boolean): void {
         this.#loaded = false;
         this.src = url;
-        this.img.src = url;
+        this.img.src = baseAdjust(url);
         this.img.onload = () => {
             this.setLoaded();
         };

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -4,6 +4,7 @@ import { useI18n } from "vue-i18n";
 import draggable from "vuedraggable";
 
 import Modal from "../../../core/components/modals/Modal.vue";
+import { baseAdjust } from "../../../core/http";
 import { useModal } from "../../../core/plugins/modals/plugin";
 import { getTarget, getValue } from "../../../core/utils";
 import { sendRequestInitiatives } from "../../api/emits/initiative";
@@ -110,7 +111,7 @@ function hasImage(actor: InitiativeData): boolean {
 
 function getImage(actor: InitiativeData): string {
     if (actor.localId === undefined) return "";
-    return (getShape(actor.localId) as IAsset).src;
+    return baseAdjust((getShape(actor.localId) as IAsset).src);
 }
 
 function canSee(actor: InitiativeData): boolean {

--- a/client/src/game/ui/settings/shape/PropertySettings.vue
+++ b/client/src/game/ui/settings/shape/PropertySettings.vue
@@ -3,7 +3,6 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../../core/components/ColourPicker.vue";
-import { baseAdjust } from "../../../../core/http";
 import { NO_SYNC, SERVER_SYNC, SyncMode } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { activeShapeStore } from "../../../../store/activeShape";
@@ -117,7 +116,7 @@ async function changeAsset(): Promise<void> {
     if (data === undefined || data.file_hash === undefined) return;
     const shape = getShape(activeShapeStore.state.id);
     if (shape === undefined || shape.type !== "assetrect") return;
-    (shape as Asset).setImage(baseAdjust(`/static/assets/${data.file_hash}`), true);
+    (shape as Asset).setImage(`/static/assets/${data.file_hash}`, true);
 }
 </script>
 


### PR DESCRIPTION
The subpath setup is a niche setup and thus from time to time happens to have some small issues.

This PR fixes two such issues:

- Initiative images not loading
- The new "Change asset" feature was taking subpaths into account, but in a wrong fashion

This fixes #1217 