### PR TITLE
Feat(Ruler): Allow grid unit steps less than 0. Also fixes incorrect counting of cells in grid mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ tech changes will usually be stripped from release notes for the public
     -   Error toasts no longer have a timeout
     -   (Shape)Labels are no longer exported/imported
 -   [tech] Select tool: only take shapes in view into account
+-   Ruler tool: allows Unit Size less than 1.0
 
 ### Fixed
 
@@ -42,6 +43,8 @@ tech changes will usually be stripped from release notes for the public
         -   This should now more properly snap shapes that are larger than 1x1
 -   Ruler Tool:
     -   Snap now properly works for hex grids
+    -   Grid mode now starts count from 0 instead of -1
+    -   Grid mode correctly counts total cells when using multiple rulers
 -   Map Tool:
     -   Now better supports hex grids
 -   Spell tool: selecting another tool would swap to the Select tool instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,11 @@ tech changes will usually be stripped from release notes for the public
         -   This should now more properly snap shapes that are larger than 1x1
 -   Ruler Tool:
     -   Snap now properly works for hex grids
-    -   Grid mode now starts count from 0 instead of -1
-    -   Grid mode correctly counts total cells when using multiple rulers
 -   Map Tool:
     -   Now better supports hex grids
--   Spell tool: selecting another tool would swap to the Select tool instead
+-   Spell tool:
+-       selecting another tool would swap to the Select tool instead
+-       Change 'Size' input box to allow entering numbers less than 1 easily
 -   Polygon:
     -   selection/contains check went wrong if a polygon used the same point multiple times
     -   selection/contains check was also hitting on the line between the first and last points when not closed

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -53,7 +53,6 @@ class SpellTool extends Tool implements ITool {
         watch(
             () => this.state.size,
             async () => {
-                if (this.state.size <= 0) this.state.size = 1;
                 if (this.shape !== undefined) await this.drawShape();
             },
         );
@@ -82,6 +81,7 @@ class SpellTool extends Tool implements ITool {
 
     async drawShape(syncChanged = false): Promise<void> {
         if (!selectedSystem.hasSelection && this.state.selectedSpellShape === SpellShape.Cone) return;
+        if (this.state.size <= 0) return;
 
         const layer = floorState.currentLayer.value!;
 

--- a/client/src/game/ui/settings/location/GridSettings.vue
+++ b/client/src/game/ui/settings/location/GridSettings.vue
@@ -38,7 +38,7 @@ const unitSize = computed({
         return getOption($.unitSize, location.value).value;
     },
     set(unitSize: number | undefined) {
-        if (unitSize === undefined || unitSize >= 1) lss.setUnitSize(unitSize, location.value, true);
+        if (unitSize === undefined || unitSize > 0) lss.setUnitSize(unitSize, location.value, true);
     },
 });
 


### PR DESCRIPTION
I realized that PA doesn't allow decimal numbers as a grid unit size while trying to make a regional map for use in an army combat scenario. I wanted to make hexes each 0.1 miles, and the UI appeared to let me, but it was silently being rejected.

I thought that it wouldn't hurt anything to allow such grid measurements, even if not very applicable to most situations. I feel like with the hex grid now working much smoother, it allows for more regional or overworld style map usage, at least in games like Pathfinder.

While I was working on this, I needed to make the 'Grid Mode' of the ruler tool function and noticed a couple bugs in the distance shown on screen. I fixed those issues while I was in working on that file since they were rather straightforward. Those being
- Measuring from a starting cell and remaining in that cell showed a distance of -1 cells
- Measurements in Grid Size Units were always 1 increment greater than they should have been.
- Using multiple rulers would give incorrect distances