### PR TITLE
feat(Asset): Add asset sharing

### DIFF
--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -28,23 +28,24 @@ export interface ApiAssetShare {
   user: string;
   right: "view" | "edit";
 }
+export interface ApiAssetAdd {
+  asset: ApiAsset;
+  parent: AssetId;
+}
+export interface ApiAssetCreateFolder {
+  name: string;
+  parent: AssetId;
+}
+export interface ApiAssetCreateShare {
+  right: "view" | "edit";
+  user: string;
+  asset: AssetId;
+}
 export interface ApiAssetFolder {
   folder: ApiAsset;
   path: AssetId[] | null;
   sharedParent: ApiAsset | null;
   sharedRight: "view" | "edit" | null;
-}
-export interface ApiAssetCreateFolderRequest {
-  name: string;
-  parent: AssetId;
-}
-export interface ApiAssetCreateFolderResponse {
-  asset: ApiAsset;
-  parent: AssetId;
-}
-export interface ApiAssetFolder {
-  folder: ApiAsset;
-  path: AssetId[] | null;
 }
 export interface ApiAssetInodeMove {
   inode: AssetId;
@@ -94,6 +95,10 @@ export interface ApiLabel {
   name: string;
   visible: boolean;
 }
+export interface ApiAssetRemoveShare {
+  asset: AssetId;
+  user: string;
+}
 export interface ApiAssetRename {
   asset: AssetId;
   name: string;
@@ -106,10 +111,6 @@ export interface ApiAssetUpload {
   slice: number;
   totalSlices: number;
   data: string | ArrayBuffer;
-}
-export interface ApiAssetUploadFinish {
-  asset: ApiAsset;
-  parent: AssetId;
 }
 export interface ApiBaseRectShape extends ApiCoreShape {
   width: number;

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -19,8 +19,20 @@ export type ApiDataBlock = ApiRoomDataBlock | ApiShapeDataBlock | ApiUserDataBlo
 export interface ApiAsset {
   id: AssetId;
   name: string;
+  owner: string;
   fileHash?: string;
   children?: ApiAsset[];
+  shares: ApiAssetShare[];
+}
+export interface ApiAssetShare {
+  user: string;
+  right: "view" | "edit";
+}
+export interface ApiAssetFolder {
+  folder: ApiAsset;
+  path: AssetId[] | null;
+  sharedParent: ApiAsset | null;
+  sharedRight: "view" | "edit" | null;
 }
 export interface ApiAssetCreateFolderRequest {
   name: string;

--- a/client/src/assetManager/AssetShare.vue
+++ b/client/src/assetManager/AssetShare.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+
+import Modal from "../core/components/modals/Modal.vue";
+
+import { sendCreateShare, sendEditShareRight, sendRemoveShare } from "./emits";
+import type { AssetId } from "./models";
+import { socket } from "./socket";
+import { assetState } from "./state";
+
+const props = defineProps<{ visible: boolean; asset: AssetId | undefined }>();
+const emit = defineEmits<(e: "close") => void>();
+
+const { t } = useI18n();
+
+const userInput = ref<string>("");
+const selectedRight = ref<"view" | "edit">("view");
+const autoComplete = ref<HTMLDivElement | null>(null);
+
+const names = ref<string[]>([]);
+
+watch(
+    () => props.visible,
+    (visible) => {
+        if (visible) {
+            socket.emit("Connections.Usernames.Get", (userNames: string[]) => (names.value = userNames));
+        }
+    },
+);
+
+const rights = ["view", "edit"] as const;
+
+const shares = computed(() => {
+    if (!props.asset) return [];
+    return assetState.reactive.idMap.get(props.asset)?.shares ?? [];
+});
+
+function setRight(event: Event, user: string): void {
+    if (props.asset === undefined) return;
+    const right = (event.target as HTMLSelectElement).value as "view" | "edit";
+    sendEditShareRight({ user, asset: props.asset, right });
+}
+
+function remove(user: string): void {
+    if (props.asset === undefined) return;
+    sendRemoveShare({ asset: props.asset, user });
+}
+
+// NEW SHARES
+
+const filteredNames = computed(() => names.value.filter((n) => n.startsWith(userInput.value)));
+
+function setNewRight(event: Event): void {
+    selectedRight.value = (event.target as HTMLSelectElement).value as "view" | "edit";
+}
+
+function submit(): void {
+    if (props.asset === undefined) return;
+    sendCreateShare({ right: selectedRight.value, user: userInput.value, asset: props.asset });
+}
+</script>
+
+<template>
+    <Modal :visible="visible" :colour="'transparent'">
+        <template #header="m">
+            <div class="modal-header" draggable="true" @dragstart="m.dragStart" @dragend="m.dragEnd">
+                Asset Sharing
+                <div class="header-close" :title="t('common.close')" @click="emit('close')">
+                    <font-awesome-icon :icon="['far', 'window-close']" />
+                </div>
+            </div>
+        </template>
+        <template #default>
+            <div class="modal-body">
+                <template v-if="shares.length > 0">
+                    <h3>Existing Shares</h3>
+                    <div id="share-table">
+                        <template v-for="share of shares" :key="share.user">
+                            <div>{{ share.user }}</div>
+                            <div class="right">
+                                <select @change="setRight($event, share.user)">
+                                    <option v-for="right of rights" :key="right" :selected="share.right === right">
+                                        {{ right }}
+                                    </option>
+                                </select>
+                            </div>
+                            <div><font-awesome-icon icon="trash-alt" @click="remove(share.user)" /></div>
+                            <div class="line"></div>
+                        </template>
+                    </div>
+                </template>
+
+                <h3>Add a new share {{ selectedRight }}</h3>
+                <div id="user-input">
+                    <div id="bar">
+                        <input
+                            v-model="userInput"
+                            type="text"
+                            @focus="autoComplete!.style.visibility = 'visible'"
+                            @blur="autoComplete!.style.visibility = 'hidden'"
+                        />
+                        <select @change="setNewRight">
+                            <option v-for="right of rights" :key="right" :selected="selectedRight === right">
+                                {{ right }}
+                            </option>
+                        </select>
+                    </div>
+                    <div v-show="userInput.length >= 1" id="autocomplete" ref="autoComplete">
+                        <div v-for="name of filteredNames" :key="name" @mousedown="userInput = name">
+                            {{ name }}
+                        </div>
+                        <div v-if="filteredNames.length === 0" style="font-style: italic">
+                            You have no known users that match this filter.
+                        </div>
+                    </div>
+                </div>
+
+                <button
+                    :disabled="!names.includes(userInput)"
+                    :title="
+                        names.includes(userInput)
+                            ? `Share this asset with ${userInput}`
+                            : 'Enter a valid username before sharing'
+                    "
+                    @click="submit"
+                >
+                    Submit
+                </button>
+            </div>
+        </template>
+    </Modal>
+</template>
+
+<style scoped lang="scss">
+.modal-header {
+    background-color: rgba(77, 0, 21);
+    padding: 10px;
+    font-size: 20px;
+    font-weight: bold;
+    cursor: move;
+    border-radius: 1rem;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.header-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+}
+
+.modal-body {
+    min-width: 15vw;
+    padding: 10px;
+    padding-top: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: left;
+    color: black;
+    background-color: white;
+}
+
+select {
+    appearance: none;
+    width: 100%;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    margin: 0;
+    outline: none;
+
+    &:hover {
+        cursor: pointer;
+    }
+}
+
+#share-table {
+    padding: 0.75rem 1rem;
+    display: grid;
+    grid-template-columns: 1fr auto 1rem;
+    background-color: bisque;
+    border-radius: 1rem;
+    align-content: center;
+    justify-content: center;
+    align-items: center;
+
+    row-gap: 0.5rem;
+
+    > div {
+        &.right {
+            margin-right: 1rem;
+        }
+
+        &.line {
+            grid-column: 1/-1;
+            border-bottom: 1px dashed black;
+
+            &:last-of-type {
+                display: none;
+            }
+        }
+    }
+}
+
+#user-input {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+
+    > #bar {
+        height: 2rem;
+        width: 100%;
+        border: solid 1px black;
+        border-radius: 1rem;
+        overflow: hidden;
+
+        display: flex;
+        align-items: center;
+
+        &:focus-within {
+            box-shadow: 0px 0px 5px black;
+            border: none;
+        }
+
+        > input {
+            border: none;
+            outline: none;
+            width: 100%;
+            padding: 0.5rem;
+            padding-left: 1.5rem;
+        }
+
+        > select {
+            background-color: bisque;
+            width: auto;
+            border-radius: 0;
+            height: 100%;
+            border: none;
+            border-left: solid 1px black;
+        }
+    }
+
+    > #autocomplete {
+        visibility: none;
+        position: absolute;
+        top: 2rem;
+        left: 1rem;
+        width: calc(100% - 7rem);
+        max-height: 10rem;
+        padding: 0.5rem;
+
+        border: solid 1px black;
+        border-radius: 1rem;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        border-top: none;
+
+        background-color: white;
+        overflow: auto;
+
+        > div {
+            border-bottom: dotted 1px black;
+            padding: 0.2rem 0;
+
+            &:first-of-type {
+                padding-top: 0;
+            }
+
+            &:last-of-type {
+                border-bottom: none;
+                padding-bottom: 0;
+            }
+
+            &:hover {
+                cursor: pointer;
+                font-weight: bold;
+            }
+        }
+
+        &:focus {
+            visibility: visible;
+        }
+    }
+}
+
+button {
+    // border: solid 1px black;
+    border-radius: 1rem;
+    padding: 0.35rem;
+    margin-top: 1rem;
+    width: 5rem;
+    align-self: flex-end;
+
+    &:hover {
+        cursor: pointer;
+    }
+}
+</style>

