### PR TITLE
bug(Notes): Return to list view if view access to open note is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Notes:
     -   It was possible to open a 'view-only' note on a tab you weren't supposed to see
-    -   Note manager could be empty and unusable when changing locations
+    -   Note manager could be empty and unusable when changing locations or losing view access to an open note
     -   Search filter not resetting page to 1 potentially causing a blank page if on an other page
     -   Default edit access on notes was not correctly applied
 -   Shape Properties:

--- a/client/src/game/ui/notes/NoteEdit.vue
+++ b/client/src/game/ui/notes/NoteEdit.vue
@@ -20,6 +20,12 @@ const modals = useModal();
 
 const note = computed(() => noteState.reactive.notes.get(noteState.reactive.currentNote!));
 
+watchEffect(() => {
+    if (note.value === undefined) {
+        emit("mode", NoteManagerMode.List);
+    }
+});
+
 const defaultAccessName = "default";
 
 const canEdit = computed(() => {


### PR DESCRIPTION
If the main note manager had a note open and your access levels for that note change such that you're no longer allowed to view it, the note manager would become an empty line that is no longer useable until you find a way to force load another note.

This PR changes it so that the View/Edit note UI will always return to list view when it can't render it's current note.