### PR TITLE
bug(Grid): Fix rendering when screen is taller than it is wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ tech changes will usually be stripped from release notes for the public
 -   Auras: Fix sometimes not being visible until a refresh or panning closer to the aura
 -   Rendering: Transparency of higher layers was no longer applied after a window resize
 -   Rendering: Some cases where vision access related changes would not rerender immediately
+-   Rendering: Grid not rendering horizontal lines when the width is smaller than the height of the screen
 -   Select: Rotation UI should stay consistent when zooming
 -   LocationBar: Fix width on drag handle for multiline locations
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)

--- a/client/src/game/layers/variants/grid.ts
+++ b/client/src/game/layers/variants/grid.ts
@@ -33,11 +33,16 @@ export class GridLayer extends Layer implements IGridLayer {
                 const state = positionState.readonly;
 
                 if (locationSettingsState.raw.gridType.value === "SQUARE") {
-                    for (let i = 0; i < this.width; i += DEFAULT_GRID_SIZE * state.zoom) {
-                        ctx.moveTo(i + (state.panX % DEFAULT_GRID_SIZE) * state.zoom, 0);
-                        ctx.lineTo(i + (state.panX % DEFAULT_GRID_SIZE) * state.zoom, this.height);
-                        ctx.moveTo(0, i + (state.panY % DEFAULT_GRID_SIZE) * state.zoom);
-                        ctx.lineTo(this.width, i + (state.panY % DEFAULT_GRID_SIZE) * state.zoom);
+                    const zoomed_grid_size = DEFAULT_GRID_SIZE * state.zoom;
+                    for (let i = 0; i < this.height; i += zoomed_grid_size) {
+                        const zoomed_pan_size = (state.panY % DEFAULT_GRID_SIZE) * state.zoom;
+                        ctx.moveTo(0, i + zoomed_pan_size);
+                        ctx.lineTo(this.width, i + zoomed_pan_size);
+                    }
+                    for (let i = 0; i < this.width; i += zoomed_grid_size) {
+                        const zoomed_pan_size = (state.panX % DEFAULT_GRID_SIZE) * state.zoom;
+                        ctx.moveTo(i + zoomed_pan_size, 0);
+                        ctx.lineTo(i + zoomed_pan_size, this.height);
                     }
                 } else {
                     const s3 = Math.sqrt(3);


### PR DESCRIPTION
The grid was not rendering all the way down if the screen had a larger Y size than X size.

Fixes #1254