### PR TITLE
feat(Tech: Spawn): Reduce amount of data passed in spawn info requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ tech changes will usually be stripped from release notes for the public
 ### Changed
 
 -   [tech] Selected system now has a proper state with better type ergonomics for focus retrieval
+-   [tech] Spawn Info no longer sends entire shape info, but just position, floor, id and name
 
 ### Fixed
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -671,6 +671,12 @@ export interface ApiLocationOptions {
   underground_map_background: string;
   limit_movement_during_initiative: boolean;
 }
+export interface ApiSpawnInfo {
+  position: PositionTuple;
+  floor: string;
+  name: string;
+  uuid: GlobalId;
+}
 export interface LocationChange {
   location: number;
   users: string[];

--- a/client/src/game/api/emits/location.ts
+++ b/client/src/game/api/emits/location.ts
@@ -1,4 +1,4 @@
-import type { ApiAssetRectShape, LocationClone, LocationOptionsSet, LocationRename } from "../../../apiTypes";
+import type { ApiSpawnInfo, LocationClone, LocationOptionsSet, LocationRename } from "../../../apiTypes";
 import type { ServerLocationOptions } from "../../systems/settings/location/models";
 import { wrapSocket } from "../helpers";
 import { socket } from "../socket";
@@ -16,9 +16,10 @@ export const sendLocationArchive = wrapSocket<number>("Location.Archive");
 export const sendLocationUnarchive = wrapSocket<number>("Location.Unarchive");
 export const sendLocationClone = wrapSocket<LocationClone>("Location.Clone");
 
-export async function requestSpawnInfo(location: number): Promise<ApiAssetRectShape[]> {
-    socket.emit("Location.Spawn.Info.Get", location);
-    return new Promise((resolve: (value: ApiAssetRectShape[]) => void) => socket.once("Location.Spawn.Info", resolve));
+export async function requestSpawnInfo(location: number): Promise<ApiSpawnInfo[]> {
+    return new Promise((resolve: (value: ApiSpawnInfo[]) => void) => {
+        socket.emit("Location.Spawn.Info.Get", location, resolve);
+    });
 }
 
 export function sendLocationOption<T extends keyof ServerLocationOptions>(

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -3,7 +3,7 @@ import { computed, toRef } from "vue";
 import type { ComputedRef } from "vue";
 import { useI18n } from "vue-i18n";
 
-import type { ApiAssetRectShape } from "../../../apiTypes";
+import type { ApiSpawnInfo } from "../../../apiTypes";
 import ContextMenu from "../../../core/components/ContextMenu.vue";
 import { defined, guard, map } from "../../../core/iter";
 import { SyncMode } from "../../../core/models/types";
@@ -192,7 +192,7 @@ async function setLocation(newLocation: number): Promise<void> {
     }
 
     const spawnInfo = await requestSpawnInfo(newLocation);
-    let spawnLocation: ApiAssetRectShape;
+    let spawnLocation: ApiSpawnInfo;
 
     switch (spawnInfo.length) {
         case 0:
@@ -221,8 +221,8 @@ async function setLocation(newLocation: number): Promise<void> {
 
     const targetPosition = {
         floor: spawnLocation.floor,
-        x: spawnLocation.x + spawnLocation.width / 2,
-        y: spawnLocation.y + spawnLocation.height / 2,
+        x: spawnLocation.position.x,
+        y: spawnLocation.position.y,
     };
 
     sendShapesMove({

--- a/server/src/api/models/common.py
+++ b/server/src/api/models/common.py
@@ -2,5 +2,5 @@ from pydantic import BaseModel
 
 
 class PositionTuple(BaseModel):
-    x: int
-    y: int
+    x: float
+    y: float

--- a/server/src/api/models/location/__init__.py
+++ b/server/src/api/models/location/__init__.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from ..common import PositionTuple
 from .settings import *
 from .settings import ApiOptionalLocationOptions
+from .spawn_info import *
 from .userOption import *
 
 

--- a/server/src/api/models/location/spawn_info.py
+++ b/server/src/api/models/location/spawn_info.py
@@ -1,0 +1,11 @@
+from pydantic import Field
+
+from ..common import PositionTuple
+from ..helpers import TypeIdModel
+
+
+class ApiSpawnInfo(TypeIdModel):
+    position: PositionTuple
+    floor: str
+    name: str
+    uuid: str = Field(..., typeId="GlobalId")

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -325,8 +325,6 @@ async def move_shapes(sid: str, raw_data: Any):
 
     location = Location.get_by_id(data.target.location)
     floor = location.floors.where(Floor.name == data.target.floor)[0]
-    x = data.target.x
-    y = data.target.y
 
     shapes = [Shape.get_by_id(sh) for sh in data.shapes]
 
@@ -336,7 +334,7 @@ async def move_shapes(sid: str, raw_data: Any):
 
     for shape in shapes:
         shape.layer = floor.layers.where(Layer.name == shape.layer.name)[0]
-        shape.center_at(x, y)
+        shape.center = data.target
         shape.save()
 
     for psid, tpr in game_state.get_t(active_location=location):

--- a/server/src/db/models/base_rect.py
+++ b/server/src/db/models/base_rect.py
@@ -9,5 +9,5 @@ class BaseRect(ShapeType):
     width = cast(float, FloatField())
     height = cast(float, FloatField())
 
-    def get_center_offset(self, x: int, y: int) -> Tuple[float, float]:
+    def get_center_offset(self) -> Tuple[float, float]:
         return self.width / 2, self.height / 2

--- a/server/src/db/models/line.py
+++ b/server/src/db/models/line.py
@@ -12,7 +12,7 @@ class Line(ShapeType):
     y2 = cast(float, FloatField())
     line_width = cast(int, IntegerField())
 
-    def get_center_offset(self, x: int, y: int) -> Tuple[float, float]:
+    def get_center_offset(self) -> Tuple[float, float]:
         return (self.x2 - self.shape.x) / 2, (self.y2 - self.shape.y) / 2
 
     def as_pydantic(self, shape: ApiCoreShape):

--- a/server/src/db/models/shape.py
+++ b/server/src/db/models/shape.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from peewee import BooleanField, FloatField, ForeignKeyField, IntegerField, TextField
 
+from ...api.models.common import PositionTuple
 from ..base import BaseDbModel
 from ..typed import SelectSequence
 from .asset import Asset
@@ -101,10 +102,16 @@ class Shape(BaseDbModel):
     def set_options(self, options: Dict[str, Any]) -> None:
         self.options = json.dumps([[k, v] for k, v in options.items()])
 
-    def center_at(self, x: float, y: float) -> None:
-        x_off, y_off = self.subtype.get_center_offset(x, y)
-        self.x = x - x_off
-        self.y = y - y_off
+    @property
+    def center(self) -> PositionTuple:
+        x_off, y_off = self.subtype.get_center_offset()
+        return PositionTuple(x=self.x + x_off, y=self.y + y_off)
+
+    @center.setter
+    def center(self, center: PositionTuple):
+        x_off, y_off = self.subtype.get_center_offset()
+        self.x = center.x - x_off
+        self.y = center.y - y_off
 
     @property
     def subtype(self) -> "ShapeType":

--- a/server/src/db/models/shape_type.py
+++ b/server/src/db/models/shape_type.py
@@ -27,7 +27,7 @@ class ShapeType(BaseDbModel):
     def as_pydantic(self, shape: ApiCoreShape) -> ApiShape:
         raise Exception(f"{self.__class__.__name__} has no pydantic model")
 
-    def get_center_offset(self, x: float, y: float) -> Tuple[float, float]:
+    def get_center_offset(self) -> Tuple[float, float]:
         return 0, 0
 
     def set_location(self, points: list[tuple[float, float]]) -> None:


### PR DESCRIPTION
The socket event `Location.Spawn.Info.Get` was receiving all shape information for the related spawn objects, although only the location and some id/name info was needed.

This PR also cleans up a couple of related concepts:
- The aforementioned socket event no longer uses a separate return event, but uses the event callback that socket.io provides
- server Shape now has a proper getter and setter for center
- server Shape subtype center offset no longer requires unused x,y arguments
- PositionTuple uses floats instead of ints