### PR TITLE
bug(Template): Fix vision_obstruction migration

### DIFF
--- a/client/src/game/shapes/templates.ts
+++ b/client/src/game/shapes/templates.ts
@@ -10,6 +10,12 @@ import { createEmptyTracker } from "../systems/trackers/utils";
 import type { SHAPE_TYPE } from "./types";
 
 export function applyTemplate<T extends ApiShape>(shape: T, template: BaseTemplate & { options?: string }): T {
+    // This is a patch for a migration of vision_obstruction from boolean to number
+    // todo: this should be addressed in a better way
+    if (template.vision_obstruction !== undefined && typeof template.vision_obstruction === "boolean") {
+        template.vision_obstruction = template.vision_obstruction ? 1 : 0;
+    }
+
     // should be shape[key], but this is something that TS cannot correctly infer (issue #31445)
     for (const key of BaseTemplateStrings) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
For the new vision mode a change was made from boolean to number representation to accomodate multiple types.

When dropping assets on the map this was not taken into account. This PR fixes this with a bandaid.

A more proper patch system for templates should be made.