### PR TITLE
bug(Tech: DB): Correct Shape.group on_delete

### DIFF
--- a/server/src/db/models/shape.py
+++ b/server/src/db/models/shape.py
@@ -77,7 +77,9 @@ class Shape(BaseDbModel):
     )
     group = cast(
         Optional[Group],
-        ForeignKeyField(Group, backref="members", null=True, default=None),
+        ForeignKeyField(
+            Group, backref="members", null=True, default=None, on_delete="SET NULL"
+        ),
     )
     annotation_visible = cast(bool, BooleanField(default=False))
     ignore_zoom_size = cast(bool, BooleanField(default=False))


### PR DESCRIPTION
The `Shape.group` foreign field had no `on_delete` configured, meaning it defaults to `NO_ACTION` which is incorrect.

In practice this never was an issue as the `Group.Remove` event already sets the group to `null` for all relevant shapes.

Nonetheless this PR cleans up this technical error.