### PR TITLE
bug(Notes): Reset node manager to list mode on location swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Notes:
     -   It was possible to open a 'view-only' note on a tab you weren't supposed to see
+    -   Note manager could be empty and unusable when changing locations
 
 ## [2024.3.0] - 2024-10-13
 

--- a/client/src/game/systems/notes/index.ts
+++ b/client/src/game/systems/notes/index.ts
@@ -26,7 +26,7 @@ import {
     sendSetNoteTitle,
 } from "./emits";
 import { noteState } from "./state";
-import type { ClientNote } from "./types";
+import { NoteManagerMode, type ClientNote } from "./types";
 import { closeNoteManager } from "./ui";
 
 const { mutableReactive: $, raw, readonly, mutable } = noteState;
@@ -54,6 +54,7 @@ class NoteSystem implements ShapeSystem {
         $.notes.clear();
         $.shapeNotes.clear();
         $.currentNote = undefined;
+        $.managerMode = NoteManagerMode.List;
     }
 
     async newNote(apiNote: ApiNote, sync: boolean): Promise<void> {


### PR DESCRIPTION
Fixes #1480 

When changing locations the note manager could get stuck in an unusable state when it had a note open previously that should not be shown in the new location.

For now the resolution is just to change back to the list view when changing locations.