### PR TITLE
bug(Modals): Fix modal drag not focusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ tech changes will usually be stripped from release notes for the public
     -   Search filter not resetting page to 1 potentially causing a blank page if on an other page
 -   Shape Properties:
     -   Input changes could not persist or save on the wrong shape if selection focus was changed while editing (see selection changes)
+-   Modals
+    -   Dragging modals (e.g. notes) now also brings them to the foreground as if clicked
 
 ## [2024.3.0] - 2024-10-13
 

--- a/client/src/core/components/modals/Modal.vue
+++ b/client/src/core/components/modals/Modal.vue
@@ -109,6 +109,9 @@ function updatePosition(): void {
 
 function dragStart(event: DragEvent): void {
     if (event === null || event.dataTransfer === null) return;
+
+    emit("focus");
+
     registerDropCallback(dragEnd);
     event.dataTransfer.setData("Hack", "");
     // Because the drag event is happening on the header, we have to change the drag image


### PR DESCRIPTION
When dragging modals around, they were not being brought to the foreground like happens when you click on a modal.

This is expected behaviour and is now fixed.

This fixes #1496