### PR TITLE
feat(NoteManager): add a clear button to the searchbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ tech changes will usually be stripped from release notes for the public
     -   The specific colours used can be configured in the user options Appearance section and will update shapes retroactively
 -   Notes:
     -   Notes can now be popped out to a separate window
+-   NoteManager:
+    -   Added a button to clear the current search
 -   [server] Assets:
     -   Added limits to the total size of assets a user can upload and the size of a single asset
     -   These limits can be configured in the server config

--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -25,6 +25,7 @@ import {
     faChevronUp,
     faCircle,
     faCircleInfo,
+    faCircleXmark,
     faClockRotateLeft,
     faCog,
     faCogs,
@@ -74,7 +75,6 @@ import {
     faUserTag,
     faUsers,
     faVideo,
-    faX,
 } from "@fortawesome/free-solid-svg-icons";
 
 export function loadFontAwesome(): void {
@@ -95,6 +95,7 @@ export function loadFontAwesome(): void {
         faChevronUp,
         faCircle,
         faCircleInfo,
+        faCircleXmark,
         faClockRotateLeft,
         faCog,
         faCogs,
@@ -154,7 +155,6 @@ export function loadFontAwesome(): void {
         faVideo,
         faWindowClose,
         faWindowRestore,
-        faX,
     );
 
     dom.watch();

--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -74,6 +74,7 @@ import {
     faUserTag,
     faUsers,
     faVideo,
+    faX,
 } from "@fortawesome/free-solid-svg-icons";
 
 export function loadFontAwesome(): void {
@@ -153,6 +154,7 @@ export function loadFontAwesome(): void {
         faVideo,
         faWindowClose,
         faWindowRestore,
+        faX,
     );
 
     dom.watch();

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -118,6 +118,12 @@ function editNote(noteId: string): void {
 function clearShapeFilter(): void {
     noteState.mutableReactive.shapeFilter = undefined;
 }
+
+function clearSearchBar(): void {
+    searchFilter.value = "";
+    searchBar.value?.focus();
+}
+
 </script>
 
 <template>
@@ -136,7 +142,10 @@ function clearShapeFilter(): void {
             />
             <font-awesome-icon icon="magnifying-glass" @click="searchBar?.focus()" />
             <div v-if="shapeName" class="shape-name" @click="clearShapeFilter">{{ shapeName }}</div>
-            <input ref="searchBar" v-model="searchFilter" type="text" placeholder="search through your notes.." />
+            <div id="search-field">
+                <input ref="searchBar" v-model="searchFilter" type="text" placeholder="search through your notes.." />
+                <font-awesome-icon v-show="searchFilter.length > 0" id="clear-button" :icon="['fas', 'x']" title="Clear Search" @click.stop="clearSearchBar" />
+            </div>
             <div v-show="showSearchFilters" id="search-filter">
                 <fieldset>
                     <legend>Where to search</legend>
@@ -302,6 +311,7 @@ header {
         border-radius: 1rem;
 
         > #kind-selector {
+            flex-shrink: 0;
             height: calc(100% + 4px); // 2px border on top and bottom
             margin-left: -2px; // 2px border on left
             border-color: black;
@@ -312,6 +322,7 @@ header {
         }
 
         > .shape-name {
+            flex-shrink: 0;
             margin-left: 0.5rem;
             font-weight: bold;
 
@@ -321,16 +332,33 @@ header {
             }
         }
 
-        > input {
-            padding: 0.5rem 1rem;
+        > #search-field {
             flex-grow: 1;
-            margin-right: 0.5rem;
+            flex-shrink: 1;
+            padding-right: 4rem;
 
             outline: none;
             border: none;
-            border-radius: 1rem;
 
-            font-size: 1.25em;
+            display: flex;
+            align-items: center;
+            width: 100%;
+
+            > input {
+                padding: 0.5rem 1rem;
+                outline: none;
+                border: none;
+                border-radius: 1rem;
+                flex-grow: 1;
+
+                font-size: 1.25em;
+            }
+            > #clear-button {
+                border: 0;
+                font-size: 1rem;
+                cursor: pointer;
+            }
+
         }
 
         > #search-icons {

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -144,7 +144,7 @@ function clearSearchBar(): void {
             <div v-if="shapeName" class="shape-name" @click="clearShapeFilter">{{ shapeName }}</div>
             <div id="search-field">
                 <input ref="searchBar" v-model="searchFilter" type="text" placeholder="search through your notes.." />
-                <font-awesome-icon v-show="searchFilter.length > 0" id="clear-button" :icon="['fas', 'x']" title="Clear Search" @click.stop="clearSearchBar" />
+                <font-awesome-icon v-show="searchFilter.length > 0" id="clear-button" icon="circle-xmark" title="Clear Search" @click.stop="clearSearchBar" />
             </div>
             <div v-show="showSearchFilters" id="search-filter">
                 <fieldset>


### PR DESCRIPTION
This adds an 'X' button on the right side of the searchbar in the NoteManager which will clear the current search query. It's never been a huge issue to not have it, but it's a pretty common feature for search boxes that I've gotten used to. This is just a minor change that I would like to see.