### PR TITLE
bug(Properties): Fix oddHexOrientation not loading properly

### DIFF
--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -650,6 +650,7 @@ export abstract class Shape implements IShape {
             isDefeated: data.is_defeated,
             showBadge: data.show_badge,
             isLocked: data.is_locked,
+            oddHexOrientation: data.odd_hex_orientation,
         });
 
         const defaultAccess = {


### PR DESCRIPTION
When toggling the new oddHexOrientation property, the value is properly saved to the backend, but during loading it is not properly processed causing it to fall back to the default on the client.