### PR TITLE
bug(SelectTool): Fix resize to grid for rotation

### DIFF
--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -21,7 +21,6 @@ export interface IShape extends SimpleShape {
     character: CharacterId | undefined;
 
     get points(): [number, number][];
-    get pointsUntransformed(): GlobalPoint[];
     get shadowPoints(): [number, number][];
     invalidatePoints: () => void;
     updatePoints: () => void;

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -77,13 +77,6 @@ export abstract class Shape implements IShape {
         return this._points;
     }
 
-    // This returns the points of the shape without any rotation applied
-    // This is slower (as it starts from the rotated points) and returns GlobalPoints instead of [number, number]
-    // This is primarily used in the context of UI tools
-    get pointsUntransformed(): GlobalPoint[] {
-        return this.points.map((p) => rotateAroundPoint(toGP(p), this.center, this.angle));
-    }
-
     get shadowPoints(): [number, number][] {
         return this._shadowPoints ?? this._points;
     }
@@ -364,7 +357,7 @@ export abstract class Shape implements IShape {
         if (resizePoint < 0) return;
 
         const gridType = locationSettingsState.raw.gridType.value;
-        const [targetPoint] = snapPointToGrid(this.pointsUntransformed[resizePoint]!, gridType, {
+        const [targetPoint] = snapPointToGrid(toGP(this.points[resizePoint]!), gridType, {
             snapDistance: Number.MAX_VALUE,
         });
         this.resize(resizePoint, targetPoint, retainAspectRatio);


### PR DESCRIPTION
Resizing points to snap to the grid was not working correctly for rotated shapes.

This fixes #1405 