### PR TITLE
feat(Ruler): Add grid mode

### DIFF
--- a/client/src/core/grid.ts
+++ b/client/src/core/grid.ts
@@ -158,7 +158,7 @@ export function getCellFromPoint(point: GlobalPoint, gridType: GridType): GridCe
     throw new Error();
 }
 
-function getCellVertices(cell: GridCell, gridType: GridType): GlobalPoint[] {
+export function getCellVertices(cell: GridCell, gridType: GridType): GlobalPoint[] {
     if (gridType === GridType.Square) {
         const { q, r } = cell;
         return [

--- a/client/src/core/grid.ts
+++ b/client/src/core/grid.ts
@@ -116,7 +116,7 @@ export function snapPointToGrid(
 }
 
 // Returns the CENTER of the specified cell
-function getCellCenter(cell: GridCell, gridType: GridType): GlobalPoint {
+export function getCellCenter(cell: GridCell, gridType: GridType): GlobalPoint {
     if (gridType === GridType.Square) {
         return toGP(
             cell.q * DEFAULT_GRID_SIZE + DEFAULT_GRID_SIZE / 2,
@@ -136,7 +136,7 @@ function getCellCenter(cell: GridCell, gridType: GridType): GlobalPoint {
     throw new Error();
 }
 
-function getCellFromPoint(point: GlobalPoint, gridType: GridType): GridCell {
+export function getCellFromPoint(point: GlobalPoint, gridType: GridType): GridCell {
     if (gridType === GridType.Square) {
         return {
             q: Math.floor(point.x / DEFAULT_GRID_SIZE),
@@ -221,6 +221,20 @@ export function getCellHeight(height: number, gridType: GridType): number {
         return height / (2 * DEFAULT_HEX_RADIUS);
     }
     throw new Error();
+}
+
+export function getCellDistance(a: GridCell, b: GridCell, gridType: GridType): number {
+    if (gridType === GridType.Square) {
+        const aCenter = getCellCenter(a, gridType);
+        const bCenter = getCellCenter(b, gridType);
+        return Math.round(
+            Math.max(
+                getCellWidth(Math.abs(bCenter.x - aCenter.x), gridType),
+                getCellHeight(Math.abs(bCenter.y - aCenter.y), gridType),
+            ),
+        );
+    }
+    return (Math.abs(a.q - b.q) + Math.abs(a.q + a.r - b.q - b.r) + Math.abs(a.r - b.r)) / 2;
 }
 
 // helpers

--- a/client/src/core/grid.ts
+++ b/client/src/core/grid.ts
@@ -48,7 +48,7 @@ export enum GridType {
     FlatHex = "FLAT_HEX",
 }
 
-function getClosestCellCenter(position: GlobalPoint, gridType: GridType): GlobalPoint {
+export function getClosestCellCenter(position: GlobalPoint, gridType: GridType): GlobalPoint {
     return getCellCenter(getCellFromPoint(position, gridType), gridType);
 }
 

--- a/client/src/core/utils.ts
+++ b/client/src/core/utils.ts
@@ -73,19 +73,20 @@ export function getChecked(event: Event): boolean {
 }
 
 export function callbackProvider(): {
-    wait: () => Promise<void>;
+    wait: (id?: string) => Promise<void>;
     resolveAll: () => void;
 } {
-    let callbacks: (() => void)[] = [];
+    let callbacks: { id?: string; cb: () => void }[] = [];
 
-    function wait(): Promise<void> {
+    function wait(id?: string): Promise<void> {
+        if (id !== undefined && callbacks.some((c) => c.id === id)) return Promise.reject();
         return new Promise((resolve, _reject) => {
-            callbacks.push(resolve);
+            callbacks.push({ id, cb: resolve });
         });
     }
 
     function resolveAll(): void {
-        for (const cb of callbacks) cb();
+        for (const { cb } of callbacks) cb();
         callbacks = [];
     }
 

--- a/client/src/game/interfaces/layer.ts
+++ b/client/src/game/interfaces/layer.ts
@@ -18,7 +18,7 @@ export interface ILayer {
     shapeIdsInSector: Set<LocalId>;
     shapesInSector: IShape[];
     postDrawCallback: {
-        wait: () => Promise<void>;
+        wait: (id?: string) => Promise<void>;
         resolveAll: () => void;
     };
 

--- a/client/src/game/rendering/basic.ts
+++ b/client/src/game/rendering/basic.ts
@@ -8,7 +8,7 @@ import { EdgeIterator } from "../vision/tds";
 import type { Edge, TDS } from "../vision/tds";
 import { ccw, cw } from "../vision/triag";
 
-function drawPoint(point: [number, number], r: number, options?: { colour?: string; fill?: boolean }): void {
+export function drawPoint(point: [number, number], r: number, options?: { colour?: string; fill?: boolean }): void {
     const dl = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
     if (dl === undefined) return;
     const ctx = dl.ctx;
@@ -41,7 +41,7 @@ function drawPointL(point: [number, number], r: number, colour?: string): void {
 
 export function drawPolygon(
     polygon: [number, number][],
-    options?: { colour?: string; strokeWidth?: number; close?: boolean; debug?: boolean },
+    options?: { fillColour?: string; strokeColour?: string; strokeWidth?: number; close?: boolean; debug?: boolean },
 ): void {
     if (polygon.length === 0) return;
 
@@ -52,10 +52,15 @@ export function drawPolygon(
     // ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
     ctx.lineJoin = "round";
     ctx.beginPath();
-    ctx.strokeStyle =
-        options?.colour === undefined
-            ? `rgb(${Math.random() * 255}, ${Math.random() * 255}, ${Math.random() * 255})`
-            : options.colour;
+
+    let performStroke = options?.strokeColour !== undefined;
+    if (options?.strokeColour === undefined && options?.fillColour === undefined) {
+        ctx.strokeStyle = `rgb(${Math.random() * 255}, ${Math.random() * 255}, ${Math.random() * 255})`;
+        performStroke = true;
+    }
+    if (options?.strokeColour !== undefined) ctx.strokeStyle = options.strokeColour;
+    if (options?.fillColour !== undefined) ctx.fillStyle = options.fillColour;
+
     const x = g2lx(polygon[0]![0]);
     const y = g2ly(polygon[0]![1]);
     ctx.moveTo(x, y);
@@ -67,8 +72,11 @@ export function drawPolygon(
         if (options?.debug ?? false) console.log(x, y);
     }
     if (options?.close ?? true) ctx.closePath();
-    if (options?.strokeWidth !== undefined) ctx.lineWidth = options.strokeWidth;
-    ctx.stroke();
+    if (performStroke) {
+        if (options?.strokeWidth !== undefined) ctx.lineWidth = options.strokeWidth;
+        ctx.stroke();
+    }
+    if (options?.fillColour !== undefined) ctx.fill();
 }
 
 function drawPolygonL(polygon: [number, number][], colour?: string): void {

--- a/client/src/game/rendering/basic.ts
+++ b/client/src/game/rendering/basic.ts
@@ -8,6 +8,7 @@ import { EdgeIterator } from "../vision/tds";
 import type { Edge, TDS } from "../vision/tds";
 import { ccw, cw } from "../vision/triag";
 
+// eslint-disable-next-line import/no-unused-modules
 export function drawPoint(point: [number, number], r: number, options?: { colour?: string; fill?: boolean }): void {
     const dl = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
     if (dl === undefined) return;

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -2,13 +2,14 @@ import tinycolor from "tinycolor2";
 import { computed, ref } from "vue";
 
 import { l2g } from "../../../core/conversions";
-import { Ray, cloneP, equalsP, toGP } from "../../../core/geometry";
+import { Ray, cloneP, equalsP, toArrayP, toGP } from "../../../core/geometry";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
 import {
     DEFAULT_GRID_SIZE,
     getCellCenter,
     getCellDistance,
     getCellFromPoint,
+    getCellVertices,
     getClosestCellCenter,
     snapPointToGrid,
 } from "../../../core/grid";
@@ -243,16 +244,11 @@ class RulerTool extends Tool implements ITool {
                 .then(() => {
                     layer.ctx.globalCompositeOperation = "destination-over";
 
-                    const half = DEFAULT_GRID_SIZE / 2;
+                    const gridType = locationSettingsState.raw.gridType.value;
                     for (const { cells } of this.rulers) {
                         for (const cell of cells) {
                             drawPolygon(
-                                [
-                                    [cell.x - half, cell.y - half],
-                                    [cell.x + half, cell.y - half],
-                                    [cell.x + half, cell.y + half],
-                                    [cell.x - half, cell.y + half],
-                                ],
+                                getCellVertices(getCellFromPoint(cell, gridType), gridType).map((p) => toArrayP(p)),
                                 { fillColour: gridHighlightColour.value },
                             );
                         }

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -35,12 +35,13 @@ export enum RulerFeatures {
     All,
 }
 
-const gridHighlightColour = computed(() => {
+const gridHighlightColours = computed(() => {
     const rulerColour = tinycolor(playerSettingsState.reactive.rulerColour.value);
-    console.log(rulerColour.toRgbString());
-    const a = rulerColour.setAlpha(rulerColour.getAlpha() * 0.25).toRgbString();
-    console.log(a);
-    return a;
+    const alpha = rulerColour.getAlpha();
+    return {
+        default: rulerColour.setAlpha(alpha * 0.25).toRgbString(),
+        start: rulerColour.setAlpha(alpha * 0.75).toRgbString(),
+    };
 });
 
 class RulerTool extends Tool implements ITool {
@@ -245,12 +246,20 @@ class RulerTool extends Tool implements ITool {
                     layer.ctx.globalCompositeOperation = "destination-over";
 
                     const gridType = locationSettingsState.raw.gridType.value;
+                    let firstCell = true;
+                    const handledCells: GlobalPoint[] = [];
                     for (const { cells } of this.rulers) {
-                        for (const cell of cells) {
+                        for (const cellCenter of cells) {
+                            if (handledCells.some((c) => equalsP(c, cellCenter))) continue;
+
                             drawPolygon(
-                                getCellVertices(getCellFromPoint(cell, gridType), gridType).map((p) => toArrayP(p)),
-                                { fillColour: gridHighlightColour.value },
+                                getCellVertices(getCellFromPoint(cellCenter, gridType), gridType).map((p) =>
+                                    toArrayP(p),
+                                ),
+                                { fillColour: gridHighlightColours.value[firstCell ? "start" : "default"] },
                             );
+                            firstCell = false;
+                            handledCells.push(cellCenter);
                         }
                     }
 

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -4,7 +4,14 @@ import { computed, ref } from "vue";
 import { l2g } from "../../../core/conversions";
 import { Ray, cloneP, equalsP, toGP } from "../../../core/geometry";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
-import { DEFAULT_GRID_SIZE, getClosestCellCenter, snapPointToGrid } from "../../../core/grid";
+import {
+    DEFAULT_GRID_SIZE,
+    getCellCenter,
+    getCellDistance,
+    getCellFromPoint,
+    getClosestCellCenter,
+    snapPointToGrid,
+} from "../../../core/grid";
 import { InvalidationMode, NO_SYNC, SyncMode } from "../../../core/models/types";
 import { i18n } from "../../../i18n";
 import { sendShapePositionUpdate } from "../../api/emits/shape/core";
@@ -172,16 +179,14 @@ class RulerTool extends Tool implements ITool {
             cells.length = 0;
             const gridType = locationSettingsState.raw.gridType.value;
 
-            const startCenter = getClosestCellCenter(start, gridType);
-            const endCenter = getClosestCellCenter(end, gridType);
-            const ray = Ray.fromPoints(startCenter, endCenter);
+            const startCell = getCellFromPoint(start, gridType);
+            const startCenter = getCellCenter(startCell, gridType);
+            const endCell = getCellFromPoint(end, gridType);
+            const endCenter = getCellCenter(endCell, gridType);
 
-            const iterations = Math.round(
-                Math.max(
-                    Math.abs(endCenter.x - startCenter.x) / DEFAULT_GRID_SIZE,
-                    Math.abs(endCenter.y - startCenter.y) / DEFAULT_GRID_SIZE,
-                ),
-            );
+            const iterations = getCellDistance(startCell, endCell, gridType);
+
+            const ray = Ray.fromPoints(startCenter, endCenter);
 
             const step = ray.tMax / iterations;
             for (let i = 0; i <= iterations; i++) {

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -1,7 +1,7 @@
 import { ref } from "vue";
 
 import { l2g } from "../../../core/conversions";
-import { cloneP, toGP } from "../../../core/geometry";
+import { Ray, cloneP, equalsP, toGP } from "../../../core/geometry";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
 import { DEFAULT_GRID_SIZE, snapPointToGrid } from "../../../core/grid";
 import { InvalidationMode, NO_SYNC, SyncMode } from "../../../core/models/types";
@@ -10,7 +10,9 @@ import { sendShapePositionUpdate } from "../../api/emits/shape/core";
 import { LayerName } from "../../models/floor";
 import { ToolName } from "../../models/tools";
 import type { ITool, ToolFeatures, ToolPermission } from "../../models/tools";
+import { Circle } from "../../shapes/variants/circle";
 import { Line } from "../../shapes/variants/line";
+import { Rect } from "../../shapes/variants/rect";
 import { Text } from "../../shapes/variants/text";
 import { accessSystem } from "../../systems/access";
 import { floorSystem } from "../../systems/floors";
@@ -23,6 +25,11 @@ import { Tool } from "../tool";
 
 export enum RulerFeatures {
     All,
+}
+
+function getCellCenter(point: GlobalPoint): GlobalPoint {
+    const gs = DEFAULT_GRID_SIZE;
+    return toGP(Math.floor(point.x / gs) * gs + gs / 2, Math.floor(point.y / gs) * gs + gs / 2);
 }
 
 class RulerTool extends Tool implements ITool {
@@ -40,6 +47,9 @@ class RulerTool extends Tool implements ITool {
 
     private currentLength = 0;
     private previousLength = 0;
+
+    private highlightedCells: Rect[] = [];
+    private highlightedCellss: Circle[] = [];
 
     get permittedTools(): ToolPermission[] {
         return [{ name: ToolName.Select, features: { enabled: [SelectFeatures.Context] } }];
@@ -126,6 +136,15 @@ class RulerTool extends Tool implements ITool {
             NO_SYNC,
         );
         layer.addShape(this.text, this.syncMode, InvalidationMode.NORMAL);
+
+        const cellCenter = getCellCenter(this.startPoint);
+        const rect = new Rect(cellCenter, DEFAULT_GRID_SIZE, DEFAULT_GRID_SIZE, undefined, {
+            fillColour: "lightblue",
+        });
+        rect.center = cellCenter;
+        this.highlightedCells.push(rect);
+        layer.addShape(rect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+
         return Promise.resolve();
     }
 
@@ -149,6 +168,40 @@ class RulerTool extends Tool implements ITool {
             });
         }
 
+        for (const shape of this.highlightedCells) {
+            layer.removeShape(shape, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
+        }
+        this.highlightedCells = [];
+        for (const shape of this.highlightedCellss) {
+            layer.removeShape(shape, { sync: SyncMode.NO_SYNC, recalculate: false, dropShapeId: true });
+        }
+        this.highlightedCellss = [];
+        const ray = Ray.fromPoints(getCellCenter(this.startPoint), getCellCenter(endPoint));
+        // const iterations = Math.round(ray.getDistance(0, ray.tMax) / DEFAULT_GRID_SIZE);
+        const iterations = Math.round(
+            Math.max(
+                Math.abs(endPoint.x - this.startPoint.x) / DEFAULT_GRID_SIZE,
+                Math.abs(endPoint.y - this.startPoint.y) / DEFAULT_GRID_SIZE,
+            ),
+        );
+        const step = ray.tMax / iterations;
+        for (let i = 0; i <= iterations; i++) {
+            const cellCenter = getCellCenter(ray.get(step * i));
+            const lastCenter = this.highlightedCells.at(-1)?.center;
+            if (lastCenter !== undefined && equalsP(cellCenter, lastCenter)) continue;
+            const rect = new Rect(cellCenter, DEFAULT_GRID_SIZE, DEFAULT_GRID_SIZE, undefined, {
+                fillColour: "rgba(173, 216, 230, 0.25)",
+            });
+            rect.center = cellCenter;
+            this.highlightedCells.push(rect);
+            layer.addShape(rect, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+        }
+        for (let i = 0; i <= iterations; i++) {
+            const blob = new Circle(ray.get(step * i), 5, undefined, { fillColour: "red" });
+            this.highlightedCellss.push(blob);
+            layer.addShape(blob, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
+        }
+
         const ruler = this.rulers.at(-1)!;
         ruler.endPoint = endPoint;
         sendShapePositionUpdate([ruler], true);
@@ -159,14 +212,22 @@ class RulerTool extends Tool implements ITool {
         const diffsign = Math.sign(end.x - start.x) * Math.sign(end.y - start.y);
         const xdiff = Math.abs(end.x - start.x);
         const ydiff = Math.abs(end.y - start.y);
-        let distance =
-            (Math.sqrt(xdiff ** 2 + ydiff ** 2) * locationSettingsState.raw.unitSize.value) / DEFAULT_GRID_SIZE;
+        // let distance =
+        // (Math.sqrt(xdiff ** 2 + ydiff ** 2) * locationSettingsState.raw.unitSize.value) / DEFAULT_GRID_SIZE;
+        let distance = this.highlightedCells.length;
         this.currentLength = distance;
         distance += this.previousLength;
 
         // round to 1 decimal
+        // const label =
+        //     i18n.global.n(Math.round(10 * distance) / 10) + " " + locationSettingsState.raw.unitSizeUnit.value;
         const label =
-            i18n.global.n(Math.round(10 * distance) / 10) + " " + locationSettingsState.raw.unitSizeUnit.value;
+            i18n.global.n(distance) +
+            " (" +
+            distance * locationSettingsState.raw.unitSize.value +
+            " " +
+            locationSettingsState.raw.unitSizeUnit.value +
+            ")";
         const angle = Math.atan2(diffsign * ydiff, xdiff);
         const xmid = Math.min(start.x, end.x) + xdiff / 2;
         const ymid = Math.min(start.y, end.y) + ydiff / 2;
@@ -174,6 +235,7 @@ class RulerTool extends Tool implements ITool {
         this.text.setText(label, SyncMode.TEMP_SYNC);
         this.text.angle = angle;
         sendShapePositionUpdate([this.text], true);
+
         layer.invalidate(true);
         return Promise.resolve();
     }

--- a/client/src/game/ui/tools/RulerTool.vue
+++ b/client/src/game/ui/tools/RulerTool.vue
@@ -16,17 +16,24 @@ function toggle(event: MouseEvent): void {
     const state = (event.target as HTMLButtonElement).getAttribute("aria-pressed") ?? "false";
     rulerTool.showPublic.value = state === "false";
 }
+
+function toggleGridMode(event: MouseEvent): void {
+    const state = (event.target as HTMLButtonElement).getAttribute("aria-pressed") ?? "false";
+    rulerTool.gridMode.value = state === "false";
+}
 </script>
 
 <template>
     <div v-if="selected" id="ruler" class="tool-detail">
         <button :aria-pressed="showPublic" @click="toggle">{{ t("game.ui.tools.RulerTool.share") }}</button>
+        <button :aria-pressed="rulerTool.gridMode.value" @click="toggleGridMode">Grid Mode</button>
     </div>
 </template>
 
 <style scoped lang="scss">
 #ruler {
     display: flex;
+    flex-direction: column;
 }
 
 button {

--- a/client/src/game/vision/te.ts
+++ b/client/src/game/vision/te.ts
@@ -39,7 +39,7 @@ export function computeVisibility(
         }
     }
 
-    if (drawt) drawPolygon(rawOutput, { colour: "red" });
+    if (drawt) drawPolygon(rawOutput, { strokeColour: "red" });
 
     return { visibility: rawOutput, shapeHits };
 }


### PR DESCRIPTION
_WIP_

This PR adds an extra option called 'grid mode' to the ruler tool (and as a result the select tool as well when it's in ruler mode).

In grid mode the ruler calculates the distance between 2 points in terms of the number of grid cells it has to traverse (e.g. the number of squares in a square grid setup).

This results in something like:
![image](https://github.com/Kruptein/PlanarAlly/assets/1814713/7e670e12-09da-44bc-8ee1-ea99a79aeccf)

Showing a total of 21 cells traversed which equals 105ft (with 1 grid = 5ft settings).