### PR TITLE
bug(Select): Fix rotation helper UI size while zooming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ tech changes will usually be stripped from release notes for the public
 -   Token Directions: Fix shown tokens not taking filtered tokens into account
 -   Auras: Fix sometimes not being visible until a refresh or panning closer to the aura
 -   Rendering: Transparency of higher layers was no longer applied after a window resize
+-   Select: Rotation UI should stay consistent when zooming
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -837,7 +837,7 @@ class SelectTool extends Tool implements ISelectTool {
         }
 
         const topCenter = toGP((bbox.topRight.x + bbox.topLeft.x) / 2, bbox.topLeft.y);
-        const topCenterPlus = addP(topCenter, new Vector(0, -DEFAULT_GRID_SIZE));
+        const topCenterPlus = addP(topCenter, new Vector(0, -Math.max(DEFAULT_GRID_SIZE, l2gz(DEFAULT_GRID_SIZE / 2))));
 
         this.angle = 0;
         this.rotationAnchor = new Line(

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -1,4 +1,4 @@
-import { watchEffect } from "vue";
+import { watch, watchEffect } from "vue";
 import { POSITION, useToast } from "vue-toastification";
 
 import { g2l, g2lx, g2ly, g2lz, l2g, l2gz, toDegrees, toRadians } from "../../../../core/conversions";
@@ -120,6 +120,17 @@ class SelectTool extends Tool implements ISelectTool {
     constructor() {
         super();
 
+        // Zoom changes
+        watch(
+            () => positionState.reactive.zoomDisplay,
+            () => {
+                if (this.rotationUiActive) {
+                    this.resetRotationHelper();
+                }
+            },
+        );
+
+        // Selection changes
         watchEffect(() => {
             const selection = selectedSystem.$.value;
 
@@ -184,6 +195,7 @@ class SelectTool extends Tool implements ISelectTool {
     }
 
     onDeselect(): void {
+        this.removeRotationUi();
         this.removePolygonEditUi();
     }
 
@@ -192,6 +204,9 @@ class SelectTool extends Tool implements ISelectTool {
         if (this.hasFeature(SelectFeatures.PolygonEdit, features)) {
             this.createPolygonEditUi();
             _$.polygonUiVisible = "hidden";
+        }
+        if (this.hasFeature(SelectFeatures.Rotate, features)) {
+            this.createRotationUi(features);
         }
         return Promise.resolve();
     }


### PR DESCRIPTION
The rotation helper was not being resized properly while zooming as reported in #1244.