### PR TITLE
bug(Notes): Fix note filtering potentially giving blank page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ tech changes will usually be stripped from release notes for the public
 -   Notes:
     -   It was possible to open a 'view-only' note on a tab you weren't supposed to see
     -   Note manager could be empty and unusable when changing locations
+    -   Search filter not resetting page to 1 potentially causing a blank page if on an other page
 -   Shape Properties:
     -   Input changes could not persist or save on the wrong shape if selection focus was changed while editing (see selection changes)
 

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DeepReadonly, computed, reactive, ref } from "vue";
+import { type DeepReadonly, computed, reactive, ref, watch } from "vue";
 
 import { arrToToggleGroup } from "../../../core/components/toggleGroup";
 import ToggleGroup from "../../../core/components/ToggleGroup.vue";
@@ -98,10 +98,15 @@ const filteredNotes = computed(() => {
     return notes;
 });
 
+watch(filteredNotes, () => {
+    searchPage.value = 1;
+});
+
+const pageSize = 25;
 const visibleNotes = computed(() => {
     return {
-        notes: filteredNotes.value.slice((searchPage.value - 1) * 25, searchPage.value * 25),
-        hasNext: filteredNotes.value.length > searchPage.value * 25,
+        notes: filteredNotes.value.slice((searchPage.value - 1) * pageSize, searchPage.value * pageSize),
+        hasNext: filteredNotes.value.length > searchPage.value * pageSize,
     };
 });
 


### PR DESCRIPTION
When there are enough notes for multiple pages to be present, the note filter was not resetting the page to 1, potentially causing the user to end up with seemingly no matching notes because they were on a different page.

This fixes #1485 