### PR TITLE
bug(Notes): Fix some note events not updating if you only have view access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ tech changes will usually be stripped from release notes for the public
 -   Notes:
     -   The filter was not properly rerunning when opening shape notes, causing notes from the previous shape to still be visible sometimes
     -   When shape filtering, the shape name in the UI would change if you clicked on another shape with the select tool.
+    -   Fix 'add shape' and 'remove shape' events not being synced immediately if you only have view access
 -   Groups:
     -   The 'edit shape' groups tab was completely broken, this has been resolved
     -   Multiple things in the groups tab have become more responsive to changes

--- a/server/src/api/socket/note.py
+++ b/server/src/api/socket/note.py
@@ -376,7 +376,7 @@ async def add_shape(sid, raw_data: Any):
     NoteShape.create(note_id=note, shape_id=data.shape_id)
 
     for psid, user in game_state.get_users(skip_sid=sid, room=pr.room):
-        if can_edit(note, user):
+        if can_view(note, user):
             await _send_game("Note.Shape.Add", data.dict(), room=psid)
 
 
@@ -406,7 +406,7 @@ async def remove_shape(sid, raw_data: Any):
     NoteShape.get(note_id=note, shape_id=data.shape_id).delete_instance()
 
     for psid, user in game_state.get_users(skip_sid=sid, room=pr.room):
-        if can_edit(note, user):
+        if can_view(note, user):
             await _send_game("Note.Shape.Remove", data.dict(), room=psid)
 
 


### PR DESCRIPTION
Shape Add and Shape Remove events were not updating on clients that only have read access to a note.