### PR TITLE
feat(Shape): Add manual size hinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ tech changes will usually be stripped from release notes for the public
 
 ### Added
 
--   Hex orientation to shape properties dialog
-    -   This is used to determine which orientation even-sized shapes should use in hex grids
+-   New grid section in Edit Shape dialog
+    -   Configure manual size for shape
+        -   Used for finetuning snapping behaviour
+    -   Configure hex orientation
+        -   This is used to determine which orientation even-sized shapes should use in hex grids
 -   Client Setting "Grid Mode Label Format" to decide what the ruler should show in grid mode
     -   This can be set to either '#cells only', 'distance only' or 'both'
 -   Import: option to specify the name for the imported campaign

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -177,6 +177,7 @@ export interface ApiCoreShape {
   labels: ApiLabel[];
   character: CharacterId | null;
   odd_hex_orientation: boolean;
+  size: number;
 }
 export interface ApiDefaultShapeOwner {
   edit_access: boolean;

--- a/client/src/game/api/emits/shape/options.ts
+++ b/client/src/game/api/emits/shape/options.ts
@@ -8,7 +8,6 @@ import { wrapSocket } from "../../helpers";
 
 export const sendShapeSetInvisible = wrapSocket<ShapeSetBooleanValue>("Shape.Options.Invisible.Set");
 export const sendShapeSetDefeated = wrapSocket<ShapeSetBooleanValue>("Shape.Options.Defeated.Set");
-export const sendShapeSetOddHexOrientation = wrapSocket<ShapeSetBooleanValue>("Shape.Options.OddHexOrientation.Set");
 export const sendShapeSetLocked = wrapSocket<ShapeSetBooleanValue>("Shape.Options.Locked.Set");
 export const sendShapeSetIsToken = wrapSocket<ShapeSetBooleanValue>("Shape.Options.Token.Set");
 export const sendShapeSetBlocksMovement = wrapSocket<ShapeSetBooleanValue>("Shape.Options.MovementBlock.Set");
@@ -25,3 +24,7 @@ export const sendShapeRemoveLabel = wrapSocket<ShapeSetStringValue>("Shape.Optio
 
 export const sendShapeSkipDraw = wrapSocket<ShapeSetBooleanValue>("Shape.Options.SkipDraw.Set");
 export const sendShapeSvgAsset = wrapSocket<ShapeSetOptionalStringValue>("Shape.Options.SvgAsset.Set");
+
+// grid related
+export const sendShapeSetSize = wrapSocket<ShapeSetIntegerValue>("Shape.Options.Size.Set");
+export const sendShapeSetOddHexOrientation = wrapSocket<ShapeSetBooleanValue>("Shape.Options.OddHexOrientation.Set");

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -62,6 +62,11 @@ socket.on(
 );
 
 socket.on(
+    "Shape.Options.Size.Set",
+    wrapSystemCall<ShapeSetIntegerValue>(propertiesSystem.setSize.bind(propertiesSystem)),
+);
+
+socket.on(
     "Shape.Options.StrokeColour.Set",
     wrapSystemCall<ShapeSetStringValue>(propertiesSystem.setStrokeColour.bind(propertiesSystem)),
 );

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -1,5 +1,6 @@
 import type { ApiCoreShape, ApiShape } from "../../apiTypes";
 import type { GlobalPoint, Vector } from "../../core/geometry";
+import type { GridType } from "../../core/grid";
 import type { LocalId } from "../id";
 import type { Floor, FloorId, LayerName } from "../models/floor";
 import type { ShapeOptions } from "../models/shapes";
@@ -25,6 +26,8 @@ export interface IShape extends SimpleShape {
     invalidatePoints: () => void;
     updatePoints: () => void;
     resetVisionIteration: () => void;
+
+    getSize: (gridType: GridType) => number;
 
     contains: (point: GlobalPoint, nearbyThreshold?: number) => boolean;
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -340,6 +340,9 @@ export abstract class Shape implements IShape {
     }
 
     getSize(gridType: GridType): number {
+        const props = getProperties(this.id)!;
+        if (props.size !== 0) return props.size;
+
         const bbox = this.getAABB();
         const s = Math.max(getCellCountFromWidth(bbox.w, gridType), getCellCountFromHeight(bbox.h, gridType));
         const cutoff = gridType === GridType.Square ? 0.25 : 0.125;
@@ -627,6 +630,7 @@ export abstract class Shape implements IShape {
             is_teleport_zone: teleportZoneSystem.isTeleportZone(this.id),
             character: this.character ?? null,
             odd_hex_orientation: props.oddHexOrientation,
+            size: props.size,
         };
     }
     fromDict(data: ApiCoreShape): void {
@@ -651,6 +655,7 @@ export abstract class Shape implements IShape {
             showBadge: data.show_badge,
             isLocked: data.is_locked,
             oddHexOrientation: data.odd_hex_orientation,
+            size: data.size,
         });
 
         const defaultAccess = {

--- a/client/src/game/systems/properties/index.ts
+++ b/client/src/game/systems/properties/index.ts
@@ -15,6 +15,7 @@ import {
     sendShapeSetNameVisible,
     sendShapeSetOddHexOrientation,
     sendShapeSetShowBadge,
+    sendShapeSetSize,
     sendShapeSetStrokeColour,
 } from "../../api/emits/shape/options";
 import { getGlobalId, getShape } from "../../id";
@@ -238,6 +239,25 @@ class PropertiesSystem implements ShapeSystem {
 
         const _shape = getShape(id)!;
         _shape.invalidate(!_shape.triggersVisionRecalc);
+    }
+
+    setSize(id: LocalId, size: number, syncTo: Sync): void {
+        const shape = mutable.data.get(id);
+        if (shape === undefined) {
+            return console.error("[Properties.setSize] Unknown local shape.");
+        }
+
+        if (size < 0) size = 0;
+
+        shape.size = size;
+
+        if (syncTo.server) {
+            const shape = getGlobalId(id);
+            if (shape) sendShapeSetSize({ shape, value: size });
+        }
+        if ($.id === id) $.size = size;
+
+        getShape(id)?.invalidate(true);
     }
 
     setOddHexOrientation(id: LocalId, oddHexOrientation: boolean, syncTo: Sync): void {

--- a/client/src/game/systems/properties/state.ts
+++ b/client/src/game/systems/properties/state.ts
@@ -17,6 +17,8 @@ export interface ShapeProperties {
     showBadge: boolean;
     isDefeated: boolean;
     isLocked: boolean;
+    // grid related
+    size: number; // if 0, infer size
     oddHexOrientation: boolean;
 }
 
@@ -43,6 +45,7 @@ const state = buildState<ReactivePropertiesState, PropertiesState>(
         showBadge: false,
         isDefeated: false,
         isLocked: false,
+        size: 0,
         oddHexOrientation: false,
     },
     {
@@ -62,6 +65,7 @@ const DEFAULT_PROPERTIES: () => ShapeProperties = () => ({
     blocksMovement: false,
     blocksVision: VisionBlock.No,
     showBadge: false,
+    size: 0,
     oddHexOrientation: false,
 });
 

--- a/client/src/game/ui/settings/shape/GridSettings.vue
+++ b/client/src/game/ui/settings/shape/GridSettings.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { GridType } from "../../../../core/grid";
+import { SERVER_SYNC } from "../../../../core/models/types";
+import { getChecked, getValue } from "../../../../core/utils";
+import { activeShapeStore } from "../../../../store/activeShape";
+import { getShape } from "../../../id";
+import { accessState } from "../../../systems/access/state";
+import { propertiesSystem } from "../../../systems/properties";
+import { propertiesState } from "../../../systems/properties/state";
+import { locationSettingsState } from "../../../systems/settings/location/state";
+
+const owned = accessState.hasEditAccess;
+
+const shape = computed(() => getShape(propertiesState.reactive.id!));
+
+const size = computed(() => {
+    if (propertiesState.reactive.size === 0) {
+        return shape.value!.getSize(locationSettingsState.reactive.gridType.value);
+    }
+    return propertiesState.reactive.size;
+});
+
+function setInferSize(event: Event): void {
+    _setSize(getChecked(event) ? 0 : size.value);
+}
+
+function setSize(event: Event): void {
+    _setSize(parseInt(getValue(event)));
+}
+
+function _setSize(size: number): void {
+    if (!owned.value) return;
+    propertiesSystem.setSize(propertiesState.raw.id!, size, SERVER_SYNC);
+}
+
+const showHexSettings = computed(() => {
+    if (activeShapeStore.state.type === undefined) return false;
+    const gridType = locationSettingsState.reactive.gridType.value;
+    if (gridType === GridType.Square) return false;
+    return true;
+});
+
+function setOddHexOrientation(event: Event): void {
+    if (!owned.value) return;
+    propertiesSystem.setOddHexOrientation(
+        propertiesState.raw.id!,
+        (event.target as HTMLInputElement).checked,
+        SERVER_SYNC,
+    );
+}
+</script>
+
+<template>
+    <div class="panel restore-panel">
+        <div class="spanrow header">Appearance</div>
+        <div class="row">
+            <label for="shapeselectiondialog-odd-hex-orientation">Infer size</label>
+            <input
+                id="shapeselectiondialog-odd-hex-orientation"
+                type="checkbox"
+                :checked="propertiesState.reactive.size === 0"
+                style="grid-column-start: toggle"
+                class="styled-checkbox"
+                :disabled="!owned"
+                @click="setInferSize"
+            />
+        </div>
+        <div class="row">
+            <label for="shapeselectiondialog-name">Size</label>
+            <input
+                id="shapeselectiondialog-name"
+                type="number"
+                :min="1"
+                :step="1"
+                :value="size"
+                style="grid-column: 2/-1; width: 3rem; justify-self: flex-end"
+                :disabled="!owned || propertiesState.reactive.size === 0"
+                @change="setSize"
+            />
+        </div>
+        <div v-if="showHexSettings" class="spanrow header">Hex Settings</div>
+        <div class="row">
+            <label for="shapeselectiondialog-odd-hex-orientation">Odd Hex Orientation</label>
+            <input
+                id="shapeselectiondialog-odd-hex-orientation"
+                type="checkbox"
+                :checked="propertiesState.reactive.oddHexOrientation"
+                style="grid-column-start: toggle"
+                class="styled-checkbox"
+                :disabled="!owned"
+                @click="setOddHexOrientation"
+            />
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.panel {
+    grid-template-columns: [label] 1fr [name] 2fr [toggle] 30px [end];
+    grid-column-gap: 5px;
+    align-items: center;
+    padding-bottom: 1em;
+    justify-items: center;
+}
+
+label {
+    justify-self: normal;
+}
+
+/* Reset PanelModal 100% style */
+input[type="text"] {
+    width: auto;
+}
+
+input[type="checkbox"] {
+    width: 16px;
+    height: 23px;
+    margin: 0 8px 0 8px;
+    white-space: nowrap;
+    display: inline-block;
+}
+
+button {
+    grid-column: 2/4;
+    justify-self: flex-end;
+}
+</style>

--- a/client/src/game/ui/settings/shape/PropertySettings.vue
+++ b/client/src/game/ui/settings/shape/PropertySettings.vue
@@ -4,7 +4,6 @@ import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../../core/components/ColourPicker.vue";
 import ToggleGroup from "../../../../core/components/ToggleGroup.vue";
-import { GridType } from "../../../../core/grid";
 import { NO_SYNC, SERVER_SYNC, SyncMode } from "../../../../core/models/types";
 import { useModal } from "../../../../core/plugins/modals/plugin";
 import { activeShapeStore } from "../../../../store/activeShape";
@@ -16,7 +15,6 @@ import { accessState } from "../../../systems/access/state";
 import { propertiesSystem } from "../../../systems/properties";
 import { getProperties, propertiesState } from "../../../systems/properties/state";
 import { VisionBlock, visionBlocks } from "../../../systems/properties/types";
-import { locationSettingsState } from "../../../systems/settings/location/state";
 
 const { t } = useI18n();
 const modals = useModal();
@@ -48,22 +46,6 @@ function setInvisible(event: Event): void {
 function setDefeated(event: Event): void {
     if (!owned.value) return;
     propertiesSystem.setIsDefeated(propertiesState.raw.id!, (event.target as HTMLInputElement).checked, SERVER_SYNC);
-}
-
-const showOddHexOrientation = computed(() => {
-    if (activeShapeStore.state.type === undefined) return false;
-    const gridType = locationSettingsState.reactive.gridType.value;
-    if (gridType === GridType.Square) return false;
-    return true;
-});
-
-function setOddHexOrientation(event: Event): void {
-    if (!owned.value) return;
-    propertiesSystem.setOddHexOrientation(
-        propertiesState.raw.id!,
-        (event.target as HTMLInputElement).checked,
-        SERVER_SYNC,
-    );
 }
 
 function setLocked(event: Event): void {
@@ -210,18 +192,6 @@ async function changeAsset(): Promise<void> {
                 class="styled-checkbox"
                 :disabled="!owned"
                 @click="setDefeated"
-            />
-        </div>
-        <div v-if="showOddHexOrientation" class="row">
-            <label for="shapeselectiondialog-odd-hex-orientation">Odd Hex Orientation</label>
-            <input
-                id="shapeselectiondialog-odd-hex-orientation"
-                type="checkbox"
-                :checked="propertiesState.reactive.oddHexOrientation"
-                style="grid-column-start: toggle"
-                class="styled-checkbox"
-                :disabled="!owned"
-                @click="setOddHexOrientation"
             />
         </div>
         <div class="row">

--- a/client/src/game/ui/settings/shape/ShapeSettings.vue
+++ b/client/src/game/ui/settings/shape/ShapeSettings.vue
@@ -12,6 +12,7 @@ import { uiState } from "../../../systems/ui/state";
 import AccessSettings from "./AccessSettings.vue";
 import { ShapeSettingCategory } from "./categories";
 import ExtraSettings from "./ExtraSettings.vue";
+import GridSettings from "./GridSettings.vue";
 import GroupSettings from "./GroupSettings.vue";
 import LogicSettings from "./LogicSettings.vue";
 import PropertySettings from "./PropertySettings.vue";
@@ -52,6 +53,7 @@ const tabs = computed(() => {
     if (!hasShape.value) return tabs;
     tabs.push(
         { name: ShapeSettingCategory.Properties, component: PropertySettings },
+        { name: ShapeSettingCategory.Grid, component: GridSettings },
         { name: ShapeSettingCategory.Trackers, component: TrackerSettings },
         { name: ShapeSettingCategory.Access, component: AccessSettings },
         { name: ShapeSettingCategory.Logic, component: LogicSettings },

--- a/client/src/game/ui/settings/shape/categories.ts
+++ b/client/src/game/ui/settings/shape/categories.ts
@@ -1,5 +1,6 @@
 export enum ShapeSettingCategory {
     Properties = "Properties",
+    Grid = "Grid",
     Trackers = "Trackers",
     Access = "Access",
     Logic = "Logic",

--- a/server/src/api/models/shape/shape.py
+++ b/server/src/api/models/shape/shape.py
@@ -43,3 +43,4 @@ class ApiCoreShape(TypeIdModel):
     labels: list[ApiLabel]
     character: int | None = Field(..., typeId="CharacterId", noneAsNull=True)
     odd_hex_orientation: bool
+    size: int

--- a/server/src/api/socket/shape/options.py
+++ b/server/src/api/socket/shape/options.py
@@ -117,6 +117,28 @@ async def set_odd_hex_orientation(sid: str, raw_data: Any):
     )
 
 
+@sio.on("Shape.Options.Size.Set", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def set_size(sid: str, raw_data: Any):
+    data = ShapeSetIntegerValue(**raw_data)
+
+    pr: PlayerRoom = game_state.get(sid)
+
+    shape = get_shape_or_none(pr, data.shape, "Size.Set")
+    if shape is None:
+        return
+
+    shape.size = data.value
+    shape.save()
+
+    await _send_game(
+        "Shape.Options.Size.Set",
+        data,
+        skip_sid=sid,
+        room=pr.active_location.get_path(),
+    )
+
+
 @sio.on("Shape.Options.Locked.Set", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def set_locked(sid: str, raw_data: Any):

--- a/server/src/db/models/shape.py
+++ b/server/src/db/models/shape.py
@@ -105,6 +105,7 @@ class Shape(BaseDbModel):
         ),
     )
     odd_hex_orientation = cast(bool, BooleanField(default=False))
+    size = cast(int, IntegerField(default=0))
 
     def __repr__(self):
         return f"<Shape {self.get_path()}>"

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 92
+SAVE_VERSION = 93
 
 import json
 import logging
@@ -589,6 +589,10 @@ def upgrade(db: SqliteExtDatabase, version: int):
             db.execute_sql(
                 "UPDATE user_options SET grid_mode_label_format = NULL WHERE id NOT IN (SELECT default_options_id FROM user)"
             )
+    elif version == 92:
+        # Add Shape.size
+        with db.atomic():
+            db.execute_sql("ALTER TABLE shape ADD COLUMN size INTEGER DEFAULT 0")
     else:
         raise UnknownVersionException(
             f"No upgrade code for save format {version} was found."

--- a/server/src/transform/to_api/shape.py
+++ b/server/src/transform/to_api/shape.py
@@ -64,5 +64,6 @@ def transform_shape(shape: Shape, pr: PlayerRoom) -> ApiShapeSubType:
         labels=labels,
         character=shape.character_id,
         odd_hex_orientation=shape.odd_hex_orientation,
+        size=shape.size,
     )
     return shape.subtype.as_pydantic(shape_model)


### PR DESCRIPTION
To snap a shape to the grid, PA needs to know how many grid cells something is supposed to represent.

PA does this by doing a best effort guess from the width/height of the shape.
This can however for multiple reasons be wrong (e.g. it might be an asset with a lot of transparency causing the width to be inflated).

This PR adds a new option to manually configure the size instead.

It should be noted that this is a single number that applies in all directions.

A known bug right now is that the UI will not update the inferred size if you resize a shape while the UI is open.