### PR TITLE
bug(DrawTool): Fix no longer snapping to most recently drawn shape

### DIFF
--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -212,6 +212,7 @@ class DrawTool extends Tool implements ITool {
                 layerName: this.shape.layer!.name,
             });
         }
+        this.shape = undefined;
         this.active.value = false;
         const layer = this.getLayer();
         if (layer !== undefined) {


### PR DESCRIPTION
Another fix to draw tool snapping in this release cycle introduced another bug; When drawing multiple shapes after each other the pointer would not snap to the most recently drawn shape. There was a workaround by swapping between tools, but it has now been properly fixed in this PR.