### PR TITLE
feat(LocationSettings): Add drop ratio to grid settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Added
+
+-   New location grid setting: drop ratio
+    -   This is used to indicate how shapes with size info dropped on the map should be resized
+    -   (e.g. a goblin_2x2 will take op 2x2 cells in any setup with dropRatio 1, with dropRatio 0.5 however it would only take up 1x1)
+    -   This addresses an issue where this was not properly working with non ft setups
+
 ### Changed
 
 -   Vision blocking shapes will now ignore themselves if they are closed

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -769,6 +769,7 @@ export interface ApiOptionalLocationOptions {
   ground_map_background?: string | null;
   underground_map_background?: string | null;
   limit_movement_during_initiative?: boolean | null;
+  drop_ratio?: number | null;
 }
 export interface ApiLocationCore {
   id: number;
@@ -792,6 +793,7 @@ export interface ApiLocationOptions {
   ground_map_background: string;
   underground_map_background: string;
   limit_movement_during_initiative: boolean;
+  drop_ratio: number;
 }
 export interface ApiSpawnInfo {
   position: PositionTuple;

--- a/client/src/game/api/emits/location.ts
+++ b/client/src/game/api/emits/location.ts
@@ -1,5 +1,10 @@
-import type { ApiSpawnInfo, LocationClone, LocationOptionsSet, LocationRename } from "../../../apiTypes";
-import type { ServerLocationOptions } from "../../systems/settings/location/models";
+import type {
+    ApiLocationOptions,
+    ApiSpawnInfo,
+    LocationClone,
+    LocationOptionsSet,
+    LocationRename,
+} from "../../../apiTypes";
 import { wrapSocket } from "../helpers";
 import { socket } from "../socket";
 
@@ -22,9 +27,9 @@ export async function requestSpawnInfo(location: number): Promise<ApiSpawnInfo[]
     });
 }
 
