### PR TITLE
bug(notes): Fix notes not saving in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ tech changes will usually be stripped from release notes for the public
     -   Fix 'add shape' and 'remove shape' events not being synced immediately if you only have view access
     -   Note icon on shape was drawn in strange locations for shapes larger than 1x1
     -   Fix shape removal not properly removing the shape from related notes client-side
+    -   Fix notes not being stored in shape templates
 -   Groups:
     -   The 'edit shape' groups tab was completely broken, this has been resolved
     -   Multiple things in the groups tab have become more responsive to changes

--- a/client/src/game/models/templates.ts
+++ b/client/src/game/models/templates.ts
@@ -46,7 +46,9 @@ export type BaseAuraTemplate = Pick<ApiAura, (typeof BaseAuraStrings)[number]>;
 export type BaseTrackerTemplate = Pick<ApiTracker, (typeof BaseTrackerStrings)[number]>;
 type BasePropertyTemplate = Pick<ApiShape, (typeof BaseTemplateStrings)[number]>;
 export type BaseTemplate = Partial<
-    BasePropertyTemplate & { auras: Partial<BaseAuraTemplate>[] } & { trackers: Partial<BaseTrackerTemplate>[] }
+    BasePropertyTemplate & { options?: string } & { auras: Partial<BaseAuraTemplate>[] } & {
+        trackers: Partial<BaseTrackerTemplate>[];
+    }
 >;
 
 // Why do these exist, templates only work for Assets at the moment?

--- a/client/src/game/shapes/templates.ts
+++ b/client/src/game/shapes/templates.ts
@@ -1,4 +1,5 @@
 import type { ApiRectShape, ApiShape } from "../../apiTypes";
+import type { ShapeOptions } from "../models/shapes";
 import { BaseAuraStrings, BaseTemplateStrings, BaseTrackerStrings, getTemplateKeys } from "../models/templates";
 import type { BaseAuraTemplate, BaseTemplate, BaseTrackerTemplate } from "../models/templates";
 import { aurasToServer } from "../systems/auras/conversion";
@@ -66,6 +67,19 @@ export function toTemplate(shape: ApiShape): BaseTemplate {
     // should be template[key], but this is something that TS cannot correctly infer (issue #31445)
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
     for (const key of BaseTemplateStrings) (template as any)[key] = shape[key];
+
+    // We usually don't want to save the options that are currently stored on the shape
+    // there are some options however that SHOULD transfer. (currently only notes)
+    if (shape.options) {
+        const options: Partial<ShapeOptions> = {};
+        const { templateNoteIds } = Object.fromEntries(JSON.parse(shape.options) as any[]) as Partial<ShapeOptions>;
+        if (templateNoteIds) {
+            options.templateNoteIds = templateNoteIds;
+        }
+        if (Object.keys(options).length > 0) {
+            template.options = JSON.stringify(Object.entries(options));
+        }
+    }
 
     template.auras = [];
     template.trackers = [];


### PR DESCRIPTION
A small oversight on my end caused note information to not be properly stored when saving templates.

Technical explanation:
`Shape.options` stores general information on a shape that does not have a proper home yet or is generally more experimental. As such this information is generally not saved along with templates.

Notes are stored in their own proper system and thus are not stored on a shape, but for the purposes of templating, the ids of the related notes are stored in the template's options, which were not being saved as mentioned earlier.