### PR TITLE
feat(Chat): Add a simple ephemeral chat experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Added
+
+-   Optional simple chat system
+    -   This is **not** stored serverside, so messages will be lost on refresh or later re-opening of the session
+    -   Chat is basic markdown aware, but does not allow direct HTML
+    -   (image) urls can be pasted without special markdown syntax
+    -   Can be collapsed by clicking on the chat title
+
 ## [2024.2.0] - 2024-05-18
 
 ### Added

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -32,6 +32,7 @@
                 "@esbuild-plugins/esm-externals": "^0.1.2",
                 "@intlify/unplugin-vue-i18n": "^4.0.0",
                 "@types/lodash": "^4.17.4",
+                "@types/markdown-it": "^14.1.1",
                 "@types/swiper": "^5.4.3",
                 "@types/tinycolor2": "^1.4.6",
                 "@typescript-eslint/eslint-plugin": "^7.10.0",
@@ -1947,10 +1948,32 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
         },
+        "node_modules/@types/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+            "dev": true
+        },
         "node_modules/@types/lodash": {
             "version": "4.17.4",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
             "integrity": "sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==",
+            "dev": true
+        },
+        "node_modules/@types/markdown-it": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
+            "dev": true,
+            "dependencies": {
+                "@types/linkify-it": "^5",
+                "@types/mdurl": "^2"
+            }
+        },
+        "node_modules/@types/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
             "dev": true
         },
         "node_modules/@types/node": {

--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
         "@esbuild-plugins/esm-externals": "^0.1.2",
         "@intlify/unplugin-vue-i18n": "^4.0.0",
         "@types/lodash": "^4.17.4",
+        "@types/markdown-it": "^14.1.1",
         "@types/swiper": "^5.4.3",
         "@types/tinycolor2": "^1.4.6",
         "@typescript-eslint/eslint-plugin": "^7.10.0",

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -126,6 +126,10 @@ export interface ApiCharacter {
   assetId: number;
   assetHash: string;
 }
+export interface ApiChatMessage {
+  author: string;
+  data: string[];
+}
 export interface ApiCircleShape extends ApiCoreShape {
   radius: number;
   viewing_angle: number | null;

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -1,6 +1,7 @@
 import "../systems/access/events";
 import "../systems/auras/events";
 import "../systems/characters/events";
+import "../systems/chat/events";
 import "../systems/groups/events";
 import "../systems/labels/events";
 import "../systems/logic/door/events";

--- a/client/src/game/clear.ts
+++ b/client/src/game/clear.ts
@@ -5,10 +5,11 @@ import { clearIds } from "./id";
 import { compositeState } from "./layers/state";
 import { stopDrawLoop } from "./rendering/core";
 import { clearSystems } from "./systems";
+import type { SystemClearReason } from "./systems/models";
 import { initiativeStore } from "./ui/initiative/state";
 import { visionState } from "./vision/state";
 
-export function clearGame(reason: "full-loading" | "partial-loading" | "leaving"): void {
+export function clearGame(reason: SystemClearReason): void {
     stopDrawLoop();
     visionState.clear();
     locationStore.setLocations([], false);

--- a/client/src/game/systems/characters/index.ts
+++ b/client/src/game/systems/characters/index.ts
@@ -7,6 +7,7 @@ import { find } from "../../../core/iter";
 import { getGlobalId, getLocalId, getShape, type LocalId } from "../../id";
 import type { IShape } from "../../interfaces/shape";
 import type { IToggleComposite } from "../../interfaces/shapes/toggleComposite";
+import type { SystemClearReason } from "../models";
 import { selectedState } from "../selected/state";
 
 import type { CharacterId } from "./models";
@@ -17,7 +18,7 @@ const { mutable, readonly, mutableReactive: $ } = characterState;
 class CharacterSystem implements ShapeSystem {
     // BEHAVIOUR
 
-    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
+    clear(reason: SystemClearReason): void {
         $.activeCharacterId = undefined;
         if (reason !== "partial-loading") {
             $.characterIds.clear();

--- a/client/src/game/systems/chat/emits.ts
+++ b/client/src/game/systems/chat/emits.ts
@@ -1,0 +1,4 @@
+import type { ApiChatMessage } from "../../../apiTypes";
+import { wrapSocket } from "../../api/helpers";
+
+export const sendChatMessage = wrapSocket<ApiChatMessage>("Chat.Add");

--- a/client/src/game/systems/chat/events.ts
+++ b/client/src/game/systems/chat/events.ts
@@ -1,0 +1,8 @@
+import type { ApiChatMessage } from "../../../apiTypes";
+import { socket } from "../../api/socket";
+
+import { chatSystem } from ".";
+
+socket.on("Chat.Add", (data: ApiChatMessage) => {
+    chatSystem.addMessage(data.author, data.data, false);
+});

--- a/client/src/game/systems/chat/image-loader.ts
+++ b/client/src/game/systems/chat/image-loader.ts
@@ -1,0 +1,30 @@
+import { chatMarkDown } from "./md";
+import { chatState } from "./state";
+
+const URL_HISTORY = new Map<string, boolean>();
+
+export async function loadChatImages(data: string[], index: number): Promise<void> {
+    // Check for images - If a URL matches an image, convert it to a markdown image
+    // This is done non-blocking to keep the chat experience smooth
+    for (const [i, el] of data.entries()) {
+        if (el.startsWith("http")) {
+            const history = URL_HISTORY.get(el);
+            let wrapImage = history === true;
+            if (history === undefined) {
+                console.log("cache miss");
+                const isImage = await isImageUrl(el);
+                URL_HISTORY.set(el, isImage);
+                wrapImage = isImage;
+            }
+            if (wrapImage) {
+                data[i] = `![](${el})`;
+                chatState.mutableReactive.messages[index]!.content = chatMarkDown.render(data.join(""));
+            }
+        }
+    }
+}
+
+async function isImageUrl(url: string): Promise<boolean> {
+    const data = await fetch(url, { method: "HEAD" });
+    return data.headers.get("content-type")?.startsWith("image/") ?? false;
+}

--- a/client/src/game/systems/chat/index.ts
+++ b/client/src/game/systems/chat/index.ts
@@ -1,0 +1,31 @@
+import { registerSystem } from "..";
+
+import { sendChatMessage } from "./emits";
+import { loadChatImages } from "./image-loader";
+import { chatMarkDown } from "./md";
+import { chatState } from "./state";
+
+const { mutableReactive: $ } = chatState;
+
+class ChatSystem {
+    clear(): void {
+        $.messages = [];
+    }
+
+    addMessage(author: string, data: string[], sync: boolean): void {
+        const message = {
+            author,
+            content: chatMarkDown.render(data.join("")),
+        };
+
+        if (sync) sendChatMessage({ author, data });
+
+        const messageIndex = $.messages.push(message) - 1;
+
+        // Non-blocking on purpose
+        loadChatImages(data, messageIndex).catch((err) => console.log("failed to load images", err));
+    }
+}
+
+export const chatSystem = new ChatSystem();
+registerSystem("chat", chatSystem, false, chatState);

--- a/client/src/game/systems/chat/index.ts
+++ b/client/src/game/systems/chat/index.ts
@@ -1,4 +1,5 @@
-import { registerSystem } from "..";
+import { type System, registerSystem } from "..";
+import type { SystemClearReason } from "../models";
 
 import { sendChatMessage } from "./emits";
 import { loadChatImages } from "./image-loader";
@@ -7,9 +8,9 @@ import { chatState } from "./state";
 
 const { mutableReactive: $ } = chatState;
 
-class ChatSystem {
-    clear(): void {
-        $.messages = [];
+class ChatSystem implements System {
+    clear(reason: SystemClearReason): void {
+        if (reason === "full-loading") $.messages = [];
     }
 
     addMessage(author: string, data: string[], sync: boolean): void {

--- a/client/src/game/systems/chat/md.ts
+++ b/client/src/game/systems/chat/md.ts
@@ -1,0 +1,8 @@
+import MarkdownIt from "markdown-it";
+
+export const chatMarkDown = new MarkdownIt({ linkify: true });
+
+chatMarkDown.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    tokens[idx]?.attrSet("target", "_blank");
+    return self.renderToken(tokens, idx, options);
+};

--- a/client/src/game/systems/chat/models.ts
+++ b/client/src/game/systems/chat/models.ts
@@ -1,0 +1,4 @@
+export interface ChatMessage {
+    author: string;
+    content: string;
+}

--- a/client/src/game/systems/chat/state.ts
+++ b/client/src/game/systems/chat/state.ts
@@ -1,0 +1,15 @@
+import { buildState } from "../state";
+
+import type { ChatMessage } from "./models";
+
+interface ReactiveChatState {
+    messages: ChatMessage[];
+}
+
+const state = buildState<ReactiveChatState>({
+    messages: [],
+});
+
+export const chatState = {
+    ...state,
+};

--- a/client/src/game/systems/index.ts
+++ b/client/src/game/systems/index.ts
@@ -1,5 +1,7 @@
 import type { LocalId } from "../id";
 
+import type { SystemClearReason } from "./models";
+
 export const SYSTEMS: Record<string, System> = {};
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 (window as any).systems = SYSTEMS;
@@ -25,14 +27,14 @@ export function dropFromSystems(id: LocalId): void {
     }
 }
 
-export function clearSystems(reason: "full-loading" | "partial-loading" | "leaving"): void {
+export function clearSystems(reason: SystemClearReason): void {
     for (const system of Object.values(SYSTEMS)) {
         system.clear(reason);
     }
 }
 
 export interface System {
-    clear: (reason: "full-loading" | "partial-loading" | "leaving") => void;
+    clear: (reason: SystemClearReason) => void;
 }
 
 export interface ShapeSystem extends System {

--- a/client/src/game/systems/modals/index.ts
+++ b/client/src/game/systems/modals/index.ts
@@ -3,6 +3,7 @@ import type { Component } from "vue";
 
 import { registerSystem } from "..";
 import type { System } from "..";
+import type { SystemClearReason } from "../models";
 
 import { modalState } from "./state";
 import type { FullModal, IndexedModal, Modal, ModalIndex } from "./types";
@@ -20,7 +21,7 @@ function fullModal(modal: Modal, modalIndex: ModalIndex): IndexedModal {
 }
 
 class ModalSystem implements System {
-    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
+    clear(reason: SystemClearReason): void {
         if (reason === "leaving") {
             $.extraModals = [];
             $.openModals.clear();

--- a/client/src/game/systems/models.ts
+++ b/client/src/game/systems/models.ts
@@ -1,0 +1,1 @@
+export type SystemClearReason = "full-loading" | "partial-loading" | "leaving";

--- a/client/src/game/systems/players/index.ts
+++ b/client/src/game/systems/players/index.ts
@@ -16,6 +16,7 @@ import { startDrawLoop } from "../../rendering/core";
 import { clientSystem } from "../client";
 import { clientState } from "../client/state";
 import { floorSystem } from "../floors";
+import type { SystemClearReason } from "../models";
 import { positionSystem } from "../position";
 
 import type { Player, PlayerId } from "./models";
@@ -24,7 +25,7 @@ import { playerState } from "./state";
 const { mutableReactive: $, raw } = playerState;
 
 class PlayerSystem implements System {
-    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
+    clear(reason: SystemClearReason): void {
         if (reason !== "partial-loading") $.players.clear();
     }
 

--- a/client/src/game/systems/settings/location/index.ts
+++ b/client/src/game/systems/settings/location/index.ts
@@ -5,6 +5,7 @@ import { updateFogColour } from "../../../colour";
 import type { GlobalId } from "../../../id";
 import { floorSystem } from "../../floors";
 import { floorState } from "../../floors/state";
+import type { SystemClearReason } from "../../models";
 
 import { isDefaultWrapper } from "./helpers";
 import type { WithLocationDefault } from "./models";
@@ -13,7 +14,7 @@ import { locationSettingsState } from "./state";
 const { mutableReactive: $, raw, reset } = locationSettingsState;
 
 class LocationSettingsSystem implements System {
-    clear(reason: "full-loading" | "partial-loading" | "leaving"): void {
+    clear(reason: SystemClearReason): void {
         if (reason !== "partial-loading") reset();
     }
 

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import { nextTick, onMounted, ref, watch } from "vue";
+
+import { chatSystem } from "../systems/chat";
+import { chatState } from "../systems/chat/state";
+import { playerSystem } from "../systems/players";
+
+const URL_REGEX =
+    /\bhttps?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g;
+
+const chatContainer = ref<HTMLElement | null>(null);
+const expanded = ref(true);
+const enlargedUrl = ref<string | null>(null);
+const dialog = ref<HTMLDialogElement | null>(null);
+
+// MutationObserver to detect new images and add onload & onClick handlers
+
+const observer = new MutationObserver(mutationHandler);
+
+function mutationHandler(childList: MutationRecord[]): void {
+    for (const child of childList) {
+        if (child.addedNodes.length === 0) continue;
+        for (const add of child.addedNodes) {
+            if (add instanceof HTMLElement) {
+                const img = add.querySelector("img");
+                if (img) {
+                    img.onload = scrollToBottom;
+                    img.onclick = () => showDialog(img.src);
+                }
+            }
+        }
+    }
+}
+
+onMounted(() => {
+    observer.observe(chatContainer.value!, { childList: true, subtree: true });
+});
+
+// Scroll to bottom when new messages are added
+
+watch(chatState.reactive.messages, async () => {
+    await nextTick();
+    scrollToBottom();
+});
+
+function scrollToBottom(): void {
+    const chatContainer = document.getElementById("chat-container");
+    chatContainer?.lastElementChild?.scrollIntoView({ behavior: "smooth" });
+}
+
+// Dialog handling
+
+function showDialog(url: string): void {
+    enlargedUrl.value = url;
+    dialog.value?.showModal();
+}
+
+function closeDialog(): void {
+    enlargedUrl.value = null;
+    dialog.value?.close();
+}
+
+// Core message handling & parsing
+
+function* parseMessage(data: string): Generator<string> {
+    const urlHits = [...data.matchAll(URL_REGEX)];
+
+    yield data.slice(0, urlHits[0]?.index);
+    for (let i = 0; i < urlHits.length; i++) {
+        yield urlHits[i]![0];
+        yield data.slice(urlHits[i]!.index + urlHits[i]![0].length, urlHits[i + 1]?.index);
+    }
+}
+
+function handleMessage(event: KeyboardEvent): void {
+    if (event.key !== "Enter" || event.shiftKey) return;
+    event.preventDefault();
+    const input = event.target as HTMLInputElement;
+    const data = [...parseMessage(input.value)];
+
+    input.value = "";
+
+    chatSystem.addMessage(playerSystem.getCurrentPlayer()?.name ?? "?", data, true);
+}
+</script>
+
+<template>
+    <dialog v-show="enlargedUrl" ref="dialog" @click="closeDialog">
+        <img v-if="enlargedUrl" :src="enlargedUrl" />
+    </dialog>
+    <div id="chat">
+        <div id="chat-title" @click="expanded = !expanded">
+            <div>Chat</div>
+        </div>
+        <div v-show="expanded" id="chat-container" ref="chatContainer">
+            <template
+                v-for="[i, message] of chatState.reactive.messages.entries()"
+                :key="`${i}-${message.content.length}`"
+            >
+                <div class="author">{{ message.author }}</div>
+                <!-- eslint-disable-next-line vue/no-v-html -->
+                <div class="message" v-html="message.content"></div>
+            </template>
+        </div>
+        <textarea v-show="expanded" @keydown.enter="handleMessage" />
+    </div>
+</template>
+
+<style scoped lang="scss">
+dialog {
+    position: absolute;
+    z-index: 1;
+    pointer-events: auto;
+
+    img {
+        max-width: 80vw;
+        max-height: 80vh;
+    }
+}
+
+#chat {
+    display: flex;
+    flex-direction: column;
+
+    width: 25rem;
+    min-width: 20rem;
+    max-width: 75vw;
+
+    margin: 1rem;
+    margin-left: 1.5rem;
+
+    background-color: lightblue;
+    border-radius: 0.75rem;
+    border: solid 2px lightblue;
+
+    pointer-events: auto;
+
+    opacity: 0.75;
+
+    resize: horizontal;
+    overflow: auto;
+
+    z-index: 1;
+
+    &:hover,
+    &:focus-within {
+        opacity: 1;
+    }
+
+    #chat-title {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        padding: 0.25rem 1rem;
+
+        font-weight: bold;
+
+        &:hover {
+            cursor: pointer;
+        }
+    }
+
+    #chat-container {
+        display: grid;
+        grid-template-columns: 5rem minmax(15rem, 1fr);
+
+        gap: 0.5rem;
+        padding: 1rem;
+        padding-right: 0;
+
+        border-top-left-radius: 0.75rem;
+        border-top-right-radius: 0.75rem;
+        background-color: aliceblue;
+
+        max-height: 35rem;
+        overflow-y: scroll;
+        overflow-x: hidden;
+        overflow-wrap: anywhere;
+
+        .author {
+            font-weight: bold;
+        }
+
+        .message {
+            margin-right: 3rem;
+
+            :deep(p) {
+                &:first-child {
+                    margin-top: 0;
+                }
+                &:last-child {
+                    margin-bottom: 0;
+                }
+            }
+
+            :deep(img) {
+                max-width: 100%;
+
+                &:hover {
+                    cursor: pointer;
+                }
+            }
+        }
+    }
+
+    textarea {
+        margin: 0.5rem;
+        padding: 0.5rem;
+        resize: none;
+        border-radius: 0.5rem;
+        height: 2.2rem;
+    }
+}
+</style>

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -9,7 +9,7 @@ const URL_REGEX =
     /\bhttps?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g;
 
 const chatContainer = ref<HTMLElement | null>(null);
-const expanded = ref(true);
+const expanded = ref(false);
 const enlargedUrl = ref<string | null>(null);
 const dialog = ref<HTMLDialogElement | null>(null);
 const messagesSeenCount = ref(chatState.raw.messages.length);

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -106,7 +106,7 @@ function handleMessage(event: KeyboardEvent): void {
     <dialog v-show="enlargedUrl" ref="dialog" @click="closeDialog">
         <img v-if="enlargedUrl" :src="enlargedUrl" />
     </dialog>
-    <div id="chat">
+    <div id="chat" :class="{ collapsed: !expanded }">
         <div id="chat-title" @click="toggleChat">
             <div>
                 Chat
@@ -166,6 +166,11 @@ dialog {
 
     resize: horizontal;
     overflow: auto;
+
+    &.collapsed {
+        min-width: 7.5rem;
+        width: 7.5rem;
+    }
 
     &:hover,
     &:focus-within {

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -143,7 +143,6 @@ dialog {
     min-width: 20rem;
     max-width: 75vw;
 
-    margin: 1rem;
     margin-left: 1.5rem;
 
     background-color: lightblue;
@@ -157,11 +156,10 @@ dialog {
     resize: horizontal;
     overflow: auto;
 
-    z-index: 1;
-
     &:hover,
     &:focus-within {
         opacity: 1;
+        z-index: 1;
     }
 
     #chat-title {

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -49,11 +49,17 @@ onMounted(() => {
 
 // Scroll to bottom when new messages are added
 
-watch(chatState.reactive.messages, async () => {
-    if (expanded.value) messagesSeenCount.value = chatState.raw.messages.length;
-    await nextTick();
-    scrollToBottom();
-});
+watch(
+    () => chatState.reactive.messages,
+    async (newData) => {
+        if (expanded.value && newData.length !== messagesSeenCount.value) {
+            messagesSeenCount.value = chatState.raw.messages.length;
+            await nextTick();
+            scrollToBottom();
+        }
+    },
+    { deep: true },
+);
 
 function scrollToBottom(): void {
     const chatContainer = document.getElementById("chat-container");
@@ -105,7 +111,8 @@ function handleMessage(event: KeyboardEvent): void {
             <div>
                 Chat
                 <span v-show="chatState.raw.messages.length > messagesSeenCount">
-                    ({{ chatState.raw.messages.length - messagesSeenCount }})
+                    ({{ chatState.raw.messages.length - messagesSeenCount }}) {{ chatState.reactive.messages.length }}
+                    {{ messagesSeenCount }}
                 </span>
             </div>
         </div>
@@ -117,6 +124,10 @@ function handleMessage(event: KeyboardEvent): void {
                 <div class="author">{{ message.author }}</div>
                 <!-- eslint-disable-next-line vue/no-v-html -->
                 <div class="message" v-html="message.content"></div>
+            </template>
+            <template v-if="chatState.reactive.messages.length === 0">
+                <div></div>
+                <div style="font-style: italic">No messages yet.</div>
             </template>
         </div>
         <textarea v-show="expanded" @keydown.enter="handleMessage" />

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -12,15 +12,19 @@ const chatContainer = ref<HTMLElement | null>(null);
 const expanded = ref(false);
 const enlargedUrl = ref<string | null>(null);
 const dialog = ref<HTMLDialogElement | null>(null);
+const textInput = ref<HTMLTextAreaElement | null>(null);
 const messagesSeenCount = ref(chatState.raw.messages.length);
 
 async function toggleChat(): Promise<void> {
     expanded.value = !expanded.value;
     const messageLength = chatState.raw.messages.length;
-    if (expanded.value && messagesSeenCount.value < messageLength) {
-        messagesSeenCount.value = messageLength;
+    if (expanded.value) {
         await nextTick();
-        scrollToBottom();
+        if (messagesSeenCount.value < messageLength) {
+            messagesSeenCount.value = messageLength;
+            scrollToBottom();
+        }
+        textInput.value?.focus();
     }
 }
 
@@ -130,7 +134,7 @@ function handleMessage(event: KeyboardEvent): void {
                 <div style="font-style: italic">No messages yet.</div>
             </template>
         </div>
-        <textarea v-show="expanded" @keydown.enter="handleMessage" />
+        <textarea v-show="expanded" ref="textInput" @keydown.enter="handleMessage" />
     </div>
 </template>
 

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -6,7 +6,7 @@ import { chatState } from "../systems/chat/state";
 import { playerSystem } from "../systems/players";
 
 const URL_REGEX =
-    /\bhttps?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g;
+    /\bhttps?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/g;
 
 const chatContainer = ref<HTMLElement | null>(null);
 const expanded = ref(false);
@@ -108,7 +108,7 @@ function handleMessage(event: KeyboardEvent): void {
 
 <template>
     <dialog v-show="enlargedUrl" ref="dialog" @click="closeDialog">
-        <img v-if="enlargedUrl" :src="enlargedUrl" />
+        <img v-if="enlargedUrl" :src="enlargedUrl" alt="Enlarged chat image" />
     </dialog>
     <div id="chat" :class="{ collapsed: !expanded }">
         <div id="chat-title" @click="toggleChat">

--- a/client/src/game/ui/Floors.vue
+++ b/client/src/game/ui/Floors.vue
@@ -140,6 +140,7 @@ const selectedLayer = computed(() => {
 #floor-layer {
     display: flex;
     list-style: none;
+    margin-top: 1rem;
     margin-left: 1.5rem;
     margin-bottom: 1.5rem;
     -webkit-user-drag: none !important;

--- a/client/src/game/ui/Floors.vue
+++ b/client/src/game/ui/Floors.vue
@@ -88,7 +88,7 @@ const selectedLayer = computed(() => {
         </div>
         <div v-if="detailsOpen" id="floor-detail">
             <draggable v-model="floors" :disabled="!gameState.reactive.isDm" item-key="reverseIndex">
-                <template #item="{ element: f }: { element: { floor: Floor, reverseIndex: FloorIndex } }">
+                <template #item="{ element: f }: { element: { floor: Floor; reverseIndex: FloorIndex } }">
                     <div class="floor-row" @click="selectFloor({ name: f.floor.name }, true)">
                         <div
                             class="floor-index"
@@ -138,8 +138,6 @@ const selectedLayer = computed(() => {
 
 <style scoped lang="scss">
 #floor-layer {
-    position: relative;
-    grid-area: layer;
     display: flex;
     list-style: none;
     margin-left: 1.5rem;

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -13,6 +13,7 @@ import { positionState } from "../systems/position/state";
 import { uiState } from "../systems/ui/state";
 
 import Annotation from "./Annotation.vue";
+import Chat from "./Chat.vue";
 import DefaultContext from "./contextmenu/DefaultContext.vue";
 import ShapeContext from "./contextmenu/ShapeContext.vue";
 import { showDefaultContextMenu, showShapeContextMenu } from "./contextmenu/state";
@@ -188,7 +189,10 @@ function setTempZoomDisplay(value: number): void {
         <MenuBar />
         <Tools />
         <LocationBar v-if="gameState.reactive.isDm" :active="visible.locations" :menu-active="visible.settings" />
-        <Floors />
+        <div id="floor-and-chat">
+            <Chat />
+            <Floors />
+        </div>
         <DefaultContext />
         <ShapeContext />
         <Annotation />
@@ -228,14 +232,21 @@ function setTempZoomDisplay(value: number): void {
     grid-template-areas:
         "topleft locations locations locations"
         "menu    menutoggle  annotation   zoom     "
-        "menu        .       .              .      "
-        "menu      layer     .            tools    ";
+        "menu        .           .          .      "
+        "menu    floor-chat      .        tools    ";
     grid-template-rows: 0 auto 1fr auto;
     grid-template-columns: 0 repeat(3, 1fr);
     width: 100%;
     height: 100%;
 
     z-index: 0;
+}
+
+#floor-and-chat {
+    grid-area: floor-chat;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
 }
 
 #logo {

--- a/server/src/api/models/__init__.py
+++ b/server/src/api/models/__init__.py
@@ -1,6 +1,7 @@
 from .asset import *
 from .aura import *
 from .character import *
+from .chat import *
 from .client import *
 from .common import *
 from .data_block import *

--- a/server/src/api/models/chat.py
+++ b/server/src/api/models/chat.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class ApiChatMessage(BaseModel):
+    author: str
+    data: list[str]

--- a/server/src/api/socket/__init__.py
+++ b/server/src/api/socket/__init__.py
@@ -2,6 +2,7 @@ def load_socket_commands():
     from . import (
         asset,  # noqa: F401.
         character,  # noqa: F401.
+        chat,  # noqa: F401.
         client,  # noqa: F401.
         connection,  # noqa: F401.
         dashboard,  # noqa: F401.

--- a/server/src/api/socket/chat.py
+++ b/server/src/api/socket/chat.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from ... import auth
+from ...api.socket.constants import GAME_NS
+from ...app import app, sio
+from ...db.models.player_room import PlayerRoom
+from ...state.game import game_state
+from ..helpers import _send_game
+from ..models.chat import ApiChatMessage
+
+
+@sio.on("Chat.Add", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def add_chat_message(sid: str, raw_data: Any):
+    data = ApiChatMessage(**raw_data)
+
+    pr: PlayerRoom = game_state.get(sid)
+
+    await _send_game("Chat.Add", data, room=pr.room.get_path(), skip_sid=sid)


### PR DESCRIPTION
This adds a collapsible simple chat feature to the bottom left of the screen.

The initial scope is small on purpose.

It currently offers the ability to send basic text based chats. There is markdown support, but no HTML can be used directly. (e.g. `**test**` will show up bold `<b>test</b>` won't.)

URLs will automatically be clickable without using the normal markdown syntax for urls, and will open in a new tab.

Image URLs specifically will automatically be converted to images in the chat container and can be clicked to see them in larger scale.

A later PR will arrive that allows you to disable this feature entirely on a campaign level if it's something you don't need.