### PR TITLE
feat(Shape): Add Shape.showCells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tech changes will usually be stripped from release notes for the public
 -   New grid section in Edit Shape dialog
     -   Configure manual size for shape
         -   Used for finetuning snapping behaviour
+    -   Show grid cells the shape occupies
     -   Configure hex orientation
         -   This is used to determine which orientation even-sized shapes should use in hex grids
 -   Client Setting "Grid Mode Label Format" to decide what the ruler should show in grid mode

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -178,6 +178,10 @@ export interface ApiCoreShape {
   character: CharacterId | null;
   odd_hex_orientation: boolean;
   size: number;
+  show_cells: boolean;
+  cell_fill_colour: string | null;
+  cell_stroke_colour: string | null;
+  cell_stroke_width: number | null;
 }
 export interface ApiDefaultShapeOwner {
   edit_access: boolean;

--- a/client/src/core/grid/hex.ts
+++ b/client/src/core/grid/hex.ts
@@ -1,0 +1,68 @@
+import { toRadians } from "../conversions";
+import { Vector } from "../geometry";
+
+import type { AxialCoords, CubeCoord } from "./types";
+
+/**
+ * A hexagon grid is a grid of hexagons. Each hexagon has 6 neighbours.
+ * The directions below apply to axial coordinates and start with the right neighbour and go counterlockwise.
+ * For flat hexes it starts with the bottom-right neighbour.
+ */
+const AXIAL_DIRECTIONS = [
+    { q: 1, r: 0 },
+    { q: 1, r: -1 },
+    { q: 0, r: -1 },
+    { q: -1, r: 0 },
+    { q: -1, r: 1 },
+    { q: 0, r: 1 },
+];
+
+// *** FUNCTIONS IN CONTEXT OF GENERIC HEX CELLS ***
+
+// See AXIAL_DIRECTIONS for info on the direction
+export function getHexNeighbour(cell: AxialCoords, direction: number): AxialCoords {
+    const vector = AXIAL_DIRECTIONS[direction];
+    if (vector === undefined) throw new Error("Invalid direction");
+    return { q: cell.q + vector.q, r: cell.r + vector.r };
+}
+
+// *** FUNCTIONS IN CONTEXT OF ACTUAL PIXELS ***
+
+// Returns a vector from the center of the hex to the vertex at the given index.
+// vertexIndex follows a similar count to the AXIAL_DIRECTIONS index,
+// starting with the (bottom) right vertex and going counterclockwise
+export function getHexVertexVector(vertexIndex: number, radius: number, isFlat: boolean): Vector {
+    const angle = toRadians(60 * vertexIndex) - (isFlat ? 0 : Math.PI / 6);
+    return new Vector(radius * Math.cos(angle), radius * Math.sin(-angle));
+}
+
+// *** HELPERS ***
+// These are taken almost verbatim from https://www.redblobgames.com/grids/hexagons/#rounding
+
+export function axialRound({ q, r }: AxialCoords): AxialCoords {
+    return cubeToAxial(cubeRound(axialToCube({ q, r })));
+}
+
+function cubeRound({ q: x, r: y, s: z }: CubeCoord): CubeCoord {
+    let rx = Math.round(x);
+    let ry = Math.round(y);
+    let rz = Math.round(z);
+
+    const xDiff = Math.abs(rx - x);
+    const yDiff = Math.abs(ry - y);
+    const zDiff = Math.abs(rz - z);
+
+    if (xDiff > yDiff && xDiff > zDiff) rx = -ry - rz;
+    else if (yDiff > zDiff) ry = -rx - rz;
+    else rz = -rx - ry;
+
+    return { q: rx, r: ry, s: rz };
+}
+
+function axialToCube({ q, r }: AxialCoords): CubeCoord {
+    return { q: q, r: r, s: -q - r };
+}
+
+function cubeToAxial({ q: x, r: y }: CubeCoord): AxialCoords {
+    return { q: x, r: y };
+}

--- a/client/src/core/grid/types.ts
+++ b/client/src/core/grid/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Axial Coords are a representation of hex grids,
+ * these are sometimes also used for square grids to provide uniform APIs
+ * in which case q maps to x and r to y directions.
+ */
+export type AxialCoords = { q: number; r: number };
+
+/**
+ * Cube Coords are similar to axial coords, in that s = -q - r.
+ * Some algorithms work smoother with cube coords, so it's useful to have both.
+ */
+export type CubeCoord = { q: number; r: number; s: number };

--- a/client/src/game/api/emits/shape/options.ts
+++ b/client/src/game/api/emits/shape/options.ts
@@ -27,4 +27,8 @@ export const sendShapeSvgAsset = wrapSocket<ShapeSetOptionalStringValue>("Shape.
 
 // grid related
 export const sendShapeSetSize = wrapSocket<ShapeSetIntegerValue>("Shape.Options.Size.Set");
+export const sendShapeSetShowCells = wrapSocket<ShapeSetBooleanValue>("Shape.Options.ShowCells.Set");
+export const sendShapeSetCellFillColour = wrapSocket<ShapeSetStringValue>("Shape.Options.CellFillColour.Set");
+export const sendShapeSetCellStrokeColour = wrapSocket<ShapeSetStringValue>("Shape.Options.CellStrokeColour.Set");
+export const sendShapeSetCellStrokeWidth = wrapSocket<ShapeSetIntegerValue>("Shape.Options.CellStrokeWidth.Set");
 export const sendShapeSetOddHexOrientation = wrapSocket<ShapeSetBooleanValue>("Shape.Options.OddHexOrientation.Set");

--- a/client/src/game/api/events/shape/options.ts
+++ b/client/src/game/api/events/shape/options.ts
@@ -67,6 +67,26 @@ socket.on(
 );
 
 socket.on(
+    "Shape.Options.ShowCells.Set",
+    wrapSystemCall<ShapeSetBooleanValue>(propertiesSystem.setShowCells.bind(propertiesSystem)),
+);
+
+socket.on(
+    "Shape.Options.CellStrokeWidth.Set",
+    wrapSystemCall<ShapeSetIntegerValue>(propertiesSystem.setCellStrokeWidth.bind(propertiesSystem)),
+);
+
+socket.on(
+    "Shape.Options.CellStrokeColour.Set",
+    wrapSystemCall<ShapeSetStringValue>(propertiesSystem.setCellStrokeColour.bind(propertiesSystem)),
+);
+
+socket.on(
+    "Shape.Options.CellFillColour.Set",
+    wrapSystemCall<ShapeSetStringValue>(propertiesSystem.setCellFillColour.bind(propertiesSystem)),
+);
+
+socket.on(
     "Shape.Options.StrokeColour.Set",
     wrapSystemCall<ShapeSetStringValue>(propertiesSystem.setStrokeColour.bind(propertiesSystem)),
 );

--- a/client/src/game/rendering/grid.ts
+++ b/client/src/game/rendering/grid.ts
@@ -1,0 +1,165 @@
+import { g2lz, g2l } from "../../core/conversions";
+import { type GlobalPoint, toArrayP, subtractP, addP } from "../../core/geometry";
+import { DEFAULT_GRID_SIZE, DEFAULT_HEX_RADIUS, GridType, getCellCenter } from "../../core/grid";
+import { getHexNeighbour, getHexVertexVector } from "../../core/grid/hex";
+import type { AxialCoords } from "../../core/grid/types";
+
+export function drawCells(
+    ctx: CanvasRenderingContext2D,
+    center: GlobalPoint,
+    size: number,
+    grid: { type: GridType; oddHexOrientation: boolean; radius?: number },
+    style?: { fill?: string; stroke?: string; strokeWidth?: number },
+): void {
+    if (grid.type === GridType.Square) {
+        drawSquarePolygon(ctx, center, size, grid.radius, style);
+    } else {
+        drawHexPolygon(ctx, center, size, grid, style);
+    }
+}
+
+function drawSquarePolygon(
+    ctx: CanvasRenderingContext2D,
+    center: GlobalPoint,
+    size: number,
+    radius?: number,
+    style?: { fill?: string; stroke?: string; strokeWidth?: number },
+): void {
+    ctx.fillStyle = style?.fill ?? "rgba(225, 0, 0, 0.2)";
+    ctx.strokeStyle = style?.stroke ?? "rgba(225, 0, 0, 0.8)";
+    ctx.lineWidth = style?.strokeWidth ?? 5;
+
+    radius ??= DEFAULT_GRID_SIZE / 2;
+
+    const localRadius = g2lz(radius);
+    const localCenter = g2l(center);
+    const x0 = localCenter.x - localRadius * size;
+    const y0 = localCenter.y - localRadius * size;
+
+    ctx.beginPath();
+    ctx.moveTo(x0, y0);
+    ctx.lineTo(x0 + localRadius * size * 2, y0);
+    ctx.lineTo(x0 + localRadius * size * 2, y0 + localRadius * size * 2);
+    ctx.lineTo(x0, y0 + localRadius * size * 2);
+    ctx.closePath();
+
+    ctx.stroke();
+    ctx.fill();
+}
+
+function drawHexPolygon(
+    ctx: CanvasRenderingContext2D,
+    center: GlobalPoint,
+    size: number,
+    grid: { type: GridType; oddHexOrientation: boolean; radius?: number },
+    style?: { fill?: string; stroke?: string; strokeWidth?: number },
+): void {
+    ctx.fillStyle = style?.fill ?? "rgba(225, 0, 0, 0.2)";
+    ctx.strokeStyle = style?.stroke ?? "rgba(225, 0, 0, 0.8)";
+    ctx.lineWidth = style?.strokeWidth ?? 5;
+
+    const radius = grid.radius ?? DEFAULT_HEX_RADIUS;
+
+    const localRadius = g2lz(radius);
+    let currentCell: AxialCoords = { q: 0, r: 0 };
+    if (size === 1) {
+        drawSingleHexPolygon(currentCell, toArrayP(g2l(center)), localRadius, ctx);
+    } else {
+        // This function can be used to draw non-grid aligned hexagons
+        // We first need to figure out what the vector is between the grid's {q:0,r:0} and our custom hexagon's {q:0,r:0}
+        // This can then be used to find local coords for our draw operations
+        const rootCellCenter = getCellCenter(currentCell, grid.type, radius);
+        const isFlat = grid.type === GridType.FlatHex;
+
+        // Evenly sized hexagons don't have a hex in the center, so we need to adjust the center point
+        // This is done in such a way that it moves towards the smaller side of the hexagon
+        if (size % 2 === 0) {
+            if (isFlat) {
+                center.x -= radius * (grid.oddHexOrientation ? -1 : 1);
+            } else {
+                center.y -= radius * (grid.oddHexOrientation ? -1 : 1);
+            }
+        }
+
+        const offsetVector = subtractP(center, rootCellCenter);
+
+        const oddSteps = size % 2 === 0 ? size / 2 - 1 : (size - 1) / 2;
+        const evenSteps = size % 2 === 0 ? size / 2 : (size - 1) / 2;
+
+        // a modulo 6 function that immediately handles the oddHexOrientation
+        const m6 = (i: number): number => (grid.oddHexOrientation ? (i + 3) % 6 : i);
+
+        // eslint-disable-next-line no-inner-declarations
+        function even(v1: number, v2: number, n: number): void {
+            for (let i = 0; i <= evenSteps; i++) {
+                let v = addP(currentCellCenter, getHexVertexVector(m6(v1), localRadius, isFlat));
+                ctx.lineTo(v.x, v.y);
+                v = addP(currentCellCenter, getHexVertexVector(m6(v2), localRadius, isFlat));
+                ctx.lineTo(v.x, v.y);
+                if (i < evenSteps) {
+                    currentCell = getHexNeighbour(currentCell, m6(n));
+                    currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
+                }
+            }
+        }
+
+        // eslint-disable-next-line no-inner-declarations
+        function odd(v1: number, v2: number, n: number): void {
+            for (let i = 0; i < oddSteps; i++) {
+                let v = addP(currentCellCenter, getHexVertexVector(m6(v1), localRadius, isFlat));
+                ctx.lineTo(v.x, v.y);
+                currentCell = getHexNeighbour(currentCell, m6(n));
+                currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
+                v = addP(currentCellCenter, getHexVertexVector(m6(v2), localRadius, isFlat));
+                ctx.lineTo(v.x, v.y);
+            }
+        }
+
+        // First step to a corner of the hexagon
+        for (let i = 0; i < (isFlat ? evenSteps : oddSteps); i++) currentCell = getHexNeighbour(currentCell, m6(1));
+        let currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
+        const start = addP(currentCellCenter, getHexVertexVector(m6(2), localRadius, isFlat));
+        ctx.moveTo(start.x, start.y);
+        ctx.beginPath();
+
+        // Now we move along the exterior of the hexagon in a structured pattern
+        // Even and Odd are used to handle the different number of steps that can occur when dealing with evenly sized hexagons
+        // these have alternating long and short edges,
+        // whereas odd sized hexagons have all their edges the same length
+        // These functions perform somewhat similar operations, but step to the next hex at a different point in time
+
+        even(1, 0, 5);
+        odd(5, 0, 4);
+        even(5, 4, 3);
+        odd(3, 4, 2);
+        even(3, 2, 1);
+        odd(1, 2, 0);
+
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+    }
+}
+
+function drawSingleHexPolygon(
+    cell: AxialCoords,
+    center: [number, number],
+    radius: number,
+    ctx: CanvasRenderingContext2D,
+): void {
+    const x0 = center[0] + radius * Math.sqrt(3) * (cell.q + cell.r / 2);
+    const y0 = center[1] + ((radius * 3) / 2) * cell.r;
+
+    ctx.beginPath();
+    const angle = (Math.PI * 2) / 6;
+    for (let i = 0; i < 6; i++) {
+        const x = x0 + radius * Math.cos(i * angle - Math.PI / 6);
+        const y = y0 + radius * Math.sin(i * angle - Math.PI / 6);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+
+    ctx.stroke();
+    ctx.fill();
+}

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -631,6 +631,10 @@ export abstract class Shape implements IShape {
             character: this.character ?? null,
             odd_hex_orientation: props.oddHexOrientation,
             size: props.size,
+            show_cells: props.showCells,
+            cell_fill_colour: props.cellFillColour ?? null,
+            cell_stroke_colour: props.cellStrokeColour ?? null,
+            cell_stroke_width: props.cellStrokeWidth ?? null,
         };
     }
     fromDict(data: ApiCoreShape): void {
@@ -656,6 +660,10 @@ export abstract class Shape implements IShape {
             isLocked: data.is_locked,
             oddHexOrientation: data.odd_hex_orientation,
             size: data.size,
+            showCells: data.show_cells,
+            ...(data.cell_fill_colour !== null ? { cellFillColour: data.cell_fill_colour } : {}),
+            ...(data.cell_stroke_colour !== null ? { cellStrokeColour: data.cell_stroke_colour } : {}),
+            ...(data.cell_stroke_width !== null ? { cellStrokeWidth: data.cell_stroke_width } : {}),
         });
 
         const defaultAccess = {

--- a/client/src/game/systems/properties/index.ts
+++ b/client/src/game/systems/properties/index.ts
@@ -6,6 +6,9 @@ import type { Sync } from "../../../core/models/types";
 import {
     sendShapeSetBlocksMovement,
     sendShapeSetBlocksVision,
+    sendShapeSetCellFillColour,
+    sendShapeSetCellStrokeColour,
+    sendShapeSetCellStrokeWidth,
     sendShapeSetDefeated,
     sendShapeSetFillColour,
     sendShapeSetInvisible,
@@ -15,6 +18,7 @@ import {
     sendShapeSetNameVisible,
     sendShapeSetOddHexOrientation,
     sendShapeSetShowBadge,
+    sendShapeSetShowCells,
     sendShapeSetSize,
     sendShapeSetStrokeColour,
 } from "../../api/emits/shape/options";
@@ -256,6 +260,74 @@ class PropertiesSystem implements ShapeSystem {
             if (shape) sendShapeSetSize({ shape, value: size });
         }
         if ($.id === id) $.size = size;
+
+        getShape(id)?.invalidate(true);
+    }
+
+    setShowCells(id: LocalId, showCells: boolean, syncTo: Sync): void {
+        const shape = mutable.data.get(id);
+        if (shape === undefined) {
+            return console.error("[Properties.setShowCell] Unknown local shape.");
+        }
+
+        shape.showCells = showCells;
+
+        if (syncTo.server) {
+            const shape = getGlobalId(id);
+            if (shape) sendShapeSetShowCells({ shape, value: showCells });
+        }
+        if ($.id === id) $.showCells = showCells;
+
+        getShape(id)?.invalidate(true);
+    }
+
+    setCellStrokeColour(id: LocalId, strokeColour: string, syncTo: Sync): void {
+        const shape = mutable.data.get(id);
+        if (shape === undefined) {
+            return console.error("[Properties.setCellStrokeColour] Unknown local shape.");
+        }
+
+        shape.cellStrokeColour = strokeColour;
+
+        if (syncTo.server) {
+            const shape = getGlobalId(id);
+            if (shape) sendShapeSetCellStrokeColour({ shape, value: strokeColour });
+        }
+        if ($.id === id) $.cellStrokeColour = strokeColour;
+
+        getShape(id)?.invalidate(true);
+    }
+
+    setCellFillColour(id: LocalId, fillColour: string, syncTo: Sync): void {
+        const shape = mutable.data.get(id);
+        if (shape === undefined) {
+            return console.error("[Properties.setCellFillColour] Unknown local shape.");
+        }
+
+        shape.cellFillColour = fillColour;
+
+        if (syncTo.server) {
+            const shape = getGlobalId(id);
+            if (shape) sendShapeSetCellFillColour({ shape, value: fillColour });
+        }
+        if ($.id === id) $.cellFillColour = fillColour;
+
+        getShape(id)?.invalidate(true);
+    }
+
+    setCellStrokeWidth(id: LocalId, strokeWidth: number, syncTo: Sync): void {
+        const shape = mutable.data.get(id);
+        if (shape === undefined) {
+            return console.error("[Properties.setCellStrokeWidth] Unknown local shape.");
+        }
+
+        shape.cellStrokeWidth = strokeWidth;
+
+        if (syncTo.server) {
+            const shape = getGlobalId(id);
+            if (shape) sendShapeSetCellStrokeWidth({ shape, value: strokeWidth });
+        }
+        if ($.id === id) $.cellStrokeWidth = strokeWidth;
 
         getShape(id)?.invalidate(true);
     }

--- a/client/src/game/systems/properties/state.ts
+++ b/client/src/game/systems/properties/state.ts
@@ -19,6 +19,10 @@ export interface ShapeProperties {
     isLocked: boolean;
     // grid related
     size: number; // if 0, infer size
+    showCells: boolean;
+    cellFillColour: string;
+    cellStrokeColour: string;
+    cellStrokeWidth: number;
     oddHexOrientation: boolean;
 }
 
@@ -46,6 +50,10 @@ const state = buildState<ReactivePropertiesState, PropertiesState>(
         isDefeated: false,
         isLocked: false,
         size: 0,
+        showCells: true,
+        cellFillColour: "rgba(225, 0, 0, 0.2)",
+        cellStrokeColour: "rgba(225, 0, 0, 0.8)",
+        cellStrokeWidth: 5,
         oddHexOrientation: false,
     },
     {
@@ -66,6 +74,10 @@ const DEFAULT_PROPERTIES: () => ShapeProperties = () => ({
     blocksVision: VisionBlock.No,
     showBadge: false,
     size: 0,
+    showCells: false,
+    cellFillColour: "rgba(225, 0, 0, 0.2)",
+    cellStrokeColour: "rgba(225, 0, 0, 0.8)",
+    cellStrokeWidth: 5,
     oddHexOrientation: false,
 });
 

--- a/client/src/game/ui/settings/shape/GridSettings.vue
+++ b/client/src/game/ui/settings/shape/GridSettings.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
+import ColourPicker from "../../../../core/components/ColourPicker.vue";
 import { GridType } from "../../../../core/grid";
-import { SERVER_SYNC } from "../../../../core/models/types";
+import { NO_SYNC, SERVER_SYNC } from "../../../../core/models/types";
 import { getChecked, getValue } from "../../../../core/utils";
 import { activeShapeStore } from "../../../../store/activeShape";
 import { getShape } from "../../../id";
@@ -35,6 +36,26 @@ function _setSize(size: number): void {
     propertiesSystem.setSize(propertiesState.raw.id!, size, SERVER_SYNC);
 }
 
+function setShowCell(event: Event): void {
+    if (!owned.value) return;
+    propertiesSystem.setShowCells(propertiesState.raw.id!, getChecked(event), SERVER_SYNC);
+}
+
+function setStrokeColour(event: string, temporary = false): void {
+    if (!owned.value) return;
+    propertiesSystem.setCellStrokeColour(propertiesState.raw.id!, event, temporary ? NO_SYNC : SERVER_SYNC);
+}
+
+function setFillColour(colour: string, temporary = false): void {
+    if (!owned.value) return;
+    propertiesSystem.setCellFillColour(propertiesState.raw.id!, colour, temporary ? NO_SYNC : SERVER_SYNC);
+}
+
+function setCellStrokeWidth(event: Event): void {
+    if (!owned.value) return;
+    propertiesSystem.setCellStrokeWidth(propertiesState.raw.id!, parseInt(getValue(event)), SERVER_SYNC);
+}
+
 const showHexSettings = computed(() => {
     if (activeShapeStore.state.type === undefined) return false;
     const gridType = locationSettingsState.reactive.gridType.value;
@@ -56,9 +77,9 @@ function setOddHexOrientation(event: Event): void {
     <div class="panel restore-panel">
         <div class="spanrow header">Appearance</div>
         <div class="row">
-            <label for="shapeselectiondialog-odd-hex-orientation">Infer size</label>
+            <label for="shapeselectiondialog-infer-size">Infer size</label>
             <input
-                id="shapeselectiondialog-odd-hex-orientation"
+                id="shapeselectiondialog-infer-size"
                 type="checkbox"
                 :checked="propertiesState.reactive.size === 0"
                 style="grid-column-start: toggle"
@@ -78,6 +99,51 @@ function setOddHexOrientation(event: Event): void {
                 style="grid-column: 2/-1; width: 3rem; justify-self: flex-end"
                 :disabled="!owned || propertiesState.reactive.size === 0"
                 @change="setSize"
+            />
+        </div>
+        <div class="row">
+            <label for="shapeselectiondialog-show-cell">Show cells</label>
+            <input
+                id="shapeselectiondialog-show-cell"
+                type="checkbox"
+                :checked="propertiesState.reactive.showCells"
+                style="grid-column-start: toggle"
+                class="styled-checkbox"
+                :disabled="!owned"
+                @click="setShowCell"
+            />
+        </div>
+        <div class="row" :class="{ 'row-disabled': !propertiesState.reactive.showCells }">
+            <label for="shapeselectiondialog-strokecolour">Fill colour</label>
+            <ColourPicker
+                :colour="propertiesState.reactive.cellFillColour"
+                style="grid-column-start: toggle"
+                :disabled="!owned || !propertiesState.reactive.showCells"
+                @input:colour="setFillColour($event, true)"
+                @update:colour="setFillColour($event)"
+            />
+        </div>
+        <div class="row" :class="{ 'row-disabled': !propertiesState.reactive.showCells }">
+            <label for="shapeselectiondialog-strokecolour">Stroke colour</label>
+            <ColourPicker
+                :colour="propertiesState.reactive.cellStrokeColour"
+                style="grid-column-start: toggle"
+                :disabled="!owned || !propertiesState.reactive.showCells"
+                @input:colour="setStrokeColour($event, true)"
+                @update:colour="setStrokeColour($event)"
+            />
+        </div>
+        <div class="row" :class="{ 'row-disabled': !propertiesState.reactive.showCells }">
+            <label for="shapeselectiondialog-name">Stroke width</label>
+            <input
+                id="shapeselectiondialog-name"
+                type="number"
+                :min="1"
+                :step="1"
+                :value="propertiesState.reactive.cellStrokeWidth"
+                style="grid-column: 2/-1; width: 3rem; justify-self: flex-end"
+                :disabled="!owned || !propertiesState.reactive.showCells"
+                @change="setCellStrokeWidth"
             />
         </div>
         <div v-if="showHexSettings" class="spanrow header">Hex Settings</div>
@@ -125,5 +191,11 @@ input[type="checkbox"] {
 button {
     grid-column: 2/4;
     justify-self: flex-end;
+}
+
+.row-disabled > *,
+.row-disabled:hover > * {
+    cursor: not-allowed;
+    color: grey;
 }
 </style>

--- a/server/src/api/models/shape/shape.py
+++ b/server/src/api/models/shape/shape.py
@@ -44,3 +44,7 @@ class ApiCoreShape(TypeIdModel):
     character: int | None = Field(..., typeId="CharacterId", noneAsNull=True)
     odd_hex_orientation: bool
     size: int
+    show_cells: bool
+    cell_fill_colour: str | None = Field(..., noneAsNull=True)
+    cell_stroke_colour: str | None = Field(..., noneAsNull=True)
+    cell_stroke_width: int | None = Field(..., noneAsNull=True)

--- a/server/src/api/socket/shape/options.py
+++ b/server/src/api/socket/shape/options.py
@@ -139,6 +139,94 @@ async def set_size(sid: str, raw_data: Any):
     )
 
 
+@sio.on("Shape.Options.ShowCells.Set", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def set_show_cells(sid: str, raw_data: Any):
+    data = ShapeSetBooleanValue(**raw_data)
+
+    pr: PlayerRoom = game_state.get(sid)
+
+    shape = get_shape_or_none(pr, data.shape, "ShowCells.Set")
+    if shape is None:
+        return
+
+    shape.show_cells = data.value
+    shape.save()
+
+    await _send_game(
+        "Shape.Options.ShowCells.Set",
+        data,
+        skip_sid=sid,
+        room=pr.active_location.get_path(),
+    )
+
+
+@sio.on("Shape.Options.CellFillColour.Set", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def set_cell_fill_colour(sid: str, raw_data: Any):
+    data = ShapeSetStringValue(**raw_data)
+
+    pr: PlayerRoom = game_state.get(sid)
+
+    shape = get_shape_or_none(pr, data.shape, "CellFillColour.Set")
+    if shape is None:
+        return
+
+    shape.cell_fill_colour = data.value
+    shape.save()
+
+    await _send_game(
+        "Shape.Options.CellFillColour.Set",
+        data,
+        skip_sid=sid,
+        room=pr.active_location.get_path(),
+    )
+
+
+@sio.on("Shape.Options.CellStrokeColour.Set", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def set_cell_stroke_colour(sid: str, raw_data: Any):
+    data = ShapeSetStringValue(**raw_data)
+
+    pr: PlayerRoom = game_state.get(sid)
+
+    shape = get_shape_or_none(pr, data.shape, "CellStrokeColour.Set")
+    if shape is None:
+        return
+
+    shape.cell_stroke_colour = data.value
+    shape.save()
+
+    await _send_game(
+        "Shape.Options.CellStrokeColour.Set",
+        data,
+        skip_sid=sid,
+        room=pr.active_location.get_path(),
+    )
+
+
+@sio.on("Shape.Options.CellStrokeWidth.Set", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def set_cell_stroke_width(sid: str, raw_data: Any):
+    data = ShapeSetIntegerValue(**raw_data)
+
+    pr: PlayerRoom = game_state.get(sid)
+
+    shape = get_shape_or_none(pr, data.shape, "CellStrokeWidth.Set")
+    if shape is None:
+        return
+
+    shape.cell_stroke_width = data.value
+    shape.save()
+
+    await _send_game(
+        "Shape.Options.CellStrokeWidth.Set",
+        data,
+        skip_sid=sid,
+        room=pr.active_location.get_path(),
+    )
+
+
 @sio.on("Shape.Options.Locked.Set", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def set_locked(sid: str, raw_data: Any):

--- a/server/src/db/models/shape.py
+++ b/server/src/db/models/shape.py
@@ -106,6 +106,10 @@ class Shape(BaseDbModel):
     )
     odd_hex_orientation = cast(bool, BooleanField(default=False))
     size = cast(int, IntegerField(default=0))
+    show_cells = cast(bool, BooleanField(default=False))
+    cell_fill_colour = cast(str, TextField(null=True, default=None))
+    cell_stroke_colour = cast(str, TextField(null=True, default=None))
+    cell_stroke_width = cast(int, IntegerField(null=True, default=None))
 
     def __repr__(self):
         return f"<Shape {self.get_path()}>"

--- a/server/src/transform/to_api/shape.py
+++ b/server/src/transform/to_api/shape.py
@@ -65,5 +65,9 @@ def transform_shape(shape: Shape, pr: PlayerRoom) -> ApiShapeSubType:
         character=shape.character_id,
         odd_hex_orientation=shape.odd_hex_orientation,
         size=shape.size,
+        show_cells=shape.show_cells,
+        cell_fill_colour=shape.cell_fill_colour,
+        cell_stroke_colour=shape.cell_stroke_colour,
+        cell_stroke_width=shape.cell_stroke_width,
     )
     return shape.subtype.as_pydantic(shape_model)


### PR DESCRIPTION
This PR adds another entry to the new grid tab in the Edit Shape dialog.

It adds a toggle called 'show cells' along with a couple of configuration settings when toggled on.

When enabled an outline of the grid cells the shape occupies will be shown below it.

e.g.

![image](https://github.com/Kruptein/PlanarAlly/assets/1814713/8acdac02-2304-483c-833e-044fc3e1100c)

The asset itself is just the image of the mech, the shown hex behind it is rendered by this new feature.