### PR TITLE
bug(Polygon): Fix creation of new polygons breaking [dev]

### DIFF
--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -280,7 +280,6 @@ export class Layer implements ILayer {
     private setServerShape(serverShape: ApiShape): void {
         const shape = createShapeFromDict(serverShape);
         if (shape === undefined) {
-            console.log(`Shape with unknown type ${serverShape.type_} could not be added`);
             return;
         }
         let invalidate = InvalidationMode.NO;

--- a/client/src/game/shapes/create.ts
+++ b/client/src/game/shapes/create.ts
@@ -42,70 +42,79 @@ export function createShapeFromDict(shape: ApiShape): IShape | undefined {
 
     // Shape Type specifics
 
-    const refPoint = toGP(shape.x, shape.y);
-    if (shape.type_ === "rect") {
-        const rect = shape as ApiRectShape;
-        sh = new Rect(refPoint, rect.width, rect.height, {
-            uuid,
-        });
-    } else if (shape.type_ === "circle") {
-        const circ = shape as ApiCircleShape;
-        sh = new Circle(refPoint, circ.radius, {
-            uuid,
-        });
-    } else if (shape.type_ === "circulartoken") {
-        const token = shape as ApiCircularTokenShape;
-        sh = new CircularToken(refPoint, token.radius, token.text, token.font, {
-            uuid,
-        });
-    } else if (shape.type_ === "line") {
-        const line = shape as ApiLineShape;
-        sh = new Line(refPoint, toGP(line.x2, line.y2), {
-            lineWidth: line.line_width,
-            uuid,
-        });
-    } else if (shape.type_ === "polygon") {
-        const polygon = shape as ApiPolygonShape;
-        const vertices = JSON.parse(polygon.vertices) as [number, number][];
-        sh = new Polygon(
-            refPoint,
-            vertices.map((v) => toGP(v)),
-            {
-                lineWidth: [polygon.line_width],
-                openPolygon: polygon.open_polygon,
+    try {
+        const refPoint = toGP(shape.x, shape.y);
+        if (shape.type_ === "rect") {
+            const rect = shape as ApiRectShape;
+            sh = new Rect(refPoint, rect.width, rect.height, {
                 uuid,
-            },
-        );
-    } else if (shape.type_ === "text") {
-        const text = shape as ApiTextShape;
-        sh = new Text(refPoint, text.text, text.font_size, {
-            uuid,
-        });
-    } else if (shape.type_ === "assetrect") {
-        const asset = shape as ApiAssetRectShape;
-        const img = new Image(asset.width, asset.height);
-        if (asset.src.startsWith("http")) img.src = baseAdjust(new URL(asset.src).pathname);
-        else img.src = baseAdjust(asset.src);
-        sh = new Asset(img, refPoint, asset.width, asset.height, { uuid, loaded: false });
-        img.onload = () => {
-            (sh as Asset).setLoaded();
-        };
-    } else if (shape.type_ === "togglecomposite") {
-        const toggleComposite = shape as ApiToggleCompositeShape;
-
-        if (toggleComposite.active_variant === null) throw new Error("ToggleComposite with no active variant found");
-
-        sh = new ToggleComposite(
-            refPoint,
-            getLocalId(toggleComposite.active_variant)!,
-            toggleComposite.variants.map((v) => ({ id: reserveLocalId(v.uuid), name: v.name })),
-            {
+            });
+        } else if (shape.type_ === "circle") {
+            const circ = shape as ApiCircleShape;
+            sh = new Circle(refPoint, circ.radius, {
                 uuid,
-            },
-        );
-    } else {
+            });
+        } else if (shape.type_ === "circulartoken") {
+            const token = shape as ApiCircularTokenShape;
+            sh = new CircularToken(refPoint, token.radius, token.text, token.font, {
+                uuid,
+            });
+        } else if (shape.type_ === "line") {
+            const line = shape as ApiLineShape;
+            sh = new Line(refPoint, toGP(line.x2, line.y2), {
+                lineWidth: line.line_width,
+                uuid,
+            });
+        } else if (shape.type_ === "polygon") {
+            const polygon = shape as ApiPolygonShape;
+            const vertices = JSON.parse(polygon.vertices) as [number, number][];
+            sh = new Polygon(
+                refPoint,
+                vertices.map((v) => toGP(v)),
+                {
+                    lineWidth: [polygon.line_width],
+                    openPolygon: polygon.open_polygon,
+                    uuid,
+                },
+            );
+        } else if (shape.type_ === "text") {
+            const text = shape as ApiTextShape;
+            sh = new Text(refPoint, text.text, text.font_size, {
+                uuid,
+            });
+        } else if (shape.type_ === "assetrect") {
+            const asset = shape as ApiAssetRectShape;
+            const img = new Image(asset.width, asset.height);
+            if (asset.src.startsWith("http")) img.src = baseAdjust(new URL(asset.src).pathname);
+            else img.src = baseAdjust(asset.src);
+            sh = new Asset(img, refPoint, asset.width, asset.height, { uuid, loaded: false });
+            img.onload = () => {
+                (sh as Asset).setLoaded();
+            };
+        } else if (shape.type_ === "togglecomposite") {
+            const toggleComposite = shape as ApiToggleCompositeShape;
+
+            if (toggleComposite.active_variant === null)
+                throw new Error("ToggleComposite with no active variant found");
+
+            sh = new ToggleComposite(
+                refPoint,
+                getLocalId(toggleComposite.active_variant)!,
+                toggleComposite.variants.map((v) => ({ id: reserveLocalId(v.uuid), name: v.name })),
+                {
+                    uuid,
+                },
+            );
+        } else {
+            console.error(`Failed to create Shape with unknown type ${shape.type_}`);
+            return undefined;
+        }
+    } catch (exception) {
+        console.error(`Failed to create Shape of type ${shape.type_}`);
+        console.error(exception);
         return undefined;
     }
+
     sh.fromDict(shape);
     return sh;
 }

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -85,7 +85,6 @@ export function addShape(shape: ApiShape, sync: SyncMode): IShape | undefined {
     const layer = floorSystem.getLayer(floorSystem.getFloor({ name: shape.floor })!, layerName)!;
     const sh = createShapeFromDict(shape);
     if (sh === undefined) {
-        console.log(`Shape with unknown type ${shape.type_} could not be added`);
         return;
     }
     layer.addShape(sh, sync, InvalidationMode.NORMAL);

--- a/server/src/db/models/polygon.py
+++ b/server/src/db/models/polygon.py
@@ -13,11 +13,6 @@ class Polygon(ShapeType):
     line_width = cast(int, IntegerField())
     open_polygon = cast(bool, BooleanField())
 
-    @staticmethod
-    def pre_create(**kwargs):
-        kwargs["vertices"] = json.dumps(kwargs["vertices"])
-        return kwargs
-
     def as_pydantic(self, shape: ApiCoreShape):
         return ApiPolygonShape(
             **shape.dict(),


### PR DESCRIPTION
A change was made to the way polygons are sent along the websocket and 1 function was not changed to take this into account, doing a wrong operation on the polygon data, breaking its representation in the database.

This PR fixes that function. It also adds some more safeguards to handle invalid shape data at the client side so that it doesn't completely crash, but skip the shape instead.