### PR TITLE
feat(Asset): Improve asset disk removal conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ tech changes will usually be stripped from release notes for the public
 
 ### Changed
 
+-   Assets removed in the asset manager will not remove the image on disk if there are still shapes depending on it
+-   Shape removal will now also remove the related image on disk if there are no other assets/shapes depending on it
 -   [tech] Selected system now has a proper state with better type ergonomics for focus retrieval
 -   [tech] Spawn Info no longer sends entire shape info, but just position, floor, id and name
 

--- a/server/src/api/socket/asset_manager/core.py
+++ b/server/src/api/socket/asset_manager/core.py
@@ -17,6 +17,7 @@ from aiohttp_security import authorized_userid
 from .... import auth
 from ....app import app, sio
 from ....db.models.asset import Asset
+from ....db.models.asset_rect import AssetRect
 from ....db.models.user import User
 from ....logs import logger
 from ....state.asset import asset_state
@@ -182,7 +183,9 @@ async def assetmgmt_rm(sid: str, data: int):
 def clean_filehash(file_hash: str):
     if (ASSETS_DIR / file_hash).exists():
         no_assets = Asset.get_or_none(file_hash=file_hash) is None
-        if no_assets:
+        no_shapes = AssetRect.get_or_none(src=f"/static/assets/{file_hash}") is None
+        print(no_assets, no_shapes)
+        if no_assets and no_shapes:
             logger.info(f"No asset maps to file {file_hash}, removing from server")
             (ASSETS_DIR / file_hash).unlink()
 


### PR DESCRIPTION
When removing an asset from the asset manager a check is done to see if the actual image that is stored on disk has to be removed.

This check only looked at whether any other asset was still using the image. This could result in the issue where you drop an asset in a campaign, then remove the asset and the shape can no longer be rendered because the disk-image was removed as part of the asset removal procedure.

This PR fixes this, by also checking if any shapes are still depending on the image before removing it. Additionally when removing a shape with an image, the same cleanup check is also run now.