### PR TITLE
feat(Vision): Exempt vision-blocking shapes from themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ tech changes will usually be stripped from release notes for the public
 
 ### Changed
 
+-   Vision blocking shapes will now ignore themselves if they are closed
+    -   e.g. a tree trunk will be visible, but what's behind the tree trunk will remain hidden
+    -   Open polygons will behave as they have in the past
 -   [tech] ModalStack now supports dynamically inserted
 
 ### Fixed

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -6,6 +6,7 @@ import type { AuraId } from "./game/systems/auras/models";
 import type { CharacterId } from "./game/systems/characters/models";
 import type { ClientId } from "./game/systems/client/models";
 import type { PlayerId } from "./game/systems/players/models";
+import type { VisionBlock } from "./game/systems/properties/types";
 import type { TrackerId } from "./game/systems/trackers/models";
 
 export type ApiShape = ApiAssetRectShape | ApiRectShape | ApiCircleShape | ApiCircularTokenShape | ApiPolygonShape | ApiTextShape | ApiLineShape | ApiToggleCompositeShape
@@ -149,7 +150,7 @@ export interface ApiCoreShape {
   name_visible: boolean;
   fill_colour: string;
   stroke_colour: string;
-  vision_obstruction: boolean;
+  vision_obstruction: VisionBlock;
   movement_obstruction: boolean;
   is_token: boolean;
   annotation: string;
@@ -658,6 +659,10 @@ export interface ShapeSetBooleanValue {
 export interface ShapeSetDoorToggleModeValue {
   shape: GlobalId;
   value: "movement" | "vision" | "both";
+}
+export interface ShapeSetIntegerValue {
+  shape: GlobalId;
+  value: number;
 }
 export interface ShapeSetOptionalStringValue {
   shape: GlobalId;

--- a/client/src/core/components/ToggleGroup.vue
+++ b/client/src/core/components/ToggleGroup.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts" generic="T, MS extends boolean">
+import { computed } from "vue";
+
+const props = withDefaults(
+    defineProps<{
+        // data
+        options: readonly { label: string; value: T }[];
+        modelValue: MS extends true ? T[] : T;
+        // styles
+        id?: string;
+        activeColor?: string;
+        color?: string;
+        disabled?: boolean;
+        multiSelect: MS;
+    }>(),
+    {
+        id: undefined,
+        color: "rgba(236, 242, 255, 0.25)",
+        activeColor: "rgba(236, 242, 255, 1)",
+        disabled: false,
+    },
+);
+const emit = defineEmits<(e: "update:modelValue", s: MS extends true ? T[] : T) => void>();
+
+const data = computed(() => (props.multiSelect ? props.modelValue : [props.modelValue]) as T[]);
+
+function toggle(option: T): void {
+    if (props.disabled) return;
+    let data: MS extends true ? T[] : T;
+    if (props.multiSelect) {
+        const arr = props.modelValue as T[];
+        if (arr.includes(option)) {
+            data = arr.filter((d) => d !== option) as MS extends true ? T[] : T;
+        } else {
+            data = [...arr, option] as MS extends true ? T[] : T;
+        }
+    } else {
+        // idk eslint and typescript are not agreeing with eachother
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        data = option as MS extends true ? T[] : T;
+    }
+    emit("update:modelValue", data);
+}
+</script>
+
+<template>
+    <div :id="id" class="toggle-group" :class="{ disabled }">
+        <div
+            v-for="option of options"
+            :key="option.label"
+            :class="{ selected: data.includes(option.value) }"
+            @click="toggle(option.value)"
+        >
+            {{ option.label }}
+        </div>
+    </div>
+</template>
+
+<style scoped lang="scss">
+.toggle-group {
+    display: flex;
+    align-items: stretch;
+    flex-wrap: wrap;
+
+    width: fit-content;
+    overflow: hidden;
+
+    border-radius: 1rem;
+    background-color: v-bind("color");
+    border: solid 2px v-bind("activeColor");
+
+    > div {
+        padding: 0.5rem 0.7rem;
+        display: flex;
+        align-items: center;
+
+        &:hover {
+            cursor: pointer;
+            background-color: v-bind("activeColor");
+        }
+
+        &.selected {
+            background-color: v-bind("activeColor");
+        }
+    }
+
+    &.disabled > {
+        div:hover {
+            cursor: not-allowed;
+        }
+
+        :not(.selected):hover {
+            background-color: inherit;
+        }
+    }
+}
+</style>

--- a/client/src/game/api/emits/shape/options.ts
+++ b/client/src/game/api/emits/shape/options.ts
@@ -1,4 +1,9 @@
-import type { ShapeSetBooleanValue, ShapeSetOptionalStringValue, ShapeSetStringValue } from "../../../../apiTypes";
+import type {
+    ShapeSetBooleanValue,
+    ShapeSetIntegerValue,
+    ShapeSetOptionalStringValue,
+    ShapeSetStringValue,
+} from "../../../../apiTypes";
 import { wrapSocket } from "../../helpers";
 
 export const sendShapeSetInvisible = wrapSocket<ShapeSetBooleanValue>("Shape.Options.Invisible.Set");
@@ -6,7 +11,7 @@ export const sendShapeSetDefeated = wrapSocket<ShapeSetBooleanValue>("Shape.Opti
 export const sendShapeSetLocked = wrapSocket<ShapeSetBooleanValue>("Shape.Options.Locked.Set");
 export const sendShapeSetIsToken = wrapSocket<ShapeSetBooleanValue>("Shape.Options.Token.Set");
 export const sendShapeSetBlocksMovement = wrapSocket<ShapeSetBooleanValue>("Shape.Options.MovementBlock.Set");
-export const sendShapeSetBlocksVision = wrapSocket<ShapeSetBooleanValue>("Shape.Options.VisionBlock.Set");
+export const sendShapeSetBlocksVision = wrapSocket<ShapeSetIntegerValue>("Shape.Options.VisionBlock.Set");
 export const sendShapeSetNameVisible = wrapSocket<ShapeSetBooleanValue>("Shape.Options.NameVisible.Set");
 export const sendShapeSetShowBadge = wrapSocket<ShapeSetBooleanValue>("Shape.Options.ShowBadge.Set");
 

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -1,4 +1,9 @@
-import type { ShapeSetBooleanValue, ShapeSetOptionalStringValue, ShapeSetStringValue } from "../../../../apiTypes";
+import type {
+    ShapeSetBooleanValue,
+    ShapeSetIntegerValue,
+    ShapeSetOptionalStringValue,
+    ShapeSetStringValue,
+} from "../../../../apiTypes";
 import { UI_SYNC } from "../../../../core/models/types";
 import type { Sync } from "../../../../core/models/types";
 import { getLocalId, getShape } from "../../../id";
@@ -64,7 +69,7 @@ socket.on(
 
 socket.on(
     "Shape.Options.VisionBlock.Set",
-    wrapSystemCall<ShapeSetBooleanValue>(propertiesSystem.setBlocksVision.bind(propertiesSystem)),
+    wrapSystemCall<ShapeSetIntegerValue>(propertiesSystem.setBlocksVision.bind(propertiesSystem)),
 );
 
 socket.on(

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -58,6 +58,7 @@ export interface IShape extends SimpleShape {
 
     get visionPolygon(): Path2D;
     _visionBbox: BoundingRect | undefined;
+    _lightBlockingNeighbours: LocalId[];
 
     // POSITION
 
@@ -81,8 +82,12 @@ export interface IShape extends SimpleShape {
 
     // DRAWING
 
-    draw: (ctx: CanvasRenderingContext2D, customScale?: { center: GlobalPoint; width: number; height: number }) => void;
-    drawPost: (ctx: CanvasRenderingContext2D) => void;
+    draw: (
+        ctx: CanvasRenderingContext2D,
+        lightRevealRender: boolean,
+        customScale?: { center: GlobalPoint; width: number; height: number },
+    ) => void;
+    drawPost: (ctx: CanvasRenderingContext2D, lightRevealRender: boolean) => void;
     drawSelection: (ctx: CanvasRenderingContext2D) => void;
 
     // VISION

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -121,6 +121,12 @@ export class FowLightingLayer extends FowLayer {
                     this.vCtx.globalCompositeOperation = "source-over";
                     this.vCtx.fillStyle = "rgba(0, 0, 0, 1)";
                     this.vCtx.fill(shape.visionPolygon);
+                    for (const sh of shape._lightBlockingNeighbours) {
+                        const hitShape = getShape(sh);
+                        if (hitShape) {
+                            hitShape.draw(this.vCtx, true);
+                        }
+                    }
                     if (auraDim > 0 && !hasGameboard) {
                         // Fill the light aura with a radial dropoff towards the outside.
                         const gradient = this.vCtx.createRadialGradient(
@@ -178,7 +184,7 @@ export class FowLightingLayer extends FowLayer {
                     else if (preShape.globalCompositeOperation === "destination-out")
                         preShape.globalCompositeOperation = "source-over";
                 }
-                preShape.draw(this.ctx);
+                preShape.draw(this.ctx, false);
                 preShape.globalCompositeOperation = ogComposite;
                 this.isEmpty = false;
             }

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -64,6 +64,12 @@ export class FowVisionLayer extends FowLayer {
                 }
 
                 this.ctx.fill(token.visionPolygon);
+                for (const sh of token._lightBlockingNeighbours) {
+                    const hitShape = getShape(sh);
+                    if (hitShape) {
+                        hitShape.draw(this.ctx, true);
+                    }
+                }
 
                 // Out of Bounds check
                 if (token._visionBbox?.visibleInCanvas({ w: this.width, h: this.height }) ?? false) {

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -423,7 +423,7 @@ export class Layer implements ILayer {
                     if (props.isInvisible && !accessSystem.hasAccessTo(shape.id, true, { vision: true })) continue;
                     if (labelSystem.isFiltered(shape.id)) continue;
 
-                    shape.draw(ctx);
+                    shape.draw(ctx, false);
                 }
             }
 
@@ -465,7 +465,7 @@ export class Layer implements ILayer {
                                     const modifiedRay = new Ray(g2l(ray.get(min)), ray.direction);
                                     drawTear(modifiedRay, { fillColour: playerSettingsState.raw.rulerColour.value });
                                     target = ray.getPointAtDistance(l2gz(68), min);
-                                    shape.draw(ctx, { center: target, width: 60, height: 60 });
+                                    shape.draw(ctx, false, { center: target, width: 60, height: 60 });
                                     positionSystem.setTokenDirection(token, g2l(target));
                                     found = true;
                                 }

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -8,6 +8,7 @@ import { clientSystem } from "../systems/client";
 import { gameState } from "../systems/game/state";
 import { teleportZoneSystem } from "../systems/logic/tp";
 import { getProperties } from "../systems/properties/state";
+import { VisionBlock } from "../systems/properties/types";
 import { selectedSystem } from "../systems/selected";
 import { locationSettingsState } from "../systems/settings/location/state";
 import { initiativeStore } from "../ui/initiative/state";
@@ -45,7 +46,7 @@ export async function moveShapes(shapes: readonly IShape[], delta: Vector, tempo
                 shape: shape.id,
             });
         }
-        if (props.blocksVision) {
+        if (props.blocksVision !== VisionBlock.No) {
             recalculateVision = true;
             visionState.deleteFromTriangulation({
                 target: TriangulationTarget.VISION,
@@ -66,7 +67,8 @@ export async function moveShapes(shapes: readonly IShape[], delta: Vector, tempo
 
         if (props.blocksMovement && !temporary)
             visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: shape.id });
-        if (props.blocksVision) visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.id });
+        if (props.blocksVision !== VisionBlock.No)
+            visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.id });
 
         // todo: Fix again
         // if (sel.refPoint.x % gridSize !== 0 || sel.refPoint.y % gridSize !== 0) sel.snapToGrid();

--- a/client/src/game/operations/resize.ts
+++ b/client/src/game/operations/resize.ts
@@ -2,6 +2,7 @@ import type { GlobalPoint } from "../../core/geometry";
 import { sendShapeSizeUpdate } from "../api/emits/shape/core";
 import type { IShape } from "../interfaces/shape";
 import { getProperties } from "../systems/properties/state";
+import { VisionBlock } from "../systems/properties/types";
 import { TriangulationTarget, visionState } from "../vision/state";
 
 export function resizeShape(
@@ -23,7 +24,7 @@ export function resizeShape(
             shape: shape.id,
         });
     }
-    if (props.blocksVision) {
+    if (props.blocksVision !== VisionBlock.No) {
         recalculateVision = true;
         visionState.deleteFromTriangulation({
             target: TriangulationTarget.VISION,
@@ -36,7 +37,8 @@ export function resizeShape(
     // todo: think about calling deleteIntersectVertex directly on the corner point
     if (props.blocksMovement && !temporary)
         visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: shape.id });
-    if (props.blocksVision) visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.id });
+    if (props.blocksVision !== VisionBlock.No)
+        visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.id });
 
     if (!shape.preventSync) sendShapeSizeUpdate({ shape, temporary });
 

--- a/client/src/game/operations/rotation.ts
+++ b/client/src/game/operations/rotation.ts
@@ -2,6 +2,7 @@ import type { GlobalPoint } from "../../core/geometry";
 import { sendShapePositionUpdate } from "../api/emits/shape/core";
 import type { IShape } from "../interfaces/shape";
 import { getProperties } from "../systems/properties/state";
+import { VisionBlock } from "../systems/properties/types";
 import { TriangulationTarget, visionState } from "../vision/state";
 
 export function rotateShapes(
@@ -24,7 +25,7 @@ export function rotateShapes(
                 shape: shape.id,
             });
         }
-        if (props.blocksVision) {
+        if (props.blocksVision !== VisionBlock.No) {
             recalculateVision = true;
             visionState.deleteFromTriangulation({
                 target: TriangulationTarget.VISION,
@@ -36,7 +37,8 @@ export function rotateShapes(
 
         if (props.blocksMovement && !temporary)
             visionState.addToTriangulation({ target: TriangulationTarget.MOVEMENT, shape: shape.id });
-        if (props.blocksVision) visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.id });
+        if (props.blocksVision !== VisionBlock.No)
+            visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.id });
 
         if (!shape.preventSync) sendShapePositionUpdate([shape], temporary);
     }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -30,6 +30,7 @@ import { teleportZoneSystem } from "../systems/logic/tp";
 import { propertiesSystem } from "../systems/properties";
 import { getProperties } from "../systems/properties/state";
 import type { ShapeProperties } from "../systems/properties/state";
+import { VisionBlock } from "../systems/properties/types";
 import { playerSettingsState } from "../systems/settings/players/state";
 import { trackerSystem } from "../systems/trackers";
 import { trackersFromServer, trackersToServer } from "../systems/trackers/conversion";
@@ -189,7 +190,10 @@ export abstract class Shape implements IShape {
                 this.floorId,
                 false,
             );
-            this._lightBlockingNeighbours = shapeHits;
+            // Only the behind-blockers need to be tracked as these require extra effort
+            this._lightBlockingNeighbours = shapeHits.filter(
+                (s) => getProperties(s)?.blocksVision === VisionBlock.Behind,
+            );
             this._visionPolygon = visibility;
             this.visionIteration = visionIteration;
             this.recalcVisionBbox();
@@ -482,7 +486,7 @@ export abstract class Shape implements IShape {
 
     updateShapeVision(alteredMovement: boolean, alteredVision: boolean): void {
         const props = getProperties(this.id)!;
-        if (props.blocksVision && !alteredVision) {
+        if (props.blocksVision !== VisionBlock.No && !alteredVision) {
             visionState.deleteFromTriangulation({
                 target: TriangulationTarget.VISION,
                 shape: this.id,

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -24,6 +24,7 @@ import { floorState } from "../systems/floors/state";
 import { groupSystem } from "../systems/groups";
 import { positionSystem } from "../systems/position";
 import { getProperties } from "../systems/properties/state";
+import { VisionBlock } from "../systems/properties/types";
 import { selectedSystem } from "../systems/selected";
 import type { TrackerId } from "../systems/trackers/models";
 import { TriangulationTarget, VisibilityMode, visionState } from "../vision/state";
@@ -190,7 +191,7 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
         const gId = getGlobalId(sel.id);
         if (gId) removed.push(gId);
         const props = getProperties(sel.id)!;
-        if (props.blocksVision) recalculateVision = true;
+        if (props.blocksVision !== VisionBlock.No) recalculateVision = true;
         if (props.blocksMovement) recalculateMovement = true;
         sel.layer?.removeShape(sel, { sync: SyncMode.NO_SYNC, recalculate: recalculateIterative, dropShapeId: true });
     }

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -98,8 +98,13 @@ export class Asset extends BaseRect implements IAsset {
         }
     }
 
-    draw(ctx: CanvasRenderingContext2D, customScale?: { center: GlobalPoint; width: number; height: number }): void {
-        super.draw(ctx, customScale);
+    draw(
+        ctx: CanvasRenderingContext2D,
+        lightRevealRender: boolean,
+        customScale?: { center: GlobalPoint; width: number; height: number },
+    ): void {
+        super.draw(ctx, lightRevealRender, customScale);
+
         const center = g2l(this.center);
         const rp = g2l(this.refPoint);
         const ogH = g2lz(this.h);
@@ -108,8 +113,9 @@ export class Asset extends BaseRect implements IAsset {
         const w = customScale ? customScale.width : ogW;
         const deltaH = (ogH - h) / 2;
         const deltaW = (ogW - w) / 2;
+
         if (!this.#loaded) {
-            ctx.fillStyle = FOG_COLOUR;
+            if (!lightRevealRender) ctx.fillStyle = FOG_COLOUR;
             ctx.fillRect(rp.x - center.x, rp.y - center.y, w, h);
         } else {
             try {
@@ -118,7 +124,8 @@ export class Asset extends BaseRect implements IAsset {
                 console.warn(`Shape ${getGlobalId(this.id) ?? "unknown"} could not load the image ${this.src}`);
             }
         }
-        super.drawPost(ctx);
+
+        super.drawPost(ctx, lightRevealRender);
     }
 
     setImage(url: string, sync: boolean): void {

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -14,6 +14,7 @@ import { LayerName } from "../../models/floor";
 import { loadSvgData } from "../../svg";
 import { floorSystem } from "../../systems/floors";
 import { getProperties } from "../../systems/properties/state";
+import { VisionBlock } from "../../systems/properties/types";
 import { TriangulationTarget, visionState } from "../../vision/state";
 import type { SHAPE_TYPE } from "../types";
 
@@ -85,7 +86,7 @@ export class Asset extends BaseRect implements IAsset {
             const svgs = await loadSvgData(`/static/assets/${this.options.svgAsset}`);
             this.svgData = [...map(svgs.values(), (svg) => ({ svg, rp: this.refPoint, paths: undefined }))];
             const props = getProperties(this.id)!;
-            if (props.blocksVision) {
+            if (props.blocksVision !== VisionBlock.No) {
                 if (this.floorId !== undefined) visionState.recalculateVision(this.floorId);
                 visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: this.id });
             }

--- a/client/src/game/shapes/variants/circle.ts
+++ b/client/src/game/shapes/variants/circle.ts
@@ -79,30 +79,37 @@ export class Circle extends Shape implements IShape {
         super.invalidatePoints();
     }
 
-    draw(ctx: CanvasRenderingContext2D): void {
-        super.draw(ctx);
+    draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
+        super.draw(ctx, lightRevealRender);
         const props = getProperties(this.id)!;
         ctx.beginPath();
-        if (props.fillColour === "fog") ctx.fillStyle = FOG_COLOUR;
-        else ctx.fillStyle = props.fillColour;
+
+        if (!lightRevealRender) {
+            if (props.fillColour === "fog") ctx.fillStyle = FOG_COLOUR;
+            else ctx.fillStyle = props.fillColour;
+        }
 
         this.drawArc(ctx, this.ignoreZoomSize ? this.r : g2lz(this.r));
         ctx.fill();
 
-        if (props.strokeColour[0] !== "rgba(0, 0, 0, 0)") {
-            const ogOperation = ctx.globalCompositeOperation;
-            if (this.options.borderOperation !== undefined) ctx.globalCompositeOperation = this.options.borderOperation;
-            ctx.beginPath();
-            ctx.lineWidth = this.ignoreZoomSize ? this.strokeWidth : g2lz(this.strokeWidth);
-            ctx.strokeStyle = props.strokeColour[0]!;
-            // Inset the border with - borderWidth / 2
-            // Slight imperfection added to account for zoom subpixel differences
-            const r = this.r - this.strokeWidth / 2.5;
-            this.drawArc(ctx, Math.max(this.strokeWidth / 2, this.ignoreZoomSize ? r : g2lz(r)));
-            ctx.stroke();
-            ctx.globalCompositeOperation = ogOperation;
+        if (!lightRevealRender) {
+            if (props.strokeColour[0] !== "rgba(0, 0, 0, 0)") {
+                const ogOperation = ctx.globalCompositeOperation;
+                if (this.options.borderOperation !== undefined)
+                    ctx.globalCompositeOperation = this.options.borderOperation;
+                ctx.beginPath();
+                ctx.lineWidth = this.ignoreZoomSize ? this.strokeWidth : g2lz(this.strokeWidth);
+                ctx.strokeStyle = props.strokeColour[0]!;
+                // Inset the border with - borderWidth / 2
+                // Slight imperfection added to account for zoom subpixel differences
+                const r = this.r - this.strokeWidth / 2.5;
+                this.drawArc(ctx, Math.max(this.strokeWidth / 2, this.ignoreZoomSize ? r : g2lz(r)));
+                ctx.stroke();
+                ctx.globalCompositeOperation = ogOperation;
+            }
         }
-        super.drawPost(ctx);
+
+        super.drawPost(ctx, lightRevealRender);
     }
 
     private drawArc(ctx: CanvasRenderingContext2D, r: number): void {

--- a/client/src/game/shapes/variants/circularToken.ts
+++ b/client/src/game/shapes/variants/circularToken.ts
@@ -50,24 +50,26 @@ export class CircularToken extends Circle implements IShape {
         this.font = data.font;
     }
 
-    draw(ctx: CanvasRenderingContext2D): void {
-        super.draw(ctx);
+    draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
+        super.draw(ctx, lightRevealRender);
 
-        const center = g2l(this.center);
-        const props = getProperties(this.id)!;
+        if (!lightRevealRender) {
+            const center = g2l(this.center);
+            const props = getProperties(this.id)!;
 
-        ctx.font = this.font;
+            ctx.font = this.font;
 
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        const fontScale = calcFontScale(ctx, this.text, g2lz(this.r - 5));
-        const pixelRatio = playerSettingsState.devicePixelRatio.value;
-        ctx.setTransform(fontScale, 0, 0, fontScale, center.x * pixelRatio, center.y * pixelRatio);
-        ctx.rotate(this.angle);
-        ctx.fillStyle = mostReadable(props.fillColour);
-        ctx.fillText(this.text, 0, 0);
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            const fontScale = calcFontScale(ctx, this.text, g2lz(this.r - 5));
+            const pixelRatio = playerSettingsState.devicePixelRatio.value;
+            ctx.setTransform(fontScale, 0, 0, fontScale, center.x * pixelRatio, center.y * pixelRatio);
+            ctx.rotate(this.angle);
+            ctx.fillStyle = mostReadable(props.fillColour);
+            ctx.fillText(this.text, 0, 0);
+        }
 
-        super.drawPost(ctx);
+        super.drawPost(ctx, lightRevealRender);
     }
 
     setText(text: string, sync: SyncMode): void {

--- a/client/src/game/shapes/variants/line.ts
+++ b/client/src/game/shapes/variants/line.ts
@@ -78,19 +78,22 @@ export class Line extends Shape implements IShape {
         );
     }
 
-    draw(ctx: CanvasRenderingContext2D): void {
-        super.draw(ctx);
+    draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
+        super.draw(ctx, lightRevealRender);
 
-        const center = g2l(this.center);
-        const props = getProperties(this.id)!;
+        if (!lightRevealRender) {
+            const center = g2l(this.center);
+            const props = getProperties(this.id)!;
 
-        ctx.strokeStyle = props.strokeColour[0]!;
-        ctx.beginPath();
-        ctx.moveTo(g2lx(this.refPoint.x) - center.x, g2ly(this.refPoint.y) - center.y);
-        ctx.lineTo(g2lx(this.endPoint.x) - center.x, g2ly(this.endPoint.y) - center.y);
-        ctx.lineWidth = this.ignoreZoomSize ? this.lineWidth : g2lz(this.lineWidth);
-        ctx.stroke();
-        super.drawPost(ctx);
+            ctx.strokeStyle = props.strokeColour[0]!;
+            ctx.beginPath();
+            ctx.moveTo(g2lx(this.refPoint.x) - center.x, g2ly(this.refPoint.y) - center.y);
+            ctx.lineTo(g2lx(this.endPoint.x) - center.x, g2ly(this.endPoint.y) - center.y);
+            ctx.lineWidth = this.ignoreZoomSize ? this.lineWidth : g2lz(this.lineWidth);
+            ctx.stroke();
+        }
+
+        super.drawPost(ctx, lightRevealRender);
     }
 
     contains(_point: GlobalPoint): boolean {

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -142,8 +142,10 @@ export class Polygon extends Shape implements IShape {
         super.invalidatePoints();
     }
 
-    draw(ctx: CanvasRenderingContext2D): void {
-        super.draw(ctx);
+    draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
+        if (lightRevealRender && this.openPolygon) return;
+
+        super.draw(ctx, lightRevealRender);
 
         const center = g2l(this.center);
 
@@ -151,8 +153,10 @@ export class Polygon extends Shape implements IShape {
         ctx.lineJoin = "round";
         const props = getProperties(this.id)!;
 
-        if (props.fillColour === "fog") ctx.fillStyle = FOG_COLOUR;
-        else ctx.fillStyle = props.fillColour;
+        if (!lightRevealRender) {
+            if (props.fillColour === "fog") ctx.fillStyle = FOG_COLOUR;
+            else ctx.fillStyle = props.fillColour;
+        }
 
         ctx.beginPath();
         let localVertex = subtractP(g2l(this.vertices[0]!), center);
@@ -169,16 +173,18 @@ export class Polygon extends Shape implements IShape {
 
         if (!this.openPolygon) ctx.fill();
 
-        for (const [i, c] of props.strokeColour.entries()) {
-            const lw = this.lineWidth[i] ?? this.lineWidth[0]!;
-            ctx.lineWidth = this.ignoreZoomSize ? lw : g2lz(lw);
+        if (!lightRevealRender) {
+            for (const [i, c] of props.strokeColour.entries()) {
+                const lw = this.lineWidth[i] ?? this.lineWidth[0]!;
+                ctx.lineWidth = this.ignoreZoomSize ? lw : g2lz(lw);
 
-            if (c === "fog") ctx.strokeStyle = FOG_COLOUR;
-            else ctx.strokeStyle = c;
-            ctx.stroke();
+                if (c === "fog") ctx.strokeStyle = FOG_COLOUR;
+                else ctx.strokeStyle = c;
+                ctx.stroke();
+            }
         }
 
-        super.drawPost(ctx);
+        super.drawPost(ctx, lightRevealRender);
     }
 
     contains(point: GlobalPoint, nearbyThreshold?: number): boolean {

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -14,6 +14,7 @@ import type { AuraId } from "../../systems/auras/models";
 import { positionState } from "../../systems/position/state";
 import { getProperties } from "../../systems/properties/state";
 import type { ShapeProperties } from "../../systems/properties/state";
+import { VisionBlock } from "../../systems/properties/types";
 import type { TrackerId } from "../../systems/trackers/models";
 import { visionState } from "../../vision/state";
 import { Shape } from "../shape";
@@ -275,7 +276,7 @@ export class Polygon extends Shape implements IShape {
             this.layer?.addShape(
                 newPolygon,
                 SyncMode.FULL_SYNC,
-                props.blocksVision ? InvalidationMode.WITH_LIGHT : InvalidationMode.NORMAL,
+                props.blocksVision !== VisionBlock.No ? InvalidationMode.WITH_LIGHT : InvalidationMode.NORMAL,
             );
 
             this.invalidatePoints();
@@ -334,7 +335,7 @@ export class Polygon extends Shape implements IShape {
         if (invalidate) {
             const props = getProperties(this.id)!;
             if (this.floorId !== undefined) {
-                if (props.blocksVision) visionState.recalculateVision(this.floorId);
+                if (props.blocksVision !== VisionBlock.No) visionState.recalculateVision(this.floorId);
                 if (props.blocksMovement) visionState.recalculateMovement(this.floorId);
             }
             if (!this.preventSync) sendShapePositionUpdate([this], false);

--- a/client/src/game/shapes/variants/rect.ts
+++ b/client/src/game/shapes/variants/rect.ts
@@ -12,21 +12,28 @@ export class Rect extends BaseRect implements IShape {
 
     readonly isClosed = true;
 
-    draw(ctx: CanvasRenderingContext2D): void {
-        super.draw(ctx);
+    draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
+        super.draw(ctx, lightRevealRender);
         const props = getProperties(this.id)!;
-        if (props.fillColour === "fog") ctx.fillStyle = FOG_COLOUR;
-        else ctx.fillStyle = props.fillColour;
+
+        if (!lightRevealRender) {
+            if (props.fillColour === "fog") ctx.fillStyle = FOG_COLOUR;
+            else ctx.fillStyle = props.fillColour;
+        }
+
         const loc = g2l(this.refPoint);
         const center = g2l(this.center);
         const state = positionState.readonly;
         ctx.fillRect(loc.x - center.x, loc.y - center.y, this.w * state.zoom, this.h * state.zoom);
-        if (props.strokeColour[0] !== "rgba(0, 0, 0, 0)") {
-            ctx.strokeStyle = props.strokeColour[0]!;
-            ctx.lineWidth = this.strokeWidth;
-            ctx.strokeRect(loc.x - center.x, loc.y - center.y, this.w * state.zoom, this.h * state.zoom);
+
+        if (!lightRevealRender) {
+            if (props.strokeColour[0] !== "rgba(0, 0, 0, 0)") {
+                ctx.strokeStyle = props.strokeColour[0]!;
+                ctx.lineWidth = this.strokeWidth;
+                ctx.strokeRect(loc.x - center.x, loc.y - center.y, this.w * state.zoom, this.h * state.zoom);
+            }
         }
 
-        super.drawPost(ctx);
+        super.drawPost(ctx, lightRevealRender);
     }
 }

--- a/client/src/game/shapes/variants/text.ts
+++ b/client/src/game/shapes/variants/text.ts
@@ -57,8 +57,10 @@ export class Text extends Shape implements IText {
         return bbox;
     }
 
-    draw(ctx: CanvasRenderingContext2D): void {
-        super.draw(ctx);
+    draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
+        if (lightRevealRender) return;
+
+        super.draw(ctx, lightRevealRender);
 
         const size = this.ignoreZoomSize ? this.fontSize : g2lz(this.fontSize);
         const props = getProperties(this.id)!;
@@ -87,7 +89,7 @@ export class Text extends Shape implements IText {
         if (this.height === 0) this.height = 5;
         else this.height = l2gz(this.height);
 
-        super.drawPost(ctx);
+        super.drawPost(ctx, lightRevealRender);
     }
 
     contains(point: GlobalPoint): boolean {

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -18,6 +18,7 @@ import { accessSystem } from "../../systems/access";
 import { auraSystem } from "../../systems/auras";
 import { getProperties } from "../../systems/properties/state";
 import type { ShapeProperties } from "../../systems/properties/state";
+import { VisionBlock } from "../../systems/properties/types";
 import { selectedSystem } from "../../systems/selected";
 import { TriangulationTarget, visionState } from "../../vision/state";
 import { Shape } from "../shape";
@@ -115,7 +116,7 @@ export class ToggleComposite extends Shape implements IToggleComposite {
                 if (props.isToken) accessSystem.removeOwnedToken(variant.id);
                 if (props.blocksMovement)
                     visionState.removeBlocker(TriangulationTarget.MOVEMENT, variant.floorId, variant, true);
-                if (props.blocksVision)
+                if (props.blocksVision !== VisionBlock.No)
                     visionState.removeBlocker(TriangulationTarget.VISION, variant.floorId, variant, true);
                 if (auraSystem.getAll(variant.id, false).length > 0)
                     visionState.removeVisionSources(variant.floorId, variant.id);
@@ -155,7 +156,7 @@ export class ToggleComposite extends Shape implements IToggleComposite {
         if (newVariant.floorId !== undefined) {
             if (props.blocksMovement)
                 visionState.addBlocker(TriangulationTarget.MOVEMENT, newVariant.id, newVariant.floorId, true);
-            if (props.blocksVision)
+            if (props.blocksVision !== VisionBlock.No)
                 visionState.addBlocker(TriangulationTarget.VISION, newVariant.id, newVariant.floorId, true);
 
             for (const au of auraSystem.getAll(newVariant.id, false)) {

--- a/client/src/game/systems/properties/index.ts
+++ b/client/src/game/systems/properties/index.ts
@@ -25,6 +25,7 @@ import { selectedState } from "../selected/state";
 import { checkMovementSources } from "./movement";
 import { getProperties, propertiesState } from "./state";
 import type { ShapeProperties } from "./state";
+import { VisionBlock } from "./types";
 import { checkVisionSources } from "./vision";
 
 const { mutable, mutableReactive: $, DEFAULT } = propertiesState;
@@ -183,7 +184,7 @@ class PropertiesSystem implements ShapeSystem {
         return alteredMovement;
     }
 
-    setBlocksVision(id: LocalId, blocksVision: boolean, syncTo: Sync, recalculate = true): void {
+    setBlocksVision(id: LocalId, blocksVision: VisionBlock, syncTo: Sync, recalculate = true): void {
         const shape = mutable.data.get(id);
         if (shape === undefined) {
             return console.error("[Properties.setBlocksVision] Unknown local shape.");
@@ -197,7 +198,7 @@ class PropertiesSystem implements ShapeSystem {
         }
         if ($.id === id) $.blocksVision = blocksVision;
 
-        const alteredVision = checkVisionSources(id, blocksVision, recalculate);
+        const alteredVision = checkVisionSources(id, blocksVision !== VisionBlock.No, recalculate);
         if (alteredVision && recalculate) getShape(id)?.invalidate(false);
         doorSystem.checkCursorState(id);
     }

--- a/client/src/game/systems/properties/state.ts
+++ b/client/src/game/systems/properties/state.ts
@@ -3,6 +3,8 @@ import type { DeepReadonly } from "vue";
 import type { LocalId } from "../../id";
 import { buildState } from "../state";
 
+import { VisionBlock } from "./types";
+
 export interface ShapeProperties {
     name: string;
     nameVisible: boolean;
@@ -11,7 +13,7 @@ export interface ShapeProperties {
     strokeColour: string[];
     fillColour: string;
     blocksMovement: boolean;
-    blocksVision: boolean;
+    blocksVision: VisionBlock;
     showBadge: boolean;
     isDefeated: boolean;
     isLocked: boolean;
@@ -36,7 +38,7 @@ const state = buildState<ReactivePropertiesState, PropertiesState>(
         strokeColour: undefined,
         fillColour: undefined,
         blocksMovement: false,
-        blocksVision: false,
+        blocksVision: VisionBlock.No,
         showBadge: false,
         isDefeated: false,
         isLocked: false,
@@ -56,7 +58,7 @@ const DEFAULT_PROPERTIES: () => ShapeProperties = () => ({
     fillColour: "#000",
     strokeColour: ["rgba(0, 0, 0, 0)"],
     blocksMovement: false,
-    blocksVision: false,
+    blocksVision: VisionBlock.No,
     showBadge: false,
 });
 

--- a/client/src/game/systems/properties/types.ts
+++ b/client/src/game/systems/properties/types.ts
@@ -1,0 +1,8 @@
+// Order is important
+export enum VisionBlock {
+    No,
+    Complete,
+    Behind,
+}
+
+export const visionBlocks = [VisionBlock.No, VisionBlock.Complete, VisionBlock.Behind];

--- a/client/src/game/systems/properties/vision.ts
+++ b/client/src/game/systems/properties/vision.ts
@@ -9,8 +9,15 @@ export function checkVisionSources(id: LocalId, blocksVision: boolean, recalcula
     let alteredVision = false;
     const visionBlockers = visionState.getBlockers(TriangulationTarget.VISION, floor);
     const obstructionIndex = visionBlockers.indexOf(id);
-    if (blocksVision && obstructionIndex === -1) {
-        visionState.addBlocker(TriangulationTarget.VISION, id, floor, recalculate);
+    if (blocksVision) {
+        if (obstructionIndex === -1) {
+            visionState.addBlocker(TriangulationTarget.VISION, id, floor, recalculate);
+        } else {
+            // This should be done if the vision block mode changes between Complete/Behind
+            // in theory this also triggers if for some reason this function is reran without changes.
+            // That should not happen in the first place, and if it does, it's not a big deal to do an extra recalc.
+            visionState.recalculateVision(floor);
+        }
         alteredVision = true;
     } else if (!blocksVision && obstructionIndex >= 0) {
         visionState.sliceBlockers(TriangulationTarget.VISION, obstructionIndex, floor, recalculate);

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -48,6 +48,7 @@ import { teleportZoneSystem } from "../../../systems/logic/tp";
 import { playerSystem } from "../../../systems/players";
 import { DEFAULT_GRID_SIZE, positionState } from "../../../systems/position/state";
 import { getProperties } from "../../../systems/properties/state";
+import { VisionBlock } from "../../../systems/properties/types";
 import { selectedSystem } from "../../../systems/selected";
 import { selectedState } from "../../../systems/selected/state";
 import { locationSettingsState } from "../../../systems/settings/location/state";
@@ -643,7 +644,7 @@ class SelectTool extends Tool implements ISelectTool {
                         this.hasFeature(SelectFeatures.Snapping, features) &&
                         !this.deltaChanged
                     ) {
-                        if (props.blocksVision) {
+                        if (props.blocksVision !== VisionBlock.No) {
                             visionState.deleteFromTriangulation({
                                 target: TriangulationTarget.VISION,
                                 shape: sel.id,
@@ -652,7 +653,7 @@ class SelectTool extends Tool implements ISelectTool {
 
                         sel.snapToGrid();
 
-                        if (props.blocksVision) {
+                        if (props.blocksVision !== VisionBlock.No) {
                             visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: sel.id });
                             recalcVision = true;
                         }
@@ -672,7 +673,7 @@ class SelectTool extends Tool implements ISelectTool {
                         this.operationReady = true;
                     }
 
-                    if (props.blocksVision) recalcVision = true;
+                    if (props.blocksVision !== VisionBlock.No) recalcVision = true;
                     if (props.blocksMovement) recalcMovement = true;
                     if (!sel.preventSync) updateList.push(sel);
                 }
@@ -699,13 +700,13 @@ class SelectTool extends Tool implements ISelectTool {
                         playerSettingsState.useSnapping(event) &&
                         this.hasFeature(SelectFeatures.Snapping, features)
                     ) {
-                        if (props.blocksVision)
+                        if (props.blocksVision !== VisionBlock.No)
                             visionState.deleteFromTriangulation({
                                 target: TriangulationTarget.VISION,
                                 shape: sel.id,
                             });
                         sel.resizeToGrid(this.resizePoint, ctrlOrCmdPressed(event));
-                        if (props.blocksVision) {
+                        if (props.blocksVision !== VisionBlock.No) {
                             visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: sel.id });
                             recalcVision = true;
                         }

--- a/client/src/game/ui/settings/shape/ExtraSettings.vue
+++ b/client/src/game/ui/settings/shape/ExtraSettings.vue
@@ -29,6 +29,7 @@ import { labelState } from "../../../systems/labels/state";
 import { playerSystem } from "../../../systems/players";
 import { DEFAULT_GRID_SIZE } from "../../../systems/position/state";
 import { propertiesSystem } from "../../../systems/properties";
+import { VisionBlock } from "../../../systems/properties/types";
 import { selectedState } from "../../../systems/selected/state";
 import { locationSettingsState } from "../../../systems/settings/location/state";
 import { visionState } from "../../../vision/state";
@@ -150,7 +151,7 @@ function applyDDraft(): void {
             UI_SYNC,
         );
 
-        propertiesSystem.setBlocksVision(shape.id, true, NO_SYNC, false);
+        propertiesSystem.setBlocksVision(shape.id, VisionBlock.Complete, NO_SYNC, false);
         propertiesSystem.setBlocksMovement(shape.id, true, NO_SYNC, false);
         fowLayer.addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO);
     }
@@ -168,7 +169,7 @@ function applyDDraft(): void {
         );
 
         if (portal.closed) {
-            propertiesSystem.setBlocksVision(shape.id, true, NO_SYNC, false);
+            propertiesSystem.setBlocksVision(shape.id, VisionBlock.Complete, NO_SYNC, false);
             propertiesSystem.setBlocksMovement(shape.id, true, NO_SYNC, false);
         }
         fowLayer.addShape(shape, SyncMode.FULL_SYNC, InvalidationMode.NO);

--- a/client/src/game/ui/settings/shape/PropertySettings.vue
+++ b/client/src/game/ui/settings/shape/PropertySettings.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../../core/components/ColourPicker.vue";
+import ToggleGroup from "../../../../core/components/ToggleGroup.vue";
 import { NO_SYNC, SERVER_SYNC, SyncMode } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { activeShapeStore } from "../../../../store/activeShape";
@@ -13,6 +14,7 @@ import type { CircularToken } from "../../../shapes/variants/circularToken";
 import { accessState } from "../../../systems/access/state";
 import { propertiesSystem } from "../../../systems/properties";
 import { getProperties, propertiesState } from "../../../systems/properties/state";
+import { VisionBlock, visionBlocks } from "../../../systems/properties/types";
 
 const { t } = useI18n();
 const modals = useModal();
@@ -56,9 +58,9 @@ function toggleBadge(event: Event): void {
     propertiesSystem.setShowBadge(propertiesState.raw.id!, (event.target as HTMLInputElement).checked, SERVER_SYNC);
 }
 
-function setBlocksVision(event: Event): void {
+function setBlocksVision(bv: VisionBlock): void {
     if (!owned.value) return;
-    propertiesSystem.setBlocksVision(propertiesState.raw.id!, (event.target as HTMLInputElement).checked, SERVER_SYNC);
+    propertiesSystem.setBlocksVision(propertiesState.raw.id!, bv, SERVER_SYNC);
 }
 
 function setBlocksMovement(event: Event): void {
@@ -221,14 +223,18 @@ async function changeAsset(): Promise<void> {
             <label for="shapeselectiondialog-visionblocker">
                 {{ t("game.ui.selection.edit_dialog.dialog.block_vision_light") }}
             </label>
-            <input
-                id="shapeselectiondialog-visionblocker"
-                type="checkbox"
-                :checked="propertiesState.reactive.blocksVision"
-                style="grid-column-start: toggle"
-                :disabled="!owned"
-                @click="setBlocksVision"
-            />
+            <div style="grid-column-start: toggle; position: relative">
+                <ToggleGroup
+                    id="kind-selector"
+                    :model-value="propertiesState.reactive.blocksVision"
+                    :options="visionBlocks.map((v) => ({ label: VisionBlock[v], value: v }))"
+                    :disabled="!owned"
+                    :multi-select="false"
+                    active-color="rgba(173, 216, 230, 0.5)"
+                    style="position: absolute; right: -10px; top: -22px; width: max-content"
+                    @update:model-value="(i) => setBlocksVision(i)"
+                />
+            </div>
         </div>
         <div class="row">
             <label for="shapeselectiondialog-moveblocker">

--- a/client/src/game/ui/tools/DrawTool.vue
+++ b/client/src/game/ui/tools/DrawTool.vue
@@ -3,9 +3,11 @@ import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../core/components/ColourPicker.vue";
+import ToggleGroup from "../../../core/components/ToggleGroup.vue";
 import { useModal } from "../../../core/plugins/modals/plugin";
 import { gameState } from "../../systems/game/state";
 import { DOOR_TOGGLE_MODES } from "../../systems/logic/door/models";
+import { VisionBlock, visionBlocks } from "../../systems/properties/types";
 import { DrawCategory, DrawMode, DrawShape, drawTool } from "../../tools/variants/draw";
 import LogicPermissions from "../settings/shape/LogicPermissions.vue";
 
@@ -23,18 +25,24 @@ const shapes = Object.values(DrawShape);
 const showPermissions = ref(false);
 
 const translationMapping = {
-    [DrawMode.Normal]: t("game.ui.tools.DrawTool.normal"),
-    [DrawMode.Reveal]: t("game.ui.tools.DrawTool.reveal"),
-    [DrawMode.Hide]: t("game.ui.tools.DrawTool.hide"),
-    [DrawMode.Erase]: t("game.ui.tools.DrawTool.erase"),
-    [DrawShape.Square]: t("game.ui.tools.DrawTool.square"),
-    [DrawShape.Circle]: t("game.ui.tools.DrawTool.circle"),
-    [DrawShape.Polygon]: t("game.ui.tools.DrawTool.draw-polygon"),
-    [DrawShape.Brush]: t("game.ui.tools.DrawTool.paint-brush"),
-    [DrawShape.Text]: t("game.ui.tools.DrawTool.text"),
-    [DrawCategory.Shape]: t("game.ui.tools.DrawTool.shape-category"),
-    [DrawCategory.Vision]: t("game.ui.tools.DrawTool.vision-category"),
-    [DrawCategory.Logic]: t("game.ui.tools.DrawTool.logic-category"),
+    modes: {
+        [DrawMode.Normal]: t("game.ui.tools.DrawTool.normal"),
+        [DrawMode.Reveal]: t("game.ui.tools.DrawTool.reveal"),
+        [DrawMode.Hide]: t("game.ui.tools.DrawTool.hide"),
+        [DrawMode.Erase]: t("game.ui.tools.DrawTool.erase"),
+    },
+    shapes: {
+        [DrawShape.Square]: t("game.ui.tools.DrawTool.square"),
+        [DrawShape.Circle]: t("game.ui.tools.DrawTool.circle"),
+        [DrawShape.Polygon]: t("game.ui.tools.DrawTool.draw-polygon"),
+        [DrawShape.Brush]: t("game.ui.tools.DrawTool.paint-brush"),
+        [DrawShape.Text]: t("game.ui.tools.DrawTool.text"),
+    },
+    categories: {
+        [DrawCategory.Shape]: t("game.ui.tools.DrawTool.shape-category"),
+        [DrawCategory.Vision]: t("game.ui.tools.DrawTool.vision-category"),
+        [DrawCategory.Logic]: t("game.ui.tools.DrawTool.logic-category"),
+    },
 };
 
 const showBorderColour = computed(() => {
@@ -45,7 +53,7 @@ const showBorderColour = computed(() => {
 
 const alerts = computed(() => {
     const a = new Set<string>();
-    if (drawTool.state.blocksMovement || drawTool.state.blocksVision) {
+    if (drawTool.state.blocksMovement || drawTool.state.blocksVision !== VisionBlock.No) {
         a.add(DrawCategory.Vision);
     }
     if (drawTool.state.isDoor) {
@@ -66,7 +74,7 @@ const alerts = computed(() => {
                     'draw-category-option-selected': drawTool.state.selectedCategory === category,
                     'draw-category-alert': drawTool.state.selectedCategory !== category && alerts.has(category),
                 }"
-                :title="translationMapping[category]"
+                :title="translationMapping.categories[category]"
                 @click="drawTool.state.selectedCategory = category"
             >
                 <font-awesome-icon :icon="category" />
@@ -80,7 +88,7 @@ const alerts = computed(() => {
                     :key="shape"
                     class="draw-select-option"
                     :class="{ 'draw-select-option-selected': drawTool.state.selectedShape === shape }"
-                    :title="translationMapping[shape]"
+                    :title="translationMapping.shapes[shape]"
                     @click="drawTool.state.selectedShape = shape"
                 >
                     <font-awesome-icon :icon="shape" />
@@ -120,7 +128,7 @@ const alerts = computed(() => {
         <template v-else-if="drawTool.state.selectedCategory === DrawCategory.Vision">
             <div class="draw-center-header">{{ t("game.ui.tools.DrawTool.mode") }}</div>
             <div v-show="gameState.reactive.isDm" class="draw-select-group">
-                <div
+                <!-- <div
                     v-for="mode in modes"
                     :key="mode"
                     class="draw-select-option"
@@ -128,19 +136,34 @@ const alerts = computed(() => {
                     @click="drawTool.state.selectedMode = mode"
                 >
                     {{ translationMapping[mode] }}
-                </div>
+                </div> -->
+                <ToggleGroup
+                    :model-value="drawTool.state.selectedMode"
+                    :options="modes.map((v) => ({ label: translationMapping.modes[v], value: v }))"
+                    active-color="#82c8a0"
+                    color="white"
+                    style="width: max-content"
+                    :multi-select="false"
+                    @update:model-value="(i) => (drawTool.state.selectedMode = i)"
+                />
             </div>
             <div class="draw-checkbox-line">
                 <div>{{ t("game.ui.selection.edit_dialog.dialog.block_vision_light") }}</div>
-                <div>
-                    <input
-                        v-model="drawTool.state.blocksVision"
-                        type="checkbox"
-                        :disabled="drawTool.state.selectedMode !== 'normal'"
-                        @click="drawTool.state.blocksVision = !drawTool.state.blocksVision"
-                    />
-                </div>
             </div>
+            <div style="display: flex">
+                <div style="flex-grow: 1"></div>
+                <ToggleGroup
+                    :model-value="drawTool.state.blocksVision"
+                    :options="visionBlocks.map((v) => ({ label: VisionBlock[v], value: v }))"
+                    :disabled="drawTool.state.selectedMode !== 'normal'"
+                    :multi-select="false"
+                    active-color="#82c8a0"
+                    color="white"
+                    style="width: max-content"
+                    @update:model-value="(i) => (drawTool.state.blocksVision = i)"
+                />
+            </div>
+
             <div class="draw-checkbox-line">
                 <div>{{ t("game.ui.selection.edit_dialog.dialog.block_movement") }}</div>
                 <div>

--- a/client/src/game/vision/iterative.ts
+++ b/client/src/game/vision/iterative.ts
@@ -187,7 +187,7 @@ export class IterativeDelete {
             };
             this.newConstraints.push({ edge: constraint, changed: false, onPath });
             if (edgeCovered) continue;
-            const edgeShapes = [...filter(vertex.shapes, (sh) => ccwv.shapes.has(sh) && sh !== this.shape)];
+            const edgeShapes = [...filter(vertex.shapes, (sh) => ccwv.shapes.has(sh) && sh !== this.shape.id)];
             if (edgeShapes.length === 0) this.addEdge(edge);
         }
         this.handledPoints.push(vertex.point!);

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -240,8 +240,8 @@ class VisionState extends Store<State> {
         if (shape.floorId !== undefined) {
             const cdt = this.getCDT(target, shape.floorId);
             const { va, vb } = cdt.insertConstraint(pa, pb);
-            va.shapes.add(shape);
-            vb.shapes.add(shape);
+            va.shapes.add(shape.id);
+            vb.shapes.add(shape.id);
             cdt.tds.addTriagVertices(shape.id, va, vb);
         }
     }

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -15,6 +15,7 @@ import type { Aura, AuraId } from "../systems/auras/models";
 import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
 import { getProperties } from "../systems/properties/state";
+import { VisionBlock } from "../systems/properties/types";
 
 import { CDT } from "./cdt";
 import { IterativeDelete } from "./iterative";
@@ -280,7 +281,7 @@ class VisionState extends Store<State> {
         if (props.blocksMovement) {
             this.moveBlocker(TriangulationTarget.MOVEMENT, id, oldFloor, newFloor, true);
         }
-        if (props.blocksVision) {
+        if (props.blocksVision !== VisionBlock.No) {
             this.moveBlocker(TriangulationTarget.VISION, id, oldFloor, newFloor, true);
         }
         this.moveVisionSource(id, auraSystem.getAll(id, true), oldFloor, newFloor);

--- a/client/src/game/vision/tds.ts
+++ b/client/src/game/vision/tds.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-duplicate-enum-values */
 import { equalPoints } from "../../core/math";
 import type { LocalId } from "../id";
-import type { IShape } from "../interfaces/shape";
 
 import type { CDT } from "./cdt";
 import { ccw, cw, orientation, sideOfOrientedCircleP, ulp } from "./triag";
@@ -160,7 +159,7 @@ export class Vertex {
     infinite = false;
     private _point: Point | undefined;
     triangle: Triangle | undefined;
-    shapes = new Set<IShape>();
+    shapes = new Set<LocalId>();
 
     constructor(point?: Point) {
         this._point = point;

--- a/client/src/game/vision/te.ts
+++ b/client/src/game/vision/te.ts
@@ -1,4 +1,5 @@
 import type { GlobalPoint } from "../../core/geometry";
+import type { LocalId } from "../id";
 import type { FloorId } from "../models/floor";
 import { drawPolygon } from "../rendering/basic";
 
@@ -14,34 +15,44 @@ export function computeVisibility(
     target: TriangulationTarget,
     floor: FloorId,
     drawt?: boolean,
-): Point[] {
+): { visibility: Point[]; shapeHits: LocalId[] } {
     if (drawt === undefined) drawt = visionState.drawTeContour;
     // console.time("CV");
     const Q: Point = [q.x, q.y];
     const rawOutput: Point[] = [];
+    const shapeHits: LocalId[] = [];
     const triangle = visionState.getCDT(target, floor).locate(Q, null).loc;
     if (triangle === null) {
         console.error("Triangle not found");
-        return [];
+        return { visibility: [], shapeHits: [] };
     }
     // triangle.fill();
-    rawOutput.push(triangle.vertices[1]!.point!);
-    if (!triangle.isConstrained(0))
-        expandEdge(Q, triangle.vertices[2]!.point!, triangle.vertices[1]!.point!, triangle, 0, rawOutput);
-    rawOutput.push(triangle.vertices[2]!.point!);
-    if (!triangle.isConstrained(1))
-        expandEdge(Q, triangle.vertices[0]!.point!, triangle.vertices[2]!.point!, triangle, 1, rawOutput);
-    rawOutput.push(triangle.vertices[0]!.point!);
-    if (!triangle.isConstrained(2))
-        expandEdge(Q, triangle.vertices[1]!.point!, triangle.vertices[0]!.point!, triangle, 2, rawOutput);
-    // console.timeEnd("CV");
+    for (let i = 0; i < 3; i++) {
+        const nextI = (i + 1) % 3;
+        const prevI = (i + 2) % 3;
+        const vNext = triangle.vertices[nextI]!;
+        const vPrev = triangle.vertices[prevI]!;
+        rawOutput.push(vNext.point!);
+        shapeHits.push(...vNext.shapes);
+        if (!triangle.isConstrained(i)) {
+            expandEdge(Q, vPrev.point!, vNext.point!, triangle, i, rawOutput, shapeHits);
+        }
+    }
 
     if (drawt) drawPolygon(rawOutput, { colour: "red" });
 
-    return rawOutput;
+    return { visibility: rawOutput, shapeHits };
 }
 
-function expandEdge(q: Point, left: Point, right: Point, fh: Triangle, index: number, rawOutput: Point[]): void {
+function expandEdge(
+    q: Point,
+    left: Point,
+    right: Point,
+    fh: Triangle,
+    index: number,
+    rawOutput: Point[],
+    shapeHits: LocalId[],
+): void {
     // fh.edge(index).draw();
     const nfh = fh.neighbours[index]!;
     // nfh.fill("rgba(255, 0, 0, 0.25)");
@@ -81,13 +92,14 @@ function expandEdge(q: Point, left: Point, right: Point, fh: Triangle, index: nu
             if (right !== rvh.point!) rawOutput.push(raySegIntersection(q, right, nvh.point!, rvh.point!));
             if (lo === Sign.COUNTERCLOCKWISE) rawOutput.push(raySegIntersection(q, left, nvh.point!, rvh.point!));
         } else {
-            if (lo === Sign.COUNTERCLOCKWISE) return expandEdge(q, left, right, nfh, rIndex, rawOutput);
-            else expandEdge(q, nvh.point!, right, nfh, rIndex, rawOutput);
+            if (lo === Sign.COUNTERCLOCKWISE) return expandEdge(q, left, right, nfh, rIndex, rawOutput, shapeHits);
+            else expandEdge(q, nvh.point!, right, nfh, rIndex, rawOutput, shapeHits);
         }
     }
 
     if (ro !== Sign.CLOCKWISE && lo !== Sign.COUNTERCLOCKWISE) {
         rawOutput.push(nvh.point!);
+        shapeHits.push(...nvh.shapes);
     }
 
     if (lo === Sign.CLOCKWISE) {
@@ -101,9 +113,9 @@ function expandEdge(q: Point, left: Point, right: Point, fh: Triangle, index: nu
             return;
         } else {
             if (ro === Sign.CLOCKWISE) {
-                return expandEdge(q, left, right, nfh, lIndex, rawOutput);
+                return expandEdge(q, left, right, nfh, lIndex, rawOutput, shapeHits);
             } else {
-                return expandEdge(q, left, nvh.point!, nfh, lIndex, rawOutput);
+                return expandEdge(q, left, nvh.point!, nfh, lIndex, rawOutput, shapeHits);
             }
         }
     }

--- a/server/generate_types.sh
+++ b/server/generate_types.sh
@@ -10,6 +10,7 @@ sed -i 's/"CharacterId"/CharacterId/g' ../client/src/apiTypes.ts
 sed -i 's/"LayerName"/LayerName/g' ../client/src/apiTypes.ts
 sed -i 's/"AssetId"/AssetId/g' ../client/src/apiTypes.ts
 sed -i 's/"Role"/Role/g' ../client/src/apiTypes.ts
+sed -i 's/"VisionBlock"/VisionBlock/g' ../client/src/apiTypes.ts
 sed -i '1s/^/'\
 'import type { AssetId } from ".\/assetManager\/models";\n'\
 'import type { GlobalId } from ".\/game\/id";\n'\
@@ -19,6 +20,7 @@ sed -i '1s/^/'\
 'import type { CharacterId } from ".\/game\/systems\/characters\/models";\n'\
 'import type { ClientId } from ".\/game\/systems\/client\/models";\n'\
 'import type { PlayerId } from ".\/game\/systems\/players\/models";\n'\
+'import type { VisionBlock } from ".\/game\/systems\/properties\/types";\n'\
 'import type { TrackerId } from ".\/game\/systems\/trackers\/models";\n'\
 '\n'\
 'export type ApiShape = ApiAssetRectShape | ApiRectShape | ApiCircleShape | ApiCircularTokenShape | ApiPolygonShape | ApiTextShape | ApiLineShape | ApiToggleCompositeShape\n'\

--- a/server/src/api/models/shape/options.py
+++ b/server/src/api/models/shape/options.py
@@ -30,6 +30,11 @@ class ShapeSetOptionalStringValue(TypeIdModel):
     value: str | None = Field(..., noneAsNull=True)
 
 
+class ShapeSetIntegerValue(TypeIdModel):
+    shape: str = Field(typeId="GlobalId")
+    value: int
+
+
 class Permissions(BaseModel):
     enabled: list[str]
     request: list[str]

--- a/server/src/api/models/shape/shape.py
+++ b/server/src/api/models/shape/shape.py
@@ -17,7 +17,7 @@ class ApiCoreShape(TypeIdModel):
     name_visible: bool
     fill_colour: str
     stroke_colour: str
-    vision_obstruction: bool
+    vision_obstruction: int = Field(..., typeId="VisionBlock")
     movement_obstruction: bool
     is_token: bool
     annotation: str

--- a/server/src/api/socket/shape/options.py
+++ b/server/src/api/socket/shape/options.py
@@ -16,6 +16,7 @@ from ...models.aura import ApiAura, ApiOptionalAura, AuraMove, ShapeSetAuraValue
 from ...models.shape.options import (
     ShapeSetBooleanValue,
     ShapeSetDoorToggleModeValue,
+    ShapeSetIntegerValue,
     ShapeSetOptionalStringValue,
     ShapeSetPermissionValue,
     ShapeSetStringValue,
@@ -172,7 +173,7 @@ async def set_movement_block(sid: str, raw_data: Any):
 @sio.on("Shape.Options.VisionBlock.Set", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def set_vision_block(sid: str, raw_data: Any):
-    data = ShapeSetBooleanValue(**raw_data)
+    data = ShapeSetIntegerValue(**raw_data)
 
     pr: PlayerRoom = game_state.get(sid)
 

--- a/server/src/db/models/shape.py
+++ b/server/src/db/models/shape.py
@@ -2,7 +2,14 @@ import json
 from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 from uuid import uuid4
 
-from peewee import BooleanField, FloatField, ForeignKeyField, IntegerField, TextField
+from peewee import (
+    BooleanField,
+    FloatField,
+    ForeignKeyField,
+    IntegerField,
+    SmallIntegerField,
+    TextField,
+)
 
 from ...api.models.common import PositionTuple
 from ..base import BaseDbModel
@@ -58,7 +65,7 @@ class Shape(BaseDbModel):
     name_visible = cast(bool, BooleanField(default=False))
     fill_colour = cast(str, TextField(default="#000"))
     stroke_colour = cast(str, TextField(default="#fff"))
-    vision_obstruction = cast(bool, BooleanField(default=False))
+    vision_obstruction = cast(int, SmallIntegerField(default=False))
     movement_obstruction = cast(bool, BooleanField(default=False))
     is_token = cast(bool, BooleanField(default=False))
     annotation = cast(str, TextField(default=""))


### PR DESCRIPTION
This PR is an attempt to tackle #1324.

## Goal

With this implementation _all_ vision blocking shapes that are _closed_ will be visible themselves, but still block everything behind them.

This fixes a longstanding issue where you can't see the pillar/tree/whatever that is blocking the vision, instead your vision is just cutoff. As a DM you could try to give some glimpse by making the vision blocking shape slightly smaller, but this is an annoying balancing act.

## What are closed shapes

It's important to focus on the _closed_ aspect. What I mean with this is shapes that actually fill their content.

Most basic shapes fit this criterion (i.e. rectangles, circles, assets).

Some shapes do not fit this criterion (e.g. Text, Brush tool, and some shapes you can't manually draw (e.g. ruler lines etc), these shapes tend to not be interesting for vision blocking anyway.

That leaves us with the polygon tool. This has always had an explicit "closed polygon" toggle that dictates whether the content should be filled and also automatically closes the polygon if you didn't do so yourself. The polygon tool's behaviour thus will depend on its closed status.

## Why only closed shapes

This is simply because I need the fill for how I ended up implementing it. Open shapes can be too wild and unpredicting to make a guess that it's better to leave them out entirely.

As said earlier, most open shapes are not interesting to begin with. Only the open polygon tool is one I use a lot myself to draw walls.

The result is that open polygons will still behave as they did before, they form a hard-block of vision and the nice thing is, this gives us an alternative for when we explicitly don't want the self-excluding behaviour.

## What about the issues mentioned in #1324

I posed 2 problems in the linked issue I had a year ago when I last attempted to solve the same problem.

(1) Although excluding vision-blocking shapes from themselves is nice for small objects like pillars etc, it can potentially have drawbacks when used for more complext things. E.g. if all walls are drawn with rectangles that now can be looked into up to the other end of the wall, potential secret rooms can be spoiled by the notion that the wall suddenly becomes smaller

This still to a certain degree is an 'issue'. However:
- I personally always draw my walls with open polygons, given that they are not impacted, my secret rooms will actually not be spoiled at all
- I'm still pondering making this system either opt-in/opt-out for individual shapes instead of hard applying it to everything. In this case it's just an extra configuration thing and you set a default that makes most sense to you.

(2) I had some version working in the past, but it had the downside that if a part of a vision-blocking shape was in vision, the entire shape would become visible even if your light aura didn't reach all the way.

This implementation no longer has this issue :D

## Todo

Main todos are:
- think about opt-in/opt-out
- verify behaviour when things move, I'm sure I need to do some invalidation still
- do a check on performance impact

## Example

Example player vision:
![image](https://github.com/Kruptein/PlanarAlly/assets/1814713/d49d060a-88ff-440b-be94-eb234807d771)

FOW behind the scenes, notice the pillar is a full circle, the door is a full rectangle, but the walls are _open_ polygons.
![image](https://github.com/Kruptein/PlanarAlly/assets/1814713/230222b8-cf7f-45f2-94a3-8efa76125096)
