### PR TITLE
feat(DM-Settings): Add Features tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ tech changes will usually be stripped from release notes for the public
     -   Chat is basic markdown aware, but does not allow direct HTML
     -   (image) urls can be pasted without special markdown syntax
     -   Can be collapsed by clicking on the chat title
+-   [DM] new DM settings section: Features
+    -   Can be used to enable/disable certain features campaign wide
+    -   Currently limited to chat & dice
 
 ## [2024.2.0] - 2024-05-18
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -604,6 +604,10 @@ export interface PositionTuple {
   x: number;
   y: number;
 }
+export interface RoomFeatures {
+  chat: boolean;
+  dice: boolean;
+}
 export interface RoomInfoPlayersAdd {
   id: PlayerId;
   name: string;
@@ -615,6 +619,7 @@ export interface RoomInfoSet {
   invitationCode: string;
   isLocked: boolean;
   publicName: string;
+  features: RoomFeatures;
 }
 export interface ShapeAdd {
   shape:

--- a/client/src/game/api/events.ts
+++ b/client/src/game/api/events.ts
@@ -8,6 +8,7 @@ import "../systems/logic/door/events";
 import "../systems/logic/tp/events";
 import "../systems/markers/events";
 import "../systems/notes/events";
+import "../systems/room/events";
 import "../systems/trackers/events";
 
 import "./events/client";
@@ -21,7 +22,6 @@ import "./events/notification";
 import "./events/player/options";
 import "./events/player/player";
 import "./events/player/players";
-import "./events/room";
 import "./events/shape/asset";
 import "./events/shape/circularToken";
 import "./events/shape/core";

--- a/client/src/game/systems/room/emits.ts
+++ b/client/src/game/systems/room/emits.ts
@@ -1,0 +1,4 @@
+import { wrapSocket } from "../../api/helpers";
+
+export const sendSetChatFeature = wrapSocket<boolean>("Room.Features.Chat.Set");
+export const sendSetDiceFeature = wrapSocket<boolean>("Room.Features.Dice.Set");

--- a/client/src/game/systems/room/events.ts
+++ b/client/src/game/systems/room/events.ts
@@ -1,8 +1,10 @@
 import type { RoomInfoPlayersAdd, RoomInfoSet } from "../../../apiTypes";
+import { socket } from "../../api/socket";
 import { Role } from "../../models/role";
-import { gameSystem } from "../../systems/game";
-import { playerSystem } from "../../systems/players";
-import { socket } from "../socket";
+import { gameSystem } from "../game";
+import { playerSystem } from "../players";
+
+import { roomSystem } from ".";
 
 socket.on("Room.Info.Set", (data: RoomInfoSet) => {
     gameSystem.setRoomName(data.name);
@@ -10,6 +12,8 @@ socket.on("Room.Info.Set", (data: RoomInfoSet) => {
     gameSystem.setInvitationCode(data.invitationCode);
     gameSystem.setIsLocked(data.isLocked, false);
     gameSystem.setPublicName(data.publicName);
+    roomSystem.setChat(data.features.chat, false);
+    roomSystem.setDice(data.features.dice, false);
 });
 
 socket.on("Room.Info.InvitationCode.Set", (invitationCode: string) => {
@@ -18,4 +22,12 @@ socket.on("Room.Info.InvitationCode.Set", (invitationCode: string) => {
 
 socket.on("Room.Info.Players.Add", (data: RoomInfoPlayersAdd) => {
     playerSystem.addPlayer({ ...data, role: Role.Player, showRect: false });
+});
+
+socket.on("Room.Features.Chat.Set", (data: boolean) => {
+    roomSystem.setChat(data, false);
+});
+
+socket.on("Room.Features.Dice.Set", (data: boolean) => {
+    roomSystem.setDice(data, false);
 });

--- a/client/src/game/systems/room/index.ts
+++ b/client/src/game/systems/room/index.ts
@@ -1,0 +1,27 @@
+import { type System, registerSystem } from "..";
+
+import { sendSetChatFeature, sendSetDiceFeature } from "./emits";
+import { roomState } from "./state";
+
+const { mutableReactive: $ } = roomState;
+
+class RoomSystem implements System {
+    clear(): void {}
+
+    setChat(enabled: boolean, sync: boolean): void {
+        $.enableChat = enabled;
+        if (sync) {
+            sendSetChatFeature(enabled);
+        }
+    }
+
+    setDice(enabled: boolean, sync: boolean): void {
+        $.enableDice = enabled;
+        if (sync) {
+            sendSetDiceFeature(enabled);
+        }
+    }
+}
+
+export const roomSystem = new RoomSystem();
+registerSystem("room", roomSystem, false, roomState);

--- a/client/src/game/systems/room/state.ts
+++ b/client/src/game/systems/room/state.ts
@@ -1,0 +1,15 @@
+import { buildState } from "../state";
+
+interface ReactiveChatState {
+    enableChat: boolean;
+    enableDice: boolean;
+}
+
+const state = buildState<ReactiveChatState>({
+    enableChat: false,
+    enableDice: false,
+});
+
+export const roomState = {
+    ...state,
+};

--- a/client/src/game/ui/Chat.vue
+++ b/client/src/game/ui/Chat.vue
@@ -115,8 +115,7 @@ function handleMessage(event: KeyboardEvent): void {
             <div>
                 Chat
                 <span v-show="chatState.raw.messages.length > messagesSeenCount">
-                    ({{ chatState.raw.messages.length - messagesSeenCount }}) {{ chatState.reactive.messages.length }}
-                    {{ messagesSeenCount }}
+                    ({{ chatState.raw.messages.length - messagesSeenCount }})
                 </span>
             </div>
         </div>

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -10,6 +10,7 @@ import { coreStore } from "../../store/core";
 import { gameState } from "../systems/game/state";
 import { positionSystem } from "../systems/position";
 import { positionState } from "../systems/position/state";
+import { roomState } from "../systems/room/state";
 import { uiState } from "../systems/ui/state";
 
 import Annotation from "./Annotation.vue";
@@ -190,7 +191,7 @@ function setTempZoomDisplay(value: number): void {
         <Tools />
         <LocationBar v-if="gameState.reactive.isDm" :active="visible.locations" :menu-active="visible.settings" />
         <div id="floor-and-chat">
-            <Chat />
+            <Chat v-if="roomState.reactive.enableChat" />
             <Floors />
         </div>
         <DefaultContext />

--- a/client/src/game/ui/settings/dm/DmSettings.vue
+++ b/client/src/game/ui/settings/dm/DmSettings.vue
@@ -13,6 +13,7 @@ import VisionSettings from "../location/VisionSettings.vue";
 
 import AdminSettings from "./AdminSettings.vue";
 import { DmSettingCategory } from "./categories";
+import FeatureSettings from "./FeatureSettings.vue";
 
 const emit = defineEmits<(e: "close" | "focus") => void>();
 defineProps<{ modalIndex: ModalIndex }>();
@@ -36,6 +37,7 @@ defineExpose({ close });
 
 const tabs: { name: string; component: Component; props: { global: true } }[] = [
     { name: t(DmSettingCategory.Admin), component: AdminSettings, props: { global: true } },
+    { name: t(DmSettingCategory.Features), component: FeatureSettings, props: { global: true } },
     { name: t(DmSettingCategory.Grid), component: GridSettings, props: { global: true } },
     { name: t(DmSettingCategory.Vision), component: VisionSettings, props: { global: true } },
     { name: t(DmSettingCategory.Floor), component: FloorSettings, props: { global: true } },

--- a/client/src/game/ui/settings/dm/FeatureSettings.vue
+++ b/client/src/game/ui/settings/dm/FeatureSettings.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { roomSystem } from "../../../systems/room";
+import { roomState } from "../../../systems/room/state";
+
+const enableChat = computed({
+    get() {
+        return roomState.reactive.enableChat;
+    },
+    set(enableChat: boolean) {
+        roomSystem.setChat(enableChat, true);
+    },
+});
+
+const enableDice = computed({
+    get() {
+        return roomState.reactive.enableDice;
+    },
+    set(enableDice: boolean) {
+        roomSystem.setDice(enableDice, true);
+    },
+});
+</script>
+
+<template>
+    <div class="panel">
+        <div class="row">
+            <label for="enableChat">Enable chat</label>
+            <input id="enableChat" v-model="enableChat" type="checkbox" />
+        </div>
+        <div class="row">
+            <label for="enableDice">Enable dice</label>
+            <input id="enableDice" v-model="enableDice" type="checkbox" />
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+/* Force higher specificity without !important abuse */
+.panel {
+    min-width: 15rem;
+    grid-template-columns: [setting] 1fr [value] auto [end];
+}
+</style>

--- a/client/src/game/ui/settings/dm/categories.ts
+++ b/client/src/game/ui/settings/dm/categories.ts
@@ -1,5 +1,6 @@
 export enum DmSettingCategory {
     Admin = "common.admin",
+    Features = "common.features",
     Floor = "common.floor",
     Grid = "common.grid",
     Vision = "common.vision",

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -10,6 +10,7 @@ import { accessState } from "../../systems/access/state";
 import { gameSystem } from "../../systems/game";
 import { gameState } from "../../systems/game/state";
 import { labelState } from "../../systems/labels/state";
+import { roomState } from "../../systems/room/state";
 import { playerSettingsState } from "../../systems/settings/players/state";
 import { activeModeTools, activeTool, activeToolMode, dmTools, toggleActiveMode, toolMap } from "../../tools/tools";
 import { initiativeStore } from "../initiative/state";
@@ -42,6 +43,8 @@ const visibleTools = computed(() => {
                 if (labelState.reactive.labels.size === 0) continue;
             } else if (toolName === ToolName.Vision) {
                 if (accessState.reactive.ownedTokens.size <= 1) continue;
+            } else if (toolName === ToolName.Dice) {
+                if (!roomState.reactive.enableDice) continue;
             }
 
             const tool = toolMap[toolName];
@@ -155,7 +158,7 @@ function toggleFakePlayer(): void {
             <MapTool v-if="activeTool === ToolName.Map" />
             <FilterTool v-if="activeTool === ToolName.Filter" />
             <VisionTool v-if="activeTool === ToolName.Vision" />
-            <DiceTool v-if="activeTool === ToolName.Dice" />
+            <DiceTool v-if="roomState.reactive.enableDice && activeTool === ToolName.Dice" />
         </div>
     </div>
 </template>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -75,7 +75,8 @@
         "name_already_in_use": "This name is already in use!",
         "varia": "Varia",
         "select": "Select",
-        "or": "or"
+        "or": "or",
+        "features": "Features"
     },
     "auth": {
         "login": {

--- a/server/src/api/models/room/info/__init__.py
+++ b/server/src/api/models/room/info/__init__.py
@@ -3,9 +3,15 @@ from pydantic import BaseModel
 from .player import *
 
 
+class RoomFeatures(BaseModel):
+    chat: bool
+    dice: bool
+
+
 class RoomInfoSet(BaseModel):
     name: str
     creator: str
     invitationCode: str
     isLocked: bool
     publicName: str
+    features: RoomFeatures

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -48,7 +48,7 @@ from ..models.location.settings import (
 from ..models.location.spawn_info import ApiSpawnInfo
 from ..models.players.info import PlayerInfoCore, PlayersInfoSet
 from ..models.players.options import PlayerOptionsSet
-from ..models.room.info import RoomInfoSet
+from ..models.room.info import RoomFeatures, RoomInfoSet
 
 
 # DATA CLASSES FOR TYPE CHECKING
@@ -136,6 +136,9 @@ async def load_location(sid: str, location: Location, *, complete=False):
                 invitationCode=str(pr.room.invitation_code),
                 isLocked=pr.room.is_locked,
                 publicName=config.get("General", "public_name", fallback=""),
+                features=RoomFeatures(
+                    chat=pr.room.enable_chat, dice=pr.room.enable_dice
+                ),
             ),
             room=sid,
         )

--- a/server/src/db/models/room.py
+++ b/server/src/db/models/room.py
@@ -32,6 +32,9 @@ class Room(BaseDbModel):
     )
     logo = ForeignKeyField(Asset, null=True, on_delete="SET NULL")
 
+    enable_chat = cast(bool, BooleanField(default=True))
+    enable_dice = cast(bool, BooleanField(default=True))
+
     def __repr__(self):
         return f"<Room {self.get_path()}>"
 

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 94
+SAVE_VERSION = 95
 
 import json
 import logging
@@ -581,6 +581,15 @@ def upgrade(db: SqliteExtDatabase, version: int):
             )
             db.execute_sql(
                 "ALTER TABLE shape ADD COLUMN cell_stroke_width INTEGER DEFAULT NULL"
+            )
+    elif version == 94:
+        # Add Room.enable_chat Room.enable_dice
+        with db.atomic():
+            db.execute_sql(
+                "ALTER TABLE room ADD COLUMN enable_chat INTEGER NOT NULL DEFAULT 1"
+            )
+            db.execute_sql(
+                "ALTER TABLE room ADD COLUMN enable_dice INTEGER NOT NULL DEFAULT 1"
             )
     else:
         raise UnknownVersionException(


### PR DESCRIPTION
This adds a new tab to the DM settings called 'Features'.

It's used to enable or disable certain features for the entire campaign (i.e. all locations).

Currently this is limited to two features:
- chat
- dice

Both of these will be configured to be enabled by default for all existing and new campaigns.
It's my intention to have some setup/start screen when making a new campaign in which you would preconfigure more things like these features.