### PR TITLE
feat(Circle): Approximate circle with polygon for vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ tech changes will usually be stripped from release notes for the public
 -   Assets removed in the asset manager will not remove the image on disk if there are still shapes depending on it
 -   Shape removal will now also remove the related image on disk if there are no other assets/shapes depending on it
 -   Don't server main app on unknown `/api/` endpoints
+-   Circles used for shadows no longer use a square bounding box, but instead use a polygon approximating the circle.
 -   [tech] Selected system now has a proper state with better type ergonomics for focus retrieval
 -   [tech] Spawn Info no longer sends entire shape info, but just position, floor, id and name
 

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -20,6 +20,7 @@ export interface IShape extends SimpleShape {
     character: CharacterId | undefined;
 
     get points(): [number, number][];
+    get shadowPoints(): [number, number][];
     invalidatePoints: () => void;
     resetVisionIteration: () => void;
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -56,8 +56,12 @@ export abstract class Shape implements IShape {
     protected _center!: GlobalPoint;
 
     protected _points: [number, number][] = [];
+    protected _shadowPoints: [number, number][] | undefined = undefined;
     get points(): [number, number][] {
         return this._points;
+    }
+    get shadowPoints(): [number, number][] {
+        return this._shadowPoints ?? this._points;
     }
 
     abstract contains(point: GlobalPoint, nearbyThreshold?: number): boolean;

--- a/client/src/game/shapes/variants/circle.ts
+++ b/client/src/game/shapes/variants/circle.ts
@@ -1,6 +1,6 @@
 import type { ApiCircleShape } from "../../../apiTypes";
 import { g2lz, clampGridLine } from "../../../core/conversions";
-import { addP, subtractP, toGP, Vector } from "../../../core/geometry";
+import { addP, subtractP, toArrayP, toGP, Vector } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import { FOG_COLOUR } from "../../colour";
 import { calculateDelta } from "../../drag";
@@ -66,6 +66,15 @@ export class Circle extends Shape implements IShape {
     }
 
     invalidatePoints(): void {
+        const ps = [];
+        const r = this.r;
+        const k = 0.75 / r;
+        const N = Math.ceil(Math.PI / Math.sqrt(2 * k));
+        const double_pi = Math.PI * 2;
+        for (let i = 0; i < double_pi; i += double_pi / N) {
+            ps.push(toArrayP(addP(this.center, new Vector(r * Math.cos(i), r * Math.sin(i)))));
+        }
+        this._shadowPoints = ps;
         this._points = this.getBoundingBox().points;
         super.invalidatePoints();
     }

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -153,7 +153,7 @@ class VisionState extends Store<State> {
     }
 
     private triangulateShape(target: TriangulationTarget, shape: IShape): void {
-        const points = shape.points; // expensive call
+        const points = shape.shadowPoints;
         if (points.length === 0) return;
         if (shape.type === "assetrect") {
             const asset = shape as IAsset;


### PR DESCRIPTION
The vision system uses points to do its magic. Given that a circle by definition has infinite points, this was originally "solved" by just approximating it with a bounding box, resulting in all circle-based light-blockers to appear as squares.

This is obviously not ideal and has lead me to use polygons for all things circle based.

This PR sets out to fix this discrimination against circles by approximating them with a polygon based on the radius of the circle. it will not be a 100% perfect overlap, but it should be close enough for your traditional needs.