### PR TITLE
bug(Initiative): Fix initiative vision lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ tech changes will usually be stripped from release notes for the public
 -   Select: Rotation UI should stay consistent when zooming
 -   LocationBar: Fix width on drag handle for multiline locations
 -   Properties: Invisible toggle not applying until a refresh for players
+-   Initiative: Vision lock not properly checking active tokens
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -14,6 +14,7 @@ import { visionState } from "../../vision/state";
 import { accessSystem } from "../access";
 import { accessState } from "../access/state";
 import { gameState } from "../game/state";
+import { getProperties } from "../properties/state";
 import { selectedSystem } from "../selected";
 
 import { aurasToServer, partialAuraToServer, toUiAuras } from "./conversion";
@@ -120,7 +121,8 @@ class AuraSystem implements ShapeSystem {
         }
         auras.push(...(this.data.get(id) ?? []));
 
-        if (gameState.raw.isFakePlayer || !accessState.activeTokens.value.has(id)) {
+        const props = getProperties(id);
+        if (gameState.raw.isFakePlayer || (props?.isToken === true && !accessState.activeTokens.value.has(id))) {
             if (!accessSystem.hasAccessTo(id, true, { vision: true })) return [...filter(auras, (a) => a.visible)];
         }
 

--- a/client/src/game/systems/auras/index.ts
+++ b/client/src/game/systems/auras/index.ts
@@ -12,6 +12,7 @@ import { compositeState } from "../../layers/state";
 import { LayerName } from "../../models/floor";
 import { visionState } from "../../vision/state";
 import { accessSystem } from "../access";
+import { accessState } from "../access/state";
 import { gameState } from "../game/state";
 import { selectedSystem } from "../selected";
 
@@ -119,7 +120,7 @@ class AuraSystem implements ShapeSystem {
         }
         auras.push(...(this.data.get(id) ?? []));
 
-        if (gameState.raw.isFakePlayer) {
+        if (gameState.raw.isFakePlayer || !accessState.activeTokens.value.has(id)) {
             if (!accessSystem.hasAccessTo(id, true, { vision: true })) return [...filter(auras, (a) => a.visible)];
         }
 


### PR DESCRIPTION
The vision lock setting in the initiative settings was no longer functioning properly.

It's intended to only show things the current active initiative participant can see (if it's a token the user controls) and this check was no longer being applied.