### PR TITLE
bug(Select): Fix polygon edit UI visual glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ tech changes will usually be stripped from release notes for the public
 
 ### Fixed
 
--   Select Tool: resizing in snapping mode was also snapping to the point being resized
+-   Select Tool:
+    -   resizing in snapping mode was also snapping to the point being resized
+    -   polygon edit UI had a small visual glitch on appearance causing a circle to appear around (0, 0)
 -   Spell tool: selecting another tool would swap to the Select tool instead
--   Polygon: selection/contains check went wrong if a polygon used the same point multiple times
--   Polygon: selection/contains check was also hitting on the line between the first and last points when not closed
+-   Polygon:
+    -   selection/contains check went wrong if a polygon used the same point multiple times
+    -   selection/contains check was also hitting on the line between the first and last points when not closed
 
 ## [2024.1.0] - 2024-01-27
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -945,6 +945,7 @@ class SelectTool extends Tool implements ISelectTool {
             },
             { fillColour: "rgba(0,0,0,0)", strokeColour: ["black"] },
         );
+        this.polygonTracer.options.skipDraw = true;
         const drawLayer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw)!;
         drawLayer.addShape(this.polygonTracer, SyncMode.NO_SYNC, InvalidationMode.NORMAL);
         this.updatePolygonEditUi(this.lastMousePosition);
@@ -1004,6 +1005,7 @@ class SelectTool extends Tool implements ISelectTool {
         if (smallest.distance <= polygon.lineWidth[0]!) {
             _$.polygonUiVisible = "visible";
             this.polygonTracer.refPoint = smallest.nearest;
+            this.polygonTracer.options.skipDraw = false;
             this.polygonTracer.layer?.invalidate(true);
             const lp = g2l(smallest.nearest);
             const radians = toRadians(smallest.angle);


### PR DESCRIPTION
The polygon edit UI shows a circle on the selected polygon to highlight where on the polygon you're currently tracing.

This circle would on first render seemingly cause a visual glitch by first appearing on (0, 0) before snapping to the polygon.