### PR TITLE
chore(Deps): Remove old markdown dep

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -25,7 +25,6 @@
                 "vue-markdown-render": "^2.1.1",
                 "vue-router": "^4.2.5",
                 "vue-toastification": "^2.0.0-rc.5",
-                "vue3-markdown-it": "^1.0.10",
                 "vuedraggable": "4.0.3"
             },
             "devDependencies": {
@@ -1355,33 +1354,11 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
         },
-        "node_modules/@types/linkify-it": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-            "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
-            "peer": true
-        },
         "node_modules/@types/lodash": {
             "version": "4.14.202",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
             "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
             "dev": true
-        },
-        "node_modules/@types/markdown-it": {
-            "version": "13.0.7",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
-            "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
-            "peer": true,
-            "dependencies": {
-                "@types/linkify-it": "*",
-                "@types/mdurl": "*"
-            }
-        },
-        "node_modules/@types/mdurl": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-            "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
-            "peer": true
         },
         "node_modules/@types/minimatch": {
             "version": "5.1.2",
@@ -4119,14 +4096,6 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/highlight.js": {
-            "version": "11.9.0",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-            "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4921,11 +4890,6 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
-        "node_modules/lodash.flow": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-            "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5013,74 +4977,6 @@
             "bin": {
                 "markdown-it": "bin/markdown-it.js"
             }
-        },
-        "node_modules/markdown-it-abbr": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/markdown-it-abbr/-/markdown-it-abbr-1.0.4.tgz",
-            "integrity": "sha512-ZeA4Z4SaBbYysZap5iZcxKmlPL6bYA8grqhzJIHB1ikn7njnzaP8uwbtuXc4YXD5LicI4/2Xmc0VwmSiFV04gg=="
-        },
-        "node_modules/markdown-it-anchor": {
-            "version": "8.6.7",
-            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-            "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
-            "peerDependencies": {
-                "@types/markdown-it": "*",
-                "markdown-it": "*"
-            }
-        },
-        "node_modules/markdown-it-deflist": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz",
-            "integrity": "sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg=="
-        },
-        "node_modules/markdown-it-emoji": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz",
-            "integrity": "sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ=="
-        },
-        "node_modules/markdown-it-footnote": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
-            "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
-        },
-        "node_modules/markdown-it-highlightjs": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-highlightjs/-/markdown-it-highlightjs-3.6.0.tgz",
-            "integrity": "sha512-ex+Lq3cVkprh0GpGwFyc53A/rqY6GGzopPCG1xMsf8Ya3XtGC8Uw9tChN1rWbpyDae7tBBhVHVcMM29h4Btamw==",
-            "dependencies": {
-                "highlight.js": "^11.3.1",
-                "lodash.flow": "^3.5.0"
-            }
-        },
-        "node_modules/markdown-it-ins": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/markdown-it-ins/-/markdown-it-ins-3.0.1.tgz",
-            "integrity": "sha512-32SSfZqSzqyAmmQ4SHvhxbFqSzPDqsZgMHDwxqPzp+v+t8RsmqsBZRG+RfRQskJko9PfKC2/oxyOs4Yg/CfiRw=="
-        },
-        "node_modules/markdown-it-mark": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-3.0.1.tgz",
-            "integrity": "sha512-HyxjAu6BRsdt6Xcv6TKVQnkz/E70TdGXEFHRYBGLncRE9lBFwDNLVtFojKxjJWgJ+5XxUwLaHXy+2sGBbDn+4A=="
-        },
-        "node_modules/markdown-it-sub": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-1.0.0.tgz",
-            "integrity": "sha512-z2Rm/LzEE1wzwTSDrI+FlPEveAAbgdAdPhdWarq/ZGJrGW/uCQbKAnhoCsE4hAbc3SEym26+W2z/VQB0cQiA9Q=="
-        },
-        "node_modules/markdown-it-sup": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz",
-            "integrity": "sha512-E32m0nV9iyhRR7CrhnzL5msqic7rL1juWre6TQNxsnApg7Uf+F97JOKxUijg5YwXz86lZ0mqfOnutoryyNdntQ=="
-        },
-        "node_modules/markdown-it-task-lists": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
-            "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="
-        },
-        "node_modules/markdown-it-toc-done-right": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-toc-done-right/-/markdown-it-toc-done-right-4.2.0.tgz",
-            "integrity": "sha512-UB/IbzjWazwTlNAX0pvWNlJS8NKsOQ4syrXZQ/C72j+jirrsjVRT627lCaylrKJFBQWfRsPmIVQie8x38DEhAQ=="
         },
         "node_modules/markdown-it/node_modules/entities": {
             "version": "2.1.0",
@@ -7242,26 +7138,6 @@
             },
             "peerDependencies": {
                 "typescript": "*"
-            }
-        },
-        "node_modules/vue3-markdown-it": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/vue3-markdown-it/-/vue3-markdown-it-1.0.10.tgz",
-            "integrity": "sha512-mTvHu0zl7jrh7ojgaZ+tTpCLiS4CVg4bTgTu4KGhw/cRRY5YgIG8QgFAPu6kCzSW6Znc9a52Beb6hFvF4hSMkQ==",
-            "dependencies": {
-                "markdown-it": "^12.3.2",
-                "markdown-it-abbr": "^1.0.4",
-                "markdown-it-anchor": "^8.4.1",
-                "markdown-it-deflist": "^2.1.0",
-                "markdown-it-emoji": "^2.0.0",
-                "markdown-it-footnote": "^3.0.3",
-                "markdown-it-highlightjs": "^3.6.0",
-                "markdown-it-ins": "^3.0.1",
-                "markdown-it-mark": "^3.0.1",
-                "markdown-it-sub": "^1.0.0",
-                "markdown-it-sup": "^1.0.0",
-                "markdown-it-task-lists": "^2.1.1",
-                "markdown-it-toc-done-right": "^4.2.0"
             }
         },
         "node_modules/vuedraggable": {

--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,6 @@
         "vue-markdown-render": "^2.1.1",
         "vue-router": "^4.2.5",
         "vue-toastification": "^2.0.0-rc.5",
-        "vue3-markdown-it": "^1.0.10",
         "vuedraggable": "4.0.3"
     },
     "devDependencies": {

--- a/client/src/core/components/modals/MarkdownModal.vue
+++ b/client/src/core/components/modals/MarkdownModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
-import VueMarkdownIt from "vue3-markdown-it";
+import VueMarkdown from "vue-markdown-render";
 
 import Modal from "./Modal.vue";
 
@@ -27,7 +27,7 @@ function close(): void {
             </div>
         </template>
         <div class="modal-body">
-            <VueMarkdownIt :source="source" />
+            <VueMarkdown :source="source" />
         </div>
     </Modal>
 </template>

--- a/client/src/core/components/modals/SelectionBox.vue
+++ b/client/src/core/components/modals/SelectionBox.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive } from "vue";
-import VueMarkdownIt from "vue3-markdown-it";
+import VueMarkdown from "vue-markdown-render";
 
 import { i18n } from "../../../i18n";
 import { map } from "../../iter";
@@ -80,7 +80,7 @@ function submit(): void {
             </div>
         </template>
         <div class="modal-body">
-            <VueMarkdownIt :source="text" />
+            <VueMarkdown :source="text" />
             <div v-if="state.error.length > 0" id="error">{{ state.error }}</div>
             <template v-if="choices.length > 0">
                 <div id="selectionbox">

--- a/client/src/game/ui/Annotation.vue
+++ b/client/src/game/ui/Annotation.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import VueMarkdownIt from "vue3-markdown-it";
+import VueMarkdown from "vue-markdown-render";
 
 import { uiState } from "../systems/ui/state";
 </script>
 
 <template>
-    <VueMarkdownIt
+    <VueMarkdown
         v-show="uiState.reactive.annotationText.length > 0"
         id="annotation"
         :source="uiState.reactive.annotationText"

--- a/client/src/shims/vue3-markdown-it.ts
+++ b/client/src/shims/vue3-markdown-it.ts
@@ -1,5 +1,0 @@
-declare module "vue3-markdown-it" {
-    import type { DefineComponent } from "vue";
-    const component: DefineComponent<{}, {}, any>;
-    export default component;
-}


### PR DESCRIPTION
The note system uses a different markdown dependency (vue-markdown-render). This PR replaces usages of the previous dependency (vue3-markdown-it) and removes the dependency itself.