### PR TITLE
feat(Spell): Render hexes in spell tool when using hex grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ tech changes will usually be stripped from release notes for the public
 
 ### Changed
 
--   Spell tool now renders hexes instead of squares in Hex grid mode
+-   Spell tool:
+    -   now renders hexes instead of squares in Hex grid mode
+    -   step size changed to 1 in Hex grid mode
+    -   shape bar is no longer visible, only hex is available in hex grid mode for now
 
 ## [2024.2.0] - 2024-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ tech changes will usually be stripped from release notes for the public
     -   Can be used to enable/disable certain features campaign wide
     -   Currently limited to chat & dice
 
+### Changed
+
+-   Spell tool now renders hexes instead of squares in Hex grid mode
+
 ## [2024.2.0] - 2024-05-18
 
 ### Added

--- a/client/src/game/shapes/variants/hex.ts
+++ b/client/src/game/shapes/variants/hex.ts
@@ -1,0 +1,107 @@
+import { g2l, g2lz, l2g } from "../../../core/conversions";
+import { addP, subtractP, toArrayP, toGP, type GlobalPoint } from "../../../core/geometry";
+import { DEFAULT_HEX_RADIUS, getCellCenter, GridType } from "../../../core/grid";
+import { getHexNeighbour, getHexVertexVector } from "../../../core/grid/hex";
+import type { AxialCoords } from "../../../core/grid/types";
+
+import { Polygon } from "./polygon";
+
+export function createHexPolygon(
+    center: GlobalPoint,
+    size: number,
+    grid: { type: GridType; oddHexOrientation: boolean; radius?: number },
+): Polygon {
+    const radius = grid.radius ?? DEFAULT_HEX_RADIUS;
+
+    const localRadius = g2lz(radius);
+    let currentCell: AxialCoords = { q: 0, r: 0 };
+    if (size === 1) {
+        return createSingleHexPolygon(currentCell, toArrayP(g2l(center)), radius);
+    } else {
+        // This function can be used to draw non-grid aligned hexagons
+        // We first need to figure out what the vector is between the grid's {q:0,r:0} and our custom hexagon's {q:0,r:0}
+        // This can then be used to find local coords for our draw operations
+        const rootCellCenter = getCellCenter(currentCell, grid.type, radius);
+        const isFlat = grid.type === GridType.FlatHex;
+
+        // Evenly sized hexagons don't have a hex in the center, so we need to adjust the center point
+        // This is done in such a way that it moves towards the smaller side of the hexagon
+        if (size % 2 === 0) {
+            if (isFlat) {
+                center.x -= radius * (grid.oddHexOrientation ? -1 : 1);
+            } else {
+                center.y -= radius * (grid.oddHexOrientation ? -1 : 1);
+            }
+        }
+
+        const offsetVector = subtractP(center, rootCellCenter);
+
+        const oddSteps = size % 2 === 0 ? size / 2 - 1 : (size - 1) / 2;
+        const evenSteps = size % 2 === 0 ? size / 2 : (size - 1) / 2;
+
+        // a modulo 6 function that immediately handles the oddHexOrientation
+        const m6 = (i: number): number => (grid.oddHexOrientation ? (i + 3) % 6 : i);
+
+        // eslint-disable-next-line no-inner-declarations
+        function even(v1: number, v2: number, n: number): void {
+            for (let i = 0; i <= evenSteps; i++) {
+                let v = addP(currentCellCenter, getHexVertexVector(m6(v1), localRadius, isFlat));
+                vertices.push(l2g(v));
+                v = addP(currentCellCenter, getHexVertexVector(m6(v2), localRadius, isFlat));
+                vertices.push(l2g(v));
+                if (i < evenSteps) {
+                    currentCell = getHexNeighbour(currentCell, m6(n));
+                    currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
+                }
+            }
+        }
+
+        // eslint-disable-next-line no-inner-declarations
+        function odd(v1: number, v2: number, n: number): void {
+            for (let i = 0; i < oddSteps; i++) {
+                let v = addP(currentCellCenter, getHexVertexVector(m6(v1), localRadius, isFlat));
+                vertices.push(l2g(v));
+                currentCell = getHexNeighbour(currentCell, m6(n));
+                currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
+                v = addP(currentCellCenter, getHexVertexVector(m6(v2), localRadius, isFlat));
+                vertices.push(l2g(v));
+            }
+        }
+
+        // First step to a corner of the hexagon
+        for (let i = 0; i < (isFlat ? evenSteps : oddSteps); i++) currentCell = getHexNeighbour(currentCell, m6(1));
+        let currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
+        const start = addP(currentCellCenter, getHexVertexVector(m6(2), localRadius, isFlat));
+
+        const vertices: GlobalPoint[] = [l2g(start)];
+
+        // Now we move along the exterior of the hexagon in a structured pattern
+        // Even and Odd are used to handle the different number of steps that can occur when dealing with evenly sized hexagons
+        // these have alternating long and short edges,
+        // whereas odd sized hexagons have all their edges the same length
+        // These functions perform somewhat similar operations, but step to the next hex at a different point in time
+
+        even(1, 0, 5);
+        odd(5, 0, 4);
+        even(5, 4, 3);
+        odd(3, 4, 2);
+        even(3, 2, 1);
+        odd(1, 2, 0);
+
+        return new Polygon(vertices[0]!, vertices.slice(1));
+    }
+}
+
+function createSingleHexPolygon(cell: AxialCoords, center: [number, number], radius: number): Polygon {
+    const x0 = center[0] + radius * Math.sqrt(3) * (cell.q + cell.r / 2);
+    const y0 = center[1] + ((radius * 3) / 2) * cell.r;
+
+    const vertices: GlobalPoint[] = [];
+    const angle = (Math.PI * 2) / 6;
+    for (let i = 0; i < 6; i++) {
+        const x = x0 + radius * Math.cos(i * angle - Math.PI / 6);
+        const y = y0 + radius * Math.sin(i * angle - Math.PI / 6);
+        vertices.push(toGP(x, y));
+    }
+    return new Polygon(vertices[0]!, vertices.slice(1));
+}

