### PR TITLE
bug(Aura): Fix aura changes not updating shape sectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ tech changes will usually be stripped from release notes for the public
 -   TpZone: Fix teleports initiated in build-mode not working correctly for players
 -   Logic: Request mode not working as intended and behaving as Enabled mode instead
 -   Token Directions: Fix shown tokens not taking filtered tokens into account
+-   Auras: Fix sometimes not being visible until a refresh or panning closer to the aura
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -132,12 +132,19 @@ class AuraSystem implements ShapeSystem {
         if (aura.active) {
             const shape = getShape(id);
 
-            if (shape && aura.visionSource) {
-                if (shape.floorId !== undefined)
-                    visionState.addVisionSource({ aura: aura.uuid, shape: id }, shape.floorId);
-            }
+            if (shape !== undefined) {
+                const layer = shape.layer;
+                if (layer !== undefined) {
+                    layer.updateSectors(id, shape.getAuraAABB());
+                }
 
-            shape?.invalidate(false);
+                if (aura.visionSource) {
+                    if (shape.floorId !== undefined)
+                        visionState.addVisionSource({ aura: aura.uuid, shape: id }, shape.floorId);
+                }
+
+                shape.invalidate(false);
+            }
         }
     }
 
@@ -164,6 +171,11 @@ class AuraSystem implements ShapeSystem {
         const oldAuraVisionSource = aura.visionSource;
 
         Object.assign(aura, delta);
+
+        const layer = shape.layer;
+        if (layer !== undefined) {
+            layer.updateSectors(id, shape.getAuraAABB());
+        }
 
         const floorId = shape.floorId;
 
@@ -193,6 +205,12 @@ class AuraSystem implements ShapeSystem {
         const oldAura = this.get(id, auraId, false);
 
         this.data.set(id, this.data.get(id)?.filter((au) => au.uuid !== auraId) ?? []);
+
+        const shape = getShape(id);
+        const layer = shape?.layer;
+        if (shape !== undefined && layer !== undefined) {
+            layer.updateSectors(id, shape.getAuraAABB());
+        }
 
         if (id === this._state.id || id === this._state.parentId) this.updateAuraState();
 


### PR DESCRIPTION
To reduce the amount of shapes that multiple render-related functions have to check, PA orders the scene in sectors and keeps track of which shapes are visible in which sectors.  A shape is visible in a sector if the shape itself or any of its active auras extend into a sector.

When modifying aura properties (the range being the most important here), the shape's sectors were not being recalculated.

This caused lights that became public to players or increased in range to not be visible in the new sectors it's supposed to be visible. They would be shown to their full extent if any of the original shape sectors were in view, but not if (only) any of the new sectors were.

In the other direction a shape that disappeared or shrank in size would still be checked in sectors it should no longer be, but this was never causing visual problems.