### PR TITLE
chore(Tech): Add some iterator helpers

### DIFF
--- a/client/src/core/components/modals/SelectionBox.vue
+++ b/client/src/core/components/modals/SelectionBox.vue
@@ -3,11 +3,12 @@ import { computed, reactive } from "vue";
 import VueMarkdownIt from "vue3-markdown-it";
 
 import { i18n } from "../../../i18n";
+import { map } from "../../iter";
 import type { SelectionBoxOptions } from "../../plugins/modals/selectionBox";
 
 import Modal from "./Modal.vue";
 
-const emit = defineEmits<{ (e: "submit", choices: string[]): void; (e: "close"): void }>();
+const emit = defineEmits<{ (e: "submit", choices: Iterable<string>): void; (e: "close"): void }>();
 const props = defineProps<{
     visible: boolean;
     title: string;
@@ -69,7 +70,7 @@ function create(): void {
 function submit(): void {
     emit(
         "submit",
-        [...state.activeSelection].map((i) => props.choices[i]!),
+        map(state.activeSelection, (i) => props.choices[i]!),
     );
 }
 </script>

--- a/client/src/core/iter.ts
+++ b/client/src/core/iter.ts
@@ -1,0 +1,33 @@
+// A set of helpers to deal with iterables
+// until TC39 iterator helpers (https://github.com/tc39/proposal-iterator-helpers/tree/main) is stable
+
+// Code is either taken literally or heavily inspired on the itertool.js project
+// https://github.com/nvie/itertools.js
+
+type Predicate<T> = (arg0: T) => boolean;
+
+export function* filter<T>(iterable: Iterable<T>, predicate: Predicate<T>): Iterable<T> {
+    for (const value of iterable) {
+        if (predicate(value)) {
+            yield value;
+        }
+    }
+}
+
+export function* guard<T, Y extends T>(iterable: Iterable<T>, guard: (a: T) => a is Y): Iterable<Y> {
+    for (const value of iterable) {
+        if (guard(value)) {
+            yield value;
+        }
+    }
+}
+
+export function defined<T>(x: T | undefined): x is T {
+    return x !== undefined;
+}
+
+export function* map<T, V>(iterable: Iterable<T>, mapper: (arg0: T) => V): Iterable<V> {
+    for (const value of iterable) {
+        yield mapper(value);
+    }
+}

--- a/client/src/dashboard/Assets.vue
+++ b/client/src/dashboard/Assets.vue
@@ -10,6 +10,7 @@ import { socket } from "../assetManager/socket";
 import { assetStore } from "../assetManager/state";
 import { changeDirectory, getIdImageSrc, showIdName } from "../assetManager/utils";
 import { baseAdjust } from "../core/http";
+import { map } from "../core/iter";
 import { useModal } from "../core/plugins/modals/plugin";
 import { ctrlOrCmdPressed } from "../core/utils";
 
@@ -75,7 +76,7 @@ async function onDrop(event: DragEvent): Promise<void> {
     hideDropZone();
     if (event.dataTransfer && event.dataTransfer.items.length > 0) {
         await parseDirectoryUpload(
-            [...event.dataTransfer.items].map((i) => i.webkitGetAsEntry()),
+            map(event.dataTransfer.items, (i) => i.webkitGetAsEntry()),
             assetStore.currentFolder.value,
         );
     }
@@ -86,7 +87,7 @@ function fsToFile(fl: FileSystemFileEntry): Promise<File> {
 }
 
 async function parseDirectoryUpload(
-    fileSystemEntries: (FileSystemEntry | null)[],
+    fileSystemEntries: Iterable<FileSystemEntry | null>,
     target: number,
     targetOffset: string[] = [],
 ): Promise<void> {
@@ -172,7 +173,7 @@ async function stopDrag(event: DragEvent, target: number): Promise<void> {
         assetStore.clearSelected();
     } else if (event.dataTransfer && event.dataTransfer.items.length > 0) {
         await parseDirectoryUpload(
-            [...event.dataTransfer.items].map((i) => i.webkitGetAsEntry()),
+            map(event.dataTransfer.items, (i) => i.webkitGetAsEntry()),
             target,
         );
     }

--- a/client/src/game/input/keyboard/up.ts
+++ b/client/src/game/input/keyboard/up.ts
@@ -1,4 +1,5 @@
 import { equalsP } from "../../../core/geometry";
+import { map } from "../../../core/iter";
 import { SyncMode } from "../../../core/models/types";
 import { ctrlOrCmdPressed } from "../../../core/utils";
 import { activeShapeStore } from "../../../store/activeShape";
@@ -21,7 +22,7 @@ export function onKeyUp(event: KeyboardEvent): void {
         if (event.key === " " || (event.code === "Numpad0" && !ctrlOrCmdPressed(event))) {
             // Spacebar or numpad-zero: cycle through own tokens
             // numpad-zero only if Ctrl is not pressed, as this would otherwise conflict with Ctrl + 0
-            const tokens = [...accessState.raw.ownedTokens].map((o) => getShape(o)!);
+            const tokens = [...map(accessState.raw.ownedTokens, (o) => getShape(o)!)];
             if (tokens.length === 0) return;
             const i = tokens.findIndex((o) => equalsP(o.center, positionSystem.screenCenter));
             const token = tokens[(i + 1) % tokens.length]!;

--- a/client/src/game/interfaces/shapes/asset.ts
+++ b/client/src/game/interfaces/shapes/asset.ts
@@ -3,7 +3,7 @@ import type { IShape } from "../shape";
 
 export interface IAsset extends IShape {
     src: string;
-    svgData?: { svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }[];
+    svgData?: Iterable<{ svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }>;
 
     get h(): number;
     get w(): number;

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -3,6 +3,7 @@ import { toRaw } from "vue";
 import type { ApiShape } from "../../../apiTypes";
 import { g2l, l2g, l2gz } from "../../../core/conversions";
 import { Ray, toLP } from "../../../core/geometry";
+import { filter } from "../../../core/iter";
 import { InvalidationMode, SyncMode, UI_SYNC } from "../../../core/models/types";
 import { debugLayers } from "../../../localStorageHelpers";
 import { activeShapeStore } from "../../../store/activeShape";
@@ -110,10 +111,10 @@ export class Layer implements ILayer {
                 const x = this.xSectors.get(i);
                 const y = this.ySectors.get(j);
                 if (x !== undefined && y !== undefined) {
-                    for (const id of [...x].filter((x) => y.has(x))) {
+                    for (const id of filter(x, (x) => y.has(x))) {
                         this.shapeIdsInSector.add(id);
                     }
-                    for (const id of [...y].filter((y) => x.has(y))) {
+                    for (const id of filter(y, (y) => x.has(y))) {
                         this.shapeIdsInSector.add(id);
                     }
                 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -506,7 +506,7 @@ export abstract class Shape implements IShape {
             vision_obstruction: props.blocksVision,
             auras: aurasToServer(uuid, auraSystem.getAll(this.id, false)),
             trackers: trackersToServer(uuid, trackerSystem.getAll(this.id, false)),
-            labels: labelSystem.getLabels(this.id),
+            labels: [...labelSystem.getLabels(this.id)],
             owners: accessSystem.getOwnersFull(this.id).map((o) => ownerToServer(o)),
             fill_colour: props.fillColour,
             stroke_colour: props.strokeColour[0]!,

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -3,6 +3,7 @@ import { g2l, g2lz } from "../../../core/conversions";
 import { toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import { baseAdjust } from "../../../core/http";
+import { map } from "../../../core/iter";
 import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import { sendAssetRectImageChange } from "../../api/emits/shape/asset";
 import { FOG_COLOUR } from "../../colour";
@@ -25,7 +26,7 @@ export class Asset extends BaseRect implements IAsset {
     src = "";
     #loaded: boolean;
 
-    svgData?: { svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }[];
+    svgData?: Iterable<{ svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }>;
 
     constructor(
         img: HTMLImageElement,
@@ -82,7 +83,7 @@ export class Asset extends BaseRect implements IAsset {
             );
             this.layer?.addShape(cover, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
             const svgs = await loadSvgData(`/static/assets/${this.options.svgAsset}`);
-            this.svgData = [...svgs.values()].map((svg) => ({ svg, rp: this.refPoint, paths: undefined }));
+            this.svgData = map(svgs.values(), (svg) => ({ svg, rp: this.refPoint, paths: undefined }));
             const props = getProperties(this.id)!;
             if (props.blocksVision) {
                 if (this.floorId !== undefined) visionState.recalculateVision(this.floorId);

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -2,6 +2,7 @@ import type { DeepReadonly } from "vue";
 
 import { registerSystem } from "..";
 import type { ShapeSystem } from "..";
+import { guard } from "../../../core/iter";
 import { NO_SYNC } from "../../../core/models/types";
 import type { Sync } from "../../../core/models/types";
 import { coreStore } from "../../../store/core";
@@ -18,7 +19,7 @@ import { locationSettingsState } from "../settings/location/state";
 
 import { sendShapeAddOwner, sendShapeDeleteOwner, sendShapeUpdateDefaultOwner, sendShapeUpdateOwner } from "./emits";
 import { accessToServer, ownerToServer } from "./helpers";
-import { DEFAULT_ACCESS, DEFAULT_ACCESS_SYMBOL } from "./models";
+import { DEFAULT_ACCESS, DEFAULT_ACCESS_SYMBOL, isNonDefaultAccessSymbol } from "./models";
 import type { ACCESS_KEY, ShapeAccess, ShapeOwner } from "./models";
 import { accessState } from "./state";
 
@@ -289,8 +290,8 @@ class AccessSystem implements ShapeSystem {
         initiativeStore._forceUpdate();
     }
 
-    getOwners(id: LocalId): DeepReadonly<string[]> {
-        return [...(this.access.get(id)?.keys() ?? [])].filter((user) => user !== DEFAULT_ACCESS_SYMBOL) as string[];
+    getOwners(id: LocalId): Iterable<string> {
+        return guard(this.access.get(id)?.keys() ?? [], isNonDefaultAccessSymbol);
     }
 
     getOwnersFull(id: LocalId): DeepReadonly<ShapeOwner[]> {

--- a/client/src/game/systems/access/models.ts
+++ b/client/src/game/systems/access/models.ts
@@ -8,6 +8,10 @@ export const DEFAULT_ACCESS: ShapeAccess = {
     vision: false,
 };
 
+export function isNonDefaultAccessSymbol(s: ACCESS_KEY): s is string {
+    return s !== DEFAULT_ACCESS_SYMBOL;
+}
+
 export interface ShapeAccess {
     edit: boolean;
     vision: boolean;

--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -5,6 +5,7 @@ import type { System } from "..";
 import type { ClientPosition, Viewport } from "../../../apiTypes";
 import { toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
+import { filter, map } from "../../../core/iter";
 import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import { setLocalStorageObject } from "../../../localStorageHelpers";
 import { sendMoveClient, sendOffset, sendViewport } from "../../api/emits/client";
@@ -48,8 +49,9 @@ class ClientSystem implements System {
         $.clientBoards.delete(client);
     }
 
-    getClients(player: PlayerId): ClientId[] {
-        return [...$.clientIds.entries()].filter(([, p]) => p === player).map(([c, _]) => c);
+    getClients(player: PlayerId): Iterable<ClientId> {
+        const filtered = filter($.clientIds.entries(), ([, p]) => p === player);
+        return map(filtered, ([c, _]) => c);
     }
 
     getPlayer(client: ClientId): PlayerId | undefined {

--- a/client/src/game/systems/groups/index.ts
+++ b/client/src/game/systems/groups/index.ts
@@ -1,5 +1,6 @@
 import { registerSystem, type ShapeSystem } from "..";
 import type { ApiGroup } from "../../../apiTypes";
+import { map } from "../../../core/iter";
 import { UI_SYNC } from "../../../core/models/types";
 import { uuidv4 } from "../../../core/utils";
 import { getGlobalId, getShape, type GlobalId, type LocalId } from "../../id";
@@ -179,12 +180,12 @@ class GroupSystem implements ShapeSystem {
             }
         }
 
-        sendMemberBadgeUpdate(
-            [...members].map((m) => ({
+        sendMemberBadgeUpdate([
+            ...map(members, (m) => ({
                 uuid: getGlobalId(m)!,
                 badge: this.getBadge(m),
             })),
-        );
+        ]);
     }
 
     // badge
@@ -202,14 +203,14 @@ class GroupSystem implements ShapeSystem {
         if (group === undefined) throw new Error("Invalid groupId provided");
 
         const members = this.getGroupMembers(groupId);
-        const badges = [...members].map((m) => this.getBadge(m));
+        const badges = new Set(map(members, (m) => this.getBadge(m)));
         const membersLength = Math.max(2 * members.size + 1, 10);
 
         if (group.creationOrder === "incrementing") {
             return Math.max(-1, ...badges) + 1;
         } else {
             let value: number | undefined;
-            while (value === undefined || badges.includes(value)) {
+            while (value === undefined || badges.has(value)) {
                 value = Math.floor(Math.random() * membersLength);
             }
             return value;

--- a/client/src/game/systems/labels/index.ts
+++ b/client/src/game/systems/labels/index.ts
@@ -1,5 +1,6 @@
 import { registerSystem, type ShapeSystem } from "..";
 import type { ApiLabel } from "../../../apiTypes";
+import { map } from "../../../core/iter";
 import { sendShapeAddLabel, sendShapeRemoveLabel } from "../../api/emits/shape/options";
 import { getGlobalId, getShape, type LocalId } from "../../id";
 import { floorSystem } from "../floors";
@@ -25,7 +26,7 @@ class LabelSystem implements ShapeSystem {
     loadState(id: LocalId): void {
         $.activeShape = {
             id,
-            labels: [...($.shapeLabels.get(id) ?? [])].map((l) => $.labels.get(l)!),
+            labels: [...map($.shapeLabels.get(id) ?? [], (l) => $.labels.get(l)!)],
         };
     }
 
@@ -67,10 +68,10 @@ class LabelSystem implements ShapeSystem {
         if (sync) sendShapeRemoveLabel({ shape: getGlobalId(id)!, value: labelId });
     }
 
-    getLabels(id: LocalId): ApiLabel[] {
+    getLabels(id: LocalId): Iterable<ApiLabel> {
         const labels = $.shapeLabels.get(id);
         if (labels === undefined) return [];
-        return [...labels].map((l) => $.labels.get(l)!);
+        return map(labels, (l) => $.labels.get(l)!);
     }
 
     addLabelFilter(filter: string, sync: boolean): void {

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -5,6 +5,7 @@ import { useI18n } from "vue-i18n";
 
 import type { ApiAssetRectShape } from "../../../apiTypes";
 import ContextMenu from "../../../core/components/ContextMenu.vue";
+import { defined, guard, map } from "../../../core/iter";
 import { SyncMode } from "../../../core/models/types";
 import { useModal } from "../../../core/plugins/modals/plugin";
 import { activeShapeStore } from "../../../store/activeShape";
@@ -288,9 +289,11 @@ async function saveTemplate(): Promise<void> {
 
 // GROUPS
 
-const groups = computed(
-    () => new Set([...selectedSystem.$.value].map((s) => groupSystem.getGroupId(s)).filter((g) => g !== undefined)),
-) as ComputedRef<Set<string>>;
+const groups = computed(() => {
+    const ids = map(selectedSystem.$.value, (s) => groupSystem.getGroupId(s));
+    const definedIds = guard(ids, defined);
+    return new Set(definedIds);
+});
 
 const hasEntireGroup = computed(() => {
     const selection = selectedSystem.$.value;

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -5,6 +5,7 @@ import draggable from "vuedraggable";
 
 import Modal from "../../../core/components/modals/Modal.vue";
 import { baseAdjust } from "../../../core/http";
+import { map } from "../../../core/iter";
 import { useModal } from "../../../core/plugins/modals/plugin";
 import { getTarget, getValue } from "../../../core/utils";
 import { sendRequestInitiatives } from "../../api/emits/initiative";
@@ -89,14 +90,14 @@ function removeEffect(shape: GlobalId, index: number): void {
 
 function toggleHighlight(actorId: LocalId | undefined, show: boolean): void {
     if (actorId === undefined) return;
-    let shapeArray: IShape[];
+    let shapeArray: Iterable<IShape>;
     const groupId = groupSystem.getGroupId(actorId);
     if (groupId === undefined) {
         const shape = getShape(actorId);
         if (shape === undefined) return;
         shapeArray = [shape];
     } else {
-        shapeArray = [...groupSystem.getGroupMembers(groupId)].map((m) => getShape(m)!);
+        shapeArray = map(groupSystem.getGroupMembers(groupId), (m) => getShape(m)!);
     }
     for (const sh of shapeArray) {
         sh.showHighlight = show;

--- a/client/src/game/ui/menu/AssetNode.vue
+++ b/client/src/game/ui/menu/AssetNode.vue
@@ -2,6 +2,7 @@
 import { computed, reactive } from "vue";
 
 import { baseAdjust } from "../../../core/http";
+import { filter } from "../../../core/iter";
 import type { AssetFile, AssetListMap } from "../../../core/models/types";
 
 interface State {
@@ -25,7 +26,7 @@ const files = computed(() => {
 });
 
 const folders = computed(() => {
-    return [...props.assets.keys()].filter((el) => "__files" !== el);
+    return filter(props.assets.keys(), (el) => "__files" !== el);
 });
 
 function toggle(folder: string): void {

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -89,7 +89,7 @@ function nameMarker(marker: LocalId): string {
 const clientInfo = computed(() => {
     const info = [];
     for (const [playerId, player] of playerState.reactive.players) {
-        const clients = clientSystem.getClients(playerId);
+        const clients = [...clientSystem.getClients(playerId)];
         if (clients.length > 0) info.push({ player, client: clients[0]! });
     }
     return info;

--- a/client/src/game/ui/settings/shape/AccessSettings.vue
+++ b/client/src/game/ui/settings/shape/AccessSettings.vue
@@ -2,6 +2,7 @@
 import { computed, ref, toRef, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 
+import { filter } from "../../../../core/iter";
 import { SERVER_SYNC } from "../../../../core/models/types";
 import type { PartialPick } from "../../../../core/types";
 import { Role } from "../../../models/role";
@@ -32,9 +33,12 @@ const defaultAccess = toRef(accessState.reactive, "defaultAccess");
 const playersWithoutAccess = computed(() => {
     const id = accessState.reactive.id;
     if (id === undefined) return [];
-    return [...playerState.reactive.players.values()].filter(
-        (p) => p.role !== Role.DM && !accessState.owners.value.some((o) => o === p.name),
-    );
+    return [
+        ...filter(
+            playerState.reactive.players.values(),
+            (p) => p.role !== Role.DM && !accessState.owners.value.some((o) => o === p.name),
+        ),
+    ];
 });
 
 function addOwner(): void {

--- a/client/src/game/ui/tools/MapTool.vue
+++ b/client/src/game/ui/tools/MapTool.vue
@@ -2,6 +2,7 @@
 import { reactive, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 
+import { map } from "../../../core/iter";
 import { getShape } from "../../id";
 import { DEFAULT_GRID_SIZE } from "../../systems/position/state";
 import { selectedSystem } from "../../systems/selected";
@@ -24,8 +25,8 @@ watchEffect(() => {
 });
 
 watchEffect(() => {
-    const selection = [...selectedSystem.$.value].map((s) => getShape(s)!);
-    mapTool.setSelection(selection);
+    const selection = map(selectedSystem.$.value, (s) => getShape(s)!);
+    mapTool.setSelection([...selection]);
 });
 
 function apply(): void {

--- a/client/src/game/ui/tools/VisionTool.vue
+++ b/client/src/game/ui/tools/VisionTool.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import { map } from "../../../core/iter";
 import { getShape } from "../../id";
 import type { LocalId } from "../../id";
 import type { IShape } from "../../interfaces/shape";
@@ -12,7 +13,7 @@ import { visionTool } from "../../tools/variants/vision";
 
 const selected = visionTool.isActiveTool;
 
-const tokens = computed(() => [...accessState.reactive.ownedTokens].map((t) => getShape(t)!));
+const tokens = computed(() => map(accessState.reactive.ownedTokens, (t) => getShape(t)!));
 const selection = computed(() => {
     if (accessState.reactive.activeTokenFilters === undefined) return accessState.reactive.ownedTokens;
     return accessState.reactive.activeTokenFilters;

--- a/client/src/game/vision/iterative.ts
+++ b/client/src/game/vision/iterative.ts
@@ -1,3 +1,4 @@
+import { filter } from "../../core/iter";
 import { equalPoints } from "../../core/math";
 import type { IShape } from "../interfaces/shape";
 
@@ -186,7 +187,7 @@ export class IterativeDelete {
             };
             this.newConstraints.push({ edge: constraint, changed: false, onPath });
             if (edgeCovered) continue;
-            const edgeShapes = [...vertex.shapes].filter((sh) => ccwv.shapes.has(sh) && sh !== this.shape);
+            const edgeShapes = [...filter(vertex.shapes, (sh) => ccwv.shapes.has(sh) && sh !== this.shape)];
             if (edgeShapes.length === 0) this.addEdge(edge);
         }
         this.handledPoints.push(vertex.point!);

--- a/client/test/game/systems/access/index.test.ts
+++ b/client/test/game/systems/access/index.test.ts
@@ -524,7 +524,7 @@ describe("Access System", () => {
             // setup
             const id = generateTestLocalId();
             // test
-            expect(accessSystem.getOwners(id).length).toBe(0);
+            expect([...accessSystem.getOwners(id)].length).toBe(0);
         });
         it("should return an empty list if no owners are associated with the shape", () => {
             // setup
@@ -534,7 +534,7 @@ describe("Access System", () => {
                 extra: [],
             });
             // test
-            expect(accessSystem.getOwners(id).length).toBe(0);
+            expect([...accessSystem.getOwners(id)].length).toBe(0);
         });
         it("should return all owners associated with the shape", () => {
             // setup
@@ -544,9 +544,9 @@ describe("Access System", () => {
                 extra: [{ user: "some user", shape: id, access: { edit: false, movement: false, vision: true } }],
             });
             // test
-            expect(accessSystem.getOwners(id)).toEqual(["some user"]);
+            expect([...accessSystem.getOwners(id)]).toEqual(["some user"]);
             accessSystem.addAccess(id, "other user", DEFAULT_ACCESS, UI_SYNC);
-            expect(accessSystem.getOwners(id)).toEqual(["some user", "other user"]);
+            expect([...accessSystem.getOwners(id)]).toEqual(["some user", "other user"]);
         });
     });
     describe("getOwnersFull", () => {


### PR DESCRIPTION
In certain places I have iterators on which I would like to map or filter, but have to convert them to an array first, causing an extra iteration without any use.

There is an active TC39 working group around this, but that has not yet landed in main ts, so I've just added some snippets until it's available in plain ts.