### PR TITLE
bug(Annotation): Fix markdown bold rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ tech changes will usually be stripped from release notes for the public
 -   Vision: Edgecase that could cause an infinite loop when drawing vision lines
 -   Draw: Reduced number of points in brush mode significantly
 -   AssetManager: Fix progressbar missing
+-   Annotation: Markdown no longer rendering as bold
 -   [server] Subpath: 2 cases where subpath based setup was not properly loading images (initiative & change asset)
 
 ## [2023.1.0] - 2023-02-14

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -78,7 +78,6 @@ body,
     min-width: 100%;
     min-height: 100%;
     font-family: "Open Sans", sans-serif;
-    font-weight: 200;
 
     display: flex;
     background-repeat: repeat;


### PR DESCRIPTION
Firefox does not set the font-weight for the `<strong>` element. This is the element used by the markdown library to render bold text.

The combination of the above and a font-weight setting that PA applied a long time ago, made it so that bold markdown was not being rendered properly in firefox.

This fixes #1255.

This PR removes the global font-weight being set by the PA application. Another approach would be to set font-weight to bold for the strong element. I might have to revision this in the future, but this addresses the issue for now.