### PR TITLE
Fixed query when checking for valid Shape on initiative change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ tech changes will usually be stripped from release notes for the public
         -   Everything badge related is now updating as it happens
         -   Members will now appear/disappear immediately
 -   [tech] FloorSystem's floors and layers properties are now only reactive on the array level and are raw for the actual elements.
+-   Initiative:
+    -   Fixed an issue where Initiative.Order.Change would fail when called with some Shape Ids.
 
 ## [2024.1.0] - 2024-01-27
 

--- a/server/src/api/socket/initiative/__init__.py
+++ b/server/src/api/socket/initiative/__init__.py
@@ -322,7 +322,7 @@ async def change_initiative_order(sid: str, raw_data: Any):
 
     pr = game_state.get(sid)
 
-    if Shape.get_or_none(data.shape) is None:
+    if Shape.get_or_none(uuid=data.shape) is None:
         logger.warning("Attempt to change initiative order for unknown shape")
         return
 


### PR DESCRIPTION
Fixed a query in sockets.initiative.

PeeWee allows just providing an id to it's query methods, such as get_or_none, but that requires the id to be an int. Since the Shape table has guid/string ids, the single argument was instead being passed as the entirety of the WHERE clause in the sql query.

This caused Sqlite to cast it to an int by only any digits at the start of the id. The result was if the id started with a non-zero digit, the query evaluated to True, and would return a shape, allowing the initiative to be updated. But if the id started with a letter, it would evaluate to false, so the query would return no results, which was interpreted as an invalid Shape. 

In searching the rest of the code base, it does seem like the other queries are correctly using keyword args, so this appears to be the only location with this specific issue.