### PR TITLE
feat(Performance: ShapeSettings): Delay loading of most shape settings UI data

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -53,6 +53,7 @@
                 "sass": "^1.58.1",
                 "typescript": "^4.9.5",
                 "upath": "^2.0.1",
+                "v-lazy-show": "^0.2.0",
                 "vite": "^4.1.1",
                 "vitest": "^0.28.5",
                 "vue-eslint-parser": "^9.1.0",
@@ -5514,6 +5515,18 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
+        "node_modules/v-lazy-show": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/v-lazy-show/-/v-lazy-show-0.2.0.tgz",
+            "integrity": "sha512-332ZC7/7aQX5QHS3JTkwioe3cdF0JD8gn28+WUlWRUPKDjW080wdKpK8SUOyNoyUPfamG24upw8Ai8DfssnsVg==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-core": "^3.2.47"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
         "node_modules/v8-to-istanbul": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
@@ -10185,6 +10198,15 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
+        },
+        "v-lazy-show": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/v-lazy-show/-/v-lazy-show-0.2.0.tgz",
+            "integrity": "sha512-332ZC7/7aQX5QHS3JTkwioe3cdF0JD8gn28+WUlWRUPKDjW080wdKpK8SUOyNoyUPfamG24upw8Ai8DfssnsVg==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-core": "^3.2.47"
+            }
         },
         "v8-to-istanbul": {
             "version": "9.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -62,6 +62,7 @@
         "sass": "^1.58.1",
         "typescript": "^4.9.5",
         "upath": "^2.0.1",
+        "v-lazy-show": "^0.2.0",
         "vite": "^4.1.1",
         "vitest": "^0.28.5",
         "vue-eslint-parser": "^9.1.0",

--- a/client/src/game/ui/settings/shape/AccessSettings.vue
+++ b/client/src/game/ui/settings/shape/AccessSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, toRef, watchEffect } from "vue";
+import { computed, ref, toRef } from "vue";
 import { useI18n } from "vue-i18n";
 
 import { filter } from "../../../../core/iter";
@@ -11,19 +11,8 @@ import { DEFAULT_ACCESS, DEFAULT_ACCESS_SYMBOL } from "../../../systems/access/m
 import type { ACCESS_KEY, ShapeAccess } from "../../../systems/access/models";
 import { accessState } from "../../../systems/access/state";
 import { playerState } from "../../../systems/players/state";
-import { selectedSystem } from "../../../systems/selected";
 
 const { t } = useI18n();
-defineProps<{ activeSelection: boolean }>();
-
-watchEffect(() => {
-    const id = selectedSystem.getFocus().value;
-    if (id !== undefined) {
-        accessSystem.loadState(id);
-    } else {
-        accessSystem.dropState();
-    }
-});
 
 const accessDropdown = ref<HTMLSelectElement | null>(null);
 
@@ -115,7 +104,7 @@ function toggleVisionAccess(user?: ACCESS_KEY): void {
 </script>
 
 <template>
-    <div v-show="activeSelection" class="panel restore-panel">
+    <div class="panel restore-panel">
         <div class="spanrow header">{{ t("game.ui.selection.edit_dialog.access.access") }}</div>
         <div class="owner">
             <em>{{ t("game.ui.selection.edit_dialog.access.default") }}</em>

--- a/client/src/game/ui/settings/shape/TrackerSettings.vue
+++ b/client/src/game/ui/settings/shape/TrackerSettings.vue
@@ -19,8 +19,6 @@ import type { Tracker, TrackerId, UiTracker } from "../../../systems/trackers/mo
 
 const { t } = useI18n();
 
-defineProps<{ activeSelection: boolean }>();
-
 const owned = accessState.hasEditAccess;
 const isComposite = activeShapeStore.isComposite;
 
@@ -122,7 +120,7 @@ function toggleCompositeAura(shape: LocalId, auraId: AuraId): void {
 </script>
 
 <template>
-    <div v-show="activeSelection" style="display: contents">
+    <div style="display: contents">
         <div id="trackers-panel">
             <div class="spanrow header">{{ t("common.trackers") }}</div>
             <div

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,11 +4,12 @@ import path from "path";
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import vueI18n from "@intlify/unplugin-vue-i18n/vite";
+import { transformLazyShow } from "v-lazy-show";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [
-        vue(),
+        vue({ template: { compilerOptions: { nodeTransforms: [transformLazyShow] } } }),
         vueI18n({
             include: path.resolve(__dirname, "./src/locales/**"),
         }),


### PR DESCRIPTION
When you select a shape, the data that is displayed in the shape settings UI's various panels is already being loaded. This allows the dialog to open immediately showing data without having to wait for this data to load. It does however also mean that just swapping between some shapes performs these loads every time even when not used.

This PR changes the logic slightly to only grab the data of the active tab and wait with fetching more data until the relevant tab is opened. This retains the quick loading of the shape settings modal window with a smaller cost.

That said, this change will be mostly unnoticeable for most people.