### PR TITLE
bug(Groups): Shape group setting UI issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ tech changes will usually be stripped from release notes for the public
 ### Fixed
 
 -   Group: No longer sending group info for each member (just once)
+-   Group: Shape group settings fixes
+    -   Create group button was not properly behaving
+    -   Remove group button was not immediately updating the UI until a reselection
 -   Auth: A logic error in the auth routing code - in some cases you had to manually go to the login page
 -   Templates: Missing some settings when saved
 -   Fake player: no longer render auras and isToken vision

--- a/client/src/game/systems/groups/index.ts
+++ b/client/src/game/systems/groups/index.ts
@@ -117,7 +117,7 @@ class GroupSystem implements ShapeSystem {
                     mutable.groupMembers.get(memberGroupId)?.delete(member.uuid);
                 }
                 if (!mutable.shapeData.has(member.uuid)) {
-                    this.inform(member.uuid, { groupId, badge: 0 });
+                    this.inform(member.uuid, { groupId, badge: member.badge });
                 } else {
                     mutable.shapeData.set(member.uuid, { groupId, badge: member.badge });
                 }

--- a/client/src/game/ui/settings/shape/GroupSettings.vue
+++ b/client/src/game/ui/settings/shape/GroupSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, toRef } from "vue";
+import { computed, toRef, watch } from "vue";
 
 import { FULL_SYNC, SERVER_SYNC } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
@@ -17,6 +17,18 @@ import { getProperties } from "../../../systems/properties/state";
 const id = toRef(activeShapeStore.state, "id");
 
 const modals = useModal();
+
+watch(
+    () => activeShapeStore.state.id,
+    (newId, oldId) => {
+        if (newId !== undefined && oldId !== newId) {
+            groupSystem.loadState(newId);
+        } else if (newId === undefined) {
+            groupSystem.dropState();
+        }
+    },
+    { immediate: true },
+);
 
 const characterSet = ["numbers", "latin characters", "custom"];
 let characterSetSelected = 0;
@@ -240,7 +252,7 @@ async function deleteGroup(): Promise<void> {
                 </div>
             </template>
         </template>
-        <template v-if="groupState.reactive.activeId === undefined">
+        <template v-if="groupState.reactive.activeGroupId === undefined">
             <div class="spanrow header">Actions</div>
             <div></div>
             <div></div>


### PR DESCRIPTION
The shape group settings UI had several issues:
- Active group info (e.g. members) was no longer visible
- Create new group button was always visible

This has now been resolved so that it is showing the proper info again.
Additionally the creation and removal of a group should immediately update in the UI for a shape instead of only updating once deselected and reselected again.