### PR TITLE
bug(Draw): Fix draw resize snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ tech changes will usually be stripped from release notes for the public
 
 ### Fixed
 
+-   Draw Tool:
+    -   snapping mode was also snapping to the point being moved
 -   Select Tool:
     -   resizing in snapping mode was also snapping to the point being resized
     -   polygon edit UI had a small visual glitch on appearance causing a circle to appear around (0, 0)

--- a/client/src/core/math.ts
+++ b/client/src/core/math.ts
@@ -42,7 +42,7 @@ export function getPointsCenter(points: GlobalPoint[]): GlobalPoint {
 export function snapToPoint(
     layer: DeepReadonly<ILayer>,
     endPoint: GlobalPoint,
-    ignore?: { shape: IShape; pointIndex: number },
+    ignore?: { shape: IShape; pointIndex?: number },
 ): [GlobalPoint, boolean] {
     const snapDistance = l2gz(20);
     let smallestPoint: [number, GlobalPoint] | undefined;
@@ -54,8 +54,9 @@ export function snapToPoint(
             // const gp = toGP(JSON.parse(point) as [number, number]);
             const gp = toGP(point);
             if (ignore?.shape.id === shape.id) {
-                const ingorePoint = toGP(ignore.shape.points[ignore.pointIndex]!);
-                if (equalsP(gp, ingorePoint)) continue;
+                if (ignore.pointIndex === undefined) continue;
+                const ignorePoint = toGP(ignore.shape.points[ignore.pointIndex]!);
+                if (equalsP(gp, ignorePoint)) continue;
             }
             const l = subtractP(endPoint, gp).length();
 

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -495,7 +495,9 @@ class DrawTool extends Tool implements ITool {
         }
 
         if (event && playerSettingsState.useSnapping(event)) {
-            const ignore = this.ruler ? { shape: this.ruler, pointIndex: 0 } : undefined;
+            let ignore = undefined;
+            if (this.ruler) ignore = { shape: this.ruler, pointIndex: 0 };
+            else if (this.shape) ignore = { shape: this.shape };
             [endPoint, this.snappedToPoint] = snapToPoint(this.getLayer()!, endPoint, ignore);
         } else this.snappedToPoint = false;
 


### PR DESCRIPTION
Similar to an earlier PR where this behaviour was fixed for the SelectTool resize, the drawtool was also having janky behaviour with snapping while dragging.

I thought I had fixed this together with the SelectTool stuff, but I only fixed it for polygon drawing, so this PR cleans it up for general shape drawing.