### PR TITLE
bug(Reactivity): Fix floors, layers, shapes becoming reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ tech changes will usually be stripped from release notes for the public
 -   Polygon:
     -   selection/contains check went wrong if a polygon used the same point multiple times
     -   selection/contains check was also hitting on the line between the first and last points when not closed
+-   [tech] FloorSystem's floors and layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27
 

--- a/client/src/game/systems/floors/index.ts
+++ b/client/src/game/systems/floors/index.ts
@@ -1,4 +1,4 @@
-import type { DeepReadonly } from "vue";
+import { markRaw, type DeepReadonly } from "vue";
 
 import { registerSystem } from "..";
 import type { System } from "..";
@@ -80,14 +80,14 @@ class FloorSystem implements System {
             const I = this.indices.findIndex((i) => i > targetIndex);
             if (I >= 0) {
                 this.indices.splice(I, 0, targetIndex);
-                $.floors.splice(I, 0, floor);
+                $.floors.splice(I, 0, markRaw(floor));
                 if (I <= floorState.raw.floorIndex) $.floorIndex = (floorState.raw.floorIndex + 1) as FloorIndex;
             } else {
                 this.indices.push(targetIndex);
-                $.floors.push(floor);
+                $.floors.push(markRaw(floor));
             }
         } else {
-            $.floors.push(floor);
+            $.floors.push(markRaw(floor));
         }
         this.layerMap.set(floor.id, []);
     }
@@ -110,7 +110,7 @@ class FloorSystem implements System {
         const floor = this.getFloor(targetFloor)!;
 
         $.floorIndex = targetFloorIndex;
-        $.layers = this.getLayers(floor);
+        $.layers = this.getLayers(floor).map((l) => markRaw(l));
 
         this.updateLayerVisibility();
 
@@ -164,7 +164,7 @@ class FloorSystem implements System {
             return;
         }
 
-        $.floors = floors.map((name) => floorState.raw.floors.find((f) => f.name === name)!);
+        $.floors = floors.map((name) => markRaw(floorState.raw.floors.find((f) => f.name === name)!));
         $.floorIndex = this.getFloorIndex({ name: activeFloorName })!;
         recalculateZIndices();
         if (sync) sendFloorReorder(floors);

--- a/client/src/game/systems/floors/state.ts
+++ b/client/src/game/systems/floors/state.ts
@@ -1,14 +1,16 @@
-import { computed } from "vue";
+import { type Raw, computed } from "vue";
 
 import type { ILayer } from "../../interfaces/layer";
 import type { Floor, FloorIndex } from "../../models/floor";
 import { buildState } from "../state";
 
+// Floors & Layers are kept in a reactive array,
+// but are themselves not reactive!
 interface ReactiveFloorState {
-    floors: Floor[];
+    floors: Raw<Floor>[];
     floorIndex: FloorIndex;
 
-    layers: ILayer[];
+    layers: Raw<ILayer>[];
     layerIndex: number;
 }
 


### PR DESCRIPTION
_This is a technical internal change_

An oversight on my end caused floors, layers and shapes to all become reactive, which isn't intended as this induces extra overhead that we aren't even using anywhere.

This PR changes the floorSystem state to only make the array holding floors and layers reactive, but not the individual items.