### PR TITLE
bug(Tech: Types): Fix typing of database get_or_none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ tech changes will usually be stripped from release notes for the public
 -   Export: Campaigns with notes could fail to export
 -   Vision: Edgecase in triangulation build
 -   Socket: Changing location was not properly leaving the socket connection to the previous location
+-   Kicking: The check to prevent the co-DM from kicking the main DM was incorrect
 
 ## [2023.2.0] - 2023-06-21
 

--- a/server/src/api/http/admin/users.py
+++ b/server/src/api/http/admin/users.py
@@ -13,17 +13,19 @@ async def collect(_request: web.Request) -> web.Response:
 async def reset(request: web.Request) -> web.Response:
     data = await request.json()
     new_pw = secrets.token_urlsafe(20)
-    user = User.by_name(data["name"])
-    user.set_password(new_pw)
-    user.save()
-    return web.json_response(new_pw)
+    if user := User.by_name(data["name"]):
+        user.set_password(new_pw)
+        user.save()
+        return web.json_response(new_pw)
+    return web.HTTPNotFound()
 
 
 async def remove(request: web.Request) -> web.Response:
     data = await request.json()
-    user = User.by_name(data["name"])
-    try:
-        user.delete_instance(recursive=True)
-    except:
-        return web.HTTPBadRequest(reason="User removal did not succeed.")
-    return web.HTTPOk()
+    if user := User.by_name(data["name"]):
+        try:
+            user.delete_instance(recursive=True)
+        except:
+            return web.HTTPBadRequest(reason="User removal did not succeed.")
+        return web.HTTPOk()
+    return web.HTTPNotFound()

--- a/server/src/api/socket/room.py
+++ b/server/src/api/socket/room.py
@@ -45,19 +45,21 @@ async def kick_player(sid: str, player_id: int):
         logger.warning(f"{pr.player.name} attempted to refresh the invitation code.")
         return
 
-    pr = PlayerRoom.get_or_none(player=player_id, room=pr.room)
-    if pr is None:
+    target_pr = PlayerRoom.get_or_none(player=player_id, room=pr.room)
+    if target_pr is None:
         return
 
     creator: User = pr.room.creator
 
-    if pr.player != creator and creator == pr.player:
-        logger.warning(f"{pr.player.name} attempted to kick the campaign creator")
+    if pr.player != creator and creator == target_pr.player:
+        logger.warning(
+            f"{target_pr.player.name} attempted to kick the campaign creator"
+        )
         return
 
-    for psid in game_state.get_sids(player=pr.player, room=pr.room):
+    for psid in game_state.get_sids(player=target_pr.player, room=target_pr.room):
         await sio.disconnect(psid, namespace=GAME_NS)
-    pr.delete_instance(True)
+    target_pr.delete_instance(True)
 
 
 @sio.on("Room.Delete", namespace=GAME_NS)

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -111,11 +111,16 @@ async def update_shape_positions(sid: str, raw_data: Any):
 
     for sh in data.shapes:
         shape = Shape.get_or_none(Shape.uuid == sh.uuid)
-        if shape is not None and not has_ownership(shape, pr, movement=True):
+        if shape is None:
+            logger.warning(
+                f"User {pr.player.name} attempted to move a shape with unknown uuid ({sh.uuid})."
+            )
+            continue
+        elif not has_ownership(shape, pr, movement=True):
             logger.warning(
                 f"User {pr.player.name} attempted to move a shape it does not own."
             )
-            return
+            continue
         shapes.append((shape, sh))
 
     if not data.temporary:

--- a/server/src/db/models/user.py
+++ b/server/src/db/models/user.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Optional, cast
 import bcrypt
 from peewee import ForeignKeyField, TextField, fn
 from playhouse.shortcuts import model_to_dict
+from typing_extensions import Self
 
 from ..base import BaseDbModel
 from ..typed import SelectSequence
@@ -50,7 +51,7 @@ class User(BaseDbModel):
         )
 
     @classmethod
-    def by_name(cls, name: str) -> "User":
+    def by_name(cls, name: str) -> Self | None:
         return cls.get_or_none(fn.Lower(cls.name) == name.lower())
 
     @classmethod

--- a/server/src/db/typed.py
+++ b/server/src/db/typed.py
@@ -105,7 +105,7 @@ class TypedModel:
             ...
 
         @classmethod
-        def get_or_none(cls, *args, **kwargs) -> Self:
+        def get_or_none(cls, *args, **kwargs) -> Self | None:
             ...
 
         @classmethod

--- a/server/src/planarserver.py
+++ b/server/src/planarserver.py
@@ -29,9 +29,13 @@ from .api import http  # noqa: F401, E402
 # Force loading of socketio routes
 from .api.socket import load_socket_commands  # noqa: E402
 from .api.socket.constants import GAME_NS  # noqa: E402
-from .app import admin_app  # noqa: E402
+from .app import (  # noqa: E402
+    admin_app,  # noqa: E402
+    runners,
+    setup_runner,
+    sio,
+)
 from .app import app as main_app  # noqa: E402
-from .app import runners, setup_runner, sio  # noqa: E402
 from .config import config  # noqa: E402
 from .logs import logger  # noqa: E402
 from .state.asset import asset_state  # noqa: E402
@@ -194,8 +198,8 @@ def remove_main(args):
     resource = args.resource.lower()
 
     if resource == "user":
-        user = User.by_name(args.name)
-        user.delete_instance(recursive=True)
+        if user := User.by_name(args.name):
+            user.delete_instance(recursive=True)
     elif resource == "room":
         room = get_room(args.name)
         room.delete_instance(recursive=True)


### PR DESCRIPTION
The typing wrapper we provide for peewee (the orm used by PA), was not correct for the `get_or_none` function. This fixed a couple of small mistakes here and there.

It also happened to fix a logic bug in the code responsible for kicking players, allowing the Co-DM to kick the main DM.