### PR TITLE
bug(Rendering): Fix some cases where vision access changes where not immediately rerendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ tech changes will usually be stripped from release notes for the public
 -   Token Directions: Fix shown tokens not taking filtered tokens into account
 -   Auras: Fix sometimes not being visible until a refresh or panning closer to the aura
 -   Rendering: Transparency of higher layers was no longer applied after a window resize
+-   Rendering: Some cases where vision access related changes would not rerender immediately
 -   Select: Rotation UI should stay consistent when zooming
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 


### PR DESCRIPTION
When updating vision access for a shape or changing the vision-tool set of active tokens, the shapes' layer would not be immediately re-rendered. Only the Light & Vision layers would re-rendered immediately.