### PR TITLE
Implement Invisibility Marker

### DIFF
--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -47,7 +47,7 @@ import { computeVisibility } from "../vision/te";
 import type { SHAPE_TYPE } from "./types";
 import { BoundingRect } from "./variants/simple/boundingRect";
 
-export class IconManager {
+class IconManager {
     iconMap : Map<string, HTMLImageElement>;
 
     constructor() {
@@ -60,7 +60,7 @@ export class IconManager {
                 this.iconMap.set(name, new Image());
             }
 
-            let element : HTMLImageElement = this.iconMap.get(name)!;
+            const element : HTMLImageElement = this.iconMap.get(name)!;
             if (element.complete && element.naturalWidth !== 0) {
                 resolve(element);
             } else {
@@ -71,7 +71,7 @@ export class IconManager {
     }
 }
 
-export const iconManager = new IconManager();
+const iconManager = new IconManager();
 
 export abstract class Shape implements IShape {
     // Used to create class instance from server shape data
@@ -475,11 +475,11 @@ export abstract class Shape implements IShape {
             const crossLength = g2lz(Math.min(bbox.w, bbox.h));
             const r = crossLength * 0.3;
 
-            iconManager.fetchImage(baseAdjust('/static/img/eye-slash-solid.svg'))
+            void iconManager.fetchImage(baseAdjust('/static/img/eye-slash-solid.svg'))
                 .then((result) => {
                     const aspect = result.width / result.height;
                     ctx.drawImage(result, location.x - r, location.y, r, r / aspect);
-                });;
+                });
         }
         if (this.showHighlight) {
             if (bbox === undefined) bbox = this.getBoundingBox();


### PR DESCRIPTION
I opened up #1264 a while back and I still want to implement invisibility markers. So this is my attempt.

I have no prior typescript or javascript experience outside of hacking on this project, so I'm sure this isn't following best practices. I did what I was capable of to get the minimal functionality I wanted so I could use it on my own PA instance. 

Now I wanted to share the work (which felt like a lot but really doesn't look like it) and see if it can be made into something that is up to snuff to be included in the project. Or maybe inspire someone to make a proper version.

Commenting on the code, I made the IconManager class as a place to hold the image so that only one copy could be shared with all shapes. I couldn't find anywhere in the codebase that looked like the right place to do that, so I just made a super simple one. The reason I made a Map data structure to hold the images is because I had an idea to implement other possible icons that would draw on top of shapes, but I didn't want to get in too deep yet :)

As for actual functionality, the marker scales and translates properly to follow the shape it's attached to and always remains in the upper right of the bounding box. The toggle within the shape properties menu turns it on and off as expected.

This is what the invisibility marker looks like on basic tokens with a few different colored borders.

![image](https://github.com/Kruptein/PlanarAlly/assets/2442544/65e4c47c-2203-4c5a-bf1d-dcd88d7b6a82)
