### PR TITLE
bug(Initiative): Fix entry removal breaking turn logic in edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ tech changes will usually be stripped from release notes for the public
 -   LocationBar: Fix width on drag handle for multiline locations
 -   Properties: Invisible toggle not applying until a refresh for players
 -   Initiative: Vision lock not properly checking active tokens
+-   Initiative: Removing the last entry while it's active could break initiative
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/api/events/initiative.ts
+++ b/client/src/game/api/events/initiative.ts
@@ -15,7 +15,12 @@ socket.on("Initiative.Set", (data: ApiInitiative) => initiativeStore.setData(dat
 socket.on("Initiative.Active.Set", (isActive: boolean) => initiativeStore.setActive(isActive));
 socket.on("Initiative.Remove", (data: GlobalId) => initiativeStore.removeInitiative(data, false));
 
-socket.on("Initiative.Turn.Update", (turn: number) => initiativeStore.setTurnCounter(turn, false));
+socket.on("Initiative.Turn.Update", (turn: number) =>
+    initiativeStore.setTurnCounter(turn, { sync: false, updateEffects: true }),
+);
+socket.on("Initiative.Turn.Set", (turn: number) =>
+    initiativeStore.setTurnCounter(turn, { sync: false, updateEffects: false }),
+);
 socket.on("Initiative.Round.Update", (round: number) => initiativeStore.setRoundCounter(round, false));
 socket.on("Initiative.Effect.New", (data: InitiativeEffectNew) => {
     initiativeStore.createEffect(data.actor, data.effect, false);


### PR DESCRIPTION
When the active initiative actor is the last entry in the initiative and is removed, the turn order was not being updated accordingly, causing the internal initiative tracker to point to an undefined entry.
Attempts to advance/rewind initiative would fail as these do some sanity checks that were now failing.

This PR fixes the issue and also adds a sanity check to turn updating to catch faulty internal state and fix it.