### PR TITLE
bug(Select): Fix multi drag no longer working

### DIFF
--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -334,7 +334,8 @@ class SelectTool extends Tool implements ISelectTool {
                 }
             }
             if (shape.contains(gp)) {
-                if (!this.currentSelection.includes(shape)) {
+                const shapeSelectionIndex = this.currentSelection.findIndex((s) => s.id === shape.id);
+                if (shapeSelectionIndex === -1) {
                     if (event && ctrlOrCmdPressed(event)) {
                         this.currentSelection.push(shape);
                     } else {
@@ -345,8 +346,10 @@ class SelectTool extends Tool implements ISelectTool {
                 } else {
                     if (event && ctrlOrCmdPressed(event)) {
                         this.currentSelection = this.currentSelection.filter((s) => s.id !== shape.id);
-                    } else {
-                        this.currentSelection = [shape];
+                    } else if (shapeSelectionIndex !== 0) {
+                        // Move it to the front of the selection, so that it becomes the new focus
+                        this.currentSelection.splice(shapeSelectionIndex, 1);
+                        this.currentSelection.unshift(shape);
                     }
                 }
                 // Drag case, a shape is selected


### PR DESCRIPTION
Fixes #1499 

While doing the select refactor in #1487 I accidentally changed a `.focus` call to act as if it was a `.set` call, causing the selection to be limited to the clicked shape instead of focusing on the shape without affecting the selection.

This caused multi drag no longer to work as it was always resetting the selection to just the clicked shape.