### PR TITLE
feat(Select): Add collapse selection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ tech changes will usually be stripped from release notes for the public
     -   Chat is basic markdown aware, but does not allow direct HTML
     -   (image) urls can be pasted without special markdown syntax
     -   Can be collapsed by clicking on the chat title
+-   Collapse Selection: Temporarily move all shapes in the selection under the cursor for easier navigation through corridors
 -   [DM] new DM settings section: Features
     -   Can be used to enable/disable certain features campaign wide
     -   Currently limited to chat & dice

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -8,14 +8,23 @@ import { coreStore } from "../store/core";
 
 import { createConnection, socket } from "./api/socket";
 import { handleDropEvent } from "./dropAsset";
-import { onKeyDown } from "./input/keyboard/down";
 import { scrollZoom } from "./input/mouse";
 import { clearUndoStacks } from "./operations/undo";
 import { floorSystem } from "./systems/floors";
 import { gameState } from "./systems/game/state";
 import { playerSettingsState } from "./systems/settings/players/state";
 import { setSelectionBoxFunction } from "./temp";
-import { keyUp, mouseDown, mouseLeave, mouseMove, mouseUp, touchEnd, touchMove, touchStart } from "./tools/events";
+import {
+    keyDown,
+    keyUp,
+    mouseDown,
+    mouseLeave,
+    mouseMove,
+    mouseUp,
+    touchEnd,
+    touchMove,
+    touchStart,
+} from "./tools/events";
 // import DebugInfo from "./ui/DebugInfo.vue";
 import UI from "./ui/UI.vue";
 
@@ -51,10 +60,11 @@ export default defineComponent({
             }
         });
 
