### PR TITLE
feat(Tech: API): Change API responses for unknown endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Assets removed in the asset manager will not remove the image on disk if there are still shapes depending on it
 -   Shape removal will now also remove the related image on disk if there are no other assets/shapes depending on it
+-   Don't server main app on unknown `/api/` endpoints
 -   [tech] Selected system now has a proper state with better type ergonomics for focus retrieval
 -   [tech] Spawn Info no longer sends entire shape info, but just position, floor, id and name
 

--- a/server/src/routes.py
+++ b/server/src/routes.py
@@ -101,7 +101,7 @@ api_app.router.add_get(f"{subpath}/campaigns", campaigns.collect)
 admin_app.router.add_static(f"{subpath}/static", STATIC_DIR)
 admin_app.add_subapp("/api/", api_app)
 
-TAIL_REGEX = "/{tail:.*}"
+TAIL_REGEX = "/{tail:(?!api).*}"
 if "dev" in sys.argv:
     main_app.router.add_route("*", TAIL_REGEX, root_dev)
     admin_app.router.add_route("*", TAIL_REGEX, partial(root_dev, admin_api=True))


### PR DESCRIPTION
Unknown API endpoints are being handled by a catch-all route right now that is serving the main app.
This is not really obvious behaviour and can be confusing when you're expecting JSON data but are suddenly receiving HTML data.

This behaviour has been changed and it now properly sends 404s.