### PR TITLE
Fix annotations not correctly handling HTML in markdown notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ tech changes will usually be stripped from release notes for the public
         -   Members will now appear/disappear immediately
 -   Initiative:
     -   Fixed an issue where Initiative.Order.Change would fail when called with some Shape Ids.
+-   Annotations:
+    -   Fixed rendering of markdown which included raw HTML elements.
 -   [tech] FloorSystem's layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27

--- a/client/src/game/ui/Annotation.vue
+++ b/client/src/game/ui/Annotation.vue
@@ -9,7 +9,7 @@ import { uiState } from "../systems/ui/state";
         v-show="uiState.reactive.annotationText.length > 0"
         id="annotation"
         :source="uiState.reactive.annotationText"
-        :html="true"
+        :options="{ html: true }"
     />
 </template>
 


### PR DESCRIPTION
While basic markdown was working as it should, annotations were rendering HTML elements within notes as raw text, while the note view would properly render the same note.

I believe this bug was created with commit  [80c6549](https://github.com/Kruptein/PlanarAlly/commit/80c6549447486697b6bd0e4949016d7a3b2da6b0) though I didn't thoroughly check to be sure. I did verify that this issue was present in release 2024.1 and updated the changelog accordingly.