### PR TITLE
bug(Floors): Fix floor UI no longer being reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,9 @@ tech changes will usually be stripped from release notes for the public
     -   Multiple things in the groups tab have become more responsive to changes
         -   Everything badge related is now updating as it happens
         -   Members will now appear/disappear immediately
--   [tech] FloorSystem's floors and layers properties are now only reactive on the array level and are raw for the actual elements.
 -   Initiative:
     -   Fixed an issue where Initiative.Order.Change would fail when called with some Shape Ids.
+-   [tech] FloorSystem's layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27
 

--- a/client/src/game/systems/floors/index.ts
+++ b/client/src/game/systems/floors/index.ts
@@ -80,14 +80,14 @@ class FloorSystem implements System {
             const I = this.indices.findIndex((i) => i > targetIndex);
             if (I >= 0) {
                 this.indices.splice(I, 0, targetIndex);
-                $.floors.splice(I, 0, markRaw(floor));
+                $.floors.splice(I, 0, floor);
                 if (I <= floorState.raw.floorIndex) $.floorIndex = (floorState.raw.floorIndex + 1) as FloorIndex;
             } else {
                 this.indices.push(targetIndex);
-                $.floors.push(markRaw(floor));
+                $.floors.push(floor);
             }
         } else {
-            $.floors.push(markRaw(floor));
+            $.floors.push(floor);
         }
         this.layerMap.set(floor.id, []);
     }
@@ -164,7 +164,7 @@ class FloorSystem implements System {
             return;
         }
 
-        $.floors = floors.map((name) => markRaw(floorState.raw.floors.find((f) => f.name === name)!));
+        $.floors = floors.map((name) => floorState.raw.floors.find((f) => f.name === name)!);
         $.floorIndex = this.getFloorIndex({ name: activeFloorName })!;
         recalculateZIndices();
         if (sync) sendFloorReorder(floors);

--- a/client/src/game/systems/floors/state.ts
+++ b/client/src/game/systems/floors/state.ts
@@ -4,10 +4,9 @@ import type { ILayer } from "../../interfaces/layer";
 import type { Floor, FloorIndex } from "../../models/floor";
 import { buildState } from "../state";
 
-// Floors & Layers are kept in a reactive array,
-// but are themselves not reactive!
+// Layers are kept in a reactive array, but are themselves not reactive!
 interface ReactiveFloorState {
-    floors: Raw<Floor>[];
+    floors: Floor[];
     floorIndex: FloorIndex;
 
     layers: Raw<ILayer>[];


### PR DESCRIPTION
This fixes #1411 

In #1382 a change was made to prevent some things from becoming reactive when they shouldn't. Layers and Shapes being the prime targets, but Floors were also included, and that ended up being a mistake.

This caused the floor UI to no longer update, this is now reverted for Floors specifically.