### PR TITLE
bug(Notes): Fix edit tabs being leaked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Fixed
+
+-   Notes:
+    -   It was possible to open a 'view-only' note on a tab you weren't supposed to see
+
 ## [2024.3.0] - 2024-10-13
 
 ### Removed

--- a/client/src/game/ui/notes/NoteEdit.vue
+++ b/client/src/game/ui/notes/NoteEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, ref } from "vue";
+import { computed, onBeforeMount, ref, watchEffect } from "vue";
 import VueMarkdown from "vue-markdown-render";
 
 import { useModal } from "../../../core/plugins/modals/plugin";
@@ -30,7 +30,7 @@ const canEdit = computed(() => {
 const localShapenotes = computed(() =>
     note.value === undefined
         ? []
-        : noteState.reactive.shapeNotes.get2(note.value.uuid)?.map((s) => ({ ...getProperties(s), id: s })) ?? [],
+        : (noteState.reactive.shapeNotes.get2(note.value.uuid)?.map((s) => ({ ...getProperties(s), id: s })) ?? []),
 );
 
 const showOnHover = computed({
@@ -99,6 +99,10 @@ const tabs = computed(
 );
 const activeTabIndex = ref(0);
 const activeTab = computed(() => tabs.value[activeTabIndex.value]!.label);
+
+watchEffect(() => {
+    if (!canEdit.value && !tabs.value[activeTabIndex.value]!.visible) activeTabIndex.value = 0;
+});
 
 // Ensure that defaultAccess is always first
 // and that defaultAccess is provided even if it has no DB value


### PR DESCRIPTION
This fixes #1476 

As outlined in the issue, the note manager remembers the tab you had open when switching notes.
If you switch to a note that you only have view-access to, you're supposed to only see the view tab,
but instead if another tab was last visited, you see that tab.

This leaves you with no way to go to the view tab as all tabs are hidden in view mode.

Additionally you are given access to edit tabs, though interacting with any of them would not result in changed data as the server still rejects your changes, so no harm was possible here.