### PR TITLE
bug(FakePlayer): Fix access handling in fake player mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ tech changes will usually be stripped from release notes for the public
     -   Remove group button was not immediately updating the UI until a reselection
 -   Auth: A logic error in the auth routing code - in some cases you had to manually go to the login page
 -   Templates: Missing some settings when saved
--   Fake player: no longer render auras and isToken vision
--   Fake player: no longer shows invisible shapes
+-   Fake Player: Proper rework of access handling
+    -   Shapes and auras should now only be rendered _if and only if_ some player in the game has `vision` access to that shape _AND_ the shape is selected in the vision tool.
+    -   This also hides invisible shapes
+    -   This also hides _all_ auras on the DM layer regardless of the vision tool
 -   Labels: Fix removal not working
 -   Toolbar: Fix vision and filter tools not immediately being available when relevant
 -   Access: Fix players with specific access rules, having edit access at all times

--- a/client/src/core/iter.ts
+++ b/client/src/core/iter.ts
@@ -31,3 +31,10 @@ export function* map<T, V>(iterable: Iterable<T>, mapper: (arg0: T) => V): Itera
         yield mapper(value);
     }
 }
+
+export function some<T>(iterable: Iterable<T>, mapper: (arg0: T) => boolean): boolean {
+    for (const value of iterable) {
+        if (mapper(value)) return true;
+    }
+    return false;
+}

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -10,6 +10,7 @@ import { accessState } from "../../systems/access/state";
 import { auraSystem } from "../../systems/auras";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
+import { gameState } from "../../systems/game/state";
 import { locationSettingsState } from "../../systems/settings/location/state";
 import { visionState } from "../../vision/state";
 
@@ -54,6 +55,7 @@ export class FowLightingLayer extends FowLayer {
                     if (shape === undefined) continue;
                     if (shape.options.skipDraw ?? false) continue;
                     if (shape.floorId !== activeFloor.id) continue;
+                    if (shape.layerName === LayerName.Dm && gameState.raw.isFakePlayer) continue;
                     const bb = shape.getBoundingBox();
                     const lcenter = g2l(shape.center);
                     const alm = 0.8 * g2lz(bb.w);

--- a/client/src/game/systems/access/models.ts
+++ b/client/src/game/systems/access/models.ts
@@ -2,6 +2,7 @@ import type { LocalId } from "../../id";
 
 export const DEFAULT_ACCESS_SYMBOL = Symbol();
 export type ACCESS_KEY = string | typeof DEFAULT_ACCESS_SYMBOL;
+export type AccessMap = Map<ACCESS_KEY, ShapeAccess>;
 export const DEFAULT_ACCESS: ShapeAccess = {
     edit: false,
     movement: false,

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -3,6 +3,7 @@ import type { DeepReadonly } from "vue";
 
 import { registerSystem } from "..";
 import type { ShapeSystem } from "..";
+import { filter } from "../../../core/iter";
 import { NO_SYNC } from "../../../core/models/types";
 import type { Sync } from "../../../core/models/types";
 import { getGlobalId, getShape } from "../../id";
@@ -10,6 +11,7 @@ import type { LocalId } from "../../id";
 import { compositeState } from "../../layers/state";
 import { LayerName } from "../../models/floor";
 import { visionState } from "../../vision/state";
+import { accessSystem } from "../access";
 import { gameState } from "../game/state";
 import { selectedSystem } from "../selected";
 
@@ -116,6 +118,11 @@ class AuraSystem implements ShapeSystem {
             }
         }
         auras.push(...(this.data.get(id) ?? []));
+
+        if (gameState.raw.isFakePlayer) {
+            if (!accessSystem.hasAccessTo(id, true, { vision: true })) return [...filter(auras, (a) => a.visible)];
+        }
+
         return auras;
     }
 


### PR DESCRIPTION
This PR hopefully tackles most fake player related issues once and for all.

Most previous fake-player related fixes were patches to very specific routines which as has been shown makes it easy to miss a bunch of cases. I've taken some time this weekend to actually properly look at the root issue of most fake player related code and _think_ I've fixed it.

This change fixes a bunch of things that were not behaving as they should.

**Rendering Changes**
Shapes that have default vision access or auras that are marked as public _should_ be visible as normal, shapes and auras that are however **not** public by default (including invisible shapes etc) will only be rendered **if and only if** there is some player with `vision` access to the shape **and** the vision tool has that shape selected.

Fixes #1243