-        const keyDown = (event: KeyboardEvent): void => void onKeyDown(event);
         onMounted(async () => {
             window.Gameboard?.setDrawerVisibility(false);
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             window.addEventListener("keyup", keyUp);
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             window.addEventListener("keydown", keyDown);
             window.addEventListener("resize", resizeWindow);
             clearUndoStacks();
@@ -64,7 +74,9 @@ export default defineComponent({
         });
 
         onUnmounted(() => {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             window.removeEventListener("keyup", keyUp);
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             window.removeEventListener("keydown", keyDown);
             window.removeEventListener("resize", resizeWindow);
             mediaQuery.removeEventListener("change", resizeWindow);

--- a/client/src/game/input/keyboard/up.ts
+++ b/client/src/game/input/keyboard/up.ts
@@ -11,7 +11,7 @@ import { floorSystem } from "../../systems/floors";
 import { positionSystem } from "../../systems/position";
 import { selectedSystem } from "../../systems/selected";
 
-export function onKeyUp(event: KeyboardEvent): void {
+export function onKeyUp(event: KeyboardEvent): Promise<void> {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
         // no-op (condition is cleaner this way)
     } else {
@@ -23,7 +23,7 @@ export function onKeyUp(event: KeyboardEvent): void {
             // Spacebar or numpad-zero: cycle through own tokens
             // numpad-zero only if Ctrl is not pressed, as this would otherwise conflict with Ctrl + 0
             const tokens = [...map(accessState.raw.ownedTokens, (o) => getShape(o)!)];
-            if (tokens.length === 0) return;
+            if (tokens.length === 0) return Promise.resolve();
             const i = tokens.findIndex((o) => equalsP(o.center, positionSystem.screenCenter));
             const token = tokens[(i + 1) % tokens.length]!;
             setCenterPosition(token.center);
@@ -35,4 +35,5 @@ export function onKeyUp(event: KeyboardEvent): void {
             }
         }
     }
+    return Promise.resolve();
 }

--- a/client/src/game/models/shapes.ts
+++ b/client/src/game/models/shapes.ts
@@ -1,3 +1,5 @@
+import type { Vector } from "../../core/geometry";
+import type { LocalId } from "../id";
 import type { DoorOptions } from "../systems/logic/door/models";
 import type { TeleportOptions } from "../systems/logic/tp/models";
 
@@ -20,6 +22,8 @@ export interface ShapeOptions {
     // used to store noteIds for templates
     // only relevant on asset drop and template creation
     templateNoteIds: string[];
+
+    collapsedIds: [LocalId, Vector][];
 }
 
 export interface ServerShapeOptions extends ShapeOptions {

--- a/client/src/game/models/tools.ts
+++ b/client/src/game/models/tools.ts
@@ -49,7 +49,8 @@ export interface ITool {
     onSelect: () => void;
     onDeselect: () => void;
 
-    onKeyUp: (event: KeyboardEvent, features: ToolFeatures) => void;
+    onKeyDown: (event: KeyboardEvent, features: ToolFeatures) => Promise<void>;
+    onKeyUp: (event: KeyboardEvent, features: ToolFeatures) => Promise<void>;
 
     onMouseUp: (event: MouseEvent, features: ToolFeatures) => Promise<void>;
     onMouseMove: (event: MouseEvent, features: ToolFeatures) => Promise<void>;

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -1,7 +1,7 @@
 import { addP, toArrayP } from "../../core/geometry";
 import type { Vector } from "../../core/geometry";
 import { sendShapePositionUpdate } from "../api/emits/shape/core";
-import type { LocalId } from "../id";
+import { getShape, type LocalId } from "../id";
 import type { IShape } from "../interfaces/shape";
 import { accessSystem } from "../systems/access";
 import { clientSystem } from "../systems/client";
@@ -61,6 +61,13 @@ export async function moveShapes(shapes: readonly IShape[], delta: Vector, tempo
         };
 
         shape.refPoint = addP(shape.refPoint, delta);
+
+        for (const [collapsedId] of shape.options?.collapsedIds ?? []) {
+            const collapsedShape = getShape(collapsedId);
+            if (collapsedShape === undefined) continue;
+            collapsedShape.center = shape.center;
+            if (!collapsedShape.preventSync) updateList.push(collapsedShape);
+        }
 
         operation.to = toArrayP(shape.refPoint);
         operationList.shapes.push(operation);

--- a/client/src/game/systems/selected/collapse.ts
+++ b/client/src/game/systems/selected/collapse.ts
@@ -1,0 +1,65 @@
+// Logic to handle collapse/expand of selection
+
+import { Vector } from "../../../core/geometry";
+import { SyncMode } from "../../../core/models/types";
+import { calculateDelta } from "../../drag";
+import { getShape } from "../../id";
+import type { IShape } from "../../interfaces/shape";
+import { moveShapes } from "../../operations/movement";
+
+import { selectedState } from "./state";
+
+import { selectedSystem } from ".";
+
+export function collapseSelection(): void {
+    const shapes = selectedSystem.get({ includeComposites: false });
+    if (shapes.length <= 1) return;
+
+    const focus = selectedState.raw.focus!;
+    const focusShape = getShape(focus);
+    if (focusShape === undefined) return;
+
+    selectedSystem.set(focus);
+    focusShape.options.collapsedIds = [];
+    const center = focusShape.center;
+
+    const layer = focusShape.layer!;
+    layer.moveShapeOrder(
+        focusShape,
+        layer.size({ includeComposites: true, onlyInView: false }) - 1,
+        SyncMode.FULL_SYNC,
+    );
+
+    for (const shape of shapes) {
+        if (shape.id === focus) {
+            continue;
+        } else {
+            focusShape.options.collapsedIds.push([shape.id, Vector.fromPoints(focusShape.center, shape.center)]);
+            shape.center = center;
+        }
+    }
+
+    focusShape.invalidate(false);
+}
+
+// UpdateList can optionally be passed to update an ongoing list of shapes to be updated
+// e.g. for server synchronization
+export async function expandSelection(updateList?: IShape[]): Promise<void> {
+    const focus = selectedState.raw.focus;
+    if (focus === undefined) return;
+
+    const shape = getShape(focus);
+    if (shape === undefined || shape.options?.collapsedIds === undefined) return;
+
+    for (const [collapsedId, vector] of shape.options.collapsedIds) {
+        const collapsedShape = getShape(collapsedId);
+        if (collapsedShape !== undefined) {
+            await moveShapes([collapsedShape], calculateDelta(vector, collapsedShape, true), true);
+            if (updateList && !collapsedShape.preventSync) updateList.push(collapsedShape);
+        }
+    }
+
+    shape.options.collapsedIds = undefined;
+
+    shape.invalidate(false);
+}

--- a/client/src/game/systems/selected/collapse.ts
+++ b/client/src/game/systems/selected/collapse.ts
@@ -55,6 +55,7 @@ export async function expandSelection(updateList?: IShape[]): Promise<void> {
         const collapsedShape = getShape(collapsedId);
         if (collapsedShape !== undefined) {
             await moveShapes([collapsedShape], calculateDelta(vector, collapsedShape, true), true);
+            selectedSystem.push(collapsedShape.id);
             if (updateList && !collapsedShape.preventSync) updateList.push(collapsedShape);
         }
     }

--- a/client/src/game/systems/selected/index.ts
+++ b/client/src/game/systems/selected/index.ts
@@ -25,6 +25,11 @@ class SelectedSystem implements ShapeSystem {
         this.push(id);
     }
 
+    // Should only be used to update the focus within a selection (e.g. clicking on an already selected shape)
+    focus(id: LocalId): void {
+        $.focus = id;
+    }
+
     push(...selection: LocalId[]): void {
         for (const sel of selection) {
             if ($.focus === undefined) $.focus = sel;

--- a/client/src/game/tools/events.ts
+++ b/client/src/game/tools/events.ts
@@ -177,19 +177,35 @@ async function contextMenu(event: MouseEvent): Promise<void> {
     }
 }
 
-export function keyUp(event: KeyboardEvent): void {
+export async function keyDown(event: KeyboardEvent): Promise<void> {
     const tool = getActiveTool();
 
     for (const permitted of tool.permittedTools) {
         if (!(permitted.early ?? false)) continue;
-        toolMap[permitted.name].onKeyUp(event, permitted.features);
+        await toolMap[permitted.name].onKeyDown(event, permitted.features);
     }
 
-    tool.onKeyUp(event, getFeatures(activeTool.value));
+    await tool.onKeyDown(event, getFeatures(activeTool.value));
 
     for (const permitted of tool.permittedTools) {
         if (permitted.early ?? false) continue;
-        toolMap[permitted.name].onKeyUp(event, permitted.features);
+        await toolMap[permitted.name].onKeyDown(event, permitted.features);
+    }
+}
+
+export async function keyUp(event: KeyboardEvent): Promise<void> {
+    const tool = getActiveTool();
+
+    for (const permitted of tool.permittedTools) {
+        if (!(permitted.early ?? false)) continue;
+        await toolMap[permitted.name].onKeyUp(event, permitted.features);
+    }
+
+    await tool.onKeyUp(event, getFeatures(activeTool.value));
+
+    for (const permitted of tool.permittedTools) {
+        if (permitted.early ?? false) continue;
+        await toolMap[permitted.name].onKeyUp(event, permitted.features);
     }
 }
 

--- a/client/src/game/tools/tool.ts
+++ b/client/src/game/tools/tool.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from "vue";
 
 import type { LocalPoint } from "../../core/geometry";
+import { onKeyDown } from "../input/keyboard/down";
 import { onKeyUp } from "../input/keyboard/up";
 import { getLocalPointFromEvent } from "../input/mouse";
 import type { ToolFeatures, ITool, ToolMode, ToolName, ToolPermission } from "../models/tools";
@@ -28,9 +29,14 @@ export abstract class Tool implements ITool {
         );
     }
 
-    onKeyUp(event: KeyboardEvent, _features: ToolFeatures): void {
+    async onKeyDown(event: KeyboardEvent, _features: ToolFeatures): Promise<void> {
         if (event.defaultPrevented) return;
-        onKeyUp(event);
+        await onKeyDown(event);
+    }
+
+    async onKeyUp(event: KeyboardEvent, _features: ToolFeatures): Promise<void> {
+        if (event.defaultPrevented) return;
+        await onKeyUp(event);
     }
 
     async onMouseDown(event: MouseEvent | TouchEvent, features: ToolFeatures): Promise<void> {

--- a/client/src/game/tools/variants/draw.ts
+++ b/client/src/game/tools/variants/draw.ts
@@ -676,7 +676,7 @@ class DrawTool extends Tool implements ITool {
             await this.onSelect(mouse);
             event.preventDefault();
         }
-        super.onKeyUp(event, features);
+        await super.onKeyUp(event, features);
     }
 
     // BRUSH

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -278,7 +278,7 @@ class RulerTool extends Tool implements ITool {
         return Promise.resolve();
     }
 
-    onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {
+    async onKeyUp(event: KeyboardEvent, features: ToolFeatures): Promise<void> {
         if (event.defaultPrevented) return;
         if (event.key === " " && this.active.value) {
             const { ruler: lastRuler } = this.rulers.at(-1)!;
@@ -306,7 +306,7 @@ class RulerTool extends Tool implements ITool {
 
             event.preventDefault();
         }
-        super.onKeyUp(event, features);
+        await super.onKeyUp(event, features);
     }
 
     private registerHighlightedCellDraw(layer: ILayer): void {

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -51,6 +51,7 @@ import { positionState } from "../../../systems/position/state";
 import { getProperties } from "../../../systems/properties/state";
 import { VisionBlock } from "../../../systems/properties/types";
 import { selectedSystem } from "../../../systems/selected";
+import { collapseSelection, expandSelection } from "../../../systems/selected/collapse";
 import { selectedState } from "../../../systems/selected/state";
 import { locationSettingsState } from "../../../systems/settings/location/state";
 import { playerSettingsState } from "../../../systems/settings/players/state";
@@ -101,6 +102,8 @@ class SelectTool extends Tool implements ISelectTool {
 
     deltaChanged = false;
     snappedToPoint = false;
+
+    private selectionCollapsed = false;
 
     // Because we never drag from the asset's (0, 0) coord and want a smoother drag experience
     // we keep track of the actual offset within the asset.
@@ -327,6 +330,8 @@ class SelectTool extends Tool implements ISelectTool {
                 } else {
                     if (event && ctrlOrCmdPressed(event)) {
                         selectedSystem.remove(shape.id);
+                    } else {
+                        selectedSystem.focus(shape.id);
                     }
                 }
                 // Drag case, a shape is selected
@@ -679,6 +684,16 @@ class SelectTool extends Tool implements ISelectTool {
                     if (props.blocksMovement) recalcMovement = true;
                     if (!sel.preventSync) updateList.push(sel);
                 }
+
+                if (
+                    this.selectionCollapsed &&
+                    layerSelection.length === 1 &&
+                    (layerSelection[0]!.options?.collapsedIds?.length ?? 0) > 0
+                ) {
+                    this.selectionCollapsed = false;
+                    await expandSelection(updateList);
+                }
+
                 sendShapePositionUpdate(updateList, false);
 
                 await teleportZoneSystem.checkTeleport(selectedSystem.get({ includeComposites: true }));
@@ -789,8 +804,11 @@ class SelectTool extends Tool implements ISelectTool {
         const layerSelection = selectedSystem.get({ includeComposites: false });
         const mouse = getLocalPointFromEvent(event);
         const globalMouse = l2g(mouse);
+
+        // First check active selection
         for (const shape of layerSelection) {
             if (shape.contains(globalMouse)) {
+                selectedSystem.focus(shape.id);
                 layer.invalidate(true);
                 openShapeContextMenu(event);
                 return Promise.resolve(true);
@@ -813,12 +831,33 @@ class SelectTool extends Tool implements ISelectTool {
         return Promise.resolve(true);
     }
 
-    onKeyUp(event: KeyboardEvent, features: ToolFeatures): void {
-        if (event.defaultPrevented) return;
-        if (event.key === " " && this.active.value) {
-            event.preventDefault();
+    onKeyDown(event: KeyboardEvent): Promise<void> {
+        if (event.defaultPrevented) return Promise.resolve();
+        if (this.active.value) {
+            if (event.key === "c") {
+                event.preventDefault();
+                this.selectionCollapsed = true;
+                collapseSelection();
+            }
         }
-        super.onKeyUp(event, features);
+        return Promise.resolve();
+    }
+
+    async onKeyUp(event: KeyboardEvent, features: ToolFeatures): Promise<void> {
+        if (event.defaultPrevented) return;
+        if (this.active.value) {
+            if (event.key === " ") {
+                event.preventDefault();
+            } else if (event.key === "c") {
+                event.preventDefault();
+                this.selectionCollapsed = false;
+
+                const shapes: IShape[] = [];
+                await expandSelection(shapes);
+                sendShapePositionUpdate(shapes, false);
+            }
+        }
+        await super.onKeyUp(event, features);
     }
 
     // ROTATION


### PR DESCRIPTION
# Intro

This PR adds a new feature to PA tentatively called "selection collapsing".

When moving a selection of multiple shapes around, it can often be a pain to navigate tight corridors or corners, due to some shapes in your selection colliding with walls.

This is an approach to help you as a DM or even player to circumvent these issues.

# How to trigger

While you have a selection and are actively dragging it (e.g. your left mouse is down) you can hold the "c" key (c for collapsing; not to be confused with ctrl+c!).
While this key is down, the selection will collapse to your currently selected shape. When you release the key the shapes will expand out again.

An alternative is to right click on a shape in your selection and choose the new context menu item "Collapse". Later on you can right click the shape again and press "Expand".[^1]

# Collapsing

Collapsed shapes are all moved to the center of the shape you're dragging and will automatically move along with it.

As all the shapes are now located in 1 position, the shape you're actively dragging is automatically put on top of all the others.

_A first version made them invisible, but shapes with bigger dimensions than the one you're dragging can still end up blocking entry through a door and while invisible this is not really clear to the user_.

# Expanding

When the selection is expanded, all shapes originally collapsed will be pushed in the direction that they originally had relative to the shape that was moved (e.g. if shape X was left of the dragged shape, it will be put left again upon expanding).

These pushes are actually properly checked for wall collisions so that no shape is suddenly able to jump to the other side of a wall.

This can however mean that multiple shapes are pushed together if the expansion happens in a small area or if the expanded shapes are all towards the side where the wall is located. I intend to improve this behavior in the future by for example trying to put shapes in free grid cells or something alike. [^2]

# Example

Here is an example of the behaviour: _(ignore the 'shift' key showing, I was still in DM mode where I move things around with shift :D)_

[pa-collapse.webm](https://github.com/Kruptein/PlanarAlly/assets/1814713/4acac7f0-ebe8-479a-8f24-ed1b0e8bf236)

# State

It's important to realise that this is fully managed client-side. If you refresh or for some reason the websocket resets and reloads, the information of collapsed shapes is lost.

That said, the shapes are still there, they're just below the selected shape, so nothing is really lost, which is why I decided to not sync this to the server. Collapsing is intended to be done for short operations during a session and not something that should be used across sessions.


[^1]: Do note that some inconsistencies can happen if one of the collapsed shapes is being moved between a collapse and expand action!
[^2]: This expansion behaviour may also be applied on teleports in the future, as those currently result in everybody being stacked on the teleport target today and that's also a bit of a pain.
