### PR TITLE
bug(Notes): Fix note shape name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,8 @@ tech changes will usually be stripped from release notes for the public
 -   Map Tool:
     -   Now better supports hex grids
 -   Spell tool:
--       selecting another tool would swap to the Select tool instead
--       Change 'Size' input box to allow entering numbers less than 1 easily
+-         selecting another tool would swap to the Select tool instead
+-         Change 'Size' input box to allow entering numbers less than 1 easily
 -   Polygon:
     -   selection/contains check went wrong if a polygon used the same point multiple times
     -   selection/contains check was also hitting on the line between the first and last points when not closed
@@ -60,6 +60,7 @@ tech changes will usually be stripped from release notes for the public
     -   If an import fails, the newly created (faulty) room will be removed
 -   Notes:
     -   The filter was not properly rerunning when opening shape notes, causing notes from the previous shape to still be visible sometimes
+    -   When shape filtering, the shape name in the UI would change if you clicked on another shape with the select tool.
 -   [tech] FloorSystem's floors and layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -35,10 +35,10 @@ const showSearchFilters = ref(false);
 const searchPage = ref(1);
 
 const shapeFiltered = computed(() => noteState.reactive.shapeFilter !== undefined);
-const shapeProps = computed(() => {
+const shapeName = computed(() => {
     const shapeId = noteState.reactive.shapeFilter;
     if (shapeId === undefined) return undefined;
-    return propertiesState.reactive;
+    return propertiesState.readonly.data.get(shapeId)?.name;
 });
 
 // this is probably disruptive if you quickly open with N and expect to close it with N again ?
@@ -118,7 +118,7 @@ function clearShapeFilter(): void {
 
 <template>
     <header>
-        <div>NOTES {{ shapeProps ? `for ${shapeProps.name}` : "" }}</div>
+        <div>NOTES {{ shapeName ? `for ${shapeName}` : "" }}</div>
     </header>
     <div id="notes-search" :class="shapeFiltered ? 'disabled' : ''">
         <div>
@@ -131,7 +131,7 @@ function clearShapeFilter(): void {
                 active-color="rgba(173, 216, 230, 0.5)"
             />
             <font-awesome-icon icon="magnifying-glass" @click="searchBar?.focus()" />
-            <div v-if="shapeProps" class="shape-name" @click="clearShapeFilter">{{ shapeProps.name }}</div>
+            <div v-if="shapeName" class="shape-name" @click="clearShapeFilter">{{ shapeName }}</div>
             <input ref="searchBar" v-model="searchFilter" type="text" placeholder="search through your notes.." />
             <div v-show="showSearchFilters" id="search-filter">
                 <fieldset>
@@ -266,7 +266,7 @@ function clearShapeFilter(): void {
     <footer>
         <div style="flex-grow: 1"></div>
         <div id="new-note-selector" @click="$emit('mode', NoteManagerMode.Create)">
-            New note{{ shapeProps ? ` for ${shapeProps.name}` : "" }}
+            New note{{ shapeName ? ` for ${shapeName}` : "" }}
         </div>
     </footer>
 </template>


### PR DESCRIPTION
When opening the note UI in shape filter mode, it's supposed to remain open on the shape that was initially selected.

When selecting another shape with the selection tool, the name of the shape shown in the note UI would update to the newly selected shape, while the actual note listing would still show the notes of the originally selected shape.

This has been rectified so that the shape name does not update.