### PR TITLE
style(Notes): Don't show pointer if there are no notes in quick info

### DIFF
--- a/client/src/game/ui/SelectionInfo.vue
+++ b/client/src/game/ui/SelectionInfo.vue
@@ -157,6 +157,7 @@ function annotate(note: DeepReadonly<ClientNote>): void {
                 <div class="info-notes">
                     <div
                         :title="notes.length > 0 ? (expandNotes ? 'Collapse notes' : 'Expand notes') : ''"
+                        :style="{ cursor: notes.length > 0 ? 'pointer' : 'default' }"
                         @click="expandNotes = !expandNotes"
                     >
                         <font-awesome-icon icon="note-sticky" title="Open note manager" @click.stop="openNotes" />
@@ -292,10 +293,6 @@ function annotate(note: DeepReadonly<ClientNote>): void {
 
             &:first-child {
                 margin-top: 0;
-
-                &:hover {
-                    cursor: pointer;
-                }
 
                 svg {
                     margin: 0 0.5rem;


### PR DESCRIPTION
The quick info section for notes provides a toggle to expand/collapse notes.
If there are no notes however it was still showing the cursor as a pointer, which can be confusing.