### PR TITLE
feat(Notes): Change icons used for popouts

### DIFF
--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -1,6 +1,13 @@
 import { dom, library } from "@fortawesome/fontawesome-svg-core";
 import { faDAndD, faDiscord, faGithub, faPatreon } from "@fortawesome/free-brands-svg-icons";
-import { faCompass, faCopy, faSquareMinus, faSquarePlus, faWindowClose } from "@fortawesome/free-regular-svg-icons";
+import {
+    faCompass,
+    faCopy,
+    faSquareMinus,
+    faSquarePlus,
+    faWindowClose,
+    faWindowRestore,
+} from "@fortawesome/free-regular-svg-icons";
 import {
     faAngleDoubleLeft,
     faArchive,
@@ -61,7 +68,6 @@ import {
     faUnlink,
     faUnlock,
     faUpload,
-    faUpRightFromSquare,
     faUserCircle,
     faUserTag,
     faUsers,
@@ -137,12 +143,12 @@ export function loadFontAwesome(): void {
         faUnlink,
         faUnlock,
         faUpload,
-        faUpRightFromSquare,
         faUserTag,
         faUserCircle,
         faUsers,
         faVideo,
         faWindowClose,
+        faWindowRestore,
     );
 
     dom.watch();

--- a/client/src/game/ui/SelectionInfo.vue
+++ b/client/src/game/ui/SelectionInfo.vue
@@ -131,15 +131,23 @@ function annotate(note: DeepReadonly<ClientNote>): void {
                                 <button
                                     class="slider-checkbox"
                                     :aria-pressed="aura.active"
-                                    @click="auraSystem.update(aura.shape, aura.uuid, { active: !aura.active }, SERVER_SYNC)"
+                                    @click="
+                                        auraSystem.update(aura.shape, aura.uuid, { active: !aura.active }, SERVER_SYNC)
+                                    "
                                 />
-                                <template v-if="(aura.angle < 360)">
+                                <template v-if="aura.angle < 360">
                                     <RotationSlider
                                         :angle="aura.direction"
                                         :show-number-input="false"
                                         :disabled="!accessState.hasEditAccess.value"
-                                        @input="(direction) => auraSystem.update(aura.shape, aura.uuid, { direction }, SERVER_SYNC)"
-                                        @change="(direction) => auraSystem.update(aura.shape, aura.uuid, { direction }, SERVER_SYNC)"
+                                        @input="
+                                            (direction) =>
+                                                auraSystem.update(aura.shape, aura.uuid, { direction }, SERVER_SYNC)
+                                        "
+                                        @change="
+                                            (direction) =>
+                                                auraSystem.update(aura.shape, aura.uuid, { direction }, SERVER_SYNC)
+                                        "
                                     />
                                 </template>
                             </div>
@@ -164,14 +172,14 @@ function annotate(note: DeepReadonly<ClientNote>): void {
                             <div>{{ note.title }}</div>
                             <div style="flex-grow: 1"></div>
                             <font-awesome-icon
-                                icon="pencil"
-                                title="Edit note in note manager"
-                                @click="editNote(note.uuid)"
-                            />
-                            <font-awesome-icon
-                                icon="up-right-from-square"
+                                :icon="['far', 'window-restore']"
                                 title="Popout note"
                                 @click="popoutNote(note.uuid)"
+                            />
+                            <font-awesome-icon
+                                icon="cog"
+                                title="Edit note in note manager"
+                                @click="editNote(note.uuid)"
                             />
                         </div>
                     </template>

--- a/client/src/game/ui/notes/NoteDialog.vue
+++ b/client/src/game/ui/notes/NoteDialog.vue
@@ -131,7 +131,6 @@ function setText(event: Event, sync: boolean): void {
                 <div>
                     <div v-if="!editing" @click="editing = true">[edit]</div>
                     <div v-else @click="editing = false">[show]</div>
-                    <div>[show to players]</div>
                     <div @click.stop="editNote(uuid)">[open in note manager]</div>
                 </div>
             </header>

--- a/client/src/game/ui/notes/NoteEdit.vue
+++ b/client/src/game/ui/notes/NoteEdit.vue
@@ -212,9 +212,9 @@ function removeShape(shape: LocalId): void {
                 @change="setTitle"
             />
             <font-awesome-icon
-                icon="up-right-from-square"
+                :icon="['far', 'window-restore']"
                 title="Popout note"
-                @click="popoutNote(noteState.reactive.currentNote!)"
+                @click.stop="popoutNote(noteState.reactive.currentNote!)"
             />
             <font-awesome-icon v-if="canEdit" title="Remove note" icon="trash-alt" @click="remove" />
         </header>

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -276,7 +276,11 @@ function clearShapeFilter(): void {
                 </div>
                 <div class="note-actions">
                     <font-awesome-icon icon="pencil" title="Edit" @click="editNote(note.uuid)" />
-                    <font-awesome-icon icon="up-right-from-square" title="Pop-out" @click="popoutNote(note.uuid)" />
+                    <font-awesome-icon
+                        :icon="['far', 'window-restore']"
+                        title="Pop-out"
+                        @click="popoutNote(note.uuid)"
+                    />
                 </div>
             </template>
         </div>


### PR DESCRIPTION
The icon used for note popouts has been changed, as I found the previous version to imply too much that a completely new window would open (which is something that I want to add later).

The quick info icon for opening the note manager has also changed to a cog wheel, and the order of the two icons has changed.

Additionally the [share with players] action in the note dialog is removed as it did nothing and it feels somewhat out of place for that view.