### PR TITLE
fix(TrackerSettings): Show scrollbar for long contents

### DIFF
--- a/client/src/game/ui/settings/shape/TrackerSettings.vue
+++ b/client/src/game/ui/settings/shape/TrackerSettings.vue
@@ -377,6 +377,8 @@ function toggleCompositeAura(shape: LocalId, auraId: AuraId): void {
 #trackers-panel {
     background-color: white;
     min-width: 15vw;
+    max-height: 60vh;
+    overflow-y: auto;
 }
 
 input[type="text"] {


### PR DESCRIPTION
I make the tracker tab have a max height of 60vh and add scrollbar to it. Now long list of trackers is easier to access.