### PR TITLE
bug(NoteManager): Fix default edit access not working on notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ tech changes will usually be stripped from release notes for the public
     -   It was possible to open a 'view-only' note on a tab you weren't supposed to see
     -   Note manager could be empty and unusable when changing locations
     -   Search filter not resetting page to 1 potentially causing a blank page if on an other page
+    -   Default edit access on notes was not correctly applied
 -   Shape Properties:
     -   Input changes could not persist or save on the wrong shape if selection focus was changed while editing (see selection changes)
 -   Modals

--- a/client/src/game/ui/notes/NoteEdit.vue
+++ b/client/src/game/ui/notes/NoteEdit.vue
@@ -20,11 +20,13 @@ const modals = useModal();
 
 const note = computed(() => noteState.reactive.notes.get(noteState.reactive.currentNote!));
 
+const defaultAccessName = "default";
+
 const canEdit = computed(() => {
     if (!note.value) return false;
     const username = coreStore.state.username;
     if (note.value.creator === username) return true;
-    return note.value.access.some((a) => a.name === username && a.can_edit);
+    return note.value.access.some((a) => (a.name === username || a.name === defaultAccessName) && a.can_edit);
 });
 
 const localShapenotes = computed(() =>
@@ -108,9 +110,9 @@ watchEffect(() => {
 // and that defaultAccess is provided even if it has no DB value
 const accessLevels = computed(() => {
     const access = [];
-    let defaultAccess = { name: "default", can_view: false, can_edit: false };
+    let defaultAccess = { name: defaultAccessName, can_view: false, can_edit: false };
     for (const a of note.value?.access ?? []) {
-        if (a.name === "default") defaultAccess = a;
+        if (a.name === defaultAccessName) defaultAccess = a;
         else access.push(a);
     }
     return [defaultAccess, ...access];
@@ -278,7 +280,7 @@ function removeShape(shape: LocalId): void {
                 <input type="checkbox" :checked="access.can_view" @click="setViewAccess(access, $event)" />
                 <input type="checkbox" :checked="access.can_edit" @click="setEditAccess(access, $event)" />
                 <font-awesome-icon
-                    v-if="access.name !== 'default'"
+                    v-if="access.name !== defaultAccessName"
                     icon="trash-alt"
                     title="Remove access"
                     @click="noteSystem.removeAccess(note!.uuid, access.name, true)"


### PR DESCRIPTION
In NoteEdit.vue, the default edit permission for notes was not being handled, making it effectively non-functional, unless your username was 'default' ;). This change makes the NoteManager check for default edit permission as well as per-user.

I also noticed that the hard-coded string was in a few places in the NoteEdit file, so since I was going to add another instance of it, I decided to make it a constant and reuse it in multiple places instead. Hope that's alright to include in this.