### PR TITLE
feat(MapTool): Improve hex grid support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ tech changes will usually be stripped from release notes for the public
         -   This should now more properly snap shapes that are larger than 1x1
 -   Ruler Tool:
     -   Snap now properly works for hex grids
+-   Map Tool:
+    -   Now better supports hex grids
 -   Spell tool: selecting another tool would swap to the Select tool instead
 -   Polygon:
     -   selection/contains check went wrong if a polygon used the same point multiple times

--- a/client/src/game/rendering/basic.ts
+++ b/client/src/game/rendering/basic.ts
@@ -26,6 +26,7 @@ export function drawPoint(point: [number, number], r: number, options?: { colour
     if (options?.fill === true) ctx.fill();
 }
 
+// eslint-disable-next-line import/no-unused-modules
 function drawPointL(point: [number, number], r: number, colour?: string): void {
     const dl = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
     if (dl === undefined) return;
@@ -40,6 +41,7 @@ function drawPointL(point: [number, number], r: number, colour?: string): void {
     ctx.stroke();
 }
 
+// eslint-disable-next-line import/no-unused-modules
 export function drawPolygon(
     polygon: [number, number][],
     options?: { fillColour?: string; strokeColour?: string; strokeWidth?: number; close?: boolean; debug?: boolean },
@@ -80,7 +82,8 @@ export function drawPolygon(
     if (options?.fillColour !== undefined) ctx.fill();
 }
 
-function drawPolygonL(polygon: [number, number][], colour?: string): void {
+// eslint-disable-next-line import/no-unused-modules
+export function drawPolygonL(polygon: [number, number][], colour?: string): void {
     if (polygon.length === 0) return;
 
     const dl = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
@@ -90,14 +93,14 @@ function drawPolygonL(polygon: [number, number][], colour?: string): void {
     // ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
     ctx.lineJoin = "round";
     ctx.beginPath();
-    ctx.strokeStyle =
+    ctx.fillStyle =
         colour === undefined ? `rgb(${Math.random() * 255}, ${Math.random() * 255}, ${Math.random() * 255})` : colour;
     ctx.moveTo(polygon[0]![0], polygon[0]![1]);
     for (const point of polygon) {
         ctx.lineTo(point[0], point[1]);
     }
     ctx.closePath();
-    ctx.stroke();
+    ctx.fill();
 }
 
 function x(xx: number, local: boolean): number {
@@ -113,6 +116,7 @@ function y(yy: number, local: boolean): number {
 let I = 0;
 let J = 0;
 
+// eslint-disable-next-line import/no-unused-modules
 export function drawLine(
     from: [number, number],
     to: [number, number],
@@ -140,6 +144,7 @@ export function drawLine(
     ctx.stroke();
 }
 
+// eslint-disable-next-line import/no-unused-modules
 export function drawTear(ray: Ray<LocalPoint>, options?: { fillColour?: string }): void {
     const dl = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw);
     if (dl === undefined) return;
@@ -176,6 +181,7 @@ export function drawTear(ray: Ray<LocalPoint>, options?: { fillColour?: string }
     // drawPointL(c, 5, "green");
 }
 
+// eslint-disable-next-line import/no-unused-modules
 function drawEdge(edge: Edge, colour: string, local = false): void {
     const from = edge.first!.vertices[edge.second === 0 ? 1 : 0]!.point as [number, number];
     const to = edge.first!.vertices[edge.second === 2 ? 1 : 2]!.point as [number, number];
@@ -190,6 +196,7 @@ function drawEdge(edge: Edge, colour: string, local = false): void {
     ctx.stroke();
 }
 
+// eslint-disable-next-line import/no-unused-modules
 function drawPolygonT(tds: TDS, local = true, clear = true, logs: 0 | 1 | 2 = 0): void {
     I = 0;
     J = 0;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -4,7 +4,13 @@ import type { ApiCoreShape, ApiShape } from "../../apiTypes";
 import { g2l, g2lx, g2ly, g2lz, getUnitDistance } from "../../core/conversions";
 import { addP, cloneP, equalsP, subtractP, toArrayP, toGP, Vector } from "../../core/geometry";
 import type { GlobalPoint } from "../../core/geometry";
-import { GridType, getCellHeight, getCellWidth, snapPointToGrid, snapShapeToGrid } from "../../core/grid";
+import {
+    GridType,
+    getCellCountFromHeight,
+    getCellCountFromWidth,
+    snapPointToGrid,
+    snapShapeToGrid,
+} from "../../core/grid";
 import { rotateAroundPoint } from "../../core/math";
 import { mostReadable } from "../../core/utils";
 import { generateLocalId, getGlobalId, getShape } from "../id";
@@ -335,7 +341,7 @@ export abstract class Shape implements IShape {
 
     getSize(gridType: GridType): number {
         const bbox = this.getAABB();
-        const s = Math.max(getCellWidth(bbox.w, gridType), getCellHeight(bbox.h, gridType));
+        const s = Math.max(getCellCountFromWidth(bbox.w, gridType), getCellCountFromHeight(bbox.h, gridType));
         const cutoff = gridType === GridType.Square ? 0.25 : 0.125;
         const customRound = (n: number): number => (n % 1 >= cutoff ? Math.ceil(n) : Math.floor(n));
         return Math.max(1, customRound(s));

--- a/client/src/game/tools/variants/map.ts
+++ b/client/src/game/tools/variants/map.ts
@@ -3,7 +3,7 @@ import { reactive } from "vue";
 import { l2g } from "../../../core/conversions";
 import { addP, cloneP, subtractP, toGP, Vector } from "../../../core/geometry";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
-import { DEFAULT_GRID_SIZE } from "../../../core/grid";
+import { getAspectRatio, getCellCountFromHeight, getCellCountFromWidth } from "../../../core/grid";
 import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import { i18n } from "../../../i18n";
 import { sendShapePositionUpdate, sendShapeSizeUpdate } from "../../api/emits/shape/core";
@@ -15,6 +15,7 @@ import { Rect } from "../../shapes/variants/rect";
 import { floorState } from "../../systems/floors/state";
 import { selectedSystem } from "../../systems/selected";
 import { selectedState } from "../../systems/selected/state";
+import { locationSettingsState } from "../../systems/settings/location/state";
 import { SelectFeatures } from "../models/select";
 import { Tool } from "../tool";
 
@@ -59,7 +60,11 @@ class MapTool extends Tool implements ITool {
             this.ogRP = this.shape.refPoint;
             this.ogW = this.shape.w;
             this.ogH = this.shape.h;
-            this.state.aspectRatio = this.shape.w / this.shape.h;
+            this.state.aspectRatio = getAspectRatio(
+                this.shape.w,
+                this.shape.h,
+                locationSettingsState.raw.gridType.value,
+            );
         } else if (shapes.length === 0) {
             this.removeRect();
         }
@@ -162,8 +167,8 @@ class MapTool extends Tool implements ITool {
         }
 
         if (this.rect !== undefined) {
-            const xFactor = (this.state.gridX * DEFAULT_GRID_SIZE) / this.rect.w;
-            const yFactor = (this.state.gridY * DEFAULT_GRID_SIZE) / this.rect.h;
+            const xFactor = this.state.sizeX / this.rect.w;
+            const yFactor = this.state.sizeY / this.rect.h;
 
             this.shape.w *= xFactor;
             this.shape.h *= yFactor;
@@ -187,9 +192,11 @@ class MapTool extends Tool implements ITool {
     skipManualDrag(): void {
         if (this.shape === undefined) return;
 
+        const gridType = locationSettingsState.raw.gridType.value;
+
         this.state.manualDrag = false;
-        this.state.gridX = this.shape.w / DEFAULT_GRID_SIZE;
-        this.state.gridY = this.shape.h / DEFAULT_GRID_SIZE;
+        this.state.gridX = getCellCountFromWidth(this.shape.w, gridType);
+        this.state.gridY = getCellCountFromHeight(this.shape.h, gridType);
         this.state.sizeX = this.shape.w;
         this.state.sizeY = this.shape.h;
     }

--- a/client/src/game/ui/tools/MapTool.vue
+++ b/client/src/game/ui/tools/MapTool.vue
@@ -2,10 +2,18 @@
 import { reactive, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 
-import { DEFAULT_GRID_SIZE } from "../../../core/grid";
+import {
+    GridType,
+    getAspectRatio,
+    getCellCountFromHeight,
+    getCellCountFromWidth,
+    getHeightFromCellCount,
+    getWidthFromCellCount,
+} from "../../../core/grid";
 import { map } from "../../../core/iter";
 import { getShape } from "../../id";
 import { selectedState } from "../../systems/selected/state";
+import { locationSettingsState } from "../../systems/settings/location/state";
 import { mapTool } from "../../tools/variants/map";
 
 const { t } = useI18n();
@@ -20,7 +28,8 @@ const skipManualDrag = (): void => mapTool.skipManualDrag();
 
 watchEffect(() => {
     if (state.lock) {
-        mapTool.state.aspectRatio = mapTool.shape!.w / mapTool.shape!.h;
+        const gridType = locationSettingsState.reactive.gridType.value;
+        mapTool.state.aspectRatio = getAspectRatio(mapTool.shape!.w, mapTool.shape!.h, gridType);
     }
 });
 
@@ -34,48 +43,86 @@ function apply(): void {
     mapTool.removeRect(false);
 }
 
-function updateGridX(): void {
-    if (state.lock) {
-        if (mapTool.state.manualDrag) {
-            mapTool.state.gridY = mapTool.state.gridX / (mapTool.rect!.w / mapTool.rect!.h);
-        } else {
-            mapTool.state.gridY = mapTool.state.gridX / mapTool.state.aspectRatio;
-        }
-        mapTool.state.sizeY = mapTool.state.gridY * DEFAULT_GRID_SIZE;
+function unzigzag(xy: number, applies: boolean): number {
+    if (applies) {
+        return 1 + (xy - 1) * 0.75;
     }
-    mapTool.state.sizeX = mapTool.state.gridX * DEFAULT_GRID_SIZE;
+    return xy;
+}
+
+function zigzag(xy: number, applies: boolean): number {
+    if (applies) {
+        return 1 + (xy - 1) / 0.75;
+    }
+    return xy;
+}
+
+function updateGridX(): void {
+    const gridType = locationSettingsState.reactive.gridType.value;
+    const realGridX = unzigzag(mapTool.state.gridX, gridType === GridType.FlatHex);
+    mapTool.state.sizeX = getWidthFromCellCount(realGridX, gridType);
+    if (state.lock) {
+        calculateY(realGridX, gridType);
+    }
     if (!mapTool.state.manualDrag && mapTool.state.gridX > 0) mapTool.preview(true);
 }
 
 function updateGridY(): void {
+    const gridType = locationSettingsState.reactive.gridType.value;
+    const realGridY = unzigzag(mapTool.state.gridY, gridType === GridType.PointyHex);
+    mapTool.state.sizeY = getHeightFromCellCount(realGridY, gridType);
     if (state.lock) {
-        if (mapTool.state.manualDrag) {
-            mapTool.state.gridX = mapTool.state.gridY * (mapTool.rect!.w / mapTool.rect!.h);
-        } else {
-            mapTool.state.gridX = mapTool.state.gridY * mapTool.state.aspectRatio;
-        }
-        mapTool.state.sizeX = mapTool.state.gridX * DEFAULT_GRID_SIZE;
+        calculateX(realGridY, gridType);
     }
-    mapTool.state.sizeY = mapTool.state.gridY * DEFAULT_GRID_SIZE;
     if (!mapTool.state.manualDrag && mapTool.state.gridY > 0) mapTool.preview(true);
 }
 
 function updateSizeX(): void {
+    const gridType = locationSettingsState.reactive.gridType.value;
+    const realGridX = getCellCountFromWidth(mapTool.state.sizeX, gridType);
+    mapTool.state.gridX = zigzag(realGridX, gridType === GridType.FlatHex);
     if (state.lock) {
-        mapTool.state.sizeY = mapTool.state.sizeX / mapTool.state.aspectRatio;
-        mapTool.state.gridY = mapTool.state.sizeY / DEFAULT_GRID_SIZE;
+        calculateY(realGridX, gridType);
     }
-    mapTool.state.gridX = mapTool.state.sizeX / DEFAULT_GRID_SIZE;
     if (mapTool.state.sizeX > 0) mapTool.preview(true);
 }
 
 function updateSizeY(): void {
+    const gridType = locationSettingsState.reactive.gridType.value;
+    const realGridY = getCellCountFromHeight(mapTool.state.sizeY, gridType);
+    mapTool.state.gridY = zigzag(realGridY, gridType === GridType.PointyHex);
     if (state.lock) {
-        mapTool.state.sizeX = mapTool.state.sizeY * mapTool.state.aspectRatio;
-        mapTool.state.gridX = mapTool.state.sizeX / DEFAULT_GRID_SIZE;
+        calculateX(realGridY, gridType);
     }
-    mapTool.state.gridY = mapTool.state.sizeY / DEFAULT_GRID_SIZE;
     if (mapTool.state.sizeY > 0) mapTool.preview(true);
+}
+
+function calculateX(gridY: number, gridType: GridType): void {
+    const aspectRatio = mapTool.state.manualDrag
+        ? getAspectRatio(mapTool.rect!.w, mapTool.rect!.h, gridType)
+        : mapTool.state.aspectRatio;
+
+    // Calculate the real width
+    const realGridX = gridY * aspectRatio;
+
+    mapTool.state.sizeX = getWidthFromCellCount(realGridX, gridType);
+
+    // Calculate the visual width (same for squares, but not for hexes)
+    mapTool.state.gridX = zigzag(realGridX, gridType === GridType.FlatHex);
+}
+
+function calculateY(gridX: number, gridType: GridType): void {
+    const aspectRatio = mapTool.state.manualDrag
+        ? getAspectRatio(mapTool.rect!.w, mapTool.rect!.h, gridType)
+        : mapTool.state.aspectRatio;
+
+    // Calculate the real height
+    const realGridY = gridX / aspectRatio;
+
+    mapTool.state.sizeY = getHeightFromCellCount(realGridY, gridType);
+
+    // Calculate the visual height (same for squares, but not for hexes)
+    mapTool.state.gridY = zigzag(realGridY, gridType === GridType.PointyHex);
 }
 </script>
 <template>


### PR DESCRIPTION
Another update in the recent chain of hex-grid improvements.

Previous PRs already fixed the most important aspects that also relate to the map tool,
but some small extra changes were necessary.

When resizing a square grid it's easy to determine a number of cells in both directions, for hex grids this is usually easy in 1 direction but less straight forward in the other. Additionally maps will rarely be cutoff cleanly in at least 1 of the 2 directions for the hex case, which can mess up the assumptions used by the map tool.

As a result I strongly recommend to ensure your dominant axis is counted properly and not worry too much about the auxiliary axis. Your dominant axis should be resized correctly, the other will very likely need some additional manual resizing, but that is just over 1 axis so should be very straightforward.

Important to note is that when you use the anchor to lock the aspect ratio, the map tool will try to approximate the number of visual cells that are present in the non-dominant axis. What I mean by this is that it will count the number of cells in a zigzag pattern. This felt more natural than counting the number of cells if they were in a clean line as that is very counterintuitive to verify.