### PR TITLE
bug(Lighting): Fix empty auras lighting up the entire map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ tech changes will usually be stripped from release notes for the public
 -   Kicking: The check to prevent the co-DM from kicking the main DM was incorrect
 -   AssetManager: Folder changing was doing an unnecessary extra call to the server
 -   Shapes: The angle of shapes while rotating was being rounded to whole integers, which is kinda awkard when dealing with radians
+-   Lighting: auras with both value and dim value set to 0 no longer light up the entire map
 
 ## [2023.2.0] - 2023-06-21
 

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -112,6 +112,8 @@ export class FowLightingLayer extends FowLayer {
                     const auraValue = aura.value > 0 && !isNaN(aura.value) ? aura.value : 0;
                     const auraDim = aura.dim > 0 && !isNaN(aura.dim) ? aura.dim : 0;
 
+                    if (auraValue + auraDim === 0) continue;
+
                     const center = shape.center;
                     const lcenter = g2l(center);
                     const innerRange = g2lr(auraValue + auraDim);


### PR DESCRIPTION
I'm somewhat confused by this one. As I have the feeling this didn't use to happen, but I can't immediately find something in the code that refutes this.

Either way, it's fixed now.