### PR TITLE
bug(Move Front/Back): Fix delayed move layer order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ tech changes will usually be stripped from release notes for the public
 -   Polygon:
     -   selection/contains check went wrong if a polygon used the same point multiple times
     -   selection/contains check was also hitting on the line between the first and last points when not closed
+-   Moving shapes to front/back not updating immediately
 -   [tech] FloorSystem's floors and layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -355,6 +355,7 @@ export class Layer implements ILayer {
                     temporary: sync === SyncMode.TEMP_SYNC,
                 });
         }
+        this.updateView();
         this.invalidate(true);
     }
 


### PR DESCRIPTION
Moving a shape to the front or back was not immediately updating the screen until a second click or another event happened that updated the view.

This is a bug introduced with the sector system a while back.

This closes #1388 