### PR TITLE
bug(Groups): Fix shape edit groups UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ tech changes will usually be stripped from release notes for the public
 -   Map Tool:
     -   Now better supports hex grids
 -   Spell tool:
--           selecting another tool would swap to the Select tool instead
--           Change 'Size' input box to allow entering numbers less than 1 easily
+-             selecting another tool would swap to the Select tool instead
+-             Change 'Size' input box to allow entering numbers less than 1 easily
 -   Polygon:
     -   selection/contains check went wrong if a polygon used the same point multiple times
     -   selection/contains check was also hitting on the line between the first and last points when not closed
@@ -62,6 +62,11 @@ tech changes will usually be stripped from release notes for the public
 -   Notes:
     -   The filter was not properly rerunning when opening shape notes, causing notes from the previous shape to still be visible sometimes
     -   When shape filtering, the shape name in the UI would change if you clicked on another shape with the select tool.
+-   Groups:
+    -   The 'edit shape' groups tab was completely broken, this has been resolved
+    -   Multiple things in the groups tab have become more responsive to changes
+        -   Everything badge related is now updating as it happens
+        -   Members will now appear/disappear immediately
 -   [tech] FloorSystem's floors and layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27

--- a/client/src/game/systems/groups/index.ts
+++ b/client/src/game/systems/groups/index.ts
@@ -29,19 +29,33 @@ class GroupSystem implements ShapeSystem {
         mutable.shapeData.delete(id);
         if ($.activeId === id) {
             $.activeId = undefined;
-            $.activeGroupId = undefined;
+            $.groupInfo = undefined;
         }
     }
 
     loadState(id: LocalId): void {
         $.activeId = id;
+        $.groupInfo = undefined;
+
         const data = mutable.shapeData.get(id);
-        $.activeGroupId = data?.groupId;
+        if (data?.groupId === undefined) return;
+
+        const group = mutable.groups.get(data.groupId);
+        if (group !== undefined) {
+            this.loadReactiveState(group);
+        }
+    }
+
+    private loadReactiveState(group: Group): void {
+        $.groupInfo = {
+            ...group,
+            badges: new Map(map(this.getGroupMembers(group.uuid), (m) => [m, this.getBadgeCharacters(m)])),
+        };
     }
 
     dropState(): void {
         $.activeId = undefined;
-        $.activeGroupId = undefined;
+        $.groupInfo = undefined;
     }
 
     clear(): void {
@@ -90,8 +104,13 @@ class GroupSystem implements ShapeSystem {
             propertiesSystem.setShowBadge(member, false, UI_SYNC);
         }
         if (sync) sendRemoveGroup(groupId);
+
         mutable.groups.delete(groupId);
         mutable.groupMembers.delete(groupId);
+
+        if ($.groupInfo?.uuid === groupId) {
+            this.dropState();
+        }
     }
 
     // members
