### PR TITLE
bug(DrawTool): Fix small issues with rectangle drawing when crossing over an axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ tech changes will usually be stripped from release notes for the public
     -   snapping mode was also snapping to the point being moved
     -   now also snaps to hex vertices
     -   the first mouse press now also properly snaps to the grid
+    -   fix small point changes when flipping the rectangle axis while drawing
 -   Select Tool:
     -   resizing in snapping mode was also snapping to the point being resized
     -   polygon edit UI had a small visual glitch on appearance causing a circle to appear around (0, 0)

--- a/client/src/game/shapes/variants/baseRect.ts
+++ b/client/src/game/shapes/variants/baseRect.ts
@@ -41,6 +41,8 @@ export abstract class BaseRect extends Shape implements IShape {
         return this._w;
     }
 
+    // THIS DOES NOT UPDATE THE CENTER
+    // A later call to either set refPoint or updateCenter is expected
     set w(width: number) {
         if (width > 0) {
             this._w = width;
@@ -52,6 +54,8 @@ export abstract class BaseRect extends Shape implements IShape {
         return this._h;
     }
 
+    // THIS DOES NOT UPDATE THE CENTER
+    // A later call to either set refPoint or updateCenter is expected
     set h(height: number) {
         if (height > 0) {
             this._h = height;

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -537,7 +537,7 @@ class DrawTool extends Tool implements ITool {
                 const rect = this.shape as IRect;
                 const newW = Math.abs(endPoint.x - this.startPoint.x);
                 const newH = Math.abs(endPoint.y - this.startPoint.y);
-                if (newW === rect.w && newH === rect.h) return Promise.resolve();
+                if ((newW === rect.w && newH === rect.h) || newW === 0 || newH === 0) return Promise.resolve();
                 rect.w = newW;
                 rect.h = newH;
                 if (endPoint.x < this.startPoint.x || endPoint.y < this.startPoint.y) {
@@ -545,6 +545,9 @@ class DrawTool extends Tool implements ITool {
                         Math.min(this.startPoint.x, endPoint.x),
                         Math.min(this.startPoint.y, endPoint.y),
                     );
+                } else {
+                    // Force proper refPoint after w/h modification
+                    rect.refPoint = cloneP(this.startPoint);
                 }
                 break;
             }


### PR DESCRIPTION
If while drawing a rectangle you move over an axis (e.g. you move the cursor left of the current left rectangle border) some funky small changes to points could occur, causing the cursor to no longer be attached to the rectangle.