--- a/client/src/game/shapes/variants/hex.ts
+++ b/client/src/game/shapes/variants/hex.ts
@@ -1,8 +1,7 @@
-import { g2l, g2lz, l2g } from "../../../core/conversions";
-import { addP, subtractP, toArrayP, toGP, type GlobalPoint } from "../../../core/geometry";
-import { DEFAULT_HEX_RADIUS, getCellCenter, GridType } from "../../../core/grid";
-import { getHexNeighbour, getHexVertexVector } from "../../../core/grid/hex";
-import type { AxialCoords } from "../../../core/grid/types";
+import { type GlobalPoint } from "../../../core/geometry";
+import type { GridType } from "../../../core/grid";
+import type { GlobalId, LocalId } from "../../id";
+import { createHex } from "../../rendering/grid";
 
 import { Polygon } from "./polygon";
 
@@ -10,98 +9,17 @@ export function createHexPolygon(
     center: GlobalPoint,
     size: number,
     grid: { type: GridType; oddHexOrientation: boolean; radius?: number },
+    options?: {
+        lineWidth?: number[];
+        openPolygon?: boolean;
+        id?: LocalId;
+        uuid?: GlobalId;
+        isSnappable?: boolean;
+    },
 ): Polygon {
-    const radius = grid.radius ?? DEFAULT_HEX_RADIUS;
-
-    const localRadius = g2lz(radius);
-    let currentCell: AxialCoords = { q: 0, r: 0 };
-    if (size === 1) {
-        return createSingleHexPolygon(currentCell, toArrayP(g2l(center)), radius);
-    } else {
-        // This function can be used to draw non-grid aligned hexagons
-        // We first need to figure out what the vector is between the grid's {q:0,r:0} and our custom hexagon's {q:0,r:0}
-        // This can then be used to find local coords for our draw operations
-        const rootCellCenter = getCellCenter(currentCell, grid.type, radius);
-        const isFlat = grid.type === GridType.FlatHex;
-
-        // Evenly sized hexagons don't have a hex in the center, so we need to adjust the center point
-        // This is done in such a way that it moves towards the smaller side of the hexagon
-        if (size % 2 === 0) {
-            if (isFlat) {
-                center.x -= radius * (grid.oddHexOrientation ? -1 : 1);
-            } else {
-                center.y -= radius * (grid.oddHexOrientation ? -1 : 1);
-            }
-        }
-
-        const offsetVector = subtractP(center, rootCellCenter);
-
-        const oddSteps = size % 2 === 0 ? size / 2 - 1 : (size - 1) / 2;
-        const evenSteps = size % 2 === 0 ? size / 2 : (size - 1) / 2;
-
-        // a modulo 6 function that immediately handles the oddHexOrientation
-        const m6 = (i: number): number => (grid.oddHexOrientation ? (i + 3) % 6 : i);
-
-        // eslint-disable-next-line no-inner-declarations
-        function even(v1: number, v2: number, n: number): void {
-            for (let i = 0; i <= evenSteps; i++) {
-                let v = addP(currentCellCenter, getHexVertexVector(m6(v1), localRadius, isFlat));
-                vertices.push(l2g(v));
-                v = addP(currentCellCenter, getHexVertexVector(m6(v2), localRadius, isFlat));
-                vertices.push(l2g(v));
-                if (i < evenSteps) {
-                    currentCell = getHexNeighbour(currentCell, m6(n));
-                    currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
-                }
-            }
-        }
-
-        // eslint-disable-next-line no-inner-declarations
-        function odd(v1: number, v2: number, n: number): void {
-            for (let i = 0; i < oddSteps; i++) {
-                let v = addP(currentCellCenter, getHexVertexVector(m6(v1), localRadius, isFlat));
-                vertices.push(l2g(v));
-                currentCell = getHexNeighbour(currentCell, m6(n));
-                currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
-                v = addP(currentCellCenter, getHexVertexVector(m6(v2), localRadius, isFlat));
-                vertices.push(l2g(v));
-            }
-        }
-
-        // First step to a corner of the hexagon
-        for (let i = 0; i < (isFlat ? evenSteps : oddSteps); i++) currentCell = getHexNeighbour(currentCell, m6(1));
-        let currentCellCenter = g2l(addP(getCellCenter(currentCell, grid.type, radius), offsetVector));
-        const start = addP(currentCellCenter, getHexVertexVector(m6(2), localRadius, isFlat));
-
-        const vertices: GlobalPoint[] = [l2g(start)];
-
-        // Now we move along the exterior of the hexagon in a structured pattern
-        // Even and Odd are used to handle the different number of steps that can occur when dealing with evenly sized hexagons
-        // these have alternating long and short edges,
-        // whereas odd sized hexagons have all their edges the same length
-        // These functions perform somewhat similar operations, but step to the next hex at a different point in time
-
-        even(1, 0, 5);
-        odd(5, 0, 4);
-        even(5, 4, 3);
-        odd(3, 4, 2);
-        even(3, 2, 1);
-        odd(1, 2, 0);
-
-        return new Polygon(vertices[0]!, vertices.slice(1));
+    const vertices = createHex(center, size, grid);
+    if (vertices.length < 2) {
+        throw new Error("Hexagon has less than 2 vertices");
     }
-}
-
-function createSingleHexPolygon(cell: AxialCoords, center: [number, number], radius: number): Polygon {
-    const x0 = center[0] + radius * Math.sqrt(3) * (cell.q + cell.r / 2);
-    const y0 = center[1] + ((radius * 3) / 2) * cell.r;
-
-    const vertices: GlobalPoint[] = [];
-    const angle = (Math.PI * 2) / 6;
-    for (let i = 0; i < 6; i++) {
-        const x = x0 + radius * Math.cos(i * angle - Math.PI / 6);
-        const y = y0 + radius * Math.sin(i * angle - Math.PI / 6);
-        vertices.push(toGP(x, y));
-    }
-    return new Polygon(vertices[0]!, vertices.slice(1));
+    return new Polygon(vertices[0]!, vertices.slice(1), options);
 }

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -31,6 +31,7 @@ export enum SpellShape {
     Square = "square",
     Circle = "circle",
     Cone = "cone",
+    Hex = "hex",
 }
 
 class SpellTool extends Tool implements ITool {
@@ -112,26 +113,12 @@ class SpellTool extends Tool implements ITool {
                 break;
             case SpellShape.Square:
                 {
-                    const gridType = locationSettingsState.raw.gridType.value;
-                    if (gridType === GridType.Square) {
-                        this.shape = new Rect(
-                            startPosition,
-                            getUnitDistance(this.state.size),
-                            getUnitDistance(this.state.size),
-                            { isSnappable: false },
-                        );
-                    } else {
-                        this.shape = createHexPolygon(
-                            shapeCenter,
-                            this.state.size,
-                            {
-                                type: gridType,
-                                oddHexOrientation: this.state.oddHexOrientation,
-                                radius: DEFAULT_HEX_RADIUS,
-                            },
-                            { isSnappable: false },
-                        );
-                    }
+                    this.shape = new Rect(
+                        startPosition,
+                        getUnitDistance(this.state.size),
+                        getUnitDistance(this.state.size),
+                        { isSnappable: false },
+                    );
                 }
                 break;
             case SpellShape.Cone:
@@ -139,6 +126,21 @@ class SpellTool extends Tool implements ITool {
                     viewingAngle: toRadians(60),
                     isSnappable: false,
                 });
+                break;
+            case SpellShape.Hex:
+                {
+                    const gridType = locationSettingsState.raw.gridType.value;
+                    this.shape = createHexPolygon(
+                        shapeCenter,
+                        this.state.size,
+                        {
+                            type: gridType,
+                            oddHexOrientation: this.state.oddHexOrientation,
+                            radius: DEFAULT_HEX_RADIUS,
+                        },
+                        { isSnappable: false },
+                    );
+                }
                 break;
         }
 
@@ -192,6 +194,15 @@ class SpellTool extends Tool implements ITool {
     async onSelect(): Promise<void> {
         if (!selectedSystem.hasSelection && this.state.selectedSpellShape === SpellShape.Cone) {
             this.state.selectedSpellShape = SpellShape.Circle;
+        }
+        if (locationSettingsState.raw.gridType.value === GridType.Square) {
+            if (this.state.selectedSpellShape === SpellShape.Hex) {
+                this.state.selectedSpellShape = SpellShape.Square;
+            }
+        } else {
+            if (this.state.selectedSpellShape !== SpellShape.Hex) {
+                this.state.selectedSpellShape = SpellShape.Hex;
+            }
         }
         await this.drawShape();
     }

--- a/client/src/game/tools/variants/spell.ts
+++ b/client/src/game/tools/variants/spell.ts
@@ -121,11 +121,16 @@ class SpellTool extends Tool implements ITool {
                             { isSnappable: false },
                         );
                     } else {
-                        this.shape = createHexPolygon(shapeCenter, this.state.size, {
-                            type: gridType,
-                            oddHexOrientation: this.state.oddHexOrientation,
-                            radius: DEFAULT_HEX_RADIUS,
-                        });
+                        this.shape = createHexPolygon(
+                            shapeCenter,
+                            this.state.size,
+                            {
+                                type: gridType,
+                                oddHexOrientation: this.state.oddHexOrientation,
+                                radius: DEFAULT_HEX_RADIUS,
+                            },
+                            { isSnappable: false },
+                        );
                     }
                 }
                 break;

