### PR TITLE
feat(Assets): Add asset upload limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ tech changes will usually be stripped from release notes for the public
 
 -   Notes:
     -   Notes can now be popped out to a separate window
+-   [server] Assets:
+    -   Added limits to the total size of assets a user can upload and the size of a single asset
+    -   These limits can be configured in the server config
+    -   By default there are no limits, it's up to the server admin to configure them
+    -   These limits will only apply to new assets, existing assets are not affected
 
 ### Changed
 

--- a/server/server_config.cfg
+++ b/server/server_config.cfg
@@ -28,6 +28,16 @@ ssl_privkey = cert/privkey.pem
 # Defaults to 10 * 1024 ** 2 = 10 MB
 max_upload_size_in_bytes = 10_485_760
 
+# Configuration limits for User asset uploads
+# Single asset is imply the max allowed upload size
+# Total asset is the total sum of all assets the user has uploaded
+# These settings only apply to checks done on new uploads and not on existing assets
+# (i.e. no assets will be removed if they're already over the limit when these settings are changed)
+#
+# A number <=0 means no limit
+max_single_asset_size_in_bytes = 0
+max_total_asset_size_in_bytes = 0
+
 [General]
 save_file = planar.sqlite
 #assets_directory = 

--- a/server/src/api/socket/asset_manager/core.py
+++ b/server/src/api/socket/asset_manager/core.py
@@ -392,10 +392,14 @@ async def assetmgmt_upload(sid: str, raw_data: Any):
     max_total_asset_size = config.getint("Webserver", "max_total_asset_size_in_bytes")
 
     if max_single_asset_size > 0 and len(data) > max_single_asset_size:
-        logger.warn(f"{user.name} attempted to upload a file that is too large ({len(data)} > {max_single_asset_size})")
+        logger.warn(
+            f"{user.name} attempted to upload a file that is too large ({len(data)} > {max_single_asset_size})"
+        )
         return
     if max_total_asset_size > 0 and total_asset_size + len(data) > max_total_asset_size:
-        logger.warn(f"{user.name} attempted to upload a file that is too large ({total_asset_size + len(data)} > {max_total_asset_size})")
+        logger.warn(
+            f"{user.name} attempted to upload a file that is too large ({total_asset_size + len(data)} > {max_total_asset_size})"
+        )
         return
 
     return_data = None

--- a/server/src/api/socket/asset_manager/core.py
+++ b/server/src/api/socket/asset_manager/core.py
@@ -15,6 +15,7 @@ from aiohttp import web
 
 from .... import auth
 from ....app import app, sio
+from ....config import config
 from ....db.models.asset import Asset
 from ....db.models.asset_rect import AssetRect
 from ....db.models.user import User
@@ -346,6 +347,17 @@ async def handle_regular_file(upload_data: ApiAssetUpload, data: bytes, sid: str
     return asset_dict
 
 
+@sio.on("Asset.Upload.Limit", namespace=ASSET_NS)
+@auth.login_required(app, sio, "asset")
+async def assetmgmt_upload_limit(sid: str):
+    user = asset_state.get_user(sid)
+    return {
+        "single": config.getint("Webserver", "max_single_asset_size_in_bytes"),
+        "used": user.get_total_asset_size(),
+        "total": config.getint("Webserver", "max_total_asset_size_in_bytes"),
+    }
+
+
 @sio.on("Asset.Upload", namespace=ASSET_NS)
 @auth.login_required(app, sio, "asset")
 async def assetmgmt_upload(sid: str, raw_data: Any):
@@ -363,6 +375,7 @@ async def assetmgmt_upload(sid: str, raw_data: Any):
     if uuid not in asset_state.pending_file_upload_cache:
         asset_state.pending_file_upload_cache[uuid] = {}
     asset_state.pending_file_upload_cache[uuid][upload_data.slice] = upload_data
+    # todo: verify that `totalSlices` does not change between messages
     if len(asset_state.pending_file_upload_cache[uuid]) != upload_data.totalSlices:
         # wait for the rest of the slices
         return
@@ -373,6 +386,17 @@ async def assetmgmt_upload(sid: str, raw_data: Any):
         data += asset_state.pending_file_upload_cache[uuid][slice_].data
 
     del asset_state.pending_file_upload_cache[upload_data.uuid]
+
+    total_asset_size = user.get_total_asset_size()
+    max_single_asset_size = config.getint("Webserver", "max_single_asset_size_in_bytes")
+    max_total_asset_size = config.getint("Webserver", "max_total_asset_size_in_bytes")
+
+    if max_single_asset_size > 0 and len(data) > max_single_asset_size:
+        logger.warn(f"{user.name} attempted to upload a file that is too large ({len(data)} > {max_single_asset_size})")
+        return
+    if max_total_asset_size > 0 and total_asset_size + len(data) > max_total_asset_size:
+        logger.warn(f"{user.name} attempted to upload a file that is too large ({total_asset_size + len(data)} > {max_total_asset_size})")
+        return
 
     return_data = None
     file_name = upload_data.name


### PR DESCRIPTION
This PR adds 2 server configuration options to control the limits of assets uploaded to the server by users.

A configuration to limit the max size of single files is present as well as a limit to the total amount of bytes a user has uploaded.

Both of these limits default to 0, which means unlimited. It's up to individual server admins to decide whether they want to limit this and by how much.

There is no visual indication as to how much storage you have left currently, but an error popup will appear if you exceed any of the two thresholds while uploading assets.

These limits only apply to newly uploaded assets. So users who are already exceeding the limits when these settings change, will not be affected.

As a server admin you can check the total size a specific user is occupying in the python shell:

```python
from src.db.all import User

# Single user
user = User.by_name("kruptein")
print(user.get_total_asset_size())

# All users
for user in User.select():
    print(user.name, user.get_total_asset_size())

# Sorted
from operator import itemgetter
counts = [[user.name, user.get_total_asset_size()] for user in User.select()]
for name, count in sorted(counts, key=itemgetter(1)):
    print(name, count)
```