### PR TITLE
bug(LocationBar): Fix multiline location drag handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ tech changes will usually be stripped from release notes for the public
 -   Rendering: Transparency of higher layers was no longer applied after a window resize
 -   Rendering: Some cases where vision access related changes would not rerender immediately
 -   Select: Rotation UI should stay consistent when zooming
+-   LocationBar: Fix width on drag handle for multiline locations
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/ui/menu/LocationBar.vue
+++ b/client/src/game/ui/menu/LocationBar.vue
@@ -359,6 +359,7 @@ const activeLocation = toRef(locationSettingsState.reactive, "activeLocation");
 }
 
 .drag-handle {
+    flex-shrink: 0; // prevent multiline location names to butt into the handle
     width: 1.6rem;
     height: 1.25rem;
 


### PR DESCRIPTION
The drag handle (the square with which you can drag locations around) was not always having the full CSS width as intended, making dragging the location harder. This happened when a location's name was split over multiple lines.

Fixes #1253