### PR TITLE
bug(Notes): Remove default access level from global notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ tech changes will usually be stripped from release notes for the public
     -   Search filter not resetting page to 1 potentially causing a blank page if on an other page
     -   Default edit access on notes was not correctly applied
     -   Fix searchbar overlapping over other modals
+    -   Global notes no longer have a default access level
 -   Shape Properties:
     -   Input changes could not persist or save on the wrong shape if selection focus was changed while editing (see selection changes)
 -   Modals

--- a/client/src/game/ui/notes/NoteEdit.vue
+++ b/client/src/game/ui/notes/NoteEdit.vue
@@ -115,6 +115,11 @@ watchEffect(() => {
 // Ensure that defaultAccess is always first
 // and that defaultAccess is provided even if it has no DB value
 const accessLevels = computed(() => {
+    if (note.value === undefined) return [];
+    // For global notes, there is no default access so just return the access levels with a filter
+    if (!note.value.isRoomNote) return note.value.access.filter((a) => a.name !== defaultAccessName);
+    // For local notes, add a default access level and make sure it's first
+    // It's possible that a specific config for the default access level is set, so we need to check for that
     const access = [];
     let defaultAccess = { name: defaultAccessName, can_view: false, can_edit: false };
     for (const a of note.value?.access ?? []) {

--- a/server/src/api/socket/note.py
+++ b/server/src/api/socket/note.py
@@ -242,6 +242,10 @@ async def add_note_access(sid, raw_data: Any):
     user = None
     if data.name != "default":
         user = User.by_name(data.name)
+    elif note.room is None:
+        logger.warning(f"Note '{uuid}' is global but tried to add default access")
+        return
+
     NoteAccess.create(
         note=note, user=user, can_edit=data.can_edit, can_view=data.can_view
     )


### PR DESCRIPTION
Notes can be shared with other players using the access tab. Sometimes you just want to quickly share with all players and the 'default' access row that we currently have is very nice for that.

For local notes this is very intuitive. It shares whatever access rights the default row has with all players in the campaign.

For global notes this is less intuitive, because there is no real link to a campaign and thus to a set of default players.  The global note might be used in multiple campaigns with a variety of players. It has no home campaign.

This leads us to the present day where a global note with default access actually is shared with _all_ users on the server. This is not really ideal, so this PR removes the default access row for global notes. Where necessary share global notes with specific users. The access UI has an interaction label to select all users in the current campaign, so it should not really impose much trouble.

It's currently resolved without a migration and simply hard filtered on the server.