### PR TITLE
bug(Notes): Implement client handling of Note.Shape.Remove events

### DIFF
--- a/client/src/game/systems/notes/events.ts
+++ b/client/src/game/systems/notes/events.ts
@@ -74,6 +74,11 @@ socket.on("Note.Shape.Add", (data: ApiNoteShape) => {
     if (id === undefined) return;
     noteSystem.attachShape(data.note_id, id, false);
 });
+socket.on("Note.Shape.Remove", (data: ApiNoteShape) => {
+    const id = getLocalId(data.shape_id);
+    if (id === undefined) return;
+    noteSystem.removeShape(data.note_id, id, false);
+});
 
 socket.on("Note.ShowOnHover.Set", (data: ApiNoteSetBoolean) => {
     noteSystem.setShowOnHover(data.uuid, data.value, false);


### PR DESCRIPTION
In #1413, the Note.Shape.Add event was properly handled so that clients saw the changes immediately. I noticed that Note.Shape.Remove events were still not being received properly.

Turns out it wasn't implemented client-side. This PR implements handling of these events. Finishes closing #1410 