### PR TITLE
bug(Notes): Fix shape note removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ tech changes will usually be stripped from release notes for the public
     -   Note icons drawn on a shape could be drawn behind the shape in some circumstances.
     -   Fix 'add shape' and 'remove shape' events not being synced immediately if you only have view access
     -   Note icon on shape was drawn in strange locations for shapes larger than 1x1
+    -   Fix shape removal not properly removing the shape from related notes client-side
 -   Groups:
     -   The 'edit shape' groups tab was completely broken, this has been resolved
     -   Multiple things in the groups tab have become more responsive to changes

--- a/client/src/game/systems/notes/index.ts
+++ b/client/src/game/systems/notes/index.ts
@@ -137,9 +137,8 @@ class NoteSystem implements System {
 
     unhookShape(shape: LocalId): void {
         if (!raw.shapeNotes.has(shape)) return;
-        const notes = $.shapeNotes.get(shape) ?? [];
-        while (notes.length) {
-            notes.pop();
+        for (const note of raw.shapeNotes.get(shape) ?? []) {
+            this.removeShape(note, shape, false);
         }
     }
 


### PR DESCRIPTION
When removing a shape, it would still appear in related notes' "Shapes" tab until a refresh.

This fixes 1 part of the issue mentioned in #1416