--- a/client/src/game/ui/tools/SpellTool.vue
+++ b/client/src/game/ui/tools/SpellTool.vue
@@ -12,7 +12,12 @@ import { SpellShape, spellTool } from "../../tools/variants/spell";
 const { t } = useI18n();
 
 const selected = spellTool.isActiveTool;
-const shapes = Object.values(SpellShape);
+
+const isHexGrid = computed(() => locationSettingsState.reactive.gridType.value !== GridType.Square);
+
+const shapes = computed(() =>
+    isHexGrid.value ? [SpellShape.Hex] : [SpellShape.Square, SpellShape.Circle, SpellShape.Cone],
+);
 
 const canConeBeCast = computed(() => selectedState.reactive.selected.size > 0);
 
@@ -20,9 +25,8 @@ const translationMapping = {
     [SpellShape.Square]: t("game.ui.tools.DrawTool.square"),
     [SpellShape.Circle]: t("game.ui.tools.DrawTool.circle"),
     [SpellShape.Cone]: t("game.ui.tools.DrawTool.cone"),
+    [SpellShape.Hex]: t("game.ui.tools.DrawTool.square"),
 };
-
-const isHexGrid = computed(() => locationSettingsState.reactive.gridType.value !== GridType.Square);
 
 const stepSize = computed(() => {
     if (isHexGrid.value && spellTool.state.selectedSpellShape === SpellShape.Square) {
@@ -39,7 +43,7 @@ async function selectShape(shape: SpellShape): Promise<void> {
 
 <template>
     <div v-if="selected" class="tool-detail">
-        <div class="selectgroup">
+        <div v-if="!isHexGrid" class="selectgroup">
             <div
                 v-for="shape in shapes"
                 :key="shape"

--- a/client/src/game/ui/tools/SpellTool.vue
+++ b/client/src/game/ui/tools/SpellTool.vue
@@ -3,8 +3,10 @@ import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ColourPicker from "../../../core/components/ColourPicker.vue";
+import { GridType } from "../../../core/grid";
 import { baseAdjust } from "../../../core/http";
 import { selectedState } from "../../systems/selected/state";
+import { locationSettingsState } from "../../systems/settings/location/state";
 import { SpellShape, spellTool } from "../../tools/variants/spell";
 
 const { t } = useI18n();
@@ -19,6 +21,15 @@ const translationMapping = {
     [SpellShape.Circle]: t("game.ui.tools.DrawTool.circle"),
     [SpellShape.Cone]: t("game.ui.tools.DrawTool.cone"),
 };
+
+const isHexGrid = computed(() => locationSettingsState.reactive.gridType.value !== GridType.Square);
+
+const stepSize = computed(() => {
+    if (isHexGrid.value && spellTool.state.selectedSpellShape === SpellShape.Square) {
+        return 1;
+    }
+    return 5;
+});
 
 async function selectShape(shape: SpellShape): Promise<void> {
     spellTool.state.selectedSpellShape = shape;
@@ -52,8 +63,17 @@ async function selectShape(shape: SpellShape): Promise<void> {
                 type="number"
                 style="flex: 1; align-self: center"
                 min="0"
-                step="5"
+                :step="stepSize"
             />
+            <template v-if="isHexGrid">
+                <label for="oddHexOrientation" style="flex: 5">Odd Hex Orientation</label>
+                <input
+                    id="oddHexOrientation"
+                    v-model.number="spellTool.state.oddHexOrientation"
+                    type="checkbox"
+                    style="flex: 1; align-self: center"
+                />
+            </template>
             <label for="colour" style="flex: 5">{{ t("common.fill_color") }}</label>
             <ColourPicker
                 v-model:colour="spellTool.state.colour"


### PR DESCRIPTION
When in hex grid mode, it makes more sense to have the spell tool output hexes instead of squares.

It's mostly still WIP for two reasons:
- FA does not have a free hexagon icon, I'm currently just using the square icon, but that might be confusing
- It basically duplicates code for hex rendering from somewhere else, but to make it a Polygon shape instead of direct canvas calls

The latter should be unified