### PR TITLE
bug(Rendering): Fix layer transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ tech changes will usually be stripped from release notes for the public
 -   Logic: Request mode not working as intended and behaving as Enabled mode instead
 -   Token Directions: Fix shown tokens not taking filtered tokens into account
 -   Auras: Fix sometimes not being visible until a refresh or panning closer to the aura
+-   Rendering: Transparency of higher layers was no longer applied after a window resize
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -387,6 +387,11 @@ export class Layer implements ILayer {
 
             if (doClear) this.clear();
 
+            if (this.name !== LayerName.Lighting) {
+                if (floorState.raw.layerIndex < this.index) ctx.globalAlpha = 0.3;
+                else ctx.globalAlpha = 1.0;
+            }
+
             // We iterate twice over all shapes
             // First to draw the auras and a second time to draw the shapes themselves
             // Otherwise auras from one shape could overlap another shape.

--- a/client/src/game/systems/floors/index.ts
+++ b/client/src/game/systems/floors/index.ts
@@ -221,16 +221,12 @@ class FloorSystem implements System {
     }
 
     selectLayer(name: string, sync = true, invalidate = true): void {
-        let found = false;
         selectedSystem.clear();
         for (const [index, layer] of this.getLayers(currentFloor.value!).entries()) {
             if (!layer.selectable) continue;
-            if (found && layer.name !== LayerName.Lighting) layer.ctx.globalAlpha = 0.3;
-            else layer.ctx.globalAlpha = 1.0;
 
             if (name === layer.name) {
                 $.layerIndex = index;
-                found = true;
                 if (sync) sendActiveLayer({ layer: layer.name, floor: this.getFloor({ id: layer.floor })!.name });
             }
 


### PR DESCRIPTION
Higher layers are rendered with a 0.3 opacity filter to make it clear that they are not in the current view.  This opacity was however only set when changing layers and not part of the main render logic. This caused a bug where resizing the screen, which does some internal changes, caused the opacity information to be lost.

This PR moves the transparency check to be a proper part of the render logic itself and not of the UI.

Fixes #1246