### PR TITLE
feat(Select): Update SelectTool to use onlyInView when fetching shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+-   [tech] Select tool: only take shapes in view into account
+
 ### Fixed
 
 -   Select Tool:

--- a/client/src/game/interfaces/layer.ts
+++ b/client/src/game/interfaces/layer.ts
@@ -29,7 +29,7 @@ export interface ILayer {
     addShape: (shape: IShape, sync: SyncMode, invalidate: InvalidationMode) => void;
     clear: () => void;
     draw: (doClear?: boolean) => void;
-    getShapes: (options: { onlyInView?: boolean; includeComposites: boolean }) => readonly IShape[];
+    getShapes: (options: { onlyInView: boolean; includeComposites: boolean }) => readonly IShape[];
     hide: () => void;
     invalidate: (skipLightUpdate: boolean) => void;
     updateView: () => void;
@@ -41,6 +41,6 @@ export interface ILayer {
     setServerShapes: (shapes: ApiShape[]) => void;
     setShapes: (...shapes: IShape[]) => void;
     show: () => void;
-    size: (options: { includeComposites: boolean }) => number;
+    size: (options: { includeComposites: boolean; onlyInView: boolean }) => number;
     updateSectors: (shapeId: LocalId, aabb: BoundingRect) => void;
 }

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -167,7 +167,7 @@ export class Layer implements ILayer {
     /**
      * Returns the number of shapes on this layer
      */
-    size(options: { includeComposites: boolean }): number {
+    size(options: { includeComposites: boolean; onlyInView: boolean }): number {
         return this.getShapes(options).length;
     }
 
@@ -240,8 +240,8 @@ export class Layer implements ILayer {
 
     // UI helpers are objects that are created for UI reaons but that are not pertinent to the actual state
     // They are often not desired unless in specific circumstances
-    getShapes(options: { includeComposites: boolean; onlyInView?: boolean }): readonly IShape[] {
-        let shapes: readonly IShape[] = options.onlyInView ?? false ? this.shapesInSector : this.shapes;
+    getShapes(options: { includeComposites: boolean; onlyInView: boolean }): readonly IShape[] {
+        let shapes: readonly IShape[] = options.onlyInView ? this.shapesInSector : this.shapes;
         if (options.includeComposites) {
             shapes = compositeState.addAllCompositeShapes(shapes);
         }

--- a/client/src/game/systems/logic/tp/core.ts
+++ b/client/src/game/systems/logic/tp/core.ts
@@ -26,7 +26,7 @@ export function getTpZoneShapes(fromZone: LocalId): LocalId[] {
     const fromShape = getShape(fromZone);
     if (fromShape === undefined) return [];
 
-    for (const shape of tokenLayer.getShapes({ includeComposites: true })) {
+    for (const shape of tokenLayer.getShapes({ includeComposites: true, onlyInView: false })) {
         if (
             shape.id !== fromZone &&
             !getProperties(shape.id)!.isLocked &&

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -34,7 +34,9 @@ export function moveFloor(shapes: IShape[], newFloor: Floor, sync: boolean): voi
         visionState.moveShape(shape.id, oldFloor.id, newFloor.id);
         shape.setLayer(newFloor.id, oldLayer.name);
     }
-    oldLayer.setShapes(...oldLayer.getShapes({ includeComposites: true }).filter((s) => !shapes.includes(s)));
+    oldLayer.setShapes(
+        ...oldLayer.getShapes({ includeComposites: true, onlyInView: false }).filter((s) => !shapes.includes(s)),
+    );
     newLayer.pushShapes(...shapes);
     oldLayer.invalidate(false);
     newLayer.invalidate(false);
@@ -59,7 +61,9 @@ export function moveLayer(shapes: readonly IShape[], newLayer: ILayer, sync: boo
 
     for (const shape of shapes) shape.setLayer(newLayer.floor, newLayer.name);
     // Update layer shapes
-    oldLayer.setShapes(...oldLayer.getShapes({ includeComposites: true }).filter((s) => !shapes.includes(s)));
+    oldLayer.setShapes(
+        ...oldLayer.getShapes({ includeComposites: true, onlyInView: false }).filter((s) => !shapes.includes(s)),
+    );
     newLayer.pushShapes(...shapes);
     // Revalidate layers  (light should at most be redone once)
     oldLayer.invalidate(true);

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -183,7 +183,11 @@ class RulerTool extends Tool implements ITool {
                 return;
             }
 
-            layer.moveShapeOrder(this.text!, layer.size({ includeComposites: true }) - 1, SyncMode.TEMP_SYNC);
+            layer.moveShapeOrder(
+                this.text!,
+                layer.size({ includeComposites: true, onlyInView: false }) - 1,
+                SyncMode.TEMP_SYNC,
+            );
 
             event.preventDefault();
         }

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -256,7 +256,7 @@ class SelectTool extends Tool implements ISelectTool {
         const layerSelection = selectedSystem.get({ includeComposites: false });
         let selectionStack: readonly IShape[];
         if (this.hasFeature(SelectFeatures.ChangeSelection, features)) {
-            const shapes = layer.getShapes({ includeComposites: false });
+            const shapes = layer.getShapes({ includeComposites: false, onlyInView: true });
             if (!layerSelection.length) selectionStack = shapes;
             else selectionStack = shapes.concat(layerSelection);
         } else {
@@ -574,7 +574,7 @@ class SelectTool extends Tool implements ISelectTool {
                 selectedSystem.clear();
             }
             const cbbox = this.selectionHelper!.getBoundingBox();
-            for (const shape of layer.getShapes({ includeComposites: false })) {
+            for (const shape of layer.getShapes({ includeComposites: false, onlyInView: true })) {
                 if (!(shape.options.preFogShape ?? false) && (shape.options.skipDraw ?? false)) continue;
                 if (!accessSystem.hasAccessTo(shape.id, false, { movement: true })) continue;
                 if (!shape.visibleInCanvas({ w: layer.width, h: layer.height }, { includeAuras: false })) continue;
@@ -797,8 +797,9 @@ class SelectTool extends Tool implements ISelectTool {
         }
 
         // Check if any other shapes are under the mouse
-        for (let i = layer.size({ includeComposites: false }) - 1; i >= 0; i--) {
-            const shape = layer.getShapes({ includeComposites: false })[i];
+        const shapes = layer.getShapes({ includeComposites: false, onlyInView: true });
+        for (let i = shapes.length - 1; i >= 0; i--) {
+            const shape = shapes[i];
             if (shape?.contains(globalMouse) === true) {
                 selectedSystem.set(shape.id);
                 layer.invalidate(true);

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -173,7 +173,7 @@ function moveToBack(): void {
 function moveToFront(): void {
     const layer = floorState.currentLayer.value!;
     for (const shape of selectedSystem.get({ includeComposites: false })) {
-        layer.moveShapeOrder(shape, layer.size({ includeComposites: true }) - 1, SyncMode.FULL_SYNC);
+        layer.moveShapeOrder(shape, layer.size({ includeComposites: true, onlyInView: false }) - 1, SyncMode.FULL_SYNC);
     }
 
     close();


### PR DESCRIPTION
The Select Tool was fetching all shapes on a layer instead of only those in view which is obviously more performant.