### PR TITLE
bug(Ruler): Fix spacebar ruler snap in grid mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ tech changes will usually be stripped from release notes for the public
     -   step size changed to 1 in Hex grid mode
     -   shape bar is no longer visible, only hex is available in hex grid mode for now
 
+### Fixed
+
+-   Ruler tool:
+    -   Gridmode spacebar did not synchronize snapped end correctly to other players
+
 ## [2024.2.0] - 2024-05-18
 
 ### Added

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -291,6 +291,7 @@ class RulerTool extends Tool implements ITool {
 
             if (this.gridMode.value) {
                 lastRuler.endPoint = getClosestCellCenter(lastRuler.endPoint, locationSettingsState.raw.gridType.value);
+                sendShapePositionUpdate([lastRuler], true);
                 this.registerHighlightedCellDraw(layer);
             }
 


### PR DESCRIPTION
When using grid mode and pressing spacebar to start a new ruler, the ruler end snaps to the center of the current cell before starting the new ruler. This snap was not sent over the socket to other clients, causing the rulers to look disjointed for other clients.