### PR TITLE
bug(Groups): Fix missing groups event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ tech changes will usually be stripped from release notes for the public
 -   Group: Shape group settings fixes
     -   Create group button was not properly behaving
     -   Remove group button was not immediately updating the UI until a reselection
+-   Group: Fix socket events no longer being listened to; Fixes multiple things that were resolved when you refreshed
 -   Auth: A logic error in the auth routing code - in some cases you had to manually go to the login page
 -   Templates: Missing some settings when saved
 -   Fake Player: Proper rework of access handling

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -1,5 +1,6 @@
 import "../systems/access/events";
 import "../systems/auras/events";
+import "../systems/groups/events";
 import "../systems/labels/events";
 import "../systems/logic/door/events";
 import "../systems/logic/tp/events";


### PR DESCRIPTION
Due to silliness the (socket) event listeners for all things groups related were no longer active. This happened due to some refactoring that I didn't pay proper attention to.

In practice this means that updates related to groups were not being received until you did a refresh.