--- a/client/src/assetManager/emits.ts
+++ b/client/src/assetManager/emits.ts
@@ -9,7 +9,7 @@ function wrapSocket<T>(event: string): (data: T) => void {
     };
 }
 
-export const sendFolderGet = wrapSocket<AssetId>("Folder.Get");
+export const sendFolderGet = wrapSocket<AssetId | undefined>("Folder.Get");
 export const sendInodeMove = wrapSocket<ApiAssetInodeMove>("Inode.Move");
 export const sendAssetRename = wrapSocket<ApiAssetRename>("Asset.Rename");
 export const sendAssetRemove = wrapSocket<AssetId>("Asset.Remove");

--- a/client/src/assetManager/emits.ts
+++ b/client/src/assetManager/emits.ts
@@ -1,4 +1,10 @@
-import type { ApiAssetInodeMove, ApiAssetRename } from "../apiTypes";
+import type {
+    ApiAssetCreateFolder,
+    ApiAssetCreateShare,
+    ApiAssetInodeMove,
+    ApiAssetRemoveShare,
+    ApiAssetRename,
+} from "../apiTypes";
 
 import type { AssetId } from "./models";
 import { socket } from "./socket";
@@ -10,6 +16,11 @@ function wrapSocket<T>(event: string): (data: T) => void {
 }
 
 export const sendFolderGet = wrapSocket<AssetId | undefined>("Folder.Get");
+export const sendFolderGetByPath = wrapSocket<string>("Folder.GetByPath");
 export const sendInodeMove = wrapSocket<ApiAssetInodeMove>("Inode.Move");
 export const sendAssetRename = wrapSocket<ApiAssetRename>("Asset.Rename");
 export const sendAssetRemove = wrapSocket<AssetId>("Asset.Remove");
+export const sendCreateFolder = wrapSocket<ApiAssetCreateFolder>("Folder.Create");
+export const sendRemoveShare = wrapSocket<ApiAssetRemoveShare>("Asset.Share.Remove");
+export const sendEditShareRight = wrapSocket<ApiAssetCreateShare>("Asset.Share.Edit");
+export const sendCreateShare = wrapSocket<ApiAssetCreateShare>("Asset.Share.Create");

