### PR TITLE
bug(Ruler): Fix server log spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ tech changes will usually be stripped from release notes for the public
 -   Polygon edit UI: was not taking rotation of shape into account
 -   Teleport: shapes would not be removed on the old location until a refresh
 -   Dice tool: would not send zero results when dice list is empty
+-   [server] log spam of "unknown" shape when temporary shapes are moved
 
 ## [2023.3.0] - 2023-09-17
 

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -87,11 +87,6 @@ async def add_shape(sid: str, raw_data: Any):
                 continue
             if not data.temporary and shape is not None:
                 data.shape = transform_shape(shape, room_player)
-            print(34593485)
-            x = ApiShapeWithLayerInfo(
-                shape=data.shape, floor=floor.name, layer=layer.name
-            )
-            print(x)
             await _send_game(
                 "Shape.Add",
                 ApiShapeWithLayerInfo(
@@ -108,23 +103,23 @@ async def update_shape_positions(sid: str, raw_data: Any):
 
     pr: PlayerRoom = game_state.get(sid)
 
-    shapes: list[tuple[Shape, ShapePositionUpdate]] = []
-
-    for sh in data.shapes:
-        shape = Shape.get_or_none(Shape.uuid == sh.uuid)
-        if shape is None:
-            logger.warning(
-                f"User {pr.player.name} attempted to move a shape with unknown uuid ({sh.uuid})."
-            )
-            continue
-        elif not has_ownership(shape, pr, movement=True):
-            logger.warning(
-                f"User {pr.player.name} attempted to move a shape it does not own."
-            )
-            continue
-        shapes.append((shape, sh))
-
     if not data.temporary:
+        shapes: list[tuple[Shape, ShapePositionUpdate]] = []
+
+        for sh in data.shapes:
+            shape = Shape.get_or_none(Shape.uuid == sh.uuid)
+            if shape is None:
+                logger.warning(
+                    f"User {pr.player.name} attempted to move a shape with unknown uuid ({sh.uuid})."
+                )
+                continue
+            elif not has_ownership(shape, pr, movement=True):
+                logger.warning(
+                    f"User {pr.player.name} attempted to move a shape it does not own."
+                )
+                continue
+            shapes.append((shape, sh))
+
         with db.atomic():
             for db_shape, data_shape in shapes:
                 points = data_shape.position.points


### PR DESCRIPTION
When using a ruler, the server log was getting flooded with some messages about unknown shapes.

This was due to a change in the code a couple of months ago that did not take temporary shapes into account.

In principle this is not ruler exclusive, but it's the biggest offender.

This had no effect on the users or actual play.