### PR TITLE
feat(NoteManager): Improve filtering by tags in note search

### DIFF
--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -25,6 +25,7 @@ import {
     faChevronUp,
     faCircle,
     faCircleInfo,
+    faCircleXmark,
     faClockRotateLeft,
     faCog,
     faCogs,
@@ -75,7 +76,6 @@ import {
     faUserTag,
     faUsers,
     faVideo,
-    faX,
 } from "@fortawesome/free-solid-svg-icons";
 
 export function loadFontAwesome(): void {
@@ -96,6 +96,7 @@ export function loadFontAwesome(): void {
         faChevronUp,
         faCircle,
         faCircleInfo,
+        faCircleXmark,
         faClockRotateLeft,
         faCog,
         faCogs,
@@ -156,7 +157,6 @@ export function loadFontAwesome(): void {
         faVideo,
         faWindowClose,
         faWindowRestore,
-        faX,
     );
 
     dom.watch();

--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -49,6 +49,7 @@ import {
     faLocationDot,
     faLock,
     faMagnifyingGlass,
+    faMinus,
     faMinusSquare,
     faNoteSticky,
     faPaintBrush,
@@ -74,6 +75,7 @@ import {
     faUserTag,
     faUsers,
     faVideo,
+    faX,
 } from "@fortawesome/free-solid-svg-icons";
 
 export function loadFontAwesome(): void {
@@ -123,6 +125,7 @@ export function loadFontAwesome(): void {
         faLocationDot,
         faLock,
         faMagnifyingGlass,
+        faMinus,
         faMinusSquare,
         faNoteSticky,
         faPaintBrush,
@@ -153,6 +156,7 @@ export function loadFontAwesome(): void {
         faVideo,
         faWindowClose,
         faWindowRestore,
+        faX,
     );
 
     dom.watch();

--- a/client/src/game/systems/notes/types.ts
+++ b/client/src/game/systems/notes/types.ts
@@ -1,8 +1,13 @@
 import type { ApiNote } from "../../../apiTypes";
 import type { DistributiveOmit } from "../../../core/types";
 
+export type NoteTag = {
+    name: string;
+    colour: string;
+};
+
 export type ClientNote = DistributiveOmit<ApiNote, "tags"> & {
-    tags: { name: string; colour: string }[];
+    tags: NoteTag[];
 };
 
 export enum NoteManagerMode {

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -31,7 +31,6 @@ watch(selectedNoteTypes, () => {
 
 const searchFilters = reactive({
     title: true,
-    tags: true,
     text: false,
     author: false,
     activeLocation: true,
@@ -127,8 +126,6 @@ const filteredNotes = computed(() => {
         }
 
         if (searchFilters.title && note.title.toLowerCase().includes(sf)) {
-            notes.push(note);
-        } else if (searchFilters.tags && note.tags.some((tag) => tag.name.toLowerCase().includes(sf))) {
             notes.push(note);
         } else if (searchFilters.text && note.text.toLowerCase().includes(sf)) {
             notes.push(note);

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -419,7 +419,7 @@ header {
         border-bottom: solid 2px black;
 
         > #filter-bubbles {
-            flex: 4 0 0;
+            flex: 5 0 0;
             display: flex;
             flex-direction: row;
             align-items: center;
@@ -435,11 +435,12 @@ header {
 
 
             > div {
-                flex: 0 0 auto;
+                flex: 0 1 auto;
+                word-break: break-word;
             }
         }
         > #tag-search-bar {
-            flex: 1 1 0;
+            flex: 2 1 0;
             height: 1.5rem;
             min-width: 8rem;
         }

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -258,11 +258,9 @@ function clearShapeFilter(): void {
                     {{ tag.name }}
                 </div>
             </div>
-            <div id="add-filters">
-                <TagAutoCompleteSearch v-show="showTagSearch" id="tag-search-bar" placeholder="Search Tags..." :options="availableTags" @picked="toggleTagInSearch" />
-                <font-awesome-icon v-if="showTagSearch" id="tag-search-show" icon="minus" title="Hide Tag Search" @click="showTagSearch = false" />
-                <font-awesome-icon v-else id="tag-search-hide" icon="plus" title="Show Tag Search" @click="showTagSearch = true" />
-            </div>
+            <TagAutoCompleteSearch v-show="showTagSearch" id="tag-search-bar" placeholder="Search Tags..." :options="availableTags" @picked="toggleTagInSearch" />
+            <font-awesome-icon v-if="showTagSearch" id="tag-search-show" icon="minus" title="Hide Tag Search" @click="showTagSearch = false" />
+            <font-awesome-icon v-else id="tag-search-hide" icon="plus" title="Show Tag Search" @click="showTagSearch = true" />
         </div>
 
     </div>
@@ -421,7 +419,7 @@ header {
         border-bottom: solid 2px black;
 
         > #filter-bubbles {
-            flex: 2 0 0;
+            flex: 4 0 0;
             display: flex;
             flex-direction: row;
             align-items: center;
@@ -440,21 +438,16 @@ header {
                 flex: 0 0 auto;
             }
         }
-        > #add-filters {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            height: 100%;
+        > #tag-search-bar {
+            flex: 1 1 0;
+            height: 1.5rem;
+            min-width: 8rem;
+        }
 
-            > #tag-search-bar {
-                height: 1.5rem;
-                min-width: 8rem;
-            }
-
-            > #tag-search-show,
-            > #tag-search-hide {
-                margin: 0 0.5rem;
-            }
+        > #tag-search-show,
+        > #tag-search-hide {
+            flex: 0 0 auto;
+            margin: 0 0.5rem;
         }
     }
 

--- a/client/src/game/ui/notes/TagAutoCompleteSearch.vue
+++ b/client/src/game/ui/notes/TagAutoCompleteSearch.vue
@@ -201,12 +201,12 @@ function handleEnter(): void {
     flex-wrap: wrap;
     row-gap: 0.5rem;
     padding: 0.5rem;
-    margin: 0;
+    margin: 0 0.7rem;
     border: 1px solid black;
     border-top: 0;
     box-shadow: 0 0.1rem 0.875rem 0 #cacaca;
     background: white;
-    width: 100%;
+    width: calc(100% - 1.4rem);
     z-index: 1;
 }
 

--- a/client/src/game/ui/notes/TagAutoCompleteSearch.vue
+++ b/client/src/game/ui/notes/TagAutoCompleteSearch.vue
@@ -195,16 +195,21 @@ function handleEnter(): void {
 
 
 #autocomplete-results {
-    position:absolute;
+    position: absolute;
     display: flex;
+    padding: 0.5rem;
+    margin: 0 0.7rem;
+
     flex-direction: row;
     flex-wrap: wrap;
     row-gap: 0.5rem;
-    padding: 0.5rem;
-    margin: 0 0.7rem;
+
     border: 1px solid black;
     border-top: 0;
-    box-shadow: 0 0.1rem 0.875rem 0 #cacaca;
+    box-shadow: 0 0.1rem 0.675rem 0 rgba(0, 0, 0, 0.5);
+    border-radius: 0 0 0.5rem 0.5rem;
+    clip-path: inset(0 -1rem -1rem -1rem);
+
     background: white;
     width: calc(100% - 1.4rem);
     z-index: 1;

--- a/client/src/game/ui/notes/TagAutoCompleteSearch.vue
+++ b/client/src/game/ui/notes/TagAutoCompleteSearch.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts" generic="T extends { name: string, colour: string }">
+import { computed, ref, watch } from "vue";
+
+import { mostReadable } from "../../../core/utils";
+
+const emit = defineEmits<{
+    (e: "picked", payload: T): void;
+    (e: "update:modelValue", payload: string): void;
+}>();
+
+const props = defineProps<{
+    options: T[];
+    placeholder: string;
+    modelValue?: string;
+}>();
+
+const searchQuery = ref(props.modelValue ?? "");
+
+const searchBar = ref<HTMLInputElement | null>(null);
+
+watch(() => props.modelValue, (newValue) => {
+    if (newValue !== undefined) {
+        searchQuery.value = newValue;
+    }
+});
+
+// https://stackoverflow.com/a/69901745
+const results = computed(() =>
+    props.options.filter(
+        (option) => option.name.toLowerCase().includes(searchQuery.value.toLowerCase())
+    )
+);
+
+const arrowCounter = ref(-1);
+const isOpen = ref(false);
+
+function isEmpty(str: string | null): boolean {
+    if (str === null) return true;
+    return !str.trim().length;
+}
+
+function onInput(event: Event): void {
+    const target  = event.target as HTMLInputElement;
+    emit("update:modelValue", target.value);
+    searchQuery.value = target.value;
+
+    if (!isEmpty(target.value)) {
+        isOpen.value = true;
+    } else {
+        isOpen.value = false;
+    }
+}
+
+function chooseResult(result: T): void {
+    emit("picked", result);
+    searchBar.value?.focus();
+}
+
+function onFocusOut(event: FocusEvent): void {
+    arrowCounter.value = -1;
+    if (!event.currentTarget) {
+        isOpen.value = false;
+        return;
+    }
+    const elem = event.currentTarget as HTMLDivElement;
+    if (!elem.contains(event.relatedTarget as Node)) {
+        isOpen.value = false;
+    }
+}
+function onFocusIn(event: FocusEvent): void {
+    if (searchQuery.value.length > 0) {
+        isOpen.value = true;
+    }
+}
+
+function shouldShowResults(): boolean {
+    return isOpen.value && (results.value.length > 0);
+}
+
+function clearSearchBar(): void {
+    emit("update:modelValue", "");
+    searchQuery.value = "";
+    searchBar.value?.focus();
+}
+
+function handleKeyDown(): void {
+    if (isOpen.value && arrowCounter.value < (results.value.length - 1)) {
+        arrowCounter.value += 1;
+    }
+    isOpen.value = true;
+}
+
+function handleKeyUp(): void {
+    if (arrowCounter.value > -1) {
+        arrowCounter.value -= 1;
+    } else {
+        isOpen.value = false;
+    }
+}
+
+function handleKeyLeft(): void {
+    if (arrowCounter.value > 0) {
+        arrowCounter.value -= 1;
+    } else if (isOpen.value && arrowCounter.value < 0) {
+        arrowCounter.value = 0;
+    }
+}
+
+function handleKeyRight(): void {
+    if (isOpen.value && arrowCounter.value < (results.value.length - 1)) {
+        arrowCounter.value += 1;
+    }
+}
+
+function handleEnter(): void {
+    if (arrowCounter.value > -1) {
+        emit("picked", results.value[arrowCounter.value] as T);
+    }
+}
+
+</script>
+
+<template>
+    <div class="autocomplete" @focusout="onFocusOut">
+        <div class="searchbar">
+            <input
+                id="search-input"
+                ref="searchBar"
+                :value="searchQuery"
+                type="text"
+                :placeholder="placeholder"
+                @input="onInput"
+                @keydown.down="handleKeyDown"
+                @keydown.up="handleKeyUp"
+                @keydown.left="handleKeyLeft"
+                @keydown.right="handleKeyRight"
+                @keydown.enter="handleEnter"
+                @focusin="onFocusIn"
+            />
+            <div v-show="searchQuery.length > 0" id="clear-button">
+                <font-awesome-icon :icon="['fas', 'x']" title="Clear Search" @click.stop="clearSearchBar" />
+            </div>
+        </div>
+        <div v-show="shouldShowResults()" id="autocomplete-results" tabindex="0" >
+            <div
+                v-for="(result, i) in results"
+                :key="i"
+                :tabindex="i"
+                class="tag-bubble"
+                :class="{ 'is-active': i === arrowCounter }"
+                :style="{ color: mostReadable(result.colour), backgroundColor: result.colour }"
+                @click="chooseResult(result)"
+            >
+                {{ result.name }}
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped lang="scss">
+
+.autocomplete{
+    position: relative;
+    width: 100%;
+}
+.searchbar {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    border: solid 1px black;
+    border-radius: 1rem;
+}
+#search-input {
+    padding: 0.25rem 0.5rem;
+    outline: none;
+    border: none;
+    border-radius: 1rem;
+    flex: 1 1 auto;
+    width: 0;
+}
+#clear-button {
+    border: 0;
+    cursor: pointer;
+    margin: 0 0.5rem;
+    font-size: 75%;
+}
+#search-tags {
+    margin-left: 1rem;
+    margin-right: -0.5rem;
+    display: flex;
+    flex-direction: row;
+}
+.search-tag {
+    flex: 0 0 auto;
+}
+
+
+#autocomplete-results {
+    position:absolute;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    row-gap: 0.5rem;
+    padding: 0.5rem;
+    margin: 0;
+    border: 1px solid black;
+    border-top: 0;
+    box-shadow: 0 0.1rem 0.875rem 0 #cacaca;
+    overflow: hidden;
+    background: white;
+    width: 100%;
+    z-index: 1;
+}
+
+.tag-bubble {
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    margin-right: 0.5rem;
+    cursor: pointer;
+}
+
+.tag-bubble.is-active,
+.tag-bubble:hover {
+    filter: brightness(85%);
+}
+
+</style>

--- a/client/src/game/ui/notes/TagAutoCompleteSearch.vue
+++ b/client/src/game/ui/notes/TagAutoCompleteSearch.vue
@@ -206,7 +206,6 @@ function handleEnter(): void {
     border: 1px solid black;
     border-top: 0;
     box-shadow: 0 0.1rem 0.875rem 0 #cacaca;
-    overflow: hidden;
     background: white;
     width: 100%;
     z-index: 1;
@@ -217,6 +216,7 @@ function handleEnter(): void {
     border-radius: 0.5rem;
     margin-right: 0.5rem;
     cursor: pointer;
+    word-break: break-word;
 }
 
 .tag-bubble.is-active,

--- a/client/src/game/ui/notes/TagAutoCompleteSearch.vue
+++ b/client/src/game/ui/notes/TagAutoCompleteSearch.vue
@@ -138,7 +138,7 @@ function handleEnter(): void {
                 @focusin="onFocusIn"
             />
             <div v-show="searchQuery.length > 0" id="clear-button" @click.stop="clearSearchBar">
-                <font-awesome-icon :icon="['fas', 'x']" title="Clear Search" />
+                <font-awesome-icon icon="circle-xmark" title="Clear Search" />
             </div>
         </div>
         <div v-show="shouldShowResults()" id="autocomplete-results" tabindex="0" >

--- a/client/src/game/ui/notes/TagAutoCompleteSearch.vue
+++ b/client/src/game/ui/notes/TagAutoCompleteSearch.vue
@@ -24,7 +24,6 @@ watch(() => props.modelValue, (newValue) => {
     }
 });
 
-// https://stackoverflow.com/a/69901745
 const results = computed(() =>
     props.options.filter(
         (option) => option.name.toLowerCase().includes(searchQuery.value.toLowerCase())

--- a/client/src/game/ui/notes/TagAutoCompleteSearch.vue
+++ b/client/src/game/ui/notes/TagAutoCompleteSearch.vue
@@ -137,8 +137,8 @@ function handleEnter(): void {
                 @keydown.enter="handleEnter"
                 @focusin="onFocusIn"
             />
-            <div v-show="searchQuery.length > 0" id="clear-button">
-                <font-awesome-icon :icon="['fas', 'x']" title="Clear Search" @click.stop="clearSearchBar" />
+            <div v-show="searchQuery.length > 0" id="clear-button" @click.stop="clearSearchBar">
+                <font-awesome-icon :icon="['fas', 'x']" title="Clear Search" />
             </div>
         </div>
         <div v-show="shouldShowResults()" id="autocomplete-results" tabindex="0" >
@@ -181,7 +181,7 @@ function handleEnter(): void {
 #clear-button {
     border: 0;
     cursor: pointer;
-    margin: 0 0.5rem;
+    padding: 0 0.5rem;
     font-size: 75%;
 }
 #search-tags {


### PR DESCRIPTION
This is one of the ideas I was talking about in https://github.com/Kruptein/PlanarAlly/pull/1500#issuecomment-2466251120.

I tried my hand at revamping the NoteManager's tag searching capabilities. I went through several ideas before deciding on this solution. I tried integrating tag bubbles in the search bar, tried implementing an autocomplete feature to the main search bar, and several other ideas that seemed good in concept but fell flat in reality.

This PR makes a few changes. Firstly the new functionality: Tag filtering is separate from the search bar entirely. I believe that this makes the search bar feel more accurate because it will by default only search for titles, which is what I want most of the time. Tags are instead handled in the "Filter" section just below the search bar.

The new "Filter" section contains bubbles with the tag names which can be clicked to remove. It also has a search bar on the right side (hidden behind a '+' icon initially to keep a minimal look) to search through existing tags and add/remove them by clicking on their respective bubbles in a dropdown menu. They can also be iterated through using the arrow keys (see video 1).

I'm not sure if the '+'/'-' button is really necessary, but it seems to be a cleaner look to me, so I left it in. It would be simple enough to remove and just have the search bar always visible if so desired.

I also believe that the tag searchbar can be reused in the NoteEdit window to add tags to a shape. Though it would need to be able to add new tags as well as search for ones that already exist. The general idea would be pretty similar though. That implementation lies outside the scope of this PR though.

Another way to toggle tags in the new "Filter" section is with the tag bubbles in the note list. These bubbles are also now clickable, toggling the tag's status as a filter in the search (see video 2).

I'm not sure they should be able to toggle the tag or should just be used to enable the tag. I left it as a toggle until I got some feedback about this idea in general.

Finally, the new "Filter" section also contains the name of the selected shape, if any, instead of putting in the search bar. It is always the leftmost object in the "Filter" area. This seems to make sense to me and should make it more clear that the name can be interacted with to remove it as a filter. When the NoteManager first came about, I didn't know that clicking on the shape name next to the search bar would remove the shape filter. I've had players also say they didn't know until I told them (see video 3).

https://github.com/user-attachments/assets/6c6ac5b0-c06b-4e8f-9f1a-1251db21e15c


https://github.com/user-attachments/assets/dbf8c5da-c80c-411d-9a0d-792a039b7bca


https://github.com/user-attachments/assets/6529991b-c6dd-4691-a75a-ee1732b70309

