### PR TITLE
bug(Shape): Fix some properties not persisting correctly when modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,17 @@ tech changes will usually be stripped from release notes for the public
     -   Changed some border colours in the create new game menu
 -   MenuBar:
     -   Add Notes button for players
+-   [tech] Select tool:
+    -   Delayed syncing of selection state to the global state from mouse down to mouse move/up
+    -   This fixes some of the entries in the Fixed section
 
 ### Fixed
 
 -   Notes:
     -   It was possible to open a 'view-only' note on a tab you weren't supposed to see
     -   Note manager could be empty and unusable when changing locations
+-   Shape Properties:
+    -   Input changes could not persist or save on the wrong shape if selection focus was changed while editing (see selection changes)
 
 ## [2024.3.0] - 2024-10-13
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -91,6 +91,12 @@ class SelectTool extends Tool implements ISelectTool {
 
     lastMousePosition = toGP(0, 0);
 
+    // This is stored to ensure that we don't push changes to the selection too early.
+    // Originally we pushed these to the selection system immediately on mouseDown,
+    // but events like blur or change on input fields trigger _after_ mouseDown,
+    // causing these event handlers to potentially run against the wrong selection.
+    currentSelection: IShape[] = [];
+
     angle = 0;
     rotationUiActive = false;
     rotationAnchor?: Line;
@@ -217,6 +223,15 @@ class SelectTool extends Tool implements ISelectTool {
         return Promise.resolve();
     }
 
+    // Syncs the local state tracked selection state to the global selection state
+    private syncSelection(): void {
+        if (this.currentSelection.length === 0) {
+            selectedSystem.clear();
+        } else {
+            selectedSystem.set(...this.currentSelection.map((s) => s.id));
+        }
+    }
+
     // INPUT HANDLERS
 
     async onDown(
@@ -257,14 +272,14 @@ class SelectTool extends Tool implements ISelectTool {
         let hit = false;
 
         // The selectionStack allows for lower positioned objects that are selected to have precedence during overlap.
-        const layerSelection = selectedSystem.get({ includeComposites: false });
+        this.currentSelection = [...selectedSystem.get({ includeComposites: false })];
         let selectionStack: readonly IShape[];
         if (this.hasFeature(SelectFeatures.ChangeSelection, features)) {
             const shapes = layer.getShapes({ includeComposites: false, onlyInView: true });
-            if (!layerSelection.length) selectionStack = shapes;
-            else selectionStack = shapes.concat(layerSelection);
+            if (!this.currentSelection.length) selectionStack = shapes;
+            else selectionStack = shapes.concat(this.currentSelection);
         } else {
-            selectionStack = layerSelection;
+            selectionStack = this.currentSelection;
         }
 
         for (let i = selectionStack.length - 1; i >= 0; i--) {
@@ -284,7 +299,7 @@ class SelectTool extends Tool implements ISelectTool {
                     hit = true;
 
                     this.operationList = { type: "rotation", center: toGP(0, 0), shapes: [] };
-                    for (const shape of selectedSystem.get({ includeComposites: false }))
+                    for (const shape of this.currentSelection)
                         this.operationList.shapes.push({ uuid: shape.id, from: shape.angle, to: 0 });
 
                     break;
@@ -294,7 +309,7 @@ class SelectTool extends Tool implements ISelectTool {
                 this.resizePoint = shape.getPointIndex(gp, l2gz(5));
                 if (this.resizePoint >= 0) {
                     // Resize case, a corner is selected
-                    selectedSystem.set(shape.id);
+                    this.currentSelection = [shape];
                     this.removeRotationUi();
                     this.createRotationUi(features);
                     const points = shape.points;
@@ -319,19 +334,19 @@ class SelectTool extends Tool implements ISelectTool {
                 }
             }
             if (shape.contains(gp)) {
-                if (!layerSelection.includes(shape)) {
+                if (!this.currentSelection.includes(shape)) {
                     if (event && ctrlOrCmdPressed(event)) {
-                        selectedSystem.push(shape.id);
+                        this.currentSelection.push(shape);
                     } else {
-                        selectedSystem.set(shape.id);
+                        this.currentSelection = [shape];
                     }
                     this.removeRotationUi();
                     this.createRotationUi(features);
                 } else {
                     if (event && ctrlOrCmdPressed(event)) {
-                        selectedSystem.remove(shape.id);
+                        this.currentSelection = this.currentSelection.filter((s) => s.id !== shape.id);
                     } else {
-                        selectedSystem.focus(shape.id);
+                        this.currentSelection = [shape];
                     }
                 }
                 // Drag case, a shape is selected
@@ -342,7 +357,7 @@ class SelectTool extends Tool implements ISelectTool {
 
                     // don't use layerSelection here as it can be outdated by the pushSelection setSelection above
                     this.operationList = { type: "movement", shapes: [] };
-                    for (const shape of selectedSystem.get({ includeComposites: false })) {
+                    for (const shape of this.currentSelection) {
                         this.operationList.shapes.push({
                             uuid: shape.id,
                             from: toArrayP(shape.refPoint),
@@ -396,7 +411,7 @@ class SelectTool extends Tool implements ISelectTool {
             }
 
             if (!(event && ctrlOrCmdPressed(event))) {
-                selectedSystem.clear();
+                this.currentSelection = [];
             }
 
             if (this.rotationUiActive) {
@@ -462,8 +477,7 @@ class SelectTool extends Tool implements ISelectTool {
             return;
         }
 
-        const layerSelection = selectedSystem.get({ includeComposites: false });
-        if (layerSelection.some((s) => getProperties(s.id)!.isLocked)) return;
+        if (this.currentSelection.some((s) => getProperties(s.id)!.isLocked)) return;
 
         this.deltaChanged = false;
 
@@ -478,7 +492,7 @@ class SelectTool extends Tool implements ISelectTool {
                 Math.min(this.selectionStartPoint.y, endPoint.y),
             );
             layer.invalidate(true);
-        } else if (layerSelection.length) {
+        } else if (this.currentSelection.length) {
             let delta = Ray.fromPoints(this.dragRay.get(this.dragRay.tMax), lp).direction.multiply(
                 1 / positionState.readonly.zoom,
             );
@@ -487,14 +501,14 @@ class SelectTool extends Tool implements ISelectTool {
                 if (ogDelta.length() === 0) return;
                 // If we are on the tokens layer do a movement block check.
                 if (layer.name === LayerName.Tokens && !(event?.shiftKey === true && gameState.raw.isDm)) {
-                    for (const sel of layerSelection) {
+                    for (const sel of this.currentSelection) {
                         if (!accessSystem.hasAccessTo(sel.id, false, { movement: true })) continue;
                         delta = calculateDelta(delta, sel, true);
                         if (delta !== ogDelta) this.deltaChanged = true;
                     }
                 }
 
-                await moveShapes(layerSelection, delta, true);
+                await moveShapes(this.currentSelection, delta, true);
 
                 if (!this.deltaChanged) {
                     this.dragRay = Ray.fromPoints(this.dragRay.origin, lp);
@@ -511,7 +525,7 @@ class SelectTool extends Tool implements ISelectTool {
 
                 layer.invalidate(false);
             } else if (this.mode === SelectOperations.Resize) {
-                const shape = layerSelection[0]!;
+                const shape = this.currentSelection[0]!;
 
                 if (!accessSystem.hasAccessTo(shape.id, false, { movement: true })) return;
 
@@ -542,6 +556,10 @@ class SelectTool extends Tool implements ISelectTool {
             } else {
                 this.updateCursor(gp, features);
             }
+            // We also sync in onUp, which always runs,
+            // however when we click and immediately drag a shape,
+            // the selection won't appear until the onUp if we don't sync here as well
+            this.syncSelection();
         } else {
             document.body.style.cursor = "default";
         }
@@ -569,35 +587,34 @@ class SelectTool extends Tool implements ISelectTool {
         }
         const layer = floorState.currentLayer.value;
 
-        let layerSelection = selectedSystem.get({ includeComposites: false });
-
-        if (layerSelection.some((s) => getProperties(s.id)!.isLocked)) return;
-
-        if (this.mode === SelectOperations.GroupSelect) {
+        if (this.currentSelection.some((s) => getProperties(s.id)!.isLocked)) {
+            // no-op - don't return because we need to run common logic afterwards
+        } else if (this.mode === SelectOperations.GroupSelect) {
             if (event && ctrlOrCmdPressed(event)) {
                 // If either control or shift are pressed, do not remove selection
             } else {
-                selectedSystem.clear();
+                this.currentSelection = [];
             }
             const cbbox = this.selectionHelper!.getBoundingBox();
             for (const shape of layer.getShapes({ includeComposites: false, onlyInView: true })) {
                 if (!(shape.options.preFogShape ?? false) && (shape.options.skipDraw ?? false)) continue;
                 if (!accessSystem.hasAccessTo(shape.id, false, { movement: true })) continue;
                 if (!shape.visibleInCanvas({ w: layer.width, h: layer.height }, { includeAuras: false })) continue;
-                if (layerSelection.some((s) => s.id === shape.id)) continue;
+                if (this.currentSelection.some((s) => s.id === shape.id)) continue;
+                if (shape.id === this.selectionHelper?.id) continue;
 
                 const points = shape.points;
                 if (points.length > 1) {
                     for (let i = 0; i < points.length; i++) {
                         const ray = Ray.fromPoints(toGP(points[i]!), toGP(points[(i + 1) % points.length]!));
                         if (cbbox.containsRay(ray).hit) {
-                            selectedSystem.push(shape.id);
+                            this.currentSelection.push(shape);
                             i = points.length; // break out of the inner loop
                         }
                     }
                 } else if (points.length === 1) {
                     if (cbbox.contains(toGP(points[0]!))) {
-                        selectedSystem.push(shape.id);
+                        this.currentSelection.push(shape);
                     }
                 }
             }
@@ -605,14 +622,12 @@ class SelectTool extends Tool implements ISelectTool {
             layer.removeShape(this.selectionHelper!, { sync: SyncMode.NO_SYNC, recalculate: true, dropShapeId: true });
             this.selectionHelper = undefined;
 
-            layerSelection = selectedSystem.get({ includeComposites: false });
-
-            if (layerSelection.some((s) => !getProperties(s.id)!.isLocked)) {
-                selectedSystem.set(...layerSelection.filter((s) => !getProperties(s.id)!.isLocked).map((s) => s.id));
+            if (this.currentSelection.some((s) => !getProperties(s.id)!.isLocked)) {
+                this.currentSelection = this.currentSelection.filter((s) => !getProperties(s.id)!.isLocked);
             }
 
             if (
-                layerSelection.length > 0 &&
+                this.currentSelection.length > 0 &&
                 !this.rotationUiActive &&
                 this.hasFeature(SelectFeatures.Rotate, features)
             ) {
@@ -620,13 +635,13 @@ class SelectTool extends Tool implements ISelectTool {
             }
 
             layer.invalidate(true);
-        } else if (layerSelection.length) {
+        } else if (this.currentSelection.length) {
             let recalcVision = false;
             let recalcMovement = false;
 
             if (this.mode === SelectOperations.Drag) {
                 const updateList = [];
-                for (const [s, sel] of layerSelection.entries()) {
+                for (const [s, sel] of this.currentSelection.entries()) {
                     if (!accessSystem.hasAccessTo(sel.id, false, { movement: true })) continue;
 
                     if (
@@ -687,8 +702,8 @@ class SelectTool extends Tool implements ISelectTool {
 
                 if (
                     this.selectionCollapsed &&
-                    layerSelection.length === 1 &&
-                    (layerSelection[0]!.options.collapsedIds?.length ?? 0) > 0
+                    this.currentSelection.length === 1 &&
+                    (this.currentSelection[0]!.options.collapsedIds?.length ?? 0) > 0
                 ) {
                     this.selectionCollapsed = false;
                     await expandSelection(updateList);
@@ -699,7 +714,7 @@ class SelectTool extends Tool implements ISelectTool {
                 await teleportZoneSystem.checkTeleport(selectedSystem.get({ includeComposites: true }));
             }
             if (this.mode === SelectOperations.Resize) {
-                for (const sel of layerSelection) {
+                for (const sel of this.currentSelection) {
                     if (!accessSystem.hasAccessTo(sel.id, false, { movement: true })) continue;
 
                     const props = getProperties(sel.id)!;
@@ -750,7 +765,7 @@ class SelectTool extends Tool implements ISelectTool {
             if (this.mode === SelectOperations.Rotate) {
                 const rotationCenter = this.rotationBox!.center;
 
-                for (const [s, sel] of layerSelection.entries()) {
+                for (const [s, sel] of this.currentSelection.entries()) {
                     if (!accessSystem.hasAccessTo(sel.id, false, { movement: true })) continue;
 
                     const newAngle = Math.round(this.angle / ANGLE_SNAP) * ANGLE_SNAP;
@@ -774,7 +789,7 @@ class SelectTool extends Tool implements ISelectTool {
                 }
             }
 
-            const floorId = layerSelection[0]?.floorId;
+            const floorId = this.currentSelection[0]?.floorId;
             if (floorId !== undefined) {
                 if (recalcVision) visionState.recalculateVision(floorId);
                 if (recalcMovement) visionState.recalculateMovement(floorId);
@@ -787,9 +802,12 @@ class SelectTool extends Tool implements ISelectTool {
             }
         }
 
+        this.syncSelection();
+        this.currentSelection = [];
+
         if (this.operationReady) addOperation(this.operationList!);
 
-        _$.hasSelection = layerSelection.length > 0;
+        _$.hasSelection = this.currentSelection.length > 0;
 
         this.mode = SelectOperations.Noop;
     }


### PR DESCRIPTION
This fixes #1484 

PA tracks internally which shapes are currently selected and the most prominent location of changes of this selection occur when you use the select tool to click on other shapes or deselect the active shape.

Before this PR, the select tool would immediately update the selection state when the `mouseDown` event is fired.  This PR changes this behaviour to wait until `mouseMove` or `mouseUp`.

When you're editing for example the name of a shape and you directly click on another shape or even just the map (causing a deselect), a bunch of browser events are fired. First the `mouseDown` event fires, which until now changed the selection info immediately, then the `change` event fires, which indicates that the name input field changed content and finally `mouseUp` is fired.

As you can see by the time the change event hits, we've already changed our selection to either a different shape or cleared the selection info. Which in turn means that the updateName function either changes the name of the wrong shape or simply doesn't have any shape to update.

By delaying the selection change to `mouseMove` or `mouseUp`, we're ensuring that these events still operate on the originally selected shape.

Some of you might wonder why the other input field (i.e. 'value') mentioned in the related ticket was working correctly before these changes. That's because that field is still using a legacy way to detect which shape is active that reactively watches the main selection system. This legacy system was getting its update a tick later which happens to be after the `change` event fired.