### PR TITLE
feat(Dashboard): Add campaign sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ tech changes will usually be stripped from release notes for the public
         -   Templates allow configuration of common data before placement, allowing unique modification afterwards
             (e.g. useful for prefilling monster info)
         -   Characters are a specific instance that remember their modifications (e.g. useful for (N)PCs)
+-   Sort campaign listing by recent play or alphabetically
+    -   Defaults to recent sort
 
 ### Changed
 

--- a/client/src/dashboard/games/CreateGame.vue
+++ b/client/src/dashboard/games/CreateGame.vue
@@ -26,7 +26,7 @@ async function create(): Promise<void> {
         logo: logo.id,
     });
     if (response.ok) {
-        await open({ creator: coreStore.state.username, name: name.value, is_locked: false });
+        await open({ creator: coreStore.state.username, name: name.value, is_locked: false, last_played: null });
         await router.push(`/game/${encodeURIComponent(coreStore.state.username)}/${encodeURIComponent(name.value)}`);
     } else if (response.statusText === "Conflict") {
         toast.error("A campaign with that name already exists!");

--- a/client/src/dashboard/games/types.ts
+++ b/client/src/dashboard/games/types.ts
@@ -3,5 +3,5 @@ export interface RoomInfo {
     creator: string;
     logo?: string;
     is_locked: boolean;
-    last_played?: string;
+    last_played: string | null;
 }

--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -4,6 +4,8 @@ import { faCompass, faCopy, faWindowClose } from "@fortawesome/free-regular-svg-
 import {
     faAngleDoubleLeft,
     faArchive,
+    faArrowDownAZ,
+    faArrowDownZA,
     faArrowRight,
     faArrowsAlt,
     faAt,
@@ -14,6 +16,7 @@ import {
     faChevronRight,
     faChevronUp,
     faCircle,
+    faClockRotateLeft,
     faCog,
     faCogs,
     faCut,
@@ -60,6 +63,8 @@ import {
 export function loadFontAwesome(): void {
     library.add(
         faArchive,
+        faArrowDownAZ,
+        faArrowDownZA,
         faArrowRight,
         faArrowsAlt,
         faAt,
@@ -70,6 +75,7 @@ export function loadFontAwesome(): void {
         faChevronRight,
         faChevronUp,
         faCircle,
+        faClockRotateLeft,
         faCog,
         faCogs,
         faCopy,


### PR DESCRIPTION
This PR tackles some low hanging fruit: sorting the game listing in the dashboard.

Up until now the shown campaigns were always ordered in whatever order the database spit them out, which is usually not really useful.

This PR modifies this behaviour to sort by most recently used and also offers the option to sort alphabetically in both directions.

At this moment these choices are not remembered in any way.