### PR TITLE
bug(Select): Fix resize snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ tech changes will usually be stripped from release notes for the public
 
 ### Fixed
 
+-   Select Tool: resizing in snapping mode was also snapping to the point being resized
 -   Spell tool: selecting another tool would swap to the Select tool instead
 
 ## [2024.1.0] - 2024-01-27

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -22,6 +22,7 @@ export interface IShape extends SimpleShape {
     get points(): [number, number][];
     get shadowPoints(): [number, number][];
     invalidatePoints: () => void;
+    updatePoints: () => void;
     resetVisionIteration: () => void;
 
     contains: (point: GlobalPoint, nearbyThreshold?: number) => boolean;
@@ -75,7 +76,6 @@ export interface IShape extends SimpleShape {
     getPositionRepresentation: () => { angle: number; points: [number, number][] };
     setPositionRepresentation: (position: { angle: number; points: [number, number][] }) => void;
     invalidate: (skipLightUpdate: boolean) => void;
-    updateLayerPoints: () => void;
     rotateAround: (point: GlobalPoint, angle: number) => void;
     rotateAroundAbsolute: (point: GlobalPoint, angle: number) => void;
     getPointIndex: (p: GlobalPoint, delta?: number) => number;

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -205,12 +205,6 @@ export class Layer implements ILayer {
         propertiesSystem.setBlocksMovement(shape.id, props.blocksMovement, UI_SYNC, invalidate !== InvalidationMode.NO);
 
         shape.invalidatePoints();
-        if (shape.isSnappable) {
-            for (const point of shape.points) {
-                const strp = JSON.stringify(point);
-                this.points.set(strp, (this.points.get(strp) ?? new Set()).add(shape.id));
-            }
-        }
 
         if (accessSystem.hasAccessTo(shape.id, false, { vision: true }) && props.isToken)
             accessSystem.addOwnedToken(shape.id);
@@ -339,13 +333,6 @@ export class Layer implements ILayer {
 
         if (options.dropShapeId) dropId(shape.id);
         markerSystem.removeMarker(shape.id, true);
-
-        for (const point of shape.points) {
-            const strp = JSON.stringify(point);
-            const val = this.points.get(strp);
-            if (val === undefined || val.size === 1) this.points.delete(strp);
-            else val.delete(shape.id);
-        }
 
         if (this.isActiveLayer) selectedSystem.remove(shape.id);
 

--- a/client/src/game/shapes/variants/baseRect.ts
+++ b/client/src/game/shapes/variants/baseRect.ts
@@ -75,7 +75,7 @@ export abstract class BaseRect extends Shape implements IShape {
         return bbox;
     }
 
-    invalidatePoints(): void {
+    updatePoints(): void {
         if (this.w === 0 || this.h === 0) {
             this._points = [[this.refPoint.x, this.refPoint.y]];
             return;
@@ -93,7 +93,6 @@ export abstract class BaseRect extends Shape implements IShape {
             [botright.x, botright.y],
             [topright.x, topright.y],
         ];
-        super.invalidatePoints();
     }
 
     contains(point: GlobalPoint): boolean {
@@ -236,7 +235,7 @@ export abstract class BaseRect extends Shape implements IShape {
         const oppositeNRP = (newResizePoint + 2) % 4;
 
         // this call needs to happen BEFORE the below code
-        this.invalidatePoints();
+        this.updatePoints(); // todo see if we can do this without the full updatePoints call
 
         const vec = Vector.fromPoints(toGP(this.points[oppositeNRP]!), toGP(oldPoints[oppositeNRP]!));
         this.refPoint = addP(this.refPoint, vec);

--- a/client/src/game/shapes/variants/circle.ts
+++ b/client/src/game/shapes/variants/circle.ts
@@ -65,7 +65,7 @@ export class Circle extends Shape implements IShape {
         return new BoundingRect(toGP(this.refPoint.x - this.r, this.refPoint.y - this.r), this.r * 2, this.r * 2);
     }
 
-    invalidatePoints(): void {
+    updatePoints(): void {
         const ps = [];
         const r = this.r;
         const k = 0.75 / r;
@@ -76,7 +76,6 @@ export class Circle extends Shape implements IShape {
         }
         this._shadowPoints = ps;
         this._points = this.getBoundingBox().points;
-        super.invalidatePoints();
     }
 
     draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {

--- a/client/src/game/shapes/variants/line.ts
+++ b/client/src/game/shapes/variants/line.ts
@@ -62,12 +62,11 @@ export class Line extends Shape implements IShape {
         return { ...this.getBaseDict(), x2: this.endPoint.x, y2: this.endPoint.y, line_width: this.lineWidth };
     }
 
-    invalidatePoints(): void {
+    updatePoints(): void {
         this._points = [
             toArrayP(rotateAroundPoint(this.refPoint, this.center, this.angle)),
             toArrayP(rotateAroundPoint(this.endPoint, this.center, this.angle)),
         ];
-        super.invalidatePoints();
     }
 
     getBoundingBox(): BoundingRect {

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -137,10 +137,9 @@ export class Polygon extends Shape implements IShape {
         return toArrayP(rotateAroundPoint(point, center, this.angle));
     }
 
-    invalidatePoints(): void {
+    updatePoints(): void {
         const center = this.center;
         this._points = this.vertices.map((point) => this.invalidatePoint(point, center));
-        super.invalidatePoints();
     }
 
     draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
@@ -292,7 +291,6 @@ export class Polygon extends Shape implements IShape {
         this._vertices.push(point);
         this._points.push(this.invalidatePoint(point, this.center));
         this.layer?.updateSectors(this.id, this.getAuraAABB());
-        if (this.isSnappable) this.updateLayerPoints();
         if (options?.simplifyEnd === true) this.simplifyEnd();
     }
 

--- a/client/src/game/shapes/variants/text.ts
+++ b/client/src/game/shapes/variants/text.ts
@@ -42,9 +42,8 @@ export class Text extends Shape implements IText {
         return { ...this.getBaseDict(), text: this.text, font_size: this.fontSize, angle: this.angle };
     }
 
-    invalidatePoints(): void {
+    updatePoints(): void {
         this._points = this.getBoundingBox().points;
-        super.invalidatePoints();
     }
 
     getBoundingBox(): BoundingRect {

--- a/client/src/game/shapes/variants/toggleComposite.ts
+++ b/client/src/game/shapes/variants/toggleComposite.ts
@@ -202,7 +202,7 @@ export class ToggleComposite extends Shape implements IToggleComposite {
         };
     }
 
-    invalidatePoints(): void {
+    updatePoints(): void {
         return;
     }
 

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -186,7 +186,6 @@ class DrawTool extends Tool implements ITool {
             this.onDeselect();
             await this.onSelect(mouse);
         } else {
-            this.shape.updateLayerPoints();
             const props = getProperties(this.shape.id)!;
 
             if (this.shape.floorId !== undefined) {
@@ -471,7 +470,7 @@ class DrawTool extends Tool implements ITool {
                 this.ruler.refPoint = lastPoint;
                 this.ruler.endPoint = lastPoint;
             }
-            const points = this.shape.points; // expensive call
+            const points = this.shape.points;
             const props = getProperties(this.shape.id)!;
             if (props.blocksVision !== VisionBlock.No && points.length > 1)
                 visionState.insertConstraint(TriangulationTarget.VISION, this.shape, points.at(-2)!, points.at(-1)!);
@@ -495,9 +494,10 @@ class DrawTool extends Tool implements ITool {
             return Promise.resolve();
         }
 
-        if (event && playerSettingsState.useSnapping(event))
-            [endPoint, this.snappedToPoint] = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
-        else this.snappedToPoint = false;
+        if (event && playerSettingsState.useSnapping(event)) {
+            const ignore = this.ruler ? { shape: this.ruler, pointIndex: 0 } : undefined;
+            [endPoint, this.snappedToPoint] = snapToPoint(this.getLayer()!, endPoint, ignore);
+        } else this.snappedToPoint = false;
 
         if (this.pointer !== undefined) {
             this.pointer.refPoint = endPoint;
@@ -538,7 +538,7 @@ class DrawTool extends Tool implements ITool {
             }
             case DrawShape.Brush: {
                 const br = this.shape as Polygon;
-                const points = br.points; // expensive call
+                const points = br.points;
                 if (equalPoints(points.at(-1)!, [endPoint.x, endPoint.y])) return Promise.resolve();
                 br.pushPoint(endPoint, { simplifyEnd: true });
                 break;
@@ -582,9 +582,10 @@ class DrawTool extends Tool implements ITool {
         }
 
         let endPoint = l2g(lp);
-        if (event && playerSettingsState.useSnapping(event))
-            [endPoint, this.snappedToPoint] = snapToPoint(this.getLayer()!, endPoint, this.ruler?.refPoint);
-        else this.snappedToPoint = false;
+        if (event && playerSettingsState.useSnapping(event)) {
+            const ignore = this.ruler ? { shape: this.ruler, pointIndex: 0 } : undefined;
+            [endPoint, this.snappedToPoint] = snapToPoint(this.getLayer()!, endPoint, ignore);
+        } else this.snappedToPoint = false;
 
         // TODO: handle touch event different than altKey, long press
         if (
@@ -629,7 +630,7 @@ class DrawTool extends Tool implements ITool {
             this.ruler = undefined;
             if (this.state.isClosedPolygon) {
                 const props = getProperties(this.shape.id)!;
-                const points = this.shape.points; // expensive call
+                const points = this.shape.points;
                 if (props.blocksVision !== VisionBlock.No && points.length > 1)
                     visionState.insertConstraint(TriangulationTarget.VISION, this.shape, points[0]!, points.at(-1)!);
                 if (props.blocksMovement && points.length > 1)

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -293,7 +293,7 @@ class SelectTool extends Tool implements ISelectTool {
                     selectedSystem.set(shape.id);
                     this.removeRotationUi();
                     this.createRotationUi(features);
-                    const points = shape.points; // expensive call
+                    const points = shape.points;
                     this.originalResizePoints = points;
                     this.mode = SelectOperations.Resize;
                     layer.invalidate(true);
@@ -509,18 +509,16 @@ class SelectTool extends Tool implements ISelectTool {
 
                 if (!accessSystem.hasAccessTo(shape.id, false, { movement: true })) return;
 
-                let ignorePoint: GlobalPoint | undefined;
-                if (this.resizePoint >= 0) {
-                    const targetPoint = this.originalResizePoints[this.resizePoint];
-                    if (targetPoint !== undefined) ignorePoint = toGP(targetPoint);
-                }
                 let targetPoint = gp;
                 if (
                     event &&
                     playerSettingsState.useSnapping(event) &&
                     this.hasFeature(SelectFeatures.Snapping, features)
                 )
-                    [targetPoint, this.snappedToPoint] = snapToPoint(floorState.currentLayer.value!, gp, ignorePoint);
+                    [targetPoint, this.snappedToPoint] = snapToPoint(floorState.currentLayer.value!, gp, {
+                        shape,
+                        pointIndex: this.resizePoint,
+                    });
                 else this.snappedToPoint = false;
 
                 this.resizePoint = resizeShape(
@@ -582,7 +580,7 @@ class SelectTool extends Tool implements ISelectTool {
                 if (!shape.visibleInCanvas({ w: layer.width, h: layer.height }, { includeAuras: false })) continue;
                 if (layerSelection.some((s) => s.id === shape.id)) continue;
 
-                const points = shape.points; // expensive call
+                const points = shape.points;
                 if (points.length > 1) {
                     for (let i = 0; i < points.length; i++) {
                         const ray = Ray.fromPoints(toGP(points[i]!), toGP(points[(i + 1) % points.length]!));


### PR DESCRIPTION
Resize snapping (i.e. resizing a shape with snapping mode on) was no longer behaving smoothly due to the point being moved snapping to itself.

I'm not sure how long this behaviour was faulty, as I have snapping mode on by default.

