### PR TITLE
bug(Notes): Fix ghost notes for shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ tech changes will usually be stripped from release notes for the public
 -   Import:
     -   Prevent a potential timing edgecase causing import to run twice
     -   If an import fails, the newly created (faulty) room will be removed
+-   Notes:
+    -   The filter was not properly rerunning when opening shape notes, causing notes from the previous shape to still be visible sometimes
 -   [tech] FloorSystem's floors and layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -64,7 +64,7 @@ const filteredNotes = computed(() => {
     const notes: typeof noteArray.value = [];
     for (const note of noteArray.value) {
         if (shapeFiltered.value) {
-            if (!note.shapes.some((s) => s === noteState.raw.shapeFilter)) {
+            if (!note.shapes.some((s) => s === noteState.reactive.shapeFilter)) {
                 continue;
             }
         } else {


### PR DESCRIPTION
The filter that ensure that only notes related to the shape or shown was not rerunning when you changed shapes until some other filter was applied. This caused the shape note listing to sometimes show notes from the previous shape.