### PR TITLE
bug(Tech: Api): Fix some api calls expecting partial data to receive full object

### DIFF
--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -52,47 +52,48 @@ function _<T>(x: T | undefined | null): x is T {
 
 function setLocationOptions(id: number | undefined, options: ApiOptionalLocationOptions, overwrite_all: boolean): void {
     // GRID
-    if (overwrite_all || _(options.use_grid))
+    if (overwrite_all || options.use_grid !== undefined)
         locationSettingsSystem.setUseGrid(options.use_grid ?? undefined, id, false);
-    if (overwrite_all || _(options.grid_type))
+    if (overwrite_all || options.grid_type !== undefined)
         locationSettingsSystem.setGridType(options.grid_type ?? undefined, id, false);
-    if (overwrite_all || _(options.unit_size))
+    if (overwrite_all || options.unit_size !== undefined)
         locationSettingsSystem.setUnitSize(options.unit_size ?? undefined, id, false);
-    if (overwrite_all || _(options.unit_size_unit))
+    if (overwrite_all || options.unit_size_unit !== undefined)
         locationSettingsSystem.setUnitSizeUnit(options.unit_size_unit ?? undefined, id, false);
 
     // VISION
 
-    if (overwrite_all || _(options.full_fow))
+    if (overwrite_all || options.full_fow !== undefined)
         locationSettingsSystem.setFullFow(options.full_fow ?? undefined, id, false);
-    if (overwrite_all || _(options.fow_los)) locationSettingsSystem.setFowLos(options.fow_los ?? undefined, id, false);
-    if (overwrite_all || _(options.fow_opacity))
+    if (overwrite_all || options.fow_los !== undefined)
+        locationSettingsSystem.setFowLos(options.fow_los ?? undefined, id, false);
+    if (overwrite_all || options.fow_opacity !== undefined)
         locationSettingsSystem.setFowOpacity(options.fow_opacity ?? undefined, id, false);
 
-    if (overwrite_all || _(options.vision_mode)) {
+    if (overwrite_all || options.vision_mode !== undefined) {
         const visionMode = _(options.vision_mode) ? visibilityModeFromString(options.vision_mode) : undefined;
         if (visionMode !== undefined) visionState.setVisionMode(visionMode, false);
     }
 
-    if (overwrite_all || _(options.vision_min_range))
+    if (overwrite_all || options.vision_min_range !== undefined)
         locationSettingsSystem.setVisionMinRange(options.vision_min_range ?? undefined, id, false);
-    if (overwrite_all || _(options.vision_max_range))
+    if (overwrite_all || options.vision_max_range !== undefined)
         locationSettingsSystem.setVisionMaxRange(options.vision_max_range ?? undefined, id, false);
 
     // FLOOR
 
-    if (overwrite_all || _(options.air_map_background))
+    if (overwrite_all || options.air_map_background !== undefined)
         locationSettingsSystem.setAirMapBackground(options.air_map_background ?? undefined, id, false);
-    if (overwrite_all || _(options.ground_map_background))
+    if (overwrite_all || options.ground_map_background !== undefined)
         locationSettingsSystem.setGroundMapBackground(options.ground_map_background ?? undefined, id, false);
-    if (overwrite_all || _(options.underground_map_background))
+    if (overwrite_all || options.underground_map_background !== undefined)
         locationSettingsSystem.setUndergroundMapBackground(options.underground_map_background ?? undefined, id, false);
 
     // VARIA
 
-    if (overwrite_all || options.move_player_on_token_change !== null)
+    if (overwrite_all || options.move_player_on_token_change !== undefined)
         locationSettingsSystem.setMovePlayerOnTokenChange(options.move_player_on_token_change ?? undefined, id, false);
-    if (overwrite_all || options.limit_movement_during_initiative !== null)
+    if (overwrite_all || options.limit_movement_during_initiative !== undefined)
         locationSettingsSystem.setLimitMovementDuringInitiative(
             options.limit_movement_during_initiative ?? undefined,
             id,

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -357,11 +357,11 @@ async def set_location_options(sid: str, raw_data: Any):
 
     if data.location is None:
         for sid in game_state.get_sids(skip_sid=sid, room=pr.room):
-            await _send_game("Location.Options.Set", data, room=sid)
+            await _send_game("Location.Options.Set", raw_data, room=sid)
     else:
         await _send_game(
             "Location.Options.Set",
-            data,
+            raw_data,
             room=pr.active_location.get_path(),
             skip_sid=sid,
         )

--- a/server/src/api/socket/shape/options.py
+++ b/server/src/api/socket/shape/options.py
@@ -502,7 +502,7 @@ async def update_tracker(sid: str, raw_data: Any):
     for psid in owners:
         await _send_game(
             "Shape.Options.Tracker.Update",
-            data,
+            raw_data,
             room=psid,
         )
     for psid in game_state.get_sids(active_location=pr.active_location, skip_sid=sid):
@@ -518,7 +518,7 @@ async def update_tracker(sid: str, raw_data: Any):
                     room=psid,
                 )
         else:
-            await _send_game("Shape.Options.Tracker.Update", data, room=psid)
+            await _send_game("Shape.Options.Tracker.Update", raw_data, room=psid)
 
 
 @sio.on("Shape.Options.Tracker.Move", namespace=GAME_NS)
@@ -594,7 +594,7 @@ async def update_aura(sid: str, raw_data: Any):
 
     owners = [*get_owner_sids(pr, shape, skip_sid=sid)]
     for psid in owners:
-        await _send_game("Shape.Options.Aura.Update", data, room=psid)
+        await _send_game("Shape.Options.Aura.Update", raw_data, room=psid)
     for psid in game_state.get_sids(active_location=pr.active_location, skip_sid=sid):
         if psid in owners:
             continue
@@ -608,7 +608,7 @@ async def update_aura(sid: str, raw_data: Any):
                     room=psid,
                 )
         else:
-            await _send_game("Shape.Options.Aura.Update", data, room=psid)
+            await _send_game("Shape.Options.Aura.Update", raw_data, room=psid)
 
 
 @sio.on("Shape.Options.Aura.Move", namespace=GAME_NS)


### PR DESCRIPTION
Some API calls operate on the basis of only sending/receiving the changed values.
When checking the validity of input, the other fields are set to None values, which when transferred back to the client can cause some havoc when it starts updating all provided values to null.

This fixes tracker and aura updates as well as location option updates.
Fixes #1232 