### PR TITLE
feat(AssetManager): Re-introduce progressbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ tech changes will usually be stripped from release notes for the public
 -   Initiative: Removing the last entry while it's active could break initiative
 -   Vision: Edgecase that could cause an infinite loop when drawing vision lines
 -   Draw: Reduced number of points in brush mode significantly
+-   AssetManager: Fix progressbar missing
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/dashboard/Assets.vue
+++ b/client/src/dashboard/Assets.vue
@@ -276,6 +276,15 @@ async function deleteSelection(): Promise<void> {
                 <div class="title">{{ showIdName(file) }}</div>
             </div>
         </div>
+        <div v-show="state.expectedUploads > 0 && state.expectedUploads !== state.resolvedUploads" id="progressbar">
+            <div id="progressbar-label">
+                {{ t("assetManager.AssetManager.uploading") }} {{ state.resolvedUploads }} /
+                {{ state.expectedUploads }}
+            </div>
+            <div id="progressbar-meter">
+                <span :style="{ width: (state.resolvedUploads / state.expectedUploads) * 100 + '%' }"></span>
+            </div>
+        </div>
     </div>
     <AssetContextMenu />
 </template>
@@ -405,6 +414,74 @@ async function deleteSelection(): Promise<void> {
 
         > .inode-not-selected::after {
             background-image: v-bind(emptySelectionUrl);
+        }
+    }
+}
+
+#progressbar {
+    position: sticky;
+    bottom: 2rem;
+
+    margin-top: 2rem;
+
+    display: flex;
+    flex-direction: row;
+
+    border: solid 2px white;
+    border-radius: 15px;
+    overflow: hidden;
+
+    #progressbar-label {
+        padding: 10px 15px;
+        background-color: rgba(137, 0, 37, 1);
+        font-weight: bold;
+    }
+
+    #progressbar-meter {
+        background-color: white;
+        padding: 1px;
+        flex-grow: 2;
+
+        > span {
+            display: block;
+            height: 100%;
+            position: relative;
+            overflow: hidden;
+            background-color: rgba(137, 0, 37, 1);
+            background-image: linear-gradient(to bottom, rgba(137, 0, 37, 1) 37%, rgba(137, 0, 37, 1) 69%);
+            box-shadow: inset 0 2px 9px rgba(255, 255, 255, 0.3), inset 0 -2px 6px rgba(0, 0, 0, 0.4);
+
+            &:after {
+                content: "";
+                position: absolute;
+                top: 0;
+                left: 0;
+                bottom: 0;
+                right: 0;
+                background-image: linear-gradient(
+                    -45deg,
+                    rgba(255, 255, 255, 0.2) 25%,
+                    transparent 25%,
+                    transparent 50%,
+                    rgba(255, 255, 255, 0.2) 50%,
+                    rgba(255, 255, 255, 0.2) 75%,
+                    transparent 75%,
+                    transparent
+                );
+                z-index: 1;
+                background-size: 50px 50px;
+                overflow: hidden;
+                animation: move 2s linear infinite;
+            }
+        }
+    }
+
+    @keyframes move {
+        0% {
+            background-position: 0 0;
+        }
+        100% {
+            background-position: 50px 50px;
         }
     }
 }


### PR DESCRIPTION
Somehow I never realized that since the incorporation of the asset manager into the dashboard UI, the progress bar never made it along.