### PR TITLE
bug(Input): Fix keydown handlers no longer triggering on key down (in select)

### DIFF
--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -831,8 +831,8 @@ class SelectTool extends Tool implements ISelectTool {
         return Promise.resolve(true);
     }
 
-    onKeyDown(event: KeyboardEvent): Promise<void> {
-        if (event.defaultPrevented) return Promise.resolve();
+    onKeyDown(event: KeyboardEvent, features: ToolFeatures<number>): Promise<void> {
+        if (event.defaultPrevented) return super.onKeyDown(event, features);
         if (this.active.value) {
             if (event.key === "c") {
                 event.preventDefault();
@@ -840,7 +840,7 @@ class SelectTool extends Tool implements ISelectTool {
                 collapseSelection();
             }
         }
-        return Promise.resolve();
+        return super.onKeyDown(event, features);
     }
 
     async onKeyUp(event: KeyboardEvent, features: ToolFeatures): Promise<void> {


### PR DESCRIPTION
A recent change to the tool logic allowed tools to directly listen to keys instead of always having to go through 1 global handler and then piping events to the correct component.

The only tool currently using this is the select tool and well I forgot to fall back to the global handler if the select tool wasn't interested, so a lot of keybindings no longer worked.