### PR TITLE
bug(Vision): Fix infinite loop edge case in marchLocate2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ tech changes will usually be stripped from release notes for the public
 -   Properties: Invisible toggle not applying until a refresh for players
 -   Initiative: Vision lock not properly checking active tokens
 -   Initiative: Removing the last entry while it's active could break initiative
+-   Vision: Edgecase that could cause an infinite loop when drawing vision lines
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/vision/cdt.ts
+++ b/client/src/game/vision/cdt.ts
@@ -30,7 +30,7 @@ export class CDT {
     }
     insertConstraint(a: Point, b: Point): { va: Vertex; vb: Vertex } {
         const va = this.insert(a);
-        const vb = this.insert(b);
+        const vb = this.insert(b, va.triangle);
         if (va !== vb) this.insertConstraintV(va, vb);
         return { va, vb };
     }
@@ -757,7 +757,11 @@ export class CDT {
             if (c.isInfinite()) {
                 return { loc: c, lt: LocateType.OUTSIDE_CONVEX_HULL, li: c.indexV(this.tds._infinite) };
             }
-            const leftFirst = 0; // Math.round(Math.random());
+            // This random coin toss decides whether the code goes left or right
+            // This is important because there are (extreme) edgecases where constantly going left can
+            // introduce an infinite loop of multiple chains long
+            // whereas sometimes going right can alleviate this
+            const leftFirst = Math.round(Math.random());
             const p0 = c.vertices[0]!.point!;
             const p1 = c.vertices[1]!.point!;
             const p2 = c.vertices[2]!.point!;


### PR DESCRIPTION
When drawing vision (e.g. using the polygon tool) there was a very rare edge-case that could be triggered which could cause an infinite loop, resulting in a frozen page.