### PR TITLE
bug(Socket): Fix location change not properly leaving sio room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Export: Campaigns with notes could fail to export
 -   Vision: Edgecase in triangulation build
+-   Socket: Changing location was not properly leaving the socket connection to the previous location
 
 ## [2023.2.0] - 2023-06-21
 

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -293,6 +293,7 @@ async def change_location(sid: str, raw_data: Any):
         for psid in game_state.get_sids(player=room_player.player, room=pr.room):
             await _send_game("Location.Change.Start", None, room=psid)
 
+    old_locations = {rp.id: rp.active_location for rp in prs_to_move}
     new_location = Location.get_by_id(data.location)
 
     # First update DB for _all_ affected players
@@ -305,7 +306,7 @@ async def change_location(sid: str, raw_data: Any):
         for psid in game_state.get_sids(player=room_player.player, room=pr.room):
             try:
                 sio.leave_room(
-                    psid, room_player.active_location.get_path(), namespace=GAME_NS
+                    psid, old_locations[room_player.id].get_path(), namespace=GAME_NS
                 )
                 sio.enter_room(psid, new_location.get_path(), namespace=GAME_NS)
             except KeyError:

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -286,29 +286,22 @@ async def change_location(sid: str, raw_data: Any):
         logger.warning(f"{pr.player.name} attempted to change location")
         return
 
-    # Send an anouncement to show loading state
-    for room_player in pr.room.players:
-        if room_player.player.name not in data.users:
-            continue
+    prs_to_move = [p for p in pr.room.players if p.player.name in data.users]
 
+    # Send an anouncement to show loading state
+    for room_player in prs_to_move:
         for psid in game_state.get_sids(player=room_player.player, room=pr.room):
             await _send_game("Location.Change.Start", None, room=psid)
 
     new_location = Location.get_by_id(data.location)
 
     # First update DB for _all_ affected players
-    for room_player in pr.room.players:
-        if room_player.player.name not in data.users:
-            continue
-
+    for room_player in prs_to_move:
         room_player.active_location = new_location
         room_player.save()
 
     # Then send out updates
-    for room_player in pr.room.players:
-        if room_player.player.name not in data.users:
-            continue
-
+    for room_player in prs_to_move:
         for psid in game_state.get_sids(player=room_player.player, room=pr.room):
             try:
                 sio.leave_room(

--- a/server/src/db/models/player_room.py
+++ b/server/src/db/models/player_room.py
@@ -10,6 +10,8 @@ from .user import User, UserOptions
 
 
 class PlayerRoom(BaseDbModel):
+    id: int
+
     role = cast(int, IntegerField(default=0))
     player = cast(
         User, ForeignKeyField(User, backref="rooms_joined", on_delete="CASCADE")


### PR DESCRIPTION
PA uses websockets (i.e. socket.io) for communication between client and server. When a player enters a game they join a sio room for the game as a whole as well as a room for the specific location they are currently in. When changing locations they're supposed to leave the room associated with the previous location as events for that location are no longer interesting to the client. (e.g. shape movements)

This was however no longer behaving correctly, causing you to receive messages from all locations you visited (in the current browsing session).