### PR TITLE
bug(Grid): Fix grid client settings not immediately updating the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ tech changes will usually be stripped from release notes for the public
     -   Fixed an issue where Initiative.Order.Change would fail when called with some Shape Ids.
 -   Annotations:
     -   Fixed rendering of markdown which included raw HTML elements.
+-   Changing client settings for the grid would not immediately update the screen
 -   [tech] FloorSystem's layers properties are now only reactive on the array level and are raw for the actual elements.
 
 ## [2024.1.0] - 2024-01-27

--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -1,3 +1,5 @@
+import { watch } from "vue";
+
 import { registerSystem } from "..";
 import type { System } from "..";
 import { g2l, l2g, zoomDisplayToFactor } from "../../../core/conversions";
@@ -113,6 +115,11 @@ class PositionSystem implements System {
         clientSystem.updateZoomFactor();
     }
 
+    // This is used to recalculate the zoom factor when the grid size changes
+    recalculateZoom(): void {
+        this.setZoomFactor($.zoomDisplay);
+    }
+
     // OOB
 
     checkOutOfBounds(): void {
@@ -214,3 +221,7 @@ class PositionSystem implements System {
 
 export const positionSystem = new PositionSystem();
 registerSystem("position", positionSystem, false, positionState);
+
+watch(playerSettingsState.gridSize, (gs) => {
+    positionSystem.recalculateZoom();
+});


### PR DESCRIPTION
The various client settings to modify the grid (e.g. physical board, grid pixel size) would upon modification seemingly not do anything. Only when a refresh or a zoom change happened would the screen readjust.

This PR fixes this behaviour.