### PR TITLE
bug(Modal): Clear modal state on exit

### DIFF
--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -88,8 +88,8 @@ socket.on("redirect", async (destination: string) => {
 
 // Bootup events
 
-socket.on("CLEAR", () => clearGame(false));
-socket.on("PARTIAL-CLEAR", () => clearGame(true));
+socket.on("CLEAR", () => clearGame("full-loading"));
+socket.on("PARTIAL-CLEAR", () => clearGame("partial-loading"));
 
 socket.on("Board.Locations.Set", (locationInfo: ApiLocationCore[]) => {
     locationStore.setLocations(locationInfo, false);

--- a/client/src/game/clear.ts
+++ b/client/src/game/clear.ts
@@ -8,7 +8,7 @@ import { clearSystems } from "./systems";
 import { initiativeStore } from "./ui/initiative/state";
 import { visionState } from "./vision/state";
 
-export function clearGame(partial: boolean): void {
+export function clearGame(reason: "full-loading" | "partial-loading" | "leaving"): void {
     stopDrawLoop();
     visionState.clear();
     locationStore.setLocations([], false);
@@ -16,6 +16,6 @@ export function clearGame(partial: boolean): void {
     compositeState.clear();
     initiativeStore.clear();
     lastGameboardStore.clear();
-    clearSystems(partial);
+    clearSystems(reason);
     clearIds();
 }

--- a/client/src/game/systems/characters/index.ts
+++ b/client/src/game/systems/characters/index.ts
@@ -16,9 +16,9 @@ const { mutable, readonly, mutableReactive: $ } = characterState;
 class CharacterSystem implements ShapeSystem {
     // BEHAVIOUR
 
-    clear(partial: boolean): void {
+    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
         $.activeCharacterId = undefined;
-        if (!partial) {
+        if (reason !== "partial-loading") {
             $.characterIds.clear();
             mutable.characters.clear();
         }

--- a/client/src/game/systems/index.ts
+++ b/client/src/game/systems/index.ts
@@ -25,14 +25,14 @@ export function dropFromSystems(id: LocalId): void {
     }
 }
 
-export function clearSystems(partial: boolean): void {
+export function clearSystems(reason: "full-loading" | "partial-loading" | "leaving"): void {
     for (const system of Object.values(SYSTEMS)) {
-        system.clear(partial);
+        system.clear(reason);
     }
 }
 
 export interface System {
-    clear: (partial: boolean) => void;
+    clear: (reason: "full-loading" | "partial-loading" | "leaving") => void;
 }
 
 export interface ShapeSystem extends System {

--- a/client/src/game/systems/modals/index.ts
+++ b/client/src/game/systems/modals/index.ts
@@ -20,8 +20,12 @@ function fullModal(modal: Modal, modalIndex: ModalIndex): IndexedModal {
 }
 
 class ModalSystem implements System {
-    clear(): void {
-        $.extraModals = [];
+    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
+        if (reason === "leaving") {
+            $.extraModals = [];
+            $.openModals.clear();
+            $.modalOrder = [];
+        }
     }
 
     // These modals are always available, but sometimes hidden

--- a/client/src/game/systems/players/index.ts
+++ b/client/src/game/systems/players/index.ts
@@ -24,8 +24,8 @@ import { playerState } from "./state";
 const { mutableReactive: $, raw } = playerState;
 
 class PlayerSystem implements System {
-    clear(partial: boolean): void {
-        if (!partial) $.players.clear();
+    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
+        if (reason !== "partial-loading") $.players.clear();
     }
 
     addPlayer(player: Player): void {

--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -24,7 +24,7 @@ import { DEFAULT_GRID_SIZE, positionState } from "./state";
 const { mutable, readonly, mutableReactive: $ } = positionState;
 
 class PositionSystem implements System {
-    clear(partial: boolean): void {
+    clear(): void {
         mutable.gridOffset = { x: 0, y: 0 };
         mutable.zoom = NaN;
     }

--- a/client/src/game/systems/settings/location/index.ts
+++ b/client/src/game/systems/settings/location/index.ts
@@ -13,8 +13,8 @@ import { locationSettingsState } from "./state";
 const { mutableReactive: $, raw, reset } = locationSettingsState;
 
 class LocationSettingsSystem implements System {
-    clear(partial: boolean): void {
-        if (!partial) reset();
+    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
+        if (reason !== "partial-loading") reset();
     }
 
     private resetValue(setting: WithLocationDefault<unknown>): void {

--- a/client/src/game/systems/settings/players/index.ts
+++ b/client/src/game/systems/settings/players/index.ts
@@ -12,9 +12,7 @@ import { playerSettingsState } from "./state";
 const { mutableReactive: $ } = playerSettingsState;
 
 class PlayerSettingsSystem implements System {
-    clear(partial: boolean): void {
-        //
-    }
+    clear(): void {}
 
     // APPEARANCE
 

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -45,7 +45,7 @@ const noAssets = computed(() => {
 const hasGameboardClients = computed(() => clientState.reactive.clientBoards.size > 0);
 
 async function exit(): Promise<void> {
-    clearGame(false);
+    clearGame("leaving");
     await router.push({ name: "games" });
 }
 


### PR DESCRIPTION
After the small enhancements to modals I did earlier, something potentially broke when leaving a campaign.

This is now fixed.