### PR TITLE
Set note icons into their own category of shape for rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ tech changes will usually be stripped from release notes for the public
 -   Notes:
     -   The filter was not properly rerunning when opening shape notes, causing notes from the previous shape to still be visible sometimes
     -   When shape filtering, the shape name in the UI would change if you clicked on another shape with the select tool.
+    -   Note icons drawn on a shape could be drawn behind the shape in some circumstances.
 -   Groups:
     -   The 'edit shape' groups tab was completely broken, this has been resolved
     -   Multiple things in the groups tab have become more responsive to changes

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -32,9 +32,7 @@ socket.on("Shape.Set", (data: ApiShapeWithLayerInfo) => {
     let deps = undefined;
     if (old) {
         deps = old.dependentShapes;
-        for (const dep of deps) {
-            old?.removeDependentShape(dep.id, { dropShapeId: false });
-        }
+        old.removeDependentShapes({ dropShapeId: false });
         old.layer?.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
     }
     const shape = addShape(apiShape, floor, layer, SyncMode.NO_SYNC, deps);

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -29,8 +29,15 @@ socket.on("Shape.Set", (data: ApiShapeWithLayerInfo) => {
     const old = getShapeFromGlobal(uuid);
     const isActive = activeShapeStore.state.id === getLocalId(uuid);
     const hasEditDialogOpen = isActive && activeShapeStore.state.showEditDialog;
-    if (old) old.layer?.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
-    const shape = addShape(apiShape, floor, layer, SyncMode.NO_SYNC);
+    let deps = undefined;
+    if (old) {
+      deps = old.layer?.getDependentShapes(old.id) ?? [];
+      for (const dep of deps) {
+        old.layer!.removeDependentShape(old.id, dep.id, { dropShapeId: false });
+      }
+      old.layer?.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
+    }
+    const shape = addShape(apiShape, floor, layer, SyncMode.NO_SYNC, deps);
 
     if (shape && isActive) {
         selectedSystem.push(shape.id);

--- a/client/src/game/api/events/shape/core.ts
+++ b/client/src/game/api/events/shape/core.ts
@@ -31,11 +31,11 @@ socket.on("Shape.Set", (data: ApiShapeWithLayerInfo) => {
     const hasEditDialogOpen = isActive && activeShapeStore.state.showEditDialog;
     let deps = undefined;
     if (old) {
-      deps = old.layer?.getDependentShapes(old.id) ?? [];
-      for (const dep of deps) {
-        old.layer!.removeDependentShape(old.id, dep.id, { dropShapeId: false });
-      }
-      old.layer?.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
+        deps = old.dependentShapes;
+        for (const dep of deps) {
+            old?.removeDependentShape(dep.id, { dropShapeId: false });
+        }
+        old.layer?.removeShape(old, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
     }
     const shape = addShape(apiShape, floor, layer, SyncMode.NO_SYNC, deps);
 

--- a/client/src/game/interfaces/layer.ts
+++ b/client/src/game/interfaces/layer.ts
@@ -43,4 +43,7 @@ export interface ILayer {
     show: () => void;
     size: (options: { includeComposites: boolean; onlyInView: boolean }) => number;
     updateSectors: (shapeId: LocalId, aabb: BoundingRect) => void;
+    addDependentShape: (parent: LocalId, shape: IShape) => void;
+    removeDependentShape: (parent: LocalId, shapeId: LocalId, options: { dropShapeId: boolean }) => void;
+    getDependentShapes: (parent: LocalId) => IShape[];
 }

--- a/client/src/game/interfaces/layer.ts
+++ b/client/src/game/interfaces/layer.ts
@@ -43,7 +43,4 @@ export interface ILayer {
     show: () => void;
     size: (options: { includeComposites: boolean; onlyInView: boolean }) => number;
     updateSectors: (shapeId: LocalId, aabb: BoundingRect) => void;
-    addDependentShape: (parent: LocalId, shape: IShape) => void;
-    removeDependentShape: (parent: LocalId, shapeId: LocalId, options: { dropShapeId: boolean }) => void;
-    getDependentShapes: (parent: LocalId) => IShape[];
 }

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -55,6 +55,9 @@ export interface IShape extends SimpleShape {
     get center(): GlobalPoint;
     set center(centerPoint: GlobalPoint);
 
+    get parentId(): LocalId | undefined;
+    set parentId(pId: LocalId);
+
     get isClosed(): boolean;
 
     get triggersVisionRecalc(): boolean;

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -69,6 +69,8 @@ export interface IShape extends SimpleShape {
     _lightBlockingNeighbours: LocalId[];
     _parentId?: LocalId;
 
+    get dependentShapes(): IShape[];
+
     // POSITION
 
     readonly floorId: FloorId | undefined;
@@ -119,4 +121,11 @@ export interface IShape extends SimpleShape {
     // UTILITY
 
     visibleInCanvas: (max: { w: number; h: number }, options: { includeAuras: boolean }) => boolean;
+
+    // DEPENDENT SHAPES
+
+    addDependentShape: (shape: IShape) => void;
+    removeDependentShape: (shapeId: LocalId, options: {dropShapeId: boolean}) => void;
+    removeDependentShapes: (options: {dropShapeId: boolean}) => void;
+
 }

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -66,7 +66,6 @@ export class Layer implements ILayer {
     // The collection of shapes that this layer contains.
     // These are ordered on a depth basis.
     protected shapes: IShape[] = [];
-    protected dependents = new Map<LocalId, IShape[]>();
     shapesInSector: IShape[] = [];
     protected xSectors = new Map<number, Set<LocalId>>();
     protected ySectors = new Map<number, Set<LocalId>>();
@@ -239,31 +238,6 @@ export class Layer implements ILayer {
         }
         shape.onLayerAdd();
     }
-    private getOrCreateDependents(key: LocalId): IShape[] {
-      let deps = this.dependents.get(key);
-      if (deps === undefined) {
-        this.dependents.set(key, []);
-        deps = this.dependents.get(key)!;
-      }
-      return deps;
-    }
-    addDependentShape(parent: LocalId, shape: IShape): void {
-      shape.setLayer(this.floor, this.name);
-
-      const deps = this.getOrCreateDependents(parent);
-      deps.push(shape);
-
-      this.invalidate(true);
-    }
-    removeDependentShape(parent: LocalId, shapeId: LocalId, options: {dropShapeId: boolean}): void {
-      this.dependents.set(parent, this.dependents.get(parent)?.filter((entry) => entry.id !== shapeId) ?? []);
-      if (options.dropShapeId) dropId(shapeId);
-
-      this.invalidate(true);
-    }
-    getDependentShapes(parent: LocalId): IShape[] {
-      return this.dependents.get(parent) ?? [];
-    }
 
     // UI helpers are objects that are created for UI reaons but that are not pertinent to the actual state
     // They are often not desired unless in specific circumstances
@@ -340,10 +314,7 @@ export class Layer implements ILayer {
                 true,
             );
         }
-        for (const dep of this.dependents.get(shape.id) ?? []) {
-          this.removeDependentShape(shape.id, dep.id, { dropShapeId: true });
-        }
-        this.dependents.delete(shape.id);
+        shape.removeDependentShapes({ dropShapeId: true });
         this.shapes.splice(idx, 1);
         this.removeShapeFromSectors(shape.id);
         this.updateView();
@@ -459,9 +430,6 @@ export class Layer implements ILayer {
                     if (labelSystem.isFiltered(shape.id)) continue;
 
                     shape.draw(ctx, false);
-                    for (const dependent of this.dependents.get(shape.id) ?? []) {
-                      dependent.draw(ctx, false);
-                    }
                 }
             }
 

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -340,6 +340,10 @@ export class Layer implements ILayer {
                 true,
             );
         }
+        for (const dep of this.dependents.get(shape.id) ?? []) {
+          this.removeDependentShape(shape.id, dep.id, { dropShapeId: true });
+        }
+        this.dependents.delete(shape.id);
         this.shapes.splice(idx, 1);
         this.removeShapeFromSectors(shape.id);
         this.updateView();

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -13,7 +13,7 @@ import {
 } from "../../core/grid";
 import { rotateAroundPoint } from "../../core/math";
 import { mostReadable } from "../../core/utils";
-import { generateLocalId, getGlobalId, getShape } from "../id";
+import { generateLocalId, getGlobalId, getShape, dropId } from "../id";
 import type { GlobalId, LocalId } from "../id";
 import type { ILayer } from "../interfaces/layer";
 import type { IShape } from "../interfaces/shape";
@@ -52,6 +52,12 @@ export abstract class Shape implements IShape {
     readonly id: LocalId;
 
     character: CharacterId | undefined;
+
+    _dependentShapes: IShape[] = [];
+
+    get dependentShapes(): IShape[] {
+        return this._dependentShapes;
+    }
 
     // The layer the shape is currently on
     floorId: FloorId | undefined;
@@ -161,10 +167,10 @@ export abstract class Shape implements IShape {
     }
 
     get parentId(): LocalId | undefined {
-      return this._parentId;
+        return this._parentId;
     }
     set parentId(pId: LocalId) {
-      this._parentId = pId;
+        this._parentId = pId;
     }
 
     // Informs whether `points` forms a close loop
@@ -495,6 +501,9 @@ export abstract class Shape implements IShape {
                 barOffset += 10;
             }
         }
+        for (const dep of this.dependentShapes) {
+            dep.draw(ctx, false);
+        }
     }
 
     drawSelection(ctx: CanvasRenderingContext2D): void {
@@ -713,4 +722,38 @@ export abstract class Shape implements IShape {
         }
         return false;
     }
+
+    // DEPENDENT SHAPES
+
+    addDependentShape(shape: IShape): void {
+        if (this.floorId === undefined || this.layerName === undefined) return;
+
+        shape.setLayer(this?.floorId, this?.layerName);
+        shape.parentId = this.id;
+
+        this.dependentShapes.push(shape);
+
+        this.invalidate(true);
+    }
+
+    removeDependentShape(shapeId: LocalId, options: {dropShapeId: boolean}): void {
+        this._dependentShapes = this._dependentShapes.filter((entry) => entry.id !== shapeId);
+        if (options.dropShapeId) dropId(shapeId);
+
+        this.invalidate(true);
+    }
+
+    removeDependentShapes(options: {dropShapeId: boolean}): void {
+        if (options.dropShapeId) {
+            for (const shape of this.dependentShapes) {
+                dropId(shape.id);
+            }
+        }
+        while (this._dependentShapes.length) {
+            this._dependentShapes.pop();
+        }
+        this.invalidate(true);
+    }
+
+
 }

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -287,6 +287,9 @@ export abstract class Shape implements IShape {
     }
 
     setLayer(floor: FloorId, layer: LayerName): void {
+        for (const dep of this._dependentShapes) {
+            dep.setLayer(floor, layer);
+        }
         this.floorId = floor;
         this.layerName = layer;
     }
@@ -742,9 +745,7 @@ export abstract class Shape implements IShape {
                 dropId(shape.id);
             }
         }
-        while (this._dependentShapes.length) {
-            this._dependentShapes.pop();
-        }
+        this._dependentShapes = [];
         this.invalidate(true);
     }
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -160,6 +160,13 @@ export abstract class Shape implements IShape {
         this._visionPolygon = undefined;
     }
 
+    get parentId(): LocalId | undefined {
+      return this._parentId;
+    }
+    set parentId(pId: LocalId) {
+      this._parentId = pId;
+    }
+
     // Informs whether `points` forms a close loop
     abstract get isClosed(): boolean;
 

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -23,7 +23,6 @@ import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
 import { groupSystem } from "../systems/groups";
 import { noteSystem } from "../systems/notes";
-import { noteState } from "../systems/notes/state";
 import { positionSystem } from "../systems/position";
 import { getProperties } from "../systems/properties/state";
 import { VisionBlock } from "../systems/properties/types";
@@ -194,12 +193,7 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
         const gId = getGlobalId(sel.id);
         if (gId) {
             removed.push(gId);
-
-            const noteList = Array.from(noteState.mutableReactive.notes.values());
-            const shapeNotes = noteList.filter((n) => n.shapes.includes(gId));
-            for (const note of shapeNotes) {
-                noteSystem.unhookShape(note, sel.id);
-            }
+            noteSystem.unhookShape(sel.id);
         }
         const props = getProperties(sel.id)!;
         if (props.blocksVision !== VisionBlock.No) recalculateVision = true;

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -22,6 +22,8 @@ import { clipboardState } from "../systems/clipboard/state";
 import { floorSystem } from "../systems/floors";
 import { floorState } from "../systems/floors/state";
 import { groupSystem } from "../systems/groups";
+import { noteSystem } from "../systems/notes";
+import { noteState } from "../systems/notes/state";
 import { positionSystem } from "../systems/position";
 import { getProperties } from "../systems/properties/state";
 import { VisionBlock } from "../systems/properties/types";
@@ -30,6 +32,7 @@ import type { TrackerId } from "../systems/trackers/models";
 import { TriangulationTarget, VisibilityMode, visionState } from "../vision/state";
 
 import { createShapeFromDict } from "./create";
+
 
 export function copyShapes(): void {
     if (!selectedSystem.hasSelection) return;
@@ -189,13 +192,19 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
         const sel = shapes[i]!;
         if (sync !== SyncMode.NO_SYNC && !accessSystem.hasAccessTo(sel.id, false, { edit: true })) continue;
         const gId = getGlobalId(sel.id);
-        if (gId) removed.push(gId);
+        if (gId) {
+            removed.push(gId);
+
+            const noteList = Array.from(noteState.mutableReactive.notes.values());
+            const shapeNotes = noteList.filter((n) => n.shapes.includes(gId));
+            for (const note of shapeNotes) {
+                noteSystem.unhookShape(note, sel.id);
+            }
+        }
         const props = getProperties(sel.id)!;
         if (props.blocksVision !== VisionBlock.No) recalculateVision = true;
         if (props.blocksMovement) recalculateMovement = true;
-        for (const dep of sel.layer?.getDependentShapes(sel.id) ?? []) {
-          sel.layer?.removeDependentShape(sel.id, dep.id, { dropShapeId: true });
-        }
+
         sel.layer?.removeShape(sel, { sync: SyncMode.NO_SYNC, recalculate: recalculateIterative, dropShapeId: true });
     }
     if (sync !== SyncMode.NO_SYNC) sendRemoveShapes({ uuids: removed, temporary: sync === SyncMode.TEMP_SYNC });

--- a/client/src/game/shapes/utils.ts
+++ b/client/src/game/shapes/utils.ts
@@ -193,6 +193,9 @@ export function deleteShapes(shapes: readonly IShape[], sync: SyncMode): void {
         const props = getProperties(sel.id)!;
         if (props.blocksVision !== VisionBlock.No) recalculateVision = true;
         if (props.blocksMovement) recalculateMovement = true;
+        for (const dep of sel.layer?.getDependentShapes(sel.id) ?? []) {
+          sel.layer?.removeDependentShape(sel.id, dep.id, { dropShapeId: true });
+        }
         sel.layer?.removeShape(sel, { sync: SyncMode.NO_SYNC, recalculate: recalculateIterative, dropShapeId: true });
     }
     if (sync !== SyncMode.NO_SYNC) sendRemoveShapes({ uuids: removed, temporary: sync === SyncMode.TEMP_SYNC });

--- a/client/src/game/systems/notes/index.ts
+++ b/client/src/game/systems/notes/index.ts
@@ -1,3 +1,5 @@
+import type { DeepReadonly } from "vue";
+
 import { registerSystem } from "..";
 import type { System } from "..";
 import type { ApiNote } from "../../../apiTypes";
@@ -125,14 +127,14 @@ class NoteSystem implements System {
     }
 
     // This is a utlity function used during loading of notes
-    hookupShape(note: ClientNote, shape: LocalId): void {
+    hookupShape(note: DeepReadonly<ClientNote>, shape: LocalId): void {
         if (!raw.shapeNotes.has(shape)) $.shapeNotes.set(shape, []);
         $.shapeNotes.get(shape)?.push(note.uuid);
 
         if (note.showIconOnShape) this.createNoteIcon(shape, note.uuid);
     }
 
-    unhookShape(note: ClientNote, shape: LocalId): void {
+    unhookShape(shape: LocalId): void {
         if (!raw.shapeNotes.has(shape)) return;
         const notes = $.shapeNotes.get(shape) ?? [];
         while (notes.length) {

--- a/client/src/game/systems/notes/index.ts
+++ b/client/src/game/systems/notes/index.ts
@@ -47,10 +47,6 @@ class NoteSystem implements System {
             const shapeId = getLocalId(shape, false);
             if (shapeId === undefined) continue;
             this.hookupShape(note, shapeId);
-
-            if (note.showIconOnShape) {
-                this.createNoteIcon(shapeId, note.uuid);
-            }
         }
         if (sync) sendNewNote(apiNote);
     }
@@ -129,11 +125,11 @@ class NoteSystem implements System {
     }
 
     // This is a utlity function used during loading of notes
-    private hookupShape(note: ClientNote, shape: LocalId): void {
+    hookupShape(note: ClientNote, shape: LocalId): void {
         if (!raw.shapeNotes.has(shape)) $.shapeNotes.set(shape, []);
         $.shapeNotes.get(shape)?.push(note.uuid);
 
-        //if (note.showIconOnShape) this.createNoteIcon(shape, note.uuid);
+        if (note.showIconOnShape) this.createNoteIcon(shape, note.uuid);
     }
 
     removeShape(noteId: string, shapeId: LocalId, sync: boolean): void {

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -33,6 +33,10 @@ export function moveFloor(shapes: IShape[], newFloor: Floor, sync: boolean): voi
     for (const shape of shapes) {
         visionState.moveShape(shape.id, oldFloor.id, newFloor.id);
         shape.setLayer(newFloor.id, oldLayer.name);
+        for (const dependent of oldLayer.getDependentShapes(shape.id)) {
+          oldLayer.removeDependentShape(shape.id, dependent.id, { dropShapeId: false });
+          newLayer.addDependentShape(shape.id, dependent);
+        }
     }
     oldLayer.setShapes(
         ...oldLayer.getShapes({ includeComposites: true, onlyInView: false }).filter((s) => !shapes.includes(s)),
@@ -59,7 +63,13 @@ export function moveLayer(shapes: readonly IShape[], newLayer: ILayer, sync: boo
         throw new Error("Mixing shapes from different floors in shape move");
     }
 
-    for (const shape of shapes) shape.setLayer(newLayer.floor, newLayer.name);
+    for (const shape of shapes) {
+      shape.setLayer(newLayer.floor, newLayer.name);
+      for (const dependent of oldLayer.getDependentShapes(shape.id)) {
+         oldLayer.removeDependentShape(shape.id, dependent.id, { dropShapeId: false });
+         newLayer.addDependentShape(shape.id, dependent);
+      }
+    }
     // Update layer shapes
     oldLayer.setShapes(
         ...oldLayer.getShapes({ includeComposites: true, onlyInView: false }).filter((s) => !shapes.includes(s)),

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -35,10 +35,6 @@ export function moveFloor(shapes: IShape[], newFloor: Floor, sync: boolean): voi
     for (const shape of shapes) {
         visionState.moveShape(shape.id, oldFloor.id, newFloor.id);
         shape.setLayer(newFloor.id, oldLayer.name);
-        for (const dependent of oldLayer.getDependentShapes(shape.id)) {
-          oldLayer.removeDependentShape(shape.id, dependent.id, { dropShapeId: false });
-          newLayer.addDependentShape(shape.id, dependent);
-        }
     }
     oldLayer.setShapes(
         ...oldLayer.getShapes({ includeComposites: true, onlyInView: false }).filter((s) => !shapes.includes(s)),
@@ -66,11 +62,7 @@ export function moveLayer(shapes: readonly IShape[], newLayer: ILayer, sync: boo
     }
 
     for (const shape of shapes) {
-      shape.setLayer(newLayer.floor, newLayer.name);
-      for (const dependent of oldLayer.getDependentShapes(shape.id)) {
-         oldLayer.removeDependentShape(shape.id, dependent.id, { dropShapeId: false });
-         newLayer.addDependentShape(shape.id, dependent);
-      }
+        shape.setLayer(newLayer.floor, newLayer.name);
     }
     // Update layer shapes
     oldLayer.setShapes(
@@ -113,8 +105,7 @@ export function addShape(shape: ApiShape, floor: string, layerName: LayerName, s
 
     layer.addShape(sh, sync, InvalidationMode.NORMAL);
     for (const dep of dependents ?? []) {
-      dep.parentId = sh.id;
-      layer.addDependentShape(sh.id, dep);
+        sh.addDependentShape(dep);
     }
     layer.invalidate(false);
     return sh;

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -97,7 +97,7 @@ export function addShape(shape: ApiShape, floor: string, layerName: LayerName, s
 
     // if this shape has been moved to a new location, notes are already set up for it client-side.
     // we need to reattach the notes to this new shape since the local id is changed!
-    const noteList = Array.from(noteState.mutableReactive.notes.values());
+    const noteList = Array.from(noteState.reactive.notes.values());
     const shapeNotes = noteList.filter((n) => n.shapes.includes(shape.uuid));
     for (const note of shapeNotes) {
         noteSystem.hookupShape(note, sh.id);

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -11,6 +11,8 @@ import type { Floor, LayerName } from "./models/floor";
 import { addOperation } from "./operations/undo";
 import { createShapeFromDict } from "./shapes/create";
 import { floorSystem } from "./systems/floors";
+import { noteSystem } from "./systems/notes";
+import { noteState } from "./systems/notes/state";
 import { getProperties } from "./systems/properties/state";
 import { visionState } from "./vision/state";
 
@@ -90,7 +92,7 @@ export function moveLayer(shapes: readonly IShape[], newLayer: ILayer, sync: boo
     }
 }
 
-export function addShape(shape: ApiShape, floor: string, layerName: LayerName, sync: SyncMode): IShape | undefined {
+export function addShape(shape: ApiShape, floor: string, layerName: LayerName, sync: SyncMode, dependents?: IShape[]): IShape | undefined {
     if (!floorSystem.hasLayer(floorSystem.getFloor({ name: floor })!, layerName)) {
         console.log(`Shape with unknown layer ${layerName} could not be added`);
         return;
@@ -100,7 +102,20 @@ export function addShape(shape: ApiShape, floor: string, layerName: LayerName, s
     if (sh === undefined) {
         return;
     }
+
+    // if this shape has been moved to a new location, notes are already set up for it client-side.
+    // we need to reattach the notes to this new shape since the local id is changed!
+    const noteList = Array.from(noteState.mutableReactive.notes.values());
+    const shapeNotes = noteList.filter((n) => n.shapes.includes(shape.uuid));
+    for (const note of shapeNotes) {
+        noteSystem.hookupShape(note, sh.id);
+    }
+
     layer.addShape(sh, sync, InvalidationMode.NORMAL);
+    for (const dep of dependents ?? []) {
+      dep.parentId = sh.id;
+      layer.addDependentShape(sh.id, dep);
+    }
     layer.invalidate(false);
     return sh;
 }


### PR DESCRIPTION
Note icons are currently drawn as an ordinary shape which works in most ways. Since they are lumped in with all other shapes in a given layer, there exist some problems such as #1406 when it comes to rendering priority. The shape could become obscured by the shape it is supposed to be attached to.

This PR introduces a new class of shapes in a layer called dependent shapes. These are treated as shapes that depend on another 'parent' shape to exist and are therefore always drawn on top of the parent shape but still remain underneath other overlapping shapes as one would expect. This new class can be utilized to allow drawing of other icons such as an invisibility indicator in the future.

This solves #1406.