### PR TITLE
bug(SpellTool): Deselect activating Select tool too aggressively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Fixed
+
+-   Spell tool: selecting another tool would swap to the Select tool instead
+
 ## [2024.1.0] - 2024-01-27
 
 ### Added

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -169,11 +169,11 @@ class SpellTool extends Tool implements ITool {
     }
 
     async onDeselect(): Promise<void> {
-        await this.close(true);
+        await this.close({ dropShapeId: true, deselectTool: false });
     }
 
     async onDown(): Promise<void> {
-        await this.close(false);
+        await this.close({ dropShapeId: false, deselectTool: true });
     }
 
     async onMove(lp: LocalPoint): Promise<void> {
@@ -203,14 +203,16 @@ class SpellTool extends Tool implements ITool {
     }
 
     async onContextMenu(): Promise<boolean> {
-        await this.close(true);
+        await this.close({ dropShapeId: true, deselectTool: true });
         return false;
     }
 
-    async close(dropShapeId: boolean): Promise<void> {
+    async close(options: { dropShapeId: boolean; deselectTool: boolean }): Promise<void> {
         if (this.shape !== undefined) {
             const layer = floorState.currentLayer.value;
             if (layer === undefined) return;
+
+            const { dropShapeId } = options;
 
             layer.removeShape(this.shape, {
                 sync: this.state.showPublic ? SyncMode.TEMP_SYNC : SyncMode.NO_SYNC,
@@ -227,7 +229,7 @@ class SpellTool extends Tool implements ITool {
             const ruler = toolMap[ToolName.Ruler];
             await ruler.onUp(toLP(0, 0), undefined, {});
         }
-        activateTool(ToolName.Select);
+        if (options.deselectTool) activateTool(ToolName.Select);
     }
 }
 


### PR DESCRIPTION
The Spell tool has a builtin deselect that hot swaps back to the Select tool. This is done when you right click to cancel the spell operation and return to the game and also when you left click and finalize your spell.

In these cases moving to the select tool is nice. The spell tool was however also activating the select tool when you manually selected another tool, which is of course not expected.