### PR TITLE
bug(Dice): Fix dice tool state resetting

### DIFF
--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -129,16 +129,14 @@ function toggleFakePlayer(): void {
             </div>
         </div>
         <div>
-            <SelectTool v-if="activeTool === ToolName.Select" />
-            <SpellTool v-if="activeTool === ToolName.Spell" />
-            <keep-alive>
-                <DrawTool v-if="activeTool === ToolName.Draw" />
-            </keep-alive>
-            <RulerTool v-if="activeTool === ToolName.Ruler" />
-            <MapTool v-if="activeTool === ToolName.Map" />
-            <FilterTool v-if="activeTool === ToolName.Filter" />
-            <VisionTool v-if="activeTool === ToolName.Vision" />
-            <DiceTool v-if="roomState.reactive.enableDice && activeTool === ToolName.Dice" />
+            <SelectTool v-lazy-show="activeTool === ToolName.Select" />
+            <SpellTool v-lazy-show="activeTool === ToolName.Spell" />
+            <DrawTool v-lazy-show="activeTool === ToolName.Draw" />
+            <RulerTool v-lazy-show="activeTool === ToolName.Ruler" />
+            <MapTool v-lazy-show="activeTool === ToolName.Map" />
+            <FilterTool v-lazy-show="activeTool === ToolName.Filter" />
+            <VisionTool v-lazy-show="activeTool === ToolName.Vision" />
+            <DiceTool v-lazy-show="roomState.reactive.enableDice && activeTool === ToolName.Dice" />
         </div>
     </div>
 </template>


### PR DESCRIPTION
The core reason for this PR is to fix the dice tool not remembering what you selected if you swap tools.

This PR changes all tools to use `v-lazy-show` over `v-if` which ensures the tools are not loaded until they are first selected, at which time they will remain loaded.