--- a/client/src/assetManager/events.ts
+++ b/client/src/assetManager/events.ts
@@ -13,8 +13,7 @@ let disConnected = false;
 
 socket.on("connect", () => {
     console.log("[Assets] connected");
-    const folder = assetState.currentFolder.value;
-    if (disConnected && folder !== undefined) sendFolderGet(folder);
+    if (disConnected) sendFolderGet(assetState.currentFolder.value);
 });
 
 socket.on("disconnect", () => {
@@ -57,9 +56,6 @@ socket.on("Asset.Export.Finish", (uuid: string) => {
 });
 
 socket.on("Asset.Import.Finish", (name: string) => {
-    const folder = assetState.currentFolder.value;
-    if (folder) {
-        assetSystem.resolveUpload(name);
-        sendFolderGet(folder);
-    }
+    assetSystem.resolveUpload(name);
+    sendFolderGet(assetState.currentFolder.value);
 });

--- a/client/src/assetManager/events.ts
+++ b/client/src/assetManager/events.ts
@@ -33,6 +33,8 @@ socket.on("Folder.Root.Set", (root: AssetId) => {
 socket.on("Folder.Set", async (data: ApiAssetFolder) => {
     assetSystem.clear();
     assetSystem.setFolderData(data.folder.id, data.folder);
+    assetState.mutableReactive.sharedParent = data.sharedParent;
+    assetState.mutableReactive.sharedRight = data.sharedRight;
     if (!assetState.readonly.modalActive) {
         if (data.path) assetSystem.setPath(data.path);
         const path = `/assets${assetState.currentFilePath.value}/`;

--- a/client/src/assetManager/events.ts
+++ b/client/src/assetManager/events.ts
@@ -1,6 +1,9 @@
-import type { ApiAssetCreateFolderResponse, ApiAssetFolder, ApiAssetUploadFinish } from "../apiTypes";
+import { useToast } from "vue-toastification";
+
+import type { ApiAssetAdd, ApiAssetCreateShare, ApiAssetFolder, ApiAssetRemoveShare } from "../apiTypes";
 import { baseAdjust } from "../core/http";
 import { router } from "../router";
+import { coreStore } from "../store/core";
 
 import { sendFolderGet } from "./emits";
 import type { AssetId } from "./models";
@@ -10,6 +13,8 @@ import { assetState } from "./state";
 import { assetSystem } from ".";
 
 let disConnected = false;
+
+const toast = useToast();
 
 socket.on("connect", () => {
     console.log("[Assets] connected");
@@ -24,6 +29,10 @@ socket.on("disconnect", () => {
 socket.on("redirect", (destination: string) => {
     console.log("redirecting");
     window.location.href = destination;
+});
+
+socket.on("Toast.Warn", (msg: string) => {
+    toast.warning(msg);
 });
 
 socket.on("Folder.Root.Set", (root: AssetId) => {
@@ -44,11 +53,11 @@ socket.on("Folder.Set", async (data: ApiAssetFolder) => {
     }
 });
 
-socket.on("Folder.Create", (data: ApiAssetCreateFolderResponse) => {
+socket.on("Asset.Add", (data: ApiAssetAdd) => {
     assetSystem.addAsset(data.asset, data.parent);
 });
 
-socket.on("Asset.Upload.Finish", (data: ApiAssetUploadFinish) => {
+socket.on("Asset.Upload.Finish", (data: ApiAssetAdd) => {
     assetSystem.addAsset(data.asset, data.parent);
     assetSystem.resolveUpload(data.asset.name);
 });
@@ -60,4 +69,32 @@ socket.on("Asset.Export.Finish", (uuid: string) => {
 socket.on("Asset.Import.Finish", (name: string) => {
     assetSystem.resolveUpload(name);
     sendFolderGet(assetState.currentFolder.value);
+});
+
+socket.on("Asset.Share.Created", (data: ApiAssetCreateShare) => {
+    const assetData = assetState.mutableReactive.idMap.get(data.asset);
+    if (assetData) {
+        assetData.shares.push({ right: data.right, user: data.user });
+    }
+});
+
+socket.on("Asset.Share.Edit", (data: ApiAssetCreateShare) => {
+    const assetData = assetState.mutableReactive.idMap.get(data.asset);
+    if (assetData) {
+        for (const share of assetData.shares) {
+            if (share.user == data.user) share.right = data.right;
+        }
+    }
+});
+
+socket.on("Asset.Share.Removed", (data: ApiAssetRemoveShare) => {
+    const assetData = assetState.mutableReactive.idMap.get(data.asset);
+    if (assetData) {
+        assetData.shares = assetData.shares.filter((s) => s.user !== data.user);
+
+        const username = coreStore.state.username;
+        if (assetData.owner !== username && data.user === username) {
+            assetSystem.removeAsset(data.asset);
+        }
+    }
 });

--- a/client/src/assetManager/index.ts
+++ b/client/src/assetManager/index.ts
@@ -204,6 +204,14 @@ class AssetSystem {
 
         return uploadedFiles;
     }
+
+    // SHARES
+
+    addShare(asset: AssetId, user: string, right: "view" | "edit"): void {
+        const data = $.idMap.get(asset);
+        if (data === undefined) return console.error("Unknown asset was provided");
+        data.shares.push({ user, right });
+    }
 }
 export const assetSystem = new AssetSystem();
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/client/src/assetManager/index.ts
+++ b/client/src/assetManager/index.ts
@@ -63,8 +63,7 @@ class AssetSystem {
             if (asset !== undefined) $.folderPath.push({ id: targetFolder, name: asset.name });
         }
         this.clearSelected();
-        const folder = assetState.currentFolder.value;
-        if (folder) sendFolderGet(folder);
+        sendFolderGet(assetState.currentFolder.value);
     }
 
     setFolderData(folder: AssetId, data: ApiAsset): void {

--- a/client/src/assetManager/index.ts
+++ b/client/src/assetManager/index.ts
@@ -29,7 +29,7 @@ class AssetSystem {
     }
 
     setPath(path: AssetId[]): void {
-        $.folderPath = path;
+        $.folderPath = [];
         let assetPath = router.currentRoute.value.path.slice("/assets/".length);
         if (assetPath.at(-1) === "/") assetPath = assetPath.slice(0, -1);
         if (assetPath.length === 0) return;
@@ -40,7 +40,7 @@ class AssetSystem {
                 console.error("Incorrect PathIndex encountered.");
                 continue;
             }
-            $.idMap.set(pathId, { id: pathId, name: part });
+            $.folderPath.push({ id: pathId, name: part });
         }
     }
 
@@ -56,10 +56,11 @@ class AssetSystem {
             $.folderPath.pop();
         } else if (targetFolder === raw.root) {
             $.folderPath = [];
-        } else if (raw.folderPath.includes(targetFolder)) {
+        } else if (raw.folderPath.some((fp) => fp.id === targetFolder)) {
             while (assetState.currentFolder.value !== targetFolder) $.folderPath.pop();
         } else {
-            $.folderPath.push(targetFolder);
+            const asset = raw.idMap.get(targetFolder);
+            if (asset !== undefined) $.folderPath.push({ id: targetFolder, name: asset.name });
         }
         this.clearSelected();
         const folder = assetState.currentFolder.value;

--- a/client/src/assetManager/state.ts
+++ b/client/src/assetManager/state.ts
@@ -13,6 +13,9 @@ interface ReactiveAssetState {
     selected: AssetId[];
     folderPath: AssetId[];
 
+    sharedParent: ApiAsset | null;
+    sharedRight: "edit" | "view" | null;
+
     pendingUploads: string[];
     expectedUploads: number;
     resolvedUploads: number;
@@ -30,6 +33,9 @@ const state = buildState<ReactiveAssetState, NonReactiveAssetState>(
         idMap: new Map(),
         selected: [],
         folderPath: [],
+
+        sharedParent: null,
+        sharedRight: null,
 
         pendingUploads: [],
         expectedUploads: 0,

--- a/client/src/assetManager/state.ts
+++ b/client/src/assetManager/state.ts
@@ -11,7 +11,8 @@ interface ReactiveAssetState {
     folders: AssetId[];
     idMap: Map<AssetId, ApiAsset>;
     selected: AssetId[];
-    folderPath: AssetId[];
+    // We track names here, as the full breadcrumb Asset info might not be known in idMap
+    folderPath: { id: AssetId; name: string }[];
 
     sharedParent: ApiAsset | null;
     sharedRight: "edit" | "view" | null;
@@ -47,15 +48,12 @@ const state = buildState<ReactiveAssetState, NonReactiveAssetState>(
 export const assetState = {
     ...state,
     currentFolder: computed(() => {
-        return state.reactive.folderPath.at(-1) ?? state.reactive.root;
+        return state.reactive.folderPath.at(-1)?.id ?? state.reactive.root;
     }),
     parentFolder: computed(() => {
-        return state.reactive.folderPath.at(-2) ?? state.reactive.root;
+        return state.reactive.folderPath.at(-2)?.id ?? state.reactive.root;
     }),
     currentFilePath: computed(() =>
-        state.reactive.folderPath.reduce(
-            (acc: string, val: AssetId) => `${acc}/${state.reactive.idMap.get(val)!.name}`,
-            "",
-        ),
+        state.reactive.folderPath.reduce((acc: string, val: { name: string }) => `${acc}/${val.name}`, ""),
     ),
 };

--- a/client/src/assetManager/utils.ts
+++ b/client/src/assetManager/utils.ts
@@ -3,16 +3,10 @@ import { baseAdjust } from "../core/http";
 import type { AssetId } from "./models";
 import { assetState } from "./state";
 
-import { assetSystem } from ".";
-
 export function showIdName(dir: AssetId): string {
     return assetState.raw.idMap.get(dir)?.name ?? "";
 }
 
 export function getIdImageSrc(file: AssetId): string {
     return baseAdjust("/static/assets/" + (assetState.raw.idMap.get(file)!.fileHash ?? ""));
-}
-
-export function changeDirectory(folder: AssetId | "POP"): void {
-    assetSystem.changeDirectory(folder);
 }

--- a/client/src/core/components/modals/AssetPicker.vue
+++ b/client/src/core/components/modals/AssetPicker.vue
@@ -6,7 +6,7 @@ import { assetSystem } from "../../../assetManager";
 import type { AssetId } from "../../../assetManager/models";
 import { socket } from "../../../assetManager/socket";
 import { assetState } from "../../../assetManager/state";
-import { changeDirectory, getIdImageSrc, showIdName } from "../../../assetManager/utils";
+import { getIdImageSrc, showIdName } from "../../../assetManager/utils";
 import { i18n } from "../../../i18n";
 
 import Modal from "./Modal.vue";
@@ -51,13 +51,13 @@ function select(event: MouseEvent, inode: AssetId): void {
             <div id="assets">
                 <div id="breadcrumbs">
                     <div>/</div>
-                    <div v-for="dir in assetState.reactive.folderPath" :key="dir">{{ showIdName(dir) }}</div>
+                    <div v-for="dir in assetState.reactive.folderPath" :key="dir.id">{{ dir.name }}</div>
                 </div>
                 <div id="explorer">
                     <div
                         v-if="assetState.reactive.folderPath.length"
                         class="inode folder"
-                        @dblclick="changeDirectory('POP')"
+                        @dblclick="assetSystem.changeDirectory('POP')"
                     >
                         <font-awesome-icon icon="folder" style="font-size: 50px" />
                         <div class="title">..</div>
@@ -69,7 +69,7 @@ function select(event: MouseEvent, inode: AssetId): void {
                         draggable="true"
                         :class="{ 'inode-selected': assetState.reactive.selected.includes(key) }"
                         @click="select($event, key)"
-                        @dblclick="changeDirectory(key)"
+                        @dblclick="assetSystem.changeDirectory(key)"
                     >
                         <font-awesome-icon icon="folder" style="font-size: 50px" />
                         <div class="title">{{ showIdName(key) }}</div>

--- a/client/src/dashboard/Assets.vue
+++ b/client/src/dashboard/Assets.vue
@@ -12,7 +12,7 @@ import { openAssetContextMenu } from "../assetManager/context";
 import type { AssetId } from "../assetManager/models";
 import { socket } from "../assetManager/socket";
 import { assetState } from "../assetManager/state";
-import { changeDirectory, getIdImageSrc, showIdName } from "../assetManager/utils";
+import { getIdImageSrc } from "../assetManager/utils";
 import { baseAdjust } from "../core/http";
 import { map } from "../core/iter";
 import { useModal } from "../core/plugins/modals/plugin";
@@ -246,9 +246,13 @@ function isShared(asset: DeepReadonly<ApiAsset>): boolean {
             </div>
         </div>
         <div id="path">
-            <div @click="changeDirectory(assetState.raw.root ?? 'POP')">/</div>
-            <div v-for="dir in assetState.reactive.folderPath" :key="dir" @click="changeDirectory(dir)">
-                {{ showIdName(dir) }}
+            <div @click="assetSystem.changeDirectory(assetState.raw.root ?? 'POP')">/</div>
+            <div
+                v-for="dir in assetState.reactive.folderPath"
+                :key="dir.id"
+                @click="assetSystem.changeDirectory(dir.id)"
+            >
+                {{ dir.name }}
             </div>
         </div>
         <div v-if="assetState.reactive.sharedParent" id="infobar">
@@ -258,7 +262,7 @@ function isShared(asset: DeepReadonly<ApiAsset>): boolean {
             <div
                 v-if="assetState.raw.folderPath.length && assetState.parentFolder.value"
                 class="inode folder"
-                @dblclick="changeDirectory('POP')"
+                @dblclick="assetSystem.changeDirectory('POP')"
                 @dragover.prevent="moveDrag"
                 @dragleave.prevent="leaveDrag"
                 @drop.prevent.stop="stopDrag($event, assetState.parentFolder.value)"
@@ -278,7 +282,7 @@ function isShared(asset: DeepReadonly<ApiAsset>): boolean {
                         assetState.reactive.selected.length > 0 && !assetState.reactive.selected.includes(folder.id),
                 }"
                 @click.stop="select($event, folder.id)"
-                @dblclick="changeDirectory(folder.id)"
+                @dblclick="assetSystem.changeDirectory(folder.id)"
                 @contextmenu.prevent="openContextMenu($event, folder.id)"
                 @dragstart="startDrag($event, folder.id)"
                 @dragover.prevent="moveDrag"

--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -52,6 +52,7 @@ import {
     faUnlock,
     faUpload,
     faUserCircle,
+    faUserTag,
     faUsers,
     faVideo,
 } from "@fortawesome/free-solid-svg-icons";
@@ -113,8 +114,9 @@ export function loadFontAwesome(): void {
         faTrashAlt,
         faUnlink,
         faUpload,
-        faUsers,
+        faUserTag,
         faUserCircle,
+        faUsers,
         faVideo,
         faWindowClose,
     );

--- a/server/src/api/helpers.py
+++ b/server/src/api/helpers.py
@@ -1,7 +1,8 @@
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from ..app import sio
-from .socket.constants import GAME_NS
+from ..logs import logger
+from .socket.constants import ASSET_NS, GAME_NS
 
 
 async def _send_game(
@@ -12,3 +13,32 @@ async def _send_game(
     skip_sid: Optional[str] = None,
 ):
     await sio.emit(event, data, room=room, skip_sid=skip_sid, namespace=GAME_NS)
+
+
+async def _send_assets(
+    event: str,
+    data: Any,
+    *,
+    room: str | None,
+    skip_sid: Optional[str] = None,
+):
+    await sio.emit(event, data, room=room, skip_sid=skip_sid, namespace=ASSET_NS)
+
+
+async def send_log_toast(
+    message: str,
+    severity: Literal["warn"],
+    room: str | None,
+    namespace: str | None,
+    skip_sid: str | None = None,
+):
+    event_name = "Toast."
+    if severity == "warn":
+        event_name += "Warn"
+        logger.warn(message)
+    else:
+        logger.debug(message)
+
+    await sio.emit(
+        event_name, message, room=room, skip_sid=skip_sid, namespace=namespace
+    )

--- a/server/src/api/models/asset/__init__.py
+++ b/server/src/api/models/asset/__init__.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from ..helpers import TypeIdModel
 from .options import *
+from .share import *
 
 
 class ApiAssetShare(TypeIdModel):
@@ -33,13 +34,8 @@ class ApiAssetFolder(TypeIdModel):
     sharedRight: Literal["view"] | Literal["edit"] | None = Field(..., noneAsNull=True)
 
 
-class ApiAssetCreateFolderRequest(TypeIdModel):
+class ApiAssetCreateFolder(TypeIdModel):
     name: str
-    parent: int = Field(..., typeId="AssetId")
-
-
-class ApiAssetCreateFolderResponse(TypeIdModel):
-    asset: ApiAsset
     parent: int = Field(..., typeId="AssetId")
 
 
@@ -63,6 +59,6 @@ class ApiAssetUpload(TypeIdModel):
     data: bytes
 
 
-class ApiAssetUploadFinish(TypeIdModel):
+class ApiAssetAdd(TypeIdModel):
     asset: ApiAsset
     parent: int = Field(..., typeId="AssetId")

--- a/server/src/api/models/asset/__init__.py
+++ b/server/src/api/models/asset/__init__.py
@@ -1,19 +1,36 @@
+from __future__ import annotations
+
+from typing import Literal
+
 from pydantic import Field
 
 from ..helpers import TypeIdModel
 from .options import *
 
 
+class ApiAssetShare(TypeIdModel):
+    user: str
+    right: Literal["view"] | Literal["edit"]
+
+
 class ApiAsset(TypeIdModel):
     id: int = Field(..., typeId="AssetId")
+    # The name of the asset can be shown differently depending on sharing state
     name: str
+    owner: str
     fileHash: str | None
+    # If specified, this provides the list of children for this asset
+    # This should only be provided for folders (i.e. assets without a fileHash)
+    # And is only provided in specific calls
     children: list["ApiAsset"] | None
+    shares: list[ApiAssetShare]  # Info on users that this specific asset is shared with
 
 
 class ApiAssetFolder(TypeIdModel):
     folder: ApiAsset
     path: list[int] | None = Field(..., typeId="AssetId", noneAsNull=True)
+    sharedParent: ApiAsset | None = Field(..., noneAsNull=True)
+    sharedRight: Literal["view"] | Literal["edit"] | None = Field(..., noneAsNull=True)
 
 
 class ApiAssetCreateFolderRequest(TypeIdModel):

--- a/server/src/api/models/asset/share.py
+++ b/server/src/api/models/asset/share.py
@@ -1,0 +1,9 @@
+from typing import Literal
+
+from ..helpers import TypeIdModel
+
+
+class ApiAssetShare(TypeIdModel):
+    right: Literal["view"] | Literal["edit"]
+    user: str
+    asset: int

--- a/server/src/api/models/asset/share.py
+++ b/server/src/api/models/asset/share.py
@@ -1,9 +1,16 @@
 from typing import Literal
 
+from pydantic import Field
+
 from ..helpers import TypeIdModel
 
 
-class ApiAssetShare(TypeIdModel):
+class ApiAssetCreateShare(TypeIdModel):
     right: Literal["view"] | Literal["edit"]
     user: str
-    asset: int
+    asset: int = Field(..., typeId="AssetId")
+
+
+class ApiAssetRemoveShare(TypeIdModel):
+    asset: int = Field(..., typeId="AssetId")
+    user: str

--- a/server/src/api/socket/__init__.py
+++ b/server/src/api/socket/__init__.py
@@ -21,4 +21,4 @@ def load_socket_commands():
         shape,  # noqa: F401.
         user,  # noqa: F401.
     )
-    from .asset_manager import core  # noqa: F401.
+    from .asset_manager import core, share  # noqa: F401.

--- a/server/src/api/socket/asset_manager/ddraft.py
+++ b/server/src/api/socket/asset_manager/ddraft.py
@@ -8,6 +8,7 @@ from typing_extensions import TypedDict
 from ....app import sio
 from ....db.models.asset import Asset
 from ....state.asset import asset_state
+from ....transform.to_api.asset import transform_asset
 from ....utils import ASSETS_DIR
 from ...models.asset import ApiAssetUpload
 from ..constants import ASSET_NS
@@ -76,7 +77,7 @@ async def handle_ddraft_file(upload_data: ApiAssetUpload, data: bytes, sid: str)
         options=json.dumps(template),
     )
 
-    asset_dict = asset.as_pydantic()
+    asset_dict = transform_asset(asset, user)
     await sio.emit(
         "Asset.Upload.Finish",
         {"asset": asset_dict, "parent": upload_data.directory},

--- a/server/src/api/socket/asset_manager/share.py
+++ b/server/src/api/socket/asset_manager/share.py
@@ -7,41 +7,182 @@ from ....db.models.asset_share import AssetShare
 from ....db.models.user import User
 from ....logs import logger
 from ....state.asset import asset_state
-from ...models.asset.share import ApiAssetShare
+from ....transform.to_api.asset import transform_asset
+from ...helpers import send_log_toast
+from ...models.asset import ApiAssetAdd
+from ...models.asset.share import ApiAssetCreateShare, ApiAssetRemoveShare
 from ..constants import ASSET_NS
 
 
-@sio.on("Asset.Share", namespace=ASSET_NS)
+@sio.on("Asset.Share.Create", namespace=ASSET_NS)
 @auth.login_required(app, sio, "asset")
 async def share_asset(sid: str, raw_data: Any):
     initiating_user = asset_state.get_user(sid)
 
-    data = ApiAssetShare(**raw_data)
+    data = ApiAssetCreateShare(**raw_data)
 
-    user = User.by_name(data.user)
-    if user is None:
-        return {"success": False, "reason": "Username does not exist"}
-    elif user == initiating_user:
-        return {"success": False, "reason": "Sharing with yourself is not valid"}
+    target_user = User.by_name(data.user)
+    if target_user is None:
+        await send_log_toast(
+            "Username does not exist", "warn", room=sid, namespace=ASSET_NS
+        )
+        return
+    elif target_user == initiating_user:
+        await send_log_toast(
+            "Sharing with yourself is not valid",
+            "warn",
+            room=sid,
+            namespace=ASSET_NS,
+        )
+        return
 
     try:
         asset = Asset.get_by_id(data.asset)
     except Asset.DoesNotExist:
-        return {"success": False, "reason": "Asset does not exist"}
+        await send_log_toast(
+            "Asset does not exist", "warn", room=sid, namespace=ASSET_NS
+        )
+        return
 
     if asset.owner != initiating_user:
-        return {"success": False, "reason": "You do not own this asset"}
+        await send_log_toast(
+            "You do not own this asset", "warn", room=sid, namespace=ASSET_NS
+        )
+        return
 
     try:
-        AssetShare.create(
+        asset_share = AssetShare.create(
             asset=asset,
-            user=user,
+            user=target_user,
             right=data.right,
             name=f"{initiating_user.name}-{asset.name}",
-            parent=Asset.get_root_folder(user),
+            parent=Asset.get_root_folder(target_user),
         )
     except:
-        logger.exception("Failed to creater Asset share")
-        return {"success": False, "reason": "Failed to create Asset Share"}
+        await send_log_toast(
+            "Failed to create asset share", "warn", room=sid, namespace=ASSET_NS
+        )
+        return
 
-    return {"success": True}
+    for user in [asset.owner, *(s.user for s in asset.shares if s.user != target_user)]:
+        for psid in asset_state.get_sids(name=user.name):
+            await sio.emit("Asset.Share.Created", data, room=psid, namespace=ASSET_NS)
+
+    for psid in asset_state.get_sids(name=target_user.name):
+        await sio.emit(
+            "Asset.Add",
+            ApiAssetAdd(
+                asset=transform_asset(asset, user=target_user),
+                parent=asset_share.parent_id,
+            ),
+            room=psid,
+            namespace=ASSET_NS,
+        )
+
+
+@sio.on("Asset.Share.Edit", namespace=ASSET_NS)
+@auth.login_required(app, sio, "asset")
+async def edit_asset_share(sid: str, raw_data: Any):
+    initiating_user = asset_state.get_user(sid)
+
+    data = ApiAssetCreateShare(**raw_data)
+
+    if asset := Asset.get_or_none(id=data.asset):
+        users_with_edit_access: list[User] = [asset.owner]
+        shares = list(asset.shares)  # we're going to iterate twice
+
+        for share in shares:
+            if share.right == "edit":
+                users_with_edit_access.append(share.user)
+
+        if initiating_user not in users_with_edit_access:
+            logger.warn(
+                f"{initiating_user.name} attempted to edit asset share rights without permissions."
+            )
+            return
+
+        for share in shares:
+            if share.user.name == data.user:
+                share.right = data.right
+                share.save()
+
+                users_to_message = set(users_with_edit_access)
+                if u := User.by_name(data.user):
+                    users_to_message.add(u)
+
+                for user in users_to_message:
+                    for psid in asset_state.get_sids(name=user.name):
+                        await sio.emit(
+                            "Asset.Share.Edit", data, room=psid, namespace=ASSET_NS
+                        )
+                break
+        else:
+            logger.warn("Attempt to edit non-existing asset share.")
+            return
+    else:
+        logger.warn("Attempt to edit asset share from unknown shape.")
+        return
+
+
+@sio.on("Asset.Share.Remove", namespace=ASSET_NS)
+@auth.login_required(app, sio, "asset")
+async def remove_asset_share(sid: str, raw_data: Any):
+    initiating_user = asset_state.get_user(sid)
+
+    data = ApiAssetRemoveShare(**raw_data)
+
+    if asset := Asset.get_or_none(id=data.asset):
+        users_with_edit_access: list[User] = [asset.owner]
+        shares = list(asset.shares)  # we're going to iterate twice
+
+        for share in shares:
+            if share.right == "edit":
+                users_with_edit_access.append(share.user)
+
+        if initiating_user not in users_with_edit_access:
+            logger.warn(
+                f"{initiating_user.name} attempted to remove asset share rights without permissions."
+            )
+            return
+
+        for share in shares:
+            if share.user.name == data.user:
+                share.delete_instance(True)
+
+                users_to_message = [*users_with_edit_access]
+                if u := User.by_name(data.user):
+                    users_to_message.append(u)
+
+                for user in users_to_message:
+                    for psid in asset_state.get_sids(name=user.name):
+                        await sio.emit(
+                            "Asset.Share.Removed", data, room=psid, namespace=ASSET_NS
+                        )
+                break
+        else:
+            logger.warn("Attempt to remove non-existing asset share.")
+            return
+    else:
+        logger.warn("Attempt to remove asset share from unknown shape.")
+        return
+
+
+@sio.on("Connections.Usernames.Get", namespace=ASSET_NS)
+@auth.login_required(app, sio, "asset")
+async def get_usernames(sid: str):
+    user = asset_state.get_user(sid)
+
+    usernames = set()
+
+    rooms = [*user.rooms_created]
+    for pr in user.rooms_joined:
+        rooms.append(pr.room)
+
+    for room in rooms:
+        usernames.add(room.creator.name)
+        for rp in room.players:
+            usernames.add(rp.player.name)
+
+    usernames.remove(user.name)
+
+    return list(usernames)

--- a/server/src/api/socket/asset_manager/share.py
+++ b/server/src/api/socket/asset_manager/share.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+from .... import auth
+from ....app import app, sio
+from ....db.models.asset import Asset
+from ....db.models.asset_share import AssetShare
+from ....db.models.user import User
+from ....logs import logger
+from ....state.asset import asset_state
+from ...models.asset.share import ApiAssetShare
+from ..constants import ASSET_NS
+
+
+@sio.on("Asset.Share", namespace=ASSET_NS)
+@auth.login_required(app, sio, "asset")
+async def share_asset(sid: str, raw_data: Any):
+    initiating_user = asset_state.get_user(sid)
+
+    data = ApiAssetShare(**raw_data)
+
+    user = User.by_name(data.user)
+    if user is None:
+        return {"success": False, "reason": "Username does not exist"}
+    elif user == initiating_user:
+        return {"success": False, "reason": "Sharing with yourself is not valid"}
+
+    try:
+        asset = Asset.get_by_id(data.asset)
+    except Asset.DoesNotExist:
+        return {"success": False, "reason": "Asset does not exist"}
+
+    if asset.owner != initiating_user:
+        return {"success": False, "reason": "You do not own this asset"}
+
+    try:
+        AssetShare.create(
+            asset=asset,
+            user=user,
+            right=data.right,
+            name=f"{initiating_user.name}-{asset.name}",
+            parent=Asset.get_root_folder(user),
+        )
+    except:
+        logger.exception("Failed to creater Asset share")
+        return {"success": False, "reason": "Failed to create Asset Share"}
+
+    return {"success": True}

--- a/server/src/db/all.py
+++ b/server/src/db/all.py
@@ -1,3 +1,5 @@
+#  Has to appear before Asset due to DeferredForeignKey
+from .models.asset_share import AssetShare  # isort: skip
 from .models.asset import Asset
 from .models.asset_rect import AssetRect
 from .models.aura import Aura
@@ -41,6 +43,7 @@ from .signals import *  # noqa: F403
 ALL_MODELS = [
     AssetRect,
     Asset,
+    AssetShare,
     Aura,
     BaseRect,
     Character,

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 from peewee import ForeignKeyField, TextField
 from typing_extensions import Self, TypedDict
@@ -55,12 +55,17 @@ class Asset(BaseDbModel):
                 asset = share.asset
         return asset
 
-    def can_be_accessed_by(self, user: User) -> bool:
+    def can_be_accessed_by(
+        self, user: User, *, right: Literal["edit", "view", "all"]
+    ) -> bool:
         asset = self
         while asset is not None:
             if asset.owner == user:
                 return True
-            if any(share.user == user for share in asset.shares):
+            if any(
+                share.user == user and (share.right == right or right == "all")
+                for share in asset.shares
+            ):
                 return True
             asset = asset.parent
         return False

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -93,9 +93,10 @@ class Asset(BaseDbModel):
             parent = cls.get_root_folder(user)
         # ideally we change this to a single query to get all assets and process them as such
         data: AssetStructure = {"__files": []}
-        for asset in Asset.select().where(
-            (Asset.owner == user) & (Asset.parent == parent)
-        ):
+        assets = [*Asset.select().where((Asset.parent == parent))]
+        for asset_share in AssetShare().select().where((AssetShare.parent == parent)):
+            assets.append(asset_share.asset)
+        for asset in assets:
             if asset.file_hash:
                 data["__files"].append(
                     {"id": asset.id, "name": asset.name, "hash": asset.file_hash}

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -28,7 +28,7 @@ class Asset(BaseDbModel):
     parent_id: int
     shares: SelectSequence["AssetShare"]
 
-    owner = ForeignKeyField(User, backref="assets", on_delete="CASCADE")
+    owner = cast(User, ForeignKeyField(User, backref="assets", on_delete="CASCADE"))
     parent = cast(
         Optional["Asset"],
         ForeignKeyField("self", backref="children", null=True, on_delete="CASCADE"),

--- a/server/src/db/models/asset_share.py
+++ b/server/src/db/models/asset_share.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING, Literal, cast
+
+from peewee import DeferredForeignKey, ForeignKeyField, TextField
+
+from ...api.models.asset import ApiAssetShare
+from ..base import BaseDbModel
+from .user import User
+
+if TYPE_CHECKING:
+    from .asset import Asset
+
+
+class AssetShare(BaseDbModel):
+    id: int
+    parent_id: int
+
+    asset = cast(
+        "Asset",
+        DeferredForeignKey(
+            "Asset",
+            deferrable="INITIALLY DEFERRED",
+            backref="shares",
+            on_delete="CASCADE",
+        ),
+    )
+    user = cast(
+        User, ForeignKeyField(User, backref="asset_shares", on_delete="CASCADE")
+    )
+    right: Literal["view"] | Literal["edit"] = cast(
+        Literal["view"] | Literal["edit"], TextField()
+    )
+    name = cast(str, TextField())
+    parent = cast(
+        "Asset",
+        DeferredForeignKey(
+            "Asset",
+            deferrable="INITIALLY DEFERRED",
+            backref="share_children",
+            on_delete="CASCADE",
+        ),
+    )
+
+    def as_pydantic(self) -> ApiAssetShare:
+        return ApiAssetShare(user=self.user.name, right=self.right)

--- a/server/src/db/typed.py
+++ b/server/src/db/typed.py
@@ -38,7 +38,7 @@ class SelectSequence(Generic[T], Sequence[T], ModelSelect):
     def filter(self, *_args, **_kwargs) -> Self:
         ...
 
-    def join(self, _model: Type[BaseDbModel]) -> Self:
+    def join(self, _model: Type[BaseDbModel], *args, **_kwargs) -> Self:
         ...
 
     def order_by(self, *args, **kwargs) -> Self:

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 87
+SAVE_VERSION = 88
 
 import json
 import logging
@@ -423,6 +423,11 @@ def upgrade(db: SqliteExtDatabase, version: int):
             db.execute_sql(
                 'CREATE UNIQUE INDEX "user_data_block_keys" ON "user_data_block" ("source", "name", "user_id");'
             )
+    elif version == 87:
+        # Add AssetShare
+        db.execute_sql(
+            'CREATE TABLE IF NOT EXISTS "asset_share" ("id" INTEGER NOT NULL PRIMARY KEY, "asset_id" INT NOT NULL, "user_id" INT NOT NULL, "right" TEXT NOT NULL, "name" TEXT NOT NULL, "parent_id" INT NOT NULL, FOREIGN KEY ("asset_id") REFERENCES "asset" ("id") ON DELETE CASCADE, FOREIGN KEY ("user_id") REFERENCES "user" ("id") ON DELETE CASCADE, FOREIGN KEY ("parent_id") REFERENCES "asset" ("id") ON DELETE CASCADE)'
+        )
     else:
         raise UnknownVersionException(
             f"No upgrade code for save format {version} was found."

--- a/server/src/transform/to_api/asset.py
+++ b/server/src/transform/to_api/asset.py
@@ -1,0 +1,63 @@
+from ...api.models.asset import ApiAsset
+from ...db.models.asset import Asset
+from ...db.models.asset_share import AssetShare
+from ...db.models.user import User
+
+
+def transform_asset(
+    asset: Asset,
+    user: User,
+    *,
+    children=False,
+    recursive=False,
+    # The following two kwargs are for internal use only
+    __share_info: AssetShare | None = None,
+    __recursed=False,
+) -> ApiAsset:
+    pydantic_children = None
+
+    if children:
+        pydantic_children = []
+        # We add all the regular child assets
+        for child in Asset.select().where((Asset.parent == asset)):
+            pydantic_children.append(
+                transform_asset(
+                    child, user, children=children and recursive, recursive=recursive
+                )
+            )
+        # We check if there are any assets that were shared with us that are located in this folder
+        for child in AssetShare.select().where(
+            (AssetShare.parent == asset) & (AssetShare.user == user)
+        ):
+            pydantic_children.append(
+                transform_asset(
+                    child.asset,
+                    user,
+                    children=children and recursive,
+                    recursive=recursive,
+                    __share_info=child,
+                    __recursed=True,
+                )
+            )
+
+    share_info = __share_info
+    # ShareInfo is only pre-provided by going through the recursive child loop above
+    # It is provided in that case, so we don't double call the DB.
+    # In the first call however the info has not yet been retrieved
+    if __share_info is None and not __recursed:
+        share_info = AssetShare.get_or_none(asset=asset, user=user)
+
+    pydantic_asset = ApiAsset(
+        id=asset.id,
+        owner=asset.owner.name,
+        name=asset.name if share_info is None else share_info.name,
+        fileHash=asset.file_hash,
+        children=pydantic_children,
+        shares=[],
+    )
+
+    if share_info is None or share_info.right == "edit":
+        for s in asset.shares:
+            pydantic_asset.shares.append(s.as_pydantic())
+
+    return pydantic_asset


### PR DESCRIPTION
This PR adds the capability to share assets with other users on the same server.
Either singular files or entire folders can be shared.

These are shared in either a "view only" or an "edit" mode. In the latter mode users can fully modify the contents of a folder including addition as well as removal of assets, so be warry with this right.

In view mode, the only thing the user can do is see the contents of the folder and drop the assets in their campaigns.

When a campaign is shared it appears in the root folder of the receiving user in the form of `${ownerName}-${assetName}` with a special icon signifying it was shared with you.  You're free to rename and move this asset around and it won't affect anything for the original user. This is purely a n anchor to link into the real asset when you enter it.

A warning banner is shown when you're browsing the content of a shared folder, indicating that if you do have edit rights, you need to be extra careful.

This closes #1298