### PR TITLE
bug(Notes): Fix duplicate note listings in selection info

### DIFF
--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -262,6 +262,7 @@ async def load_location(sid: str, location: Location, *, complete=False):
                     )
                 )
             )
+            .group_by(Note.uuid)
         ],
         room=sid,
     )


### PR DESCRIPTION
It was possible for a note to appear twice in the selection info.

This was caused by the server sending some notes multiple times if certain conditions were met. (e.g. being the creator of the note but also having default view access)