### PR TITLE
feat(Notes): Add Notes button to player's MenuBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Changed
+-   Add Notes button to MenuBar for players
+
 ## [2024.3.0] - 2024-10-13
 
 ### Removed

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -93,10 +93,6 @@ const openClientSettings = (): void => uiSystem.showClientSettings(!uiState.raw.
         <div style="width: 12.5rem; overflow-y: auto; overflow-x: hidden">
             <!-- CHARACTERS -->
             <Characters />
-            <!-- NOTES -->
-            <button class="menu-accordion" @click="toggleNoteManager">
-                {{ t("common.notes") }}
-            </button>
             <!-- ASSETS -->
             <template v-if="gameState.isDmOrFake.value">
                 <button class="menu-accordion">{{ t("common.assets") }}</button>
@@ -118,6 +114,12 @@ const openClientSettings = (): void => uiSystem.showClientSettings(!uiState.raw.
                         </div>
                     </div>
                 </div>
+            </template>
+            <!-- NOTES -->
+            <button class="menu-accordion" @click="toggleNoteManager">
+                {{ t("common.notes") }}
+            </button>
+            <template v-if="gameState.isDmOrFake.value">
                 <!-- DM SETTINGS -->
                 <button class="menu-accordion" @click="openDmSettings">
                     {{ t("game.ui.menu.MenuBar.dm_settings") }}

--- a/client/src/game/ui/menu/MenuBar.vue
+++ b/client/src/game/ui/menu/MenuBar.vue
@@ -93,6 +93,10 @@ const openClientSettings = (): void => uiSystem.showClientSettings(!uiState.raw.
         <div style="width: 12.5rem; overflow-y: auto; overflow-x: hidden">
             <!-- CHARACTERS -->
             <Characters />
+            <!-- NOTES -->
+            <button class="menu-accordion" @click="toggleNoteManager">
+                {{ t("common.notes") }}
+            </button>
             <!-- ASSETS -->
             <template v-if="gameState.isDmOrFake.value">
                 <button class="menu-accordion">{{ t("common.assets") }}</button>
@@ -114,10 +118,6 @@ const openClientSettings = (): void => uiSystem.showClientSettings(!uiState.raw.
                         </div>
                     </div>
                 </div>
-                <!-- NOTES -->
-                <button class="menu-accordion" @click="toggleNoteManager">
-                    {{ t("common.notes") }}
-                </button>
                 <!-- DM SETTINGS -->
                 <button class="menu-accordion" @click="openDmSettings">
                     {{ t("game.ui.menu.MenuBar.dm_settings") }}


### PR DESCRIPTION
I noticed that as a player, you cannot access the NoteManager from the MenuBar like you can as the DM. The player has access to the NoteManager in other ways (eg right click menu of shape), so I feel like it would be nice to have a consistent way to open for them. This would also allow them access if there are only notes without shapes attached.