### PR TITLE
bug(Draw): Fix draw tool movement block label toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ tech changes will usually be stripped from release notes for the public
 
 ### Fixed
 
+-   Draw tool:
+    -   Clicking on the "blocks movement" label in the draw tool's vision setting now properly toggles the related checkbox
 -   Ruler tool:
     -   Gridmode spacebar did not synchronize snapped end correctly to other players
 

--- a/client/src/game/ui/tools/DrawTool.vue
+++ b/client/src/game/ui/tools/DrawTool.vue
@@ -164,9 +164,12 @@ const alerts = computed(() => {
             </div>
 
             <div class="draw-checkbox-line">
-                <div>{{ t("game.ui.selection.edit_dialog.dialog.block_movement") }}</div>
+                <label for="vision-dialog-movement-block-toggle">
+                    {{ t("game.ui.selection.edit_dialog.dialog.block_movement") }}
+                </label>
                 <div>
                     <input
+                        id="vision-dialog-movement-block-toggle"
                         v-model="drawTool.state.blocksMovement"
                         type="checkbox"
                         :disabled="drawTool.state.selectedMode !== 'normal'"


### PR DESCRIPTION
When clicking on the "blocks movement" label in the vision settings of the draw tool, the related checkbox was not being toggled.