### PR TITLE
feat(ClientSettings): Add format for ruler label in grid mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ tech changes will usually be stripped from release notes for the public
 
 -   Hex orientation to shape properties dialog
     -   This is used to determine which orientation even-sized shapes should use in hex grids
+-   Client Setting "Grid Mode Label Format" to decide what the ruler should show in grid mode
+    -   This can be set to either '#cells only', 'distance only' or 'both'
 
 ### Changed
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -7,6 +7,7 @@ import type { CharacterId } from "./game/systems/characters/models";
 import type { ClientId } from "./game/systems/client/models";
 import type { PlayerId } from "./game/systems/players/models";
 import type { VisionBlock } from "./game/systems/properties/types";
+import type { GridModeLabelFormat } from "./game/systems/settings/players/models";
 import type { TrackerId } from "./game/systems/trackers/models";
 
 export type ApiShape = ApiAssetRectShape | ApiRectShape | ApiCircleShape | ApiCircularTokenShape | ApiPolygonShape | ApiTextShape | ApiLineShape | ApiToggleCompositeShape
@@ -324,6 +325,7 @@ export interface ApiOptionalUserOptions {
   ruler_colour?: string | null;
   use_tool_icons?: boolean | null;
   show_token_directions?: boolean | null;
+  grid_mode_label_format?: GridModeLabelFormat | null;
   invert_alt?: boolean | null;
   disable_scroll_to_zoom?: boolean | null;
   default_tracker_mode?: boolean | null;
@@ -368,6 +370,7 @@ export interface ApiUserOptions {
   ruler_colour: string;
   use_tool_icons: boolean;
   show_token_directions: boolean;
+  grid_mode_label_format: GridModeLabelFormat;
   invert_alt: boolean;
   disable_scroll_to_zoom: boolean;
   default_tracker_mode: boolean;

--- a/client/src/game/api/events/player/options.ts
+++ b/client/src/game/api/events/player/options.ts
@@ -35,6 +35,10 @@ socket.on("Player.Options.Set", (options: PlayerOptionsSet) => {
         sync: false,
         default: defaultOptions.showTokenDirections,
     });
+    playerSettingsSystem.setGridModeLabelFormat(roomOptions?.gridModeLabelFormat, {
+        sync: false,
+        default: defaultOptions.gridModeLabelFormat,
+    });
 
     // Behaviour
     playerSettingsSystem.setInvertAlt(roomOptions?.invertAlt, {

--- a/client/src/game/systems/settings/players/index.ts
+++ b/client/src/game/systems/settings/players/index.ts
@@ -7,6 +7,7 @@ import type { InitiativeEffectMode } from "../../../models/initiative";
 import { floorSystem } from "../../floors";
 import { floorState } from "../../floors/state";
 
+import type { GridModeLabelFormat } from "./models";
 import { playerSettingsState } from "./state";
 
 const { mutableReactive: $ } = playerSettingsState;
@@ -59,6 +60,16 @@ class PlayerSettingsSystem implements System {
         const floor = floorState.currentFloor.value;
         if (floor !== undefined) floorSystem.getLayer(floor, LayerName.Draw)?.invalidate(true);
         if (options.sync) sendRoomClientOptions("show_token_directions", showTokenDirections, options.default);
+    }
+
+    setGridModeLabelFormat(
+        gridModeLabelFormat: GridModeLabelFormat | undefined,
+        options: { sync: boolean; default?: GridModeLabelFormat },
+    ): void {
+        $.gridModeLabelFormat.override = gridModeLabelFormat;
+        if (options.default !== undefined) $.gridModeLabelFormat.default = options.default;
+        $.gridModeLabelFormat.value = gridModeLabelFormat ?? $.gridModeLabelFormat.default;
+        if (options.sync) sendRoomClientOptions("grid_mode_label_format", gridModeLabelFormat, options.default);
     }
 
     // BEHAVIOUR

--- a/client/src/game/systems/settings/players/models.ts
+++ b/client/src/game/systems/settings/players/models.ts
@@ -7,6 +7,7 @@ export interface PlayerOptions {
     rulerColour: string;
     useToolIcons: boolean;
     showTokenDirections: boolean;
+    gridModeLabelFormat: GridModeLabelFormat;
 
     // Behaviour
     invertAlt: boolean;
@@ -29,4 +30,11 @@ export interface PlayerOptions {
 
     // Performance
     renderAllFloors: boolean;
+}
+
+// Order must match with en.json!
+export enum GridModeLabelFormat {
+    Both,
+    Distance,
+    Cells,
 }

--- a/client/src/game/systems/settings/players/state.ts
+++ b/client/src/game/systems/settings/players/state.ts
@@ -5,7 +5,7 @@ import { InitiativeEffectMode } from "../../../models/initiative";
 import { buildState } from "../../state";
 import { locationSettingsState } from "../location/state";
 
-import type { PlayerOptions } from "./models";
+import { GridModeLabelFormat, type PlayerOptions } from "./models";
 
 interface WithDefault<T> {
     default: T;
@@ -22,6 +22,7 @@ const state = buildState<PlayerState, "gridSize">({
     rulerColour: init("rgba(255, 0, 0, 1)"),
     useToolIcons: init(true),
     showTokenDirections: init(true),
+    gridModeLabelFormat: init(GridModeLabelFormat.Both),
 
     invertAlt: init(false),
     disableScrollToZoom: init(false),

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -28,6 +28,7 @@ import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
 import { playerSystem } from "../../systems/players";
 import { locationSettingsState } from "../../systems/settings/location/state";
+import { GridModeLabelFormat } from "../../systems/settings/players/models";
 import { playerSettingsState } from "../../systems/settings/players/state";
 import { SelectFeatures } from "../models/select";
 import { Tool } from "../tool";
@@ -229,7 +230,14 @@ class RulerTool extends Tool implements ITool {
         if (this.gridMode.value) {
             const cellCount = distance - 1;
             const distanceInUnits = distance * locationSettingsState.raw.unitSize.value;
-            label = `${cellCount} (${distanceInUnits} ${unit})`;
+            const labelMode = playerSettingsState.raw.gridModeLabelFormat.value;
+            if (labelMode === GridModeLabelFormat.Both) {
+                label = `${cellCount} - ${distanceInUnits} ${unit}`;
+            } else if (labelMode === GridModeLabelFormat.Distance) {
+                label = `${distanceInUnits} ${unit}`;
+            } else {
+                label = `${cellCount}`;
+            }
         } else {
             // round to 1 decimal
             const distanceInUnits = i18n.global.n(Math.round(10 * distance) / 10);

--- a/client/src/game/ui/settings/client/AppearanceSettings.vue
+++ b/client/src/game/ui/settings/client/AppearanceSettings.vue
@@ -5,6 +5,7 @@ import { useI18n } from "vue-i18n";
 import ColourPicker from "../../../../core/components/ColourPicker.vue";
 import LanguageSelect from "../../../../core/components/LanguageSelect.vue";
 import { playerSettingsSystem } from "../../../systems/settings/players";
+import { GridModeLabelFormat } from "../../../systems/settings/players/models";
 import { playerSettingsState } from "../../../systems/settings/players/state";
 
 const { t } = useI18n();
@@ -36,6 +37,15 @@ const gridColour = computed({
     },
     set(gridColour: string | undefined) {
         pss.setGridColour(gridColour, { sync: true });
+    },
+});
+
+const gridModeLabelFormat = computed({
+    get() {
+        return $.gridModeLabelFormat.value;
+    },
+    set(gridModeLabelFormat: GridModeLabelFormat | undefined) {
+        pss.setGridModeLabelFormat(gridModeLabelFormat, { sync: true });
     },
 });
 
@@ -133,6 +143,38 @@ const rulerColour = computed({
                 <div
                     :title="t('game.ui.settings.common.sync_default')"
                     @click="pss.setRulerColour(undefined, { sync: true, default: $.rulerColour.override })"
+                >
+                    <font-awesome-icon icon="sync-alt" />
+                </div>
+            </template>
+        </div>
+        <div class="row">
+            <label for="gridModeLabelFormat">
+                {{ t("game.ui.settings.client.AppearanceSettings.grid_mode_label_format") }}
+            </label>
+            <div>
+                <select v-model="gridModeLabelFormat">
+                    <option
+                        v-for="option in Object.keys(GridModeLabelFormat).length / 2"
+                        :key="option"
+                        :value="option - 1"
+                        :label="t('game.ui.settings.client.AppearanceSettings.grid_mode_label_format_' + (option - 1))"
+                        :selected="option - 1 === gridModeLabelFormat"
+                    ></option>
+                </select>
+            </div>
+            <template v-if="$.gridModeLabelFormat.override !== undefined">
+                <div :title="t('game.ui.settings.common.reset_default')" @click="gridModeLabelFormat = undefined">
+                    <font-awesome-icon icon="times-circle" />
+                </div>
+                <div
+                    :title="t('game.ui.settings.common.sync_default')"
+                    @click="
+                        pss.setGridModeLabelFormat(undefined, {
+                            sync: true,
+                            default: $.gridModeLabelFormat.override,
+                        })
+                    "
                 >
                     <font-awesome-icon icon="sync-alt" />
                 </div>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -240,7 +240,11 @@
                         "toolbars": "Toolbars",
                         "use_tool_icons": "Use icons",
                         "fog": "Fog",
-                        "show_token_directions": "Show off-screen token directions"
+                        "show_token_directions": "Show off-screen token directions",
+                        "grid_mode_label_format": "Label format in grid mode",
+                        "grid_mode_label_format_0": "Both",
+                        "grid_mode_label_format_1": "Distance only",
+                        "grid_mode_label_format_2": "#cells only"
                     },
                     "BehaviourSettings": {
                         "invert_alt_set": "Invert ALT behaviour",

--- a/server/generate_types.sh
+++ b/server/generate_types.sh
@@ -11,6 +11,7 @@ sed -i 's/"LayerName"/LayerName/g' ../client/src/apiTypes.ts
 sed -i 's/"AssetId"/AssetId/g' ../client/src/apiTypes.ts
 sed -i 's/"Role"/Role/g' ../client/src/apiTypes.ts
 sed -i 's/"VisionBlock"/VisionBlock/g' ../client/src/apiTypes.ts
+sed -i 's/"GridModeLabelFormat"/GridModeLabelFormat/g' ../client/src/apiTypes.ts
 sed -i '1s/^/'\
 'import type { AssetId } from ".\/assetManager\/models";\n'\
 'import type { GlobalId } from ".\/game\/id";\n'\
@@ -21,6 +22,7 @@ sed -i '1s/^/'\
 'import type { ClientId } from ".\/game\/systems\/client\/models";\n'\
 'import type { PlayerId } from ".\/game\/systems\/players\/models";\n'\
 'import type { VisionBlock } from ".\/game\/systems\/properties\/types";\n'\
+'import type { GridModeLabelFormat } from ".\/game\/systems\/settings\/players\/models";\n'\
 'import type { TrackerId } from ".\/game\/systems\/trackers\/models";\n'\
 '\n'\
 'export type ApiShape = ApiAssetRectShape | ApiRectShape | ApiCircleShape | ApiCircularTokenShape | ApiPolygonShape | ApiTextShape | ApiLineShape | ApiToggleCompositeShape\n'\

--- a/server/src/api/models/user/__init__.py
+++ b/server/src/api/models/user/__init__.py
@@ -1,14 +1,15 @@
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from ..helpers import TypeIdModel
 
 
-class ApiUserOptions(BaseModel):
+class ApiUserOptions(TypeIdModel):
     fow_colour: str
     grid_colour: str
     ruler_colour: str
     use_tool_icons: bool
     show_token_directions: bool
+    grid_mode_label_format: int = Field(..., typeId="GridModeLabelFormat")
 
     invert_alt: bool
     disable_scroll_to_zoom: bool
@@ -30,26 +31,31 @@ class ApiUserOptions(BaseModel):
 
 
 class ApiOptionalUserOptions(TypeIdModel):
-    fow_colour: str | None = Field(defaul=None, noneAsNull=True)
-    grid_colour: str | None = Field(defaul=None, noneAsNull=True)
-    ruler_colour: str | None = Field(defaul=None, noneAsNull=True)
-    use_tool_icons: bool | None = Field(defaul=None, noneAsNull=True)
-    show_token_directions: bool | None = Field(defaul=None, noneAsNull=True)
+    fow_colour: str | None = Field(default=None, noneAsNull=True)
+    grid_colour: str | None = Field(default=None, noneAsNull=True)
+    ruler_colour: str | None = Field(default=None, noneAsNull=True)
+    use_tool_icons: bool | None = Field(default=None, noneAsNull=True)
+    show_token_directions: bool | None = Field(default=None, noneAsNull=True)
+    grid_mode_label_format: int | None = Field(
+        default=None,
+        typeId="GridModeLabelFormat",
+        noneAsNull=True,
+    )
 
-    invert_alt: bool | None = Field(defaul=None, noneAsNull=True)
-    disable_scroll_to_zoom: bool | None = Field(defaul=None, noneAsNull=True)
-    default_tracker_mode: bool | None = Field(defaul=None, noneAsNull=True)
-    mouse_pan_mode: int | None = Field(defaul=None, noneAsNull=True)
+    invert_alt: bool | None = Field(default=None, noneAsNull=True)
+    disable_scroll_to_zoom: bool | None = Field(default=None, noneAsNull=True)
+    default_tracker_mode: bool | None = Field(default=None, noneAsNull=True)
+    mouse_pan_mode: int | None = Field(default=None, noneAsNull=True)
 
-    use_high_dpi: bool | None = Field(defaul=None, noneAsNull=True)
-    grid_size: int | None = Field(defaul=None, noneAsNull=True)
-    use_as_physical_board: bool | None = Field(defaul=None, noneAsNull=True)
-    mini_size: float | None = Field(defaul=None, noneAsNull=True)
-    ppi: int | None = Field(defaul=None, noneAsNull=True)
+    use_high_dpi: bool | None = Field(default=None, noneAsNull=True)
+    grid_size: int | None = Field(default=None, noneAsNull=True)
+    use_as_physical_board: bool | None = Field(default=None, noneAsNull=True)
+    mini_size: float | None = Field(default=None, noneAsNull=True)
+    ppi: int | None = Field(default=None, noneAsNull=True)
 
-    initiative_camera_lock: bool | None = Field(defaul=None, noneAsNull=True)
-    initiative_vision_lock: bool | None = Field(defaul=None, noneAsNull=True)
-    initiative_effect_visibility: str | None = Field(defaul=None, noneAsNull=True)
-    initiative_open_on_activate: bool | None = Field(defaul=None, noneAsNull=True)
+    initiative_camera_lock: bool | None = Field(default=None, noneAsNull=True)
+    initiative_vision_lock: bool | None = Field(default=None, noneAsNull=True)
+    initiative_effect_visibility: str | None = Field(default=None, noneAsNull=True)
+    initiative_open_on_activate: bool | None = Field(default=None, noneAsNull=True)
 
-    render_all_floors: bool | None = Field(defaul=None, noneAsNull=True)
+    render_all_floors: bool | None = Field(default=None, noneAsNull=True)

--- a/server/src/db/models/user_options.py
+++ b/server/src/db/models/user_options.py
@@ -14,6 +14,7 @@ class UserOptions(BaseDbModel):
     ruler_colour = cast(str | None, TextField(default="#F00", null=True))
     use_tool_icons = cast(bool | None, BooleanField(default=True, null=True))
     show_token_directions = cast(bool | None, BooleanField(default=True, null=True))
+    grid_mode_label_format = cast(int | None, IntegerField(default=0, null=True))
 
     invert_alt = cast(bool | None, BooleanField(default=False, null=True))
     disable_scroll_to_zoom = cast(bool | None, BooleanField(default=False, null=True))
@@ -47,6 +48,7 @@ class UserOptions(BaseDbModel):
             ruler_colour=None,
             use_tool_icons=None,
             show_token_directions=None,
+            grid_mode_label_format=None,
             invert_alt=None,
             disable_scroll_to_zoom=None,
             default_tracker_mode=None,
@@ -84,6 +86,7 @@ class UserOptions(BaseDbModel):
             ruler_colour=self.ruler_colour,  # type: ignore
             use_tool_icons=self.use_tool_icons,  # type: ignore
             show_token_directions=self.show_token_directions,  # type: ignore
+            grid_mode_label_format=self.grid_mode_label_format,  # type: ignore
             invert_alt=self.invert_alt,  # type: ignore
             disable_scroll_to_zoom=self.disable_scroll_to_zoom,  # type: ignore
             default_tracker_mode=self.default_tracker_mode,  # type: ignore

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 91
+SAVE_VERSION = 92
 
 import json
 import logging
@@ -579,6 +579,15 @@ def upgrade(db: SqliteExtDatabase, version: int):
         with db.atomic():
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN odd_hex_orientation INTEGER DEFAULT 0"
+            )
+    elif version == 91:
+        # Add UserOptions.grid_mode_label_format
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE user_options ADD COLUMN grid_mode_label_format INTEGER DEFAULT 0"
+            )
+            db.execute_sql(
+                "UPDATE user_options SET grid_mode_label_format = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
             )
     else:
         raise UnknownVersionException(


### PR DESCRIPTION
This PR adds a new client setting to configure the label format used for the ruler in grid mode.

It can be configured to only show the number of cells, only show the total distance or both.

This closes #777 