-export function sendLocationOption<T extends keyof ServerLocationOptions>(
+export function sendLocationOption<T extends keyof ApiLocationOptions>(
     key: T,
-    value: ServerLocationOptions[T] | undefined,
+    value: ApiLocationOptions[T] | undefined,
     location: number | undefined,
 ): void {
     const data: LocationOptionsSet = { options: { [key]: value ?? null }, location };

--- a/client/src/game/api/events/location.ts
+++ b/client/src/game/api/events/location.ts
@@ -60,6 +60,8 @@ function setLocationOptions(id: number | undefined, options: ApiOptionalLocation
         locationSettingsSystem.setUnitSize(options.unit_size ?? undefined, id, false);
     if (overwrite_all || options.unit_size_unit !== undefined)
         locationSettingsSystem.setUnitSizeUnit(options.unit_size_unit ?? undefined, id, false);
+    if (overwrite_all || options.drop_ratio !== undefined)
+        locationSettingsSystem.setDropRatio(options.drop_ratio ?? undefined, id, false);
 
     // VISION
 

--- a/client/src/game/dropAsset.ts
+++ b/client/src/game/dropAsset.ts
@@ -98,6 +98,7 @@ export async function dropAsset(
             if (dimensions?.groups !== undefined) {
                 const dimX = Number.parseInt(dimensions.groups.x ?? "0");
                 const dimY = Number.parseInt(dimensions.groups.y ?? "0");
+                // DropRatio is already accounted for in applyTemplate!!
                 template = {
                     width: dimX * DEFAULT_GRID_SIZE,
                     height: dimY * DEFAULT_GRID_SIZE,

--- a/client/src/game/shapes/templates.ts
+++ b/client/src/game/shapes/templates.ts
@@ -38,7 +38,8 @@ export function applyTemplate<T extends ApiShape>(shape: T, template: BaseTempla
         shape.auras.push({ ...defaultAura, ...auraTemplate });
     }
 
-    const gridRescale = 5 / locationSettingsState.raw.unitSize.value;
+    // This also handles dropAsset rescaling
+    const gridRescale = locationSettingsState.raw.dropRatio.value;
 
     // Shape specific keys
     for (const key of getTemplateKeys(shape.type_ as SHAPE_TYPE)) {

--- a/client/src/game/systems/settings/location/index.ts
+++ b/client/src/game/systems/settings/location/index.ts
@@ -95,6 +95,12 @@ class LocationSettingsSystem implements System {
         if (sync) sendLocationOption("unit_size_unit", unitSizeUnit, location);
     }
 
+    setDropRatio(dropRatio: number | undefined, location: number | undefined, sync: boolean): void {
+        if (!this.setValue($.dropRatio, dropRatio, location)) return;
+
+        if (sync) sendLocationOption("drop_ratio", dropRatio, location);
+    }
+
     // VISION
 
     setFullFow(fullFow: boolean | undefined, location: number | undefined, sync: boolean): void {

--- a/client/src/game/systems/settings/location/models.ts
+++ b/client/src/game/systems/settings/location/models.ts
@@ -11,26 +11,6 @@ export interface WithLocationDefault<T> {
     location: Record<number, T | undefined>;
 }
 
-export interface ServerLocationOptions {
-    use_grid: boolean;
-    grid_type: string;
-    unit_size: number;
-    unit_size_unit: string;
-    full_fow: boolean;
-    fow_opacity: number;
-    fow_los: boolean;
-    vision_mode: string;
-    vision_min_range: number;
-    vision_max_range: number;
-    spawn_locations: string;
-    move_player_on_token_change: boolean;
-    limit_movement_during_initiative: boolean;
-
-    air_map_background: string;
-    ground_map_background: string;
-    underground_map_background: string;
-}
-
 export interface LocationOptions {
     useGrid: boolean;
     gridType: string;
@@ -47,6 +27,7 @@ export interface LocationOptions {
     spawnLocations: GlobalId[];
     movePlayerOnTokenChange: boolean;
     limitMovementDuringInitiative: boolean;
+    dropRatio: number;
 
     airMapBackground: string;
     groundMapBackground: string;

--- a/client/src/game/systems/settings/location/state.ts
+++ b/client/src/game/systems/settings/location/state.ts
@@ -23,6 +23,7 @@ function getInitState(): State {
         visionMinRange: init(0),
         visionMode: init(""),
         limitMovementDuringInitiative: init(false),
+        dropRatio: init(1),
 
         airMapBackground: init("none"),
         groundMapBackground: init("none"),

--- a/client/src/game/ui/settings/location/GridSettings.vue
+++ b/client/src/game/ui/settings/location/GridSettings.vue
@@ -51,6 +51,15 @@ const unitSizeUnit = computed({
     },
 });
 
+const dropRatio = computed({
+    get() {
+        return getOption($.dropRatio, location.value).value;
+    },
+    set(dropRatio: number | undefined) {
+        lss.setDropRatio(dropRatio, location.value, true);
+    },
+});
+
 function o(k: any): boolean {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return getOption(k, location.value).override !== undefined;
@@ -132,6 +141,27 @@ function o(k: any): boolean {
                 v-if="!global && o($.unitSize)"
                 :title="t('game.ui.settings.common.reset_default')"
                 @click="unitSize = undefined"
+            >
+                <font-awesome-icon icon="times-circle" />
+            </div>
+            <div v-else></div>
+        </div>
+        <div class="row" :class="{ overwritten: !global && o($.dropRatio) }">
+            <div>
+                <label
+                    :for="'dropRatioInput-' + location"
+                    title="The drop ratio is used for shapes with size information (e.g. goblin_1x1). The drop ratio is applied to this info to determine the final size."
+                >
+                    Drop Ratio
+                </label>
+            </div>
+            <div>
+                <input :id="'dropRatioInput-' + location" v-model.number="dropRatio" type="number" step="any" />
+            </div>
+            <div
+                v-if="!global && o($.dropRatio)"
+                :title="t('game.ui.settings.common.reset_default')"
+                @click="dropRatio = undefined"
             >
                 <font-awesome-icon icon="times-circle" />
             </div>

--- a/server/src/api/models/location/settings.py
+++ b/server/src/api/models/location/settings.py
@@ -21,6 +21,7 @@ class ApiLocationOptions(BaseModel):
     ground_map_background: str
     underground_map_background: str
     limit_movement_during_initiative: bool
+    drop_ratio: float
 
 
 class ApiOptionalLocationOptions(TypeIdModel):
@@ -41,6 +42,7 @@ class ApiOptionalLocationOptions(TypeIdModel):
     ground_map_background: str | None = Field(default=None, noneAsNull=True)
     underground_map_background: str | None = Field(default=None, noneAsNull=True)
     limit_movement_during_initiative: bool | None = Field(default=None, noneAsNull=True)
+    drop_ratio: float | None = Field(default=None, noneAsNull=True)
 
 
 class LocationSettingsSet(BaseModel):

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -64,6 +64,7 @@ class LocationOptionKeys(TypedDict, total=False):
     vision_min_range: float
     vision_max_range: float
     spawn_locations: str
+    drop_ratio: float
 
 
 @sio.on("Location.Load", namespace=GAME_NS)

--- a/server/src/db/models/location_options.py
+++ b/server/src/db/models/location_options.py
@@ -30,6 +30,7 @@ class LocationOptions(BaseDbModel):
     limit_movement_during_initiative = cast(
         bool | None, BooleanField(default=False, null=True)
     )
+    drop_ratio = cast(float | None, FloatField(default=1.0, null=True))
 
     @classmethod
     def create_empty(cls):
@@ -49,6 +50,7 @@ class LocationOptions(BaseDbModel):
             ground_map_background=None,
             underground_map_background=None,
             limit_movement_during_initiative=None,
+            drop_ratio=None,
         )
 
     @overload
@@ -86,4 +88,5 @@ class LocationOptions(BaseDbModel):
             underground_map_background=self.underground_map_background,  # type: ignore
             limit_movement_during_initiative=self.limit_movement_during_initiative,  # type: ignore
             spawn_locations=self.spawn_locations,
+            drop_ratio=self.drop_ratio,  # type: ignore
         )

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 89
+SAVE_VERSION = 90
 
 import json
 import logging
@@ -611,6 +611,15 @@ def upgrade(db: SqliteExtDatabase, version: int):
                 'INSERT INTO "shape" ("uuid", "layer_id", "type_", "x", "y", "name", "name_visible", "fill_colour", "stroke_colour", "vision_obstruction", "movement_obstruction", "is_token", "draw_operator", "index", "options", "badge", "show_badge", "default_edit_access", "default_vision_access", "is_invisible", "default_movement_access", "is_locked", "angle", "stroke_width", "asset_id", "group_id", "ignore_zoom_size", "is_defeated", "is_door", "is_teleport_zone", "character_id") SELECT "uuid", "layer_id", "type_", "x", "y", "name", "name_visible", "fill_colour", "stroke_colour", "vision_obstruction", "movement_obstruction", "is_token", "draw_operator", "index", "options", "badge", "show_badge", "default_edit_access", "default_vision_access", "is_invisible", "default_movement_access", "is_locked", "angle", "stroke_width", "asset_id", "group_id", "ignore_zoom_size", "is_defeated", "is_door", "is_teleport_zone", "character_id" FROM _shape_88'
             )
             db.execute_sql("DROP TABLE _shape_88")
+    elif version == 89:
+        # Add LocationOptions.drop_ratio
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE location_options ADD COLUMN drop_ratio REAL DEFAULT 1"
+            )
+            db.execute_sql(
+                "UPDATE location_options SET drop_ratio = NULL WHERE id NOT IN (SELECT default_options_id FROM room)"
+            )
     else:
         raise UnknownVersionException(
             f"No upgrade code for save format {version} was found."


### PR DESCRIPTION
**[This performs a database migration]**

This is a new feature that at the same time also is a bugfix.
It adds a new setting to the location grid setting.

context:
PA has an option to auto scale assets when dropped if they have a specific format in their name. For example goblin_1x1 should in normal circumstances fit exactly 1 grid cell, dragon_3x3 should be resized to 3 by 3 grid cells.

The existing implementation was erroneously using a method to do this based on the common 5ft system to automatically adjust this when a location had a bigger size (e.g. 10ft maps would automatically make something_2x2 fit in 1 cell)

This however completely breaks for everything that does not use the 5ft system, be it because you use SI units or because your system uses something custom or you enjoy defining your sizes in terms of pizzas.

The simple fix is to disable that system, but then dropping assets on maps that have a different scale no longer works properly. So to address that as well, a new setting is added that defines how these assets should be scaled when dropped on the map.

A drop ratio of 1 is the default, it means the asset will resize purely on it's specified dimensions.
A drop ratio of 0.5 would resize a something_2x2 to 1x1.

This fixes #1345.