### PR TITLE
bug(Polygon): Fix code that checks if a certain point is on the polygon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ tech changes will usually be stripped from release notes for the public
 
 -   Select Tool: resizing in snapping mode was also snapping to the point being resized
 -   Spell tool: selecting another tool would swap to the Select tool instead
+-   Polygon: selection/contains check went wrong if a polygon used the same point multiple times
+-   Polygon: selection/contains check was also hitting on the line between the first and last points when not closed
 
 ## [2024.1.0] - 2024-01-27
 

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -193,8 +193,9 @@ export class Polygon extends Shape implements IShape {
         if (!bbox.contains(point)) return false;
         if (this.isClosed) return true;
         if (this.angle !== 0) point = rotateAroundPoint(point, this.center, -this.angle);
-        const vertices = this.uniqueVertices;
+        const vertices = this.vertices;
         for (const [i, v] of vertices.entries()) {
+            if (i === this.vertices.length - 1 && this.openPolygon) break;
             const nv = vertices[(i + 1) % vertices.length]!;
             const { distance } = getDistanceToSegment(point, [v, nv]);
             if (distance <= nearbyThreshold) return true;


### PR DESCRIPTION
Two bugs were fixed in this code.

The below image shows a blue polygon with in red what the contains check was actually going through.

![image](https://github.com/Kruptein/PlanarAlly/assets/1814713/4a837678-7ab7-47d1-9b34-803fd6290bb0)

The contains code was wrongly using code that filters out duplicate points, causing 2 edges to be completely skipped and a direct line being drawn between two vertices that are not connected.

Additionally the first and last points were also being connected even though the polygon is not closed.