### PR TITLE
bug(Notes): Fix search bar overlapping other modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ tech changes will usually be stripped from release notes for the public
     -   Note manager could be empty and unusable when changing locations
     -   Search filter not resetting page to 1 potentially causing a blank page if on an other page
     -   Default edit access on notes was not correctly applied
+    -   Fix searchbar overlapping over other modals
 -   Shape Properties:
     -   Input changes could not persist or save on the wrong shape if selection focus was changed while editing (see selection changes)
 -   Modals

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -300,7 +300,6 @@ header {
         height: 2.7rem;
         border: solid 2px black;
         border-radius: 1rem;
-        z-index: 1;
 
         > #kind-selector {
             height: calc(100% + 4px); // 2px border on top and bottom


### PR DESCRIPTION
Fixes #1495

The note manager search bar would overlap over other modals that are on top.

I'm not sure why it had a z-index to begin with as I generally dislike those, but I couldn't see a specific visual change when removed.