### PR TITLE
feat(AssetManager): Reduce server calls on folder change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ tech changes will usually be stripped from release notes for the public
 -   Vision: Edgecase in triangulation build
 -   Socket: Changing location was not properly leaving the socket connection to the previous location
 -   Kicking: The check to prevent the co-DM from kicking the main DM was incorrect
+-   AssetManager: Folder changing was doing an unnecessary extra call to the server
 
 ## [2023.2.0] - 2023-06-21
 

--- a/client/src/dashboard/Assets.vue
+++ b/client/src/dashboard/Assets.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { trimEnd } from "lodash";
 import { onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { onBeforeRouteLeave, onBeforeRouteUpdate, useRoute } from "vue-router";
@@ -51,7 +52,7 @@ onBeforeRouteLeave(() => {
 });
 
 onBeforeRouteUpdate((to: RouteLocationNormalized) => {
-    if (getCurrentPath(to.path) !== assetState.currentFilePath.value) {
+    if (trimEnd(getCurrentPath(to.path), "/") !== trimEnd(assetState.currentFilePath.value, "/")) {
         loadFolder(getCurrentPath(to.path));
     }
 });


### PR DESCRIPTION
When changing folders both a `Folder.Get` and a `Folder.GetByPath` call would be sent to the server. Only one of these has to happen as they return the same information.