### PR TITLE
feat(TpZone): Change view area behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Templates no longer save certain settings
 -   Bring players no longer changes the zoom level of the players
+-   TpZone: When a player TP request arrives, the view area action will bring the DM to the trigger location and not to the target location
 
 ### Fixed
 

--- a/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
+++ b/client/src/game/ui/toasts/LogicRequestHandlerToast.vue
@@ -43,15 +43,17 @@ function approveDoor(request: LogicDoorRequest): void {
 }
 
 async function approveTp(request: LogicTeleportRequest): Promise<void> {
+    const shape = getLocalId(request.fromZone);
+    if (shape === undefined) return;
     await teleport(
-        getLocalId(request.fromZone)!,
+        shape,
         request.toZone,
         request.transfers.map((t) => getLocalId(t)!),
     );
 }
 
 function showArea(): void {
-    const uuid = props.data.request.logic === "door" ? props.data.request.door : props.data.request.toZone;
+    const uuid = props.data.request.logic === "door" ? props.data.request.door : props.data.request.fromZone;
     const shape = getShapeFromGlobal(uuid);
     if (shape?.floorId === undefined) return;
 


### PR DESCRIPTION
When a player requests the use of a TP zone, the DM has the option to view the area of the related request.

Up until now the area shown was the target of the teleport zone and not the teleport zone itself.
This PR changes this behaviour and instead shows the teleport zone itself, allowing the DM to properly see which shapes are about to teleport.