### PR TITLE
feat(UI): Prevent out of screen scrolling with touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ tech changes will usually be stripped from release notes for the public
 ### Added
 
 -   Drop new assets on the game directly
+-   Scroll-like touch gestures no longer attempt to scroll the gameboard out of bounds
 
 ### Changed
 

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -224,6 +224,7 @@ svg {
     width: 100%;
     height: 100%;
     box-sizing: border-box;
+    touch-action: none;
 
     &.disconnected {
         border: solid 5px red;

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -259,6 +259,7 @@ DIRECTORY.CSS changes
     background-color: #fa5a5a;
     overflow: auto;
     pointer-events: auto;
+    touch-action: none;
 }
 
 .actionButton {


### PR DESCRIPTION
On touch devices (and mostly mobile devices), the browser handles scrolling the UI differently and will try to slide the entire screen to the top or bottom which looks jarring in the context of PA.

This PR just adds some css rules to prevent the browser from handling touch input as well on the board itself as well as the side menubar.

It does _not_ initiate fullscreen stuff as mentioned in #1155 however.
