### PR TITLE
bug(RotationSlider): Fix anchor position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ tech changes will usually be stripped from release notes for the public
 -   Character: a collection of bugs with variants have been fixed
 -   Trackers: add max-height and scrolling
 -   RotationSlider: fix sync issues
+-   RotationSlider: fix slider anchor not sticking to the rail under certain angles
 -   [server] log spam of "unknown" shape when temporary shapes are moved
 
 ## [2023.3.0] - 2023-09-17

--- a/client/src/core/components/RotationSlider.vue
+++ b/client/src/core/components/RotationSlider.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<(e: "change" | "input", angle: number) => void>();
 const circle = ref<HTMLDivElement | null>(null);
 
 let active = false;
-const radius = 10;
+const radius = 8; // circle is 20px - 2px border diameter -> 8px radius
 const radianAngle = ref(0);
 
 const degreeAngle = computed({


### PR DESCRIPTION
The anchor that shows the current angle on the rotation slider would not stick properly to the rail for certain angles.