### PR TITLE
bug(Note): Fix note position when drawn on shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ tech changes will usually be stripped from release notes for the public
     -   When shape filtering, the shape name in the UI would change if you clicked on another shape with the select tool.
     -   Note icons drawn on a shape could be drawn behind the shape in some circumstances.
     -   Fix 'add shape' and 'remove shape' events not being synced immediately if you only have view access
+    -   Note icon on shape was drawn in strange locations for shapes larger than 1x1
 -   Groups:
     -   The 'edit shape' groups tab was completely broken, this has been resolved
     -   Multiple things in the groups tab have become more responsive to changes

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -4,7 +4,7 @@ import type { GridType } from "../../core/grid";
 import type { LocalId } from "../id";
 import type { Floor, FloorId, LayerName } from "../models/floor";
 import type { ShapeOptions } from "../models/shapes";
-import type { SHAPE_TYPE } from "../shapes/types";
+import type { DepShape, SHAPE_TYPE } from "../shapes/types";
 import type { BoundingRect } from "../shapes/variants/simple/boundingRect";
 import type { CharacterId } from "../systems/characters/models";
 
@@ -68,7 +68,7 @@ export interface IShape extends SimpleShape {
     _lightBlockingNeighbours: LocalId[];
     _parentId?: LocalId;
 
-    get dependentShapes(): IShape[];
+    get dependentShapes(): readonly DepShape[];
 
     // POSITION
 
@@ -123,8 +123,7 @@ export interface IShape extends SimpleShape {
 
     // DEPENDENT SHAPES
 
-    addDependentShape: (shape: IShape) => void;
-    removeDependentShape: (shapeId: LocalId, options: {dropShapeId: boolean}) => void;
-    removeDependentShapes: (options: {dropShapeId: boolean}) => void;
-
+    addDependentShape: (depShape: DepShape) => void;
+    removeDependentShape: (shapeId: LocalId, options: { dropShapeId: boolean }) => void;
+    removeDependentShapes: (options: { dropShapeId: boolean }) => void;
 }

--- a/client/src/game/interfaces/shapes/asset.ts
+++ b/client/src/game/interfaces/shapes/asset.ts
@@ -6,7 +6,11 @@ export interface IAsset extends IShape {
     svgData?: { svg: Node; rp: GlobalPoint; paths?: [number, number][][][] }[];
 
     get h(): number;
+    set h(w: number);
+    resizeH: (w: number, keepAspectratio: boolean) => void;
     get w(): number;
+    set w(w: number);
+    resizeW: (w: number, keepAspectratio: boolean) => void;
 
     loadSvgs: () => Promise<void>;
 }

--- a/client/src/game/shapes/types.ts
+++ b/client/src/game/shapes/types.ts
@@ -1,3 +1,7 @@
+import type { IShape } from "../interfaces/shape";
+
+import type { BoundingRect } from "./variants/simple/boundingRect";
+
 export type SHAPE_TYPE =
     | "assetrect"
     | "circle"
@@ -8,3 +12,8 @@ export type SHAPE_TYPE =
     | "rect"
     | "text"
     | "togglecomposite";
+
+export type DepShape = {
+    shape: IShape;
+    render: (ctx: CanvasRenderingContext2D, bbox: BoundingRect, depShape: IShape) => void;
+};

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -82,6 +82,18 @@ export class Asset extends BaseRect implements IAsset {
         }
     }
 
+    resizeH(h: number, keepAspectratio: boolean): void {
+        const ar = this.h / this.w;
+        this.h = h;
+        if (keepAspectratio) this.w = h / ar;
+    }
+
+    resizeW(w: number, keepAspectratio: boolean): void {
+        const ar = this.h / this.w;
+        this.w = w;
+        if (keepAspectratio) this.h = w * ar;
+    }
+
     async loadSvgs(): Promise<void> {
         if (this.options.svgAsset !== undefined) {
             const cover = new Polygon(

--- a/client/src/game/temp.ts
+++ b/client/src/game/temp.ts
@@ -10,6 +10,7 @@ import type { IShape } from "./interfaces/shape";
 import type { Floor, LayerName } from "./models/floor";
 import { addOperation } from "./operations/undo";
 import { createShapeFromDict } from "./shapes/create";
+import type { DepShape } from "./shapes/types";
 import { floorSystem } from "./systems/floors";
 import { noteSystem } from "./systems/notes";
 import { noteState } from "./systems/notes/state";
@@ -84,7 +85,13 @@ export function moveLayer(shapes: readonly IShape[], newLayer: ILayer, sync: boo
     }
 }
 
-export function addShape(shape: ApiShape, floor: string, layerName: LayerName, sync: SyncMode, dependents?: IShape[]): IShape | undefined {
+export function addShape(
+    shape: ApiShape,
+    floor: string,
+    layerName: LayerName,
+    sync: SyncMode,
+    dependents?: readonly DepShape[],
+): IShape | undefined {
     if (!floorSystem.hasLayer(floorSystem.getFloor({ name: floor })!, layerName)) {
         console.log(`Shape with unknown layer ${layerName} could not be added`);
         return;


### PR DESCRIPTION
This fixes #1408

As mentioned in the ticket, the position of the note icon on the map is pretty random if your shape is not a nice 1x1. It was using a hardcoded (0, -30) vector compared to the refPoint of the related shape, which makes little sense if the shape starts having bigger dimensions.

The current fix is to always render using the bounding box bottom left corner of the shape and by applying a scaling factor based on the same bbox to adjust the size of the note icon based on the size of the related shape. This functions similarly to what badges currently do.

This allows it to work decently with rectangles and circles. It's still pretty wonky for polygons and text shapes, but I'm honestly not sure if there really is a decent use case for attaching a note with a specific icon to these shapes.