### PR TITLE
Add length check for diceArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Polygon edit UI: was not taking rotation of shape into account
 -   Teleport: shapes would not be removed on the old location until a refresh
+-   Dice tool: would not send zero results when dice list is empty
 
 ## [2023.3.0] - 2023-09-17
 

--- a/client/src/game/ui/tools/DiceTool.vue
+++ b/client/src/game/ui/tools/DiceTool.vue
@@ -63,6 +63,9 @@ async function reroll(roll: string): Promise<void> {
 }
 
 async function go(): Promise<void> {
+    if (diceArray.value.length === 0) {
+        return;
+    }
     clearTimeout(timeout);
     button.value?.classList.remove("transition");
     const roll = diceText.value;


### PR DESCRIPTION
I found that client sent zero results when player clicked `GO` botton in the dice tool due to an empty dice list. This would cause a little confusion when players accidentally click `GO` multiple times. 
A length check on diceArray would easily fix this issue. I have also add one line in the CHANGELOG.