### PR TITLE
feat(Note): Show notification on note share

### DIFF
--- a/client/src/core/components/toasts/SingleButtonToast.vue
+++ b/client/src/core/components/toasts/SingleButtonToast.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 const emit = defineEmits(["close-toast"]);
-const props = defineProps<{ text: string; onClick: () => Promise<void> }>();
+const props = defineProps<{ text: string; buttonText?: string; onClick: () => Promise<void> }>();
 
 async function action(): Promise<void> {
     emit("close-toast");
@@ -11,7 +11,7 @@ async function action(): Promise<void> {
 <template>
     <div class="toast-container">
         <span>{{ text }}</span>
-        <span class="action" @click.stop="action">USE</span>
+        <span class="action" @click.stop="action">{{ buttonText ?? "USE" }}</span>
     </div>
 </template>
 
@@ -24,6 +24,7 @@ async function action(): Promise<void> {
     justify-content: space-between;
 
     .action {
+        margin-left: 0.5rem;
         padding: 5px;
         background-color: white;
         color: $vt-color-info;

--- a/client/src/game/systems/notes/events.ts
+++ b/client/src/game/systems/notes/events.ts
@@ -1,14 +1,38 @@
+import { POSITION, useToast } from "vue-toastification";
+
 import type { ApiNote, ApiNoteAccessEdit, ApiNoteSetBoolean, ApiNoteSetString, ApiNoteShape } from "../../../apiTypes";
+import SingleButtonToastVue from "../../../core/components/toasts/SingleButtonToast.vue";
 import { socket } from "../../api/socket";
 import { getLocalId } from "../../id";
 
+import { popoutNote } from "./ui";
+
 import { noteSystem } from ".";
+
+const toast = useToast();
 
 socket.on("Notes.Set", async (notes: ApiNote[]) => {
     for (const note of notes) await noteSystem.newNote(note, false);
 });
 
-socket.on("Note.Add", async (data: ApiNote) => await noteSystem.newNote(data, false));
+socket.on("Note.Add", async (data: ApiNote) => {
+    await noteSystem.newNote(data, false);
+
+    toast.info(
+        {
+            component: SingleButtonToastVue,
+            props: {
+                text: `You were granted access to a note: ${data.title}`,
+                buttonText: "Open",
+                onClick: () => popoutNote(data.uuid),
+            },
+        },
+        {
+            position: POSITION.TOP_RIGHT,
+            timeout: 10_000,
+        },
+    );
+});
 
 socket.on("Note.Remove", (data: string) => noteSystem.removeNote(data, false));
 


### PR DESCRIPTION
When gaining access to a note, you'll now receive a notification in the top right of the screen with a quick open action.

This helps with flows where a note is shared with the players after a discovery. Asking the players to manually open the note manager and searching for it, is quite a bother.