### PR TITLE
feat(DrawTool): Reduce the number of points when using brush mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ tech changes will usually be stripped from release notes for the public
 -   Initiative: Vision lock not properly checking active tokens
 -   Initiative: Removing the last entry while it's active could break initiative
 -   Vision: Edgecase that could cause an infinite loop when drawing vision lines
+-   Draw: Reduced number of points in brush mode significantly
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -1,6 +1,6 @@
 import type { ApiPolygonShape } from "../../../apiTypes";
-import { g2l, g2lz } from "../../../core/conversions";
-import { addP, getDistanceToSegment, subtractP, toArrayP, toGP } from "../../../core/geometry";
+import { g2l, g2lz, toDegrees } from "../../../core/conversions";
+import { Vector, addP, getAngleBetween, getDistanceToSegment, subtractP, toArrayP, toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import { equalPoints, filterEqualPoints, getPointsCenter, rotateAroundPoint } from "../../../core/math";
 import { InvalidationMode, SyncMode } from "../../../core/models/types";
@@ -11,6 +11,7 @@ import { getGlobalId } from "../../id";
 import type { GlobalId, LocalId } from "../../id";
 import type { IShape } from "../../interfaces/shape";
 import type { AuraId } from "../../systems/auras/models";
+import { positionState } from "../../systems/position/state";
 import { getProperties } from "../../systems/properties/state";
 import type { ShapeProperties } from "../../systems/properties/state";
 import type { TrackerId } from "../../systems/trackers/models";
@@ -19,6 +20,11 @@ import { Shape } from "../shape";
 import type { SHAPE_TYPE } from "../types";
 
 import { BoundingRect } from "./simple/boundingRect";
+
+// Consts for simplifyEnd
+const MIN_AREA = 0.04 * 5;
+const MAX_AREA = 13 * 5;
+const ANGLE_C = 56;
 
 export class Polygon extends Shape implements IShape {
     type: SHAPE_TYPE = "polygon";
@@ -270,11 +276,12 @@ export class Polygon extends Shape implements IShape {
         }
     }
 
-    pushPoint(point: GlobalPoint): void {
+    pushPoint(point: GlobalPoint, options?: { simplifyEnd?: boolean }): void {
         this._vertices.push(point);
         this._points.push(this.invalidatePoint(point, this.center));
         this.layer?.updateSectors(this.id, this.getAuraAABB());
         if (this.isSnappable) this.updateLayerPoints();
+        if (options?.simplifyEnd === true) this.simplifyEnd();
     }
 
     addPoint(point: GlobalPoint): void {
@@ -323,6 +330,40 @@ export class Polygon extends Shape implements IShape {
 
             this.invalidatePoints();
             this.invalidate(true);
+        }
+    }
+
+    // Run a Visvalingam-Whyatt style simplification on the end of the polygon
+    // This assumes that a new point was added to the end and that the previous points have been simplified before
+    private simplifyEnd(): void {
+        function area(t: [number, number][]): number {
+            return Math.abs(
+                (t[0]![0] - t[2]![0]) * (t[1]![1] - t[0]![1]) - (t[0]![0] - t[1]![0]) * (t[2]![1] - t[0]![1]),
+            );
+        }
+
+        const max_area = MAX_AREA / positionState.readonly.zoom;
+        const min_area = MIN_AREA / positionState.readonly.zoom;
+
+        while (this._points.length >= 3) {
+            const a = area(this._points.slice(-3));
+            if (a > max_area) {
+                break;
+            } else if (a >= min_area) {
+                let angle = toDegrees(
+                    getAngleBetween(
+                        Vector.fromPoints(toGP(this._points.at(-2)!), toGP(this._points.at(-3)!)),
+                        Vector.fromPoints(toGP(this._points.at(-2)!), toGP(this._points.at(-1)!)),
+                    ),
+                );
+                if (angle < 0) angle *= -1;
+                if (angle <= 180 - ANGLE_C || angle >= 180 + ANGLE_C) {
+                    break;
+                }
+            }
+
+            const p = this._vertices.at(-2)!;
+            this.removePoint(p);
         }
     }
 }

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -534,7 +534,7 @@ class DrawTool extends Tool implements ITool {
                 const br = this.shape as Polygon;
                 const points = br.points; // expensive call
                 if (equalPoints(points.at(-1)!, [endPoint.x, endPoint.y])) return Promise.resolve();
-                br.pushPoint(endPoint);
+                br.pushPoint(endPoint, { simplifyEnd: true });
                 break;
             }
             case DrawShape.Polygon: {


### PR DESCRIPTION
_I'm unsure whether I would classify this as a change or a bugfix :D._

The brush mode in the draw tool has been an eye sore for a _loong_ time.
It exists, but is a performance hog which means you probably should avoid it at almost all times.

The reason for that performance issue was with how the shape is stored internally.
Behind the scenes it's exactly the same kind of structure as a shape drawn with the polygon tool,
but the difference is in their creation.  In polygon mode, you dictate the points with clicks, whereas in brush mode your mouse drag dictates the polygon.

Long story short, the mouse drag was adding _a lot_ of points. This PR implements an algorithm that will during a drag simplify the polygon by trying to remove points that contribute close to nothing to the actual shape.

Some small changes in the overall shape might occur, but they should be very subtle if any.