### PR TITLE
bug(Character): Fix server not rejecting character creation for shape already with character

### DIFF
--- a/server/src/api/socket/character.py
+++ b/server/src/api/socket/character.py
@@ -28,6 +28,9 @@ async def create_character(sid: str, raw_data: Any):
     elif not has_ownership(shape, pr):
         logger.warn("Attempt to create character without access")
         return
+    elif shape.character_id is not None:
+        logger.warn("Shape is already associated with a character")
+        return
 
     try:
         char = Character.create(


### PR DESCRIPTION
The server was fine with creating characters for shapes that already have a character. Causing invalid state for the previous character as it no longer points to a shape.