### PR TITLE
bug(Spell): Fix stepsize for hex grids

### DIFF
--- a/client/src/game/ui/tools/SpellTool.vue
+++ b/client/src/game/ui/tools/SpellTool.vue
@@ -29,7 +29,7 @@ const translationMapping = {
 };
 
 const stepSize = computed(() => {
-    if (isHexGrid.value && spellTool.state.selectedSpellShape === SpellShape.Square) {
+    if (isHexGrid.value && spellTool.state.selectedSpellShape === SpellShape.Hex) {
         return 1;
     }
     return 5;


### PR DESCRIPTION
My earlier hex-grid spell change was supposed to also change it so that the step-size for the size input would not jump by 5 but by 1.

I did a last minute refactor of something though and forget to adapt the step size accordingly :)