### PR TITLE
bug(Export): Fix campaign export with notes failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ tech changes will usually be stripped from release notes for the public
 
 ### Fixed
 
+-   Export: Campaigns with notes could fail to export
 -   Vision: Edgecase in triangulation build
 
 ## [2023.2.0] - 2023-06-21

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -29,7 +29,7 @@ ssl_privkey = cert/privkey.pem
 max_upload_size_in_bytes = 10_485_760
 
 [General]
-save_file = planar.sqlite
+save_file = be.sqlite
 #assets_directory = 
 #public_name = 
 

--- a/server/src/export/campaign.py
+++ b/server/src/export/campaign.py
@@ -867,13 +867,10 @@ class CampaignMigrator:
                 note_data["uuid"] = new_uuid
                 note_data["room"] = self.room_mapping[room.id]
                 note_data["user"] = self.user_mapping.get(note_data["user"])
+
                 if note_data["user"] is None:
                     continue
-                if note_data["location"]:
-                    note_data["location"] = self.location_mapping[note_data["location"]]
 
-                with self.to_db.bind_ctx([Note]):
-                    Note.create(**note_data)
                 if note_data["location"]:
                     note_data["location"] = self.location_mapping[note_data["location"]]
 


### PR DESCRIPTION
Campaign exports that contained notes would no longer work due to a couple of lines being duplicated at the end of the export function by a conflict between 2 formatting extensions in my editor.