### PR TITLE
feat(Notes): Add an in-between menu for note creation

### DIFF
--- a/client/src/game/systems/notes/types.ts
+++ b/client/src/game/systems/notes/types.ts
@@ -6,8 +6,9 @@ export type ClientNote = DistributiveOmit<ApiNote, "tags"> & {
 };
 
 export enum NoteManagerMode {
-    List,
-    Edit,
-    Map,
     AttachShape,
+    Create,
+    Edit,
+    List,
+    Map,
 }

--- a/client/src/game/ui/notes/NoteCreate.vue
+++ b/client/src/game/ui/notes/NoteCreate.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { onDeactivated, ref } from "vue";
+
+import type { ApiNote } from "../../../apiTypes";
+import { uuidv4 } from "../../../core/utils";
+import { coreStore } from "../../../store/core";
+import { noteSystem } from "../../systems/notes";
+import { noteState } from "../../systems/notes/state";
+import { NoteManagerMode } from "../../systems/notes/types";
+import { locationSettingsState } from "../../systems/settings/location/state";
+
+const emit = defineEmits<(e: "mode", mode: NoteManagerMode) => void>();
+
+const title = ref("");
+const isLocal = ref(true);
+
+onDeactivated(() => {
+    title.value = "";
+    isLocal.value = true;
+});
+
+async function createNote(): Promise<void> {
+    const uuid = uuidv4();
+    const note: ApiNote = {
+        uuid,
+        creator: coreStore.state.username,
+        title: title.value || "New note...",
+        text: "",
+        showOnHover: false,
+        showIconOnShape: false,
+        isRoomNote: isLocal.value,
+        location: isLocal.value ? locationSettingsState.reactive.activeLocation : null,
+        tags: [],
+        access: [],
+        shapes: [],
+    };
+    await noteSystem.newNote(note, true);
+    if (noteState.raw.shapeFilter) noteSystem.attachShape(uuid, noteState.raw.shapeFilter, true);
+
+    noteState.mutableReactive.currentNote = note.uuid;
+    emit("mode", NoteManagerMode.Edit);
+}
+</script>
+
+<template>
+    <header>
+        <span id="return" title="Back to list" @click="$emit('mode', NoteManagerMode.List)">↩</span>
+        Create a new note
+    </header>
+    <div id="create-note">
+        <label for="new-note-title">Title:</label>
+        <input id="new-note-title" v-model="title" type="text" placeholder="New note..." autofocus />
+        <label for="new-note-type">Type:</label>
+        <div @click="isLocal = true">
+            <input type="radio" name="new-note-type" value="local" :checked="isLocal" />
+            <div>
+                <div>Local note</div>
+                <div>
+                    A note that is relevant to the current campaign only. This is the most common kind of type and
+                    should be used for most cases.
+                </div>
+            </div>
+        </div>
+        <div @click="isLocal = false">
+            <input type="radio" name="new-note-type" value="global" :checked="!isLocal" />
+            <div>
+                <div>Global note</div>
+                <div>
+                    A note that will be visible in all campaigns. This is a special type that can be used to note down
+                    information on common things like monster stats thare are used in multiple campaigns.
+                </div>
+            </div>
+        </div>
+        <button @click="createNote">Create note</button>
+    </div>
+</template>
+
+<style scoped lang="scss">
+header {
+    display: flex;
+    font-size: 1.75em;
+    align-items: center;
+
+    #return {
+        margin-right: 1rem;
+
+        &:hover {
+            cursor: pointer;
+            font-weight: bold;
+        }
+    }
+
+    #title {
+        flex-grow: 1;
+        margin-right: 1rem;
+        border: none;
+        border-bottom: solid 1px black;
+        font-weight: bold;
+        font-size: inherit;
+        padding: 0.5rem;
+
+        &.edit:hover {
+            cursor: text;
+        }
+    }
+}
+
+#create-note {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    column-gap: 1rem;
+    row-gap: 1rem;
+
+    margin-top: 1rem;
+
+    > label {
+        font-weight: bold;
+    }
+
+    > input {
+        border-radius: 1rem;
+        padding: 0.5rem 1rem;
+        border-style: solid;
+    }
+
+    > div {
+        grid-column: 1/-1;
+        display: flex;
+
+        padding: 1rem;
+
+        border: solid 1px black;
+
+        &:hover {
+            cursor: pointer;
+        }
+
+        &:first-of-type {
+            border-top-left-radius: 1rem;
+            border-top-right-radius: 1rem;
+            margin-bottom: -1rem; // offset row-gap
+            border-bottom: none;
+        }
+
+        &:last-of-type {
+            border-bottom-left-radius: 1rem;
+            border-bottom-right-radius: 1rem;
+        }
+
+        > div {
+            display: flex;
+            flex-direction: column;
+
+            margin-left: 1rem;
+
+            > div:first-of-type {
+                font-weight: bold;
+            }
+        }
+    }
+
+    button {
+        background-color: lightblue;
+        border: solid 2px lightblue;
+        border-width: 1px;
+        border-radius: 1rem;
+        padding: 0.5rem 0.75rem;
+
+        grid-column: 1/-1;
+
+        width: 10rem;
+
+        &:hover {
+            cursor: pointer;
+            background-color: rgba(173, 216, 230, 0.5);
+        }
+    }
+}
+</style>

--- a/client/src/game/ui/notes/NoteManager.vue
+++ b/client/src/game/ui/notes/NoteManager.vue
@@ -7,6 +7,7 @@ import { NoteManagerMode } from "../../systems/notes/types";
 import { closeNoteManager } from "../../systems/notes/ui";
 import NoteTool from "../tools/NoteTool.vue";
 
+import NoteCreate from "./NoteCreate.vue";
 import NoteEdit from "./NoteEdit.vue";
 import NoteList from "./NoteList.vue";
 
@@ -34,7 +35,8 @@ function close(): void {
         <div id="notes" @click="$emit('focus')">
             <font-awesome-icon id="close-notes" :icon="['far', 'window-close']" @click="close" />
             <KeepAlive>
-                <NoteList v-if="mode === NoteManagerMode.List" @edit-note="setMode(NoteManagerMode.Edit)" />
+                <NoteList v-if="mode === NoteManagerMode.List" @mode="setMode($event)" />
+                <NoteCreate v-else-if="mode === NoteManagerMode.Create" @mode="setMode($event)" />
                 <NoteEdit v-else-if="mode === NoteManagerMode.Edit" @mode="setMode($event)" />
             </KeepAlive>
         </div>


### PR DESCRIPTION
In the new note system a new note button is present in the main note manager listing.
This offers a direct option to create a new global or local note.

It's however not necessarily clear for users what Global or Local means unless they did a more in-depth read through the note docs.

As global notes are usually not desirable unless you know what you're doing, this will cause more harm than good, so this PR instead simplifies this to 1 create new note button, which opens a new view where you have to choose between local and global, but with more information on what those choices entail.