@@ -110,6 +129,7 @@ class GroupSystem implements ShapeSystem {
             if (member.badge === undefined) {
                 member.badge = this.generateNewBadge(groupId);
             }
+
             newMembers.push({ badge: member.badge, uuid });
             const memberGroupId = this.getGroupId(member.uuid);
             if (groupId !== memberGroupId) {
@@ -125,6 +145,13 @@ class GroupSystem implements ShapeSystem {
             }
             mutable.groupMembers.get(groupId)?.add(member.uuid);
         }
+
+        if ($.groupInfo?.uuid === groupId) {
+            // slight bit of overhead as we should only update the badges,
+            // but that's the biggest part of the data anyway
+            this.loadReactiveState(mutable.groups.get(groupId)!);
+        }
+
         if (sync) {
             sendGroupJoin({
                 group_id: groupId,
@@ -142,6 +169,11 @@ class GroupSystem implements ShapeSystem {
         mutable.shapeData.delete(member);
 
         propertiesSystem.setShowBadge(member, false, UI_SYNC);
+
+        if ($.groupInfo?.uuid === groupId) {
+            $.groupInfo.badges.delete(member);
+        }
+
         if (sync) {
             sendGroupLeave([{ uuid, group_id: groupId }]);
         }
@@ -150,27 +182,34 @@ class GroupSystem implements ShapeSystem {
     // char set
 
     setCharacterSet(groupId: string, characterSet: string[]): void {
-        const group = readonly.groups.get(groupId);
+        const group = mutable.groups.get(groupId);
         if (group === undefined) return;
 
-        const newGroupInfo = { ...group, characterSet };
-        mutable.groups.set(groupId, newGroupInfo);
-        sendGroupUpdate(groupToServer(newGroupInfo));
+        group.characterSet = characterSet;
+        sendGroupUpdate(groupToServer(group));
+
+        if ($.groupInfo?.uuid === groupId) {
+            $.groupInfo.characterSet = characterSet;
+        }
     }
 
     setCreationOrder(groupId: string, creationOrder: CREATION_ORDER_TYPES): void {
-        const group = readonly.groups.get(groupId);
+        const group = mutable.groups.get(groupId);
         if (group === undefined) return;
 
-        const newGroupInfo = { ...group, creationOrder, characterSet: [...group.characterSet] };
-        mutable.groups.set(groupId, newGroupInfo);
-        sendGroupUpdate(groupToServer(newGroupInfo));
+        group.creationOrder = creationOrder;
+        sendGroupUpdate(groupToServer(group));
+
+        if ($.groupInfo?.uuid === groupId) {
+            $.groupInfo.creationOrder = creationOrder;
+        }
 
         const members = this.getGroupMembers(groupId);
 
         const alphabet = Array.from({ length: Math.max(10, members.size * 2) }, (_, i) => i);
 
-        for (const [i, member] of members.entries()) {
+        let i = 0;
+        for (const member of members) {
             if (creationOrder === "incrementing") {
                 this.setBadge(member, i);
             } else {
@@ -178,6 +217,7 @@ class GroupSystem implements ShapeSystem {
                 this.setBadge(member, alphabet[index]!);
                 alphabet.splice(index, 1);
             }
+            i += 1;
         }
 
         sendMemberBadgeUpdate([
@@ -196,9 +236,13 @@ class GroupSystem implements ShapeSystem {
 
     setBadge(id: LocalId, badge: number): void {
         mutable.shapeData.get(id)!.badge = badge;
+
+        if ($.groupInfo?.badges.has(id) === true) {
+            $.groupInfo.badges.set(id, this.getBadgeCharacters(id));
+        }
     }
 
-    generateNewBadge(groupId: string): number {
+    private generateNewBadge(groupId: string): number {
         const group = readonly.groups.get(groupId);
         if (group === undefined) throw new Error("Invalid groupId provided");
 
@@ -248,6 +292,11 @@ class GroupSystem implements ShapeSystem {
     updateGroupFromServer(serverGroup: ApiGroup): void {
         const group = groupToClient(serverGroup);
         mutable.groups.set(group.uuid, group);
+
+        if ($.groupInfo?.uuid === group.uuid) {
+            this.loadReactiveState(group);
+        }
+
         for (const member of this.getGroupMembers(group.uuid)) {
             getShape(member)?.layer?.invalidate(true);
         }

--- a/client/src/game/systems/groups/models.ts
+++ b/client/src/game/systems/groups/models.ts
@@ -12,8 +12,8 @@ export const CHARACTER_SETS = [CharacterSet.number, CharacterSet.latin];
 
 export interface Group {
     uuid: string;
-    readonly characterSet: string[];
-    readonly creationOrder: CREATION_ORDER_TYPES;
+    characterSet: string[];
+    creationOrder: CREATION_ORDER_TYPES;
 }
 
 export const groupToServer = (group: Group): ApiGroup => ({

--- a/client/src/game/systems/groups/state.ts
+++ b/client/src/game/systems/groups/state.ts
@@ -1,5 +1,3 @@
-import { computed } from "vue";
-
 import { type LocalId } from "../../id";
 import { buildState } from "../state";
 
@@ -7,7 +5,7 @@ import type { Group } from "./models";
 
 interface ReactiveGroupState {
     activeId: LocalId | undefined;
-    activeGroupId: string | undefined;
+    groupInfo: (Group & { badges: Map<LocalId, string> }) | undefined;
 }
 
 interface GroupState {
@@ -19,16 +17,11 @@ interface GroupState {
 const state = buildState<ReactiveGroupState, GroupState>(
     {
         activeId: undefined,
-        activeGroupId: undefined,
+        groupInfo: undefined,
     },
     { shapeData: new Map(), groups: new Map(), groupMembers: new Map() },
 );
 
 export const groupState = {
     ...state,
-    activeGroup: computed(() => {
-        const groupId = state.reactive.activeGroupId;
-        if (groupId === undefined) return undefined;
-        return state.readonly.groups.get(groupId);
-    }),
 };

--- a/client/src/game/systems/properties/index.ts
+++ b/client/src/game/systems/properties/index.ts
@@ -69,12 +69,13 @@ class PropertiesSystem implements ShapeSystem {
     }
 
     dropState(id: LocalId, source: string): void {
-        $.data.delete(id);
-
         const leases = this.shapeLeases.get(id);
         if (leases === undefined) return console.error("Dropping state for shape without active lease.");
         leases.delete(source);
-        if (leases.size === 0) this.shapeLeases.delete(id);
+        if (leases.size === 0) {
+            this.shapeLeases.delete(id);
+            $.data.delete(id);
+        }
     }
 
     setName(id: LocalId, name: string, syncTo: Sync): void {

--- a/client/src/game/ui/settings/shape/GroupSettings.vue
+++ b/client/src/game/ui/settings/shape/GroupSettings.vue
@@ -12,7 +12,7 @@ import { groupSystem } from "../../../systems/groups";
 import { CHARACTER_SETS, type CREATION_ORDER_TYPES, CREATION_ORDER_OPTIONS } from "../../../systems/groups/models";
 import { groupState } from "../../../systems/groups/state";
 import { propertiesSystem } from "../../../systems/properties";
-import { getProperties } from "../../../systems/properties/state";
+import { propertiesState } from "../../../systems/properties/state";
 
 const id = toRef(activeShapeStore.state, "id");
 
@@ -38,11 +38,34 @@ let defaultCreationOrder: CREATION_ORDER_TYPES = "incrementing";
 const owned = accessState.hasEditAccess;
 
 const groupMembers = computed(() => {
-    const groupId = groupState.reactive.activeGroupId;
-    if (groupId === undefined) return [];
-    const members = [...(groupState.readonly.groupMembers.get(groupId) ?? [])];
-    return members.map((m) => ({ ...groupState.readonly.shapeData.get(m)!, id: m })).sort((a, b) => a.badge - b.badge);
+    const group = groupState.reactive.groupInfo;
+    if (group === undefined) return [];
+    return [...group.badges.entries()].sort((a, b) => a[1].localeCompare(b[1]));
 });
+
+watch(
+    groupMembers,
+    (newMembers, oldMembers) => {
+        for (const [member] of oldMembers ?? []) {
+            propertiesSystem.dropState(member, "group-ui");
+        }
+        for (const [member] of newMembers) {
+            propertiesSystem.loadState(member, "group-ui");
+        }
+    },
+    { immediate: true },
+);
+
+const memberShowBadges = computed(() => {
+    const data = new Map<LocalId, boolean>();
+    for (const [member] of groupMembers.value) {
+        const shown = propertiesState.reactive.data.get(member)?.showBadge ?? false;
+        data.set(member, shown);
+    }
+    return data;
+});
+
+const allBadgesShown = computed(() => [...memberShowBadges.value.values()].every((v) => v));
 
 function invalidate(): void {
     const shape = getShape(activeShapeStore.state.id!)!;
@@ -51,7 +74,7 @@ function invalidate(): void {
 
 const selectedCharacterSet = computed({
     get() {
-        const group = groupState.activeGroup.value;
+        const group = groupState.reactive.groupInfo;
         if (group === undefined) {
             return characterSetSelected;
         } else {
@@ -62,15 +85,15 @@ const selectedCharacterSet = computed({
     },
     set(index: number) {
         if (!owned.value) return;
-        const group = groupState.activeGroup.value;
+        const groupId = groupState.raw.groupInfo?.uuid;
 
-        if (group === undefined) {
+        if (groupId === undefined) {
             characterSetSelected = index;
         } else {
             if (index === CHARACTER_SETS.length) {
-                groupSystem.setCharacterSet(group.uuid, []);
+                groupSystem.setCharacterSet(groupId, []);
             } else if (index < CHARACTER_SETS.length) {
-                groupSystem.setCharacterSet(group.uuid, CHARACTER_SETS[index]!);
+                groupSystem.setCharacterSet(groupId, CHARACTER_SETS[index]!);
                 invalidate();
             }
         }
@@ -79,7 +102,7 @@ const selectedCharacterSet = computed({
 
 const customCharacterSet = computed({
     get() {
-        const group = groupState.activeGroup.value;
+        const group = groupState.reactive.groupInfo;
         if (group === undefined) {
             return customText.join(",");
         }
@@ -87,20 +110,20 @@ const customCharacterSet = computed({
     },
     set(characterSet: string) {
         if (!owned.value) return;
-        const group = groupState.activeGroup.value;
+        const groupId = groupState.raw.groupInfo?.uuid;
 
         const value = characterSet.split(",");
-        if (group === undefined) {
+        if (groupId === undefined) {
             customText = value;
         } else {
-            groupSystem.setCharacterSet(group.uuid, value);
+            groupSystem.setCharacterSet(groupId, value);
             invalidate();
         }
     },
 });
 
 const creationOrder = computed(() => {
-    const group = groupState.activeGroup.value;
+    const group = groupState.reactive.groupInfo;
     if (group === undefined) {
         return defaultCreationOrder;
     }
@@ -109,7 +132,7 @@ const creationOrder = computed(() => {
 
 async function _setCreationOrder(order: CREATION_ORDER_TYPES): Promise<void> {
     if (!owned.value) return;
-    const group = groupState.activeGroup.value;
+    const group = groupState.reactive.groupInfo;
 
     if (group === undefined) {
         defaultCreationOrder = order;
@@ -127,9 +150,8 @@ async function _setCreationOrder(order: CREATION_ORDER_TYPES): Promise<void> {
 
 function updateToggles(checked: boolean): void {
     if (!owned.value) return;
-    for (const member of groupMembers.value) {
-        if (getProperties(member.id)?.showBadge !== checked)
-            propertiesSystem.setShowBadge(member.id, checked, SERVER_SYNC);
+    for (const [member] of groupMembers.value) {
+        if (memberShowBadges.value.get(member) !== checked) propertiesSystem.setShowBadge(member, checked, SERVER_SYNC);
     }
 }
 
@@ -160,13 +182,13 @@ function removeMember(memberId: LocalId): void {
 
 function createGroup(): void {
     if (!owned.value) return;
-    if (groupState.reactive.activeGroupId !== undefined || id.value === undefined) return;
+    if (groupState.reactive.groupInfo !== undefined || id.value === undefined) return;
     groupSystem.createNewGroupForShapes([id.value]);
 }
 
 async function deleteGroup(): Promise<void> {
     if (!owned.value) return;
-    const groupId = groupState.reactive.activeGroupId;
+    const groupId = groupState.reactive.groupInfo?.uuid;
     if (groupId === undefined) return;
 
     const remove = await modals.confirm(
@@ -217,8 +239,8 @@ async function deleteGroup(): Promise<void> {
             <div>
                 <input
                     id="toggleCheckbox"
-                    ref="toggleCheckbox"
                     type="checkbox"
+                    :checked="allBadgesShown"
                     @click="updateToggles(getChecked($event))"
                 />
             </div>
@@ -227,32 +249,32 @@ async function deleteGroup(): Promise<void> {
             <div></div>
             <div class="subheader">Show Badge</div>
             <div class="subheader">Remove</div>
-            <template v-for="member of groupMembers" :key="member.id">
+            <template v-for="[member, badge] of groupMembers" :key="member">
                 <div
                     class="badge"
                     title="Center on this member"
-                    @click="centerMember(member.id)"
-                    @mouseenter="toggleHighlight(member.id, true)"
-                    @mouseleave="toggleHighlight(member.id, false)"
+                    @click="centerMember(member)"
+                    @mouseenter="toggleHighlight(member, true)"
+                    @mouseleave="toggleHighlight(member, false)"
                 >
-                    <template v-if="member.id === id">></template>
-                    {{ groupSystem.getBadgeCharacters(member.id) }}
-                    <template v-if="member.id === id">&lt;</template>
+                    <template v-if="member === id">></template>
+                    {{ badge }}
+                    <template v-if="member === id">&lt;</template>
                 </div>
                 <div></div>
                 <div>
                     <input
                         type="checkbox"
-                        :checked="getProperties(member.id)!.showBadge"
-                        @click="showBadge(member.id, getChecked($event))"
+                        :checked="memberShowBadges.get(member)"
+                        @click="showBadge(member, getChecked($event))"
                     />
                 </div>
                 <div :style="{ textAlign: 'center' }">
-                    <font-awesome-icon icon="trash-alt" @click="removeMember(member.id)" />
+                    <font-awesome-icon icon="trash-alt" @click="removeMember(member)" />
                 </div>
             </template>
         </template>
-        <template v-if="groupState.reactive.activeGroupId === undefined">
+        <template v-if="groupState.reactive.groupInfo === undefined">
             <div class="spanrow header">Actions</div>
             <div></div>
             <div></div>


### PR DESCRIPTION
The Groups tab in the 'Edit Shape' dialog historically had some issues with certain things not immediately updating in the UI until a fresh reselect was done of the shape.
In a recent update however the UI became broken in general, always showing the leftmost options in the settings regardless of the actual option set.

This PR handles all of the above at once. Original behaviour for the settings has been restored and the areas that were not responsive should now update on the spot properly.