### PR TITLE
bug(Access): Remove Fake player full access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,14 @@ tech changes will usually be stripped from release notes for the public
 -   Auth: A logic error in the auth routing code - in some cases you had to manually go to the login page
 -   Templates: Missing some settings when saved
 -   Fake player: no longer render auras and isToken vision
+-   Fake player: no longer shows invisible shapes
 -   Labels: Fix removal not working
 -   Toolbar: Fix vision and filter tools not immediately being available when relevant
 -   Access: Fix players with specific access rules, having edit access at all times
 -   Access: Changing access would not live update the edit shape UI if it was open by another client
 -   Access: Fix default access in UI not being up to date if shape has no access modifications until reload
 -   Access: Prevent DMs from having an explicit access rule
+-   Access: No longer gives full access for fake DM
 -   TpZone: Fix tp zone moving a player to a different floor not moving their view along (if 'move players' configured)
 -   TpZone: Fix non-immediate player initiated teleports not working correctly
 -   TpZone: Fix teleports initiated in build-mode not working correctly for players

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -120,11 +120,13 @@ class AccessSystem implements ShapeSystem {
 
         if (props.isToken && limitToActiveTokens) {
             if (!activeTokens.value.has(id)) {
+                // In theory we should check default permission rights here
+                // But that's a usecase I haven't come across yet.
                 return false;
             }
         }
 
-        if (gameState.isDmOrFake.value) return true;
+        if (gameState.raw.isDm) return true;
 
         const accessMap = this.access.get(id);
         if (accessMap === undefined) return false;

--- a/client/test/game/systems/access/index.test.ts
+++ b/client/test/game/systems/access/index.test.ts
@@ -188,15 +188,15 @@ describe("Access System", () => {
             coreStore.setUsername("userWithFullRights");
             expect(accessSystem.hasAccessTo(id2, true, { edit: true })).toBe(false);
         });
-        it("should return true if fake player is activated", () => {
+        it("should return false if fake player is activated", () => {
             // setup
             gameSystem.setFakePlayer(true);
             // test
-            expect(accessSystem.hasAccessTo(id, false, { movement: true })).toBe(true);
+            expect(accessSystem.hasAccessTo(id, false, { movement: true })).toBe(false);
             // extra checks
             // 1. user access is not granted
             coreStore.setUsername("userWithNoRights");
-            expect(accessSystem.hasAccessTo(id2, false, { edit: true })).toBe(true);
+            expect(accessSystem.hasAccessTo(id2, false, { edit: true })).toBe(false);
             // teardown
             gameSystem.setFakePlayer(false);
             gameSystem.setDm(false); // fakeplayer resets isDm


### PR DESCRIPTION
Fake player mode was receiving full access rights in certain situations.

This was responsible for things like showing invisible shapes even though no access was provided. (Fixes #1240)

Bear in mind that in the past (due to a bug) the DM user sometimes would be given explicit access to a shape, in order to have invisible shapes _not_ show up in fake player mode, you must ensure that your DM user does not have an explicit access rule for the shape. If there is a rule, just remove it.