### PR TITLE
bug(AssetManager): Fix the .. folder always being visible

### DIFF
--- a/client/src/dashboard/Assets.vue
+++ b/client/src/dashboard/Assets.vue
@@ -239,7 +239,7 @@ async function deleteSelection(): Promise<void> {
         </div>
         <div id="assets" :class="{ dropzone: dragState > 0 }" @dragover.prevent @drop.prevent.stop="onDrop">
             <div
-                v-if="assetState.parentFolder.value"
+                v-if="assetState.raw.folderPath.length && assetState.parentFolder.value"
                 class="inode folder"
                 @dblclick="changeDirectory('POP')"
                 @dragover.prevent="moveDrag"


### PR DESCRIPTION
My latest refactor of some internals, left the `..` folder always visible. This PR fixe that.