### PR TITLE
bug(Shape): Fix invisible sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ tech changes will usually be stripped from release notes for the public
 -   Rendering: Grid not rendering horizontal lines when the width is smaller than the height of the screen
 -   Select: Rotation UI should stay consistent when zooming
 -   LocationBar: Fix width on drag handle for multiline locations
+-   Properties: Invisible toggle not applying until a refresh for players
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -44,7 +44,7 @@ socket.on(
 
 socket.on(
     "Shape.Options.Invisible.Set",
-    wrapSystemCall<ShapeSetBooleanValue>(propertiesSystem.setIsToken.bind(propertiesSystem)),
+    wrapSystemCall<ShapeSetBooleanValue>(propertiesSystem.setIsInvisible.bind(propertiesSystem)),
 );
 
 socket.on(


### PR DESCRIPTION
When toggling the "Is Invisible" property of a shape, it is not updated live for all other connected clients until they refresh.

Fixes #1262 