### PR TITLE
bug(TokenDirections): Fix token directions showing filtered tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ tech changes will usually be stripped from release notes for the public
 -   TpZone: Fix non-immediate player initiated teleports not working correctly
 -   TpZone: Fix teleports initiated in build-mode not working correctly for players
 -   Logic: Request mode not working as intended and behaving as Enabled mode instead
--   Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
+-   Token Directions: Fix shown tokens not taking filtered tokens into account
+-   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14
 

--- a/client/src/game/ui/TokenDirections.vue
+++ b/client/src/game/ui/TokenDirections.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-import { toRef } from "vue";
+import { computed } from "vue";
 
+import { filter } from "../../core/iter";
 import { getShape } from "../id";
 import type { LocalId } from "../id";
 import { setCenterPosition } from "../position";
+import { accessState } from "../systems/access/state";
 import { positionState } from "../systems/position/state";
 
-const tokens = toRef(positionState.reactive, "tokenDirections");
+const tokens = computed(() =>
+    filter(positionState.reactive.tokenDirections.entries(), ([id]) => accessState.activeTokens.value.has(id)),
+);
 
 function center(token: LocalId): void {
     const shape = getShape(token);


### PR DESCRIPTION
The set of active tokens limited by the vision tool was ignored for the token directions UI. Instead it was always showing all owned tokens.