### PR TITLE
feat(Ruler): Default to share with other users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ tech changes will usually be stripped from release notes for the public
     -   now renders hexes instead of squares in Hex grid mode
     -   step size changed to 1 in Hex grid mode
     -   shape bar is no longer visible, only hex is available in hex grid mode for now
+-   Ruler tool:
+    -   now defaults to sharing with other users
 
 ### Fixed
 

--- a/client/src/game/tools/variants/ruler.ts
+++ b/client/src/game/tools/variants/ruler.ts
@@ -51,7 +51,7 @@ class RulerTool extends Tool implements ITool {
     readonly toolTranslation = i18n.global.t("tool.Ruler");
 
     // REACTIVE PROPERTIES
-    showPublic = ref(false);
+    showPublic = ref(true);
     gridMode = ref(false);
 
     // NON REACTIVE PROPERTIES


### PR DESCRIPTION
This is a small change that changes the default settings to share rulers with other users.

In practice most rulers I or my players draw are shared with each other, so changing this makes more sense.