### PR TITLE
bug(Character): Fix multiple variant bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ tech changes will usually be stripped from release notes for the public
 -   Polygon edit UI: was not taking rotation of shape into account
 -   Teleport: shapes would not be removed on the old location until a refresh
 -   Dice tool: would not send zero results when dice list is empty
+-   Character: a collection of bugs with variants have been fixed
 -   [server] log spam of "unknown" shape when temporary shapes are moved
 
 ## [2023.3.0] - 2023-09-17

--- a/client/src/game/interfaces/shapes/toggleComposite.ts
+++ b/client/src/game/interfaces/shapes/toggleComposite.ts
@@ -4,6 +4,7 @@ import type { IShape } from "../shape";
 
 export interface IToggleComposite extends IShape {
     get variants(): readonly { id: LocalId; name: string }[];
+    get activeVariant(): LocalId;
 
     addVariant: (uuid: LocalId, name: string, sync: boolean) => void;
     removeVariant: (id: LocalId, syncTo: Sync) => void;

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -54,6 +54,10 @@ export class ToggleComposite extends Shape implements IToggleComposite {
         return this._variants;
     }
 
+    get activeVariant(): LocalId {
+        return this.active_variant;
+    }
+
     addVariant(id: LocalId, name: string, sync: boolean): void {
         const variant = { id, name };
         this._variants.push(variant);

--- a/client/src/game/systems/characters/index.ts
+++ b/client/src/game/systems/characters/index.ts
@@ -6,6 +6,7 @@ import type { ApiCharacter } from "../../../apiTypes";
 import { find } from "../../../core/iter";
 import { getGlobalId, getLocalId, getShape, type LocalId } from "../../id";
 import type { IShape } from "../../interfaces/shape";
+import type { IToggleComposite } from "../../interfaces/shapes/toggleComposite";
 import { selectedState } from "../selected/state";
 
 import type { CharacterId } from "./models";
@@ -64,7 +65,14 @@ class CharacterSystem implements ShapeSystem {
         const shapeId = mutable.characters.get(character)?.shapeId;
         if (shapeId) {
             const localId = getLocalId(shapeId, false);
-            if (localId) return getShape(localId);
+            if (localId) {
+                const shape = getShape(localId);
+                if (shape === undefined) return undefined;
+                if (shape.type === "togglecomposite") {
+                    return getShape((shape as IToggleComposite).activeVariant);
+                }
+                return shape;
+            }
         }
     }
 }

--- a/client/src/game/ui/settings/shape/VariantSwitcher.vue
+++ b/client/src/game/ui/settings/shape/VariantSwitcher.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, toRef } from "vue";
+import { useToast } from "vue-toastification";
 
 import { cloneP } from "../../../../core/geometry";
 import { InvalidationMode, SERVER_SYNC, SyncMode } from "../../../../core/models/types";
@@ -12,6 +13,7 @@ import { compositeState } from "../../../layers/state";
 import { ToggleComposite } from "../../../shapes/variants/toggleComposite";
 
 const modals = useModal();
+const toast = useToast();
 
 const vState = activeShapeStore.state;
 
@@ -65,14 +67,17 @@ async function addVariant(): Promise<void> {
         return;
     }
 
+    const name = await modals.prompt("What name should this variant have?", "Name variant");
+    if (name === undefined) return;
+
     const newShape = await dropAsset(
         { imageSource: `/static/assets/${asset.fileHash}`, assetId: asset.id },
         shape.refPoint,
     );
-    if (newShape === undefined) return;
-
-    const name = await modals.prompt("What name should this variant have?", "Name variant");
-    if (name === undefined) return;
+    if (newShape === undefined) {
+        toast.error("Something went wrong trying to add this variant.");
+        return;
+    }
 
     let parent = compositeParent.value;
     if (parent === undefined) {

--- a/server/src/db/models/composite_shape_association.py
+++ b/server/src/db/models/composite_shape_association.py
@@ -10,4 +10,3 @@ class CompositeShapeAssociation(BaseDbModel):
     variant = ForeignKeyField(Shape, backref="composite_parent", on_delete="CASCADE")
     parent = ForeignKeyField(Shape, backref="shape_variants", on_delete="CASCADE")
     name = cast(str, TextField())
-    name = cast(str, TextField())


### PR DESCRIPTION
Variants/ToggleComposites are a common source of issues and the character system wanted to experience this as well.

This PR closes a bunch of bugs related to the use of shapes with variants as characters.

Variants are completely separate shapes behind the scenes currently and only one of them is getting marked as a character, which ended up causing funky bugs when another variant is active and you try to interact with the character system. This ranged from not being able to move a character by dropping it using the menu to actually removing shapes when deleting them instead of preserving them for later use.

This PR mostly prevents issues with shapes that are not bugged yet.  So if you have some weird shenanigans already going on, you might have to remake the shape/character and get rid of the old ones.


As the variants system often introduces issues I'm likely going to do an overhaul to the entire shape system in the release following the next one so that these kind of issues are no longer a thing or will be caught way earlier.