### PR TITLE
hotfix(2024.3.1): Downgrade peewee + script to remove broken shape states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+## [2024.3.1] - 2024-11-12
+
+This is a hotfix that addresses an issue causing some shapes to be in a broken DB state, causing the related location to no longer load.
+The issue only happens when removing a Character. The root of this issue seems to be related to an upgrade of the db framework which has a regression in its handling of certain removes.
+
+The only change in this patch is a downgrade of the db framework and a temporary script to remove broken shapes.
+
+The script is added to the server folder and can be run with `python remove-broken-shape-links.py`.
+When run as is, it will loop through all shapes and print out the ones with broken links.
+
+When run with the `delete` argument, it will remove the broken shapes from the DB. (i.e. `python remove-broken-shape-links.py delete`)
+
 ## [2024.3.0] - 2024-10-13
 
 ### Added

--- a/server/remove-broken-shape-links.py
+++ b/server/remove-broken-shape-links.py
@@ -1,0 +1,36 @@
+import sys
+
+from src.db.all import Shape
+
+
+def run(delete: bool = False):
+    found = False
+    print("Starting loop through all shapes")
+    print()
+    for shape in Shape.select():
+        try:
+            shape.subtype
+        except Exception as e:
+            found = True
+            if delete:
+                shape.delete_instance(True)
+                print(f"Deleted {shape.uuid}")
+                print()
+            else:
+                print(e)
+                print(shape.uuid, shape.type_, repr(shape.layer))
+                print()
+    print("Finished loop through all shapes")
+    if not delete and found:
+        print()
+        print("Run with `delete` argument to remove the broken shapes.")
+    if not found:
+        print()
+        print("No broken shapes found.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "delete":
+        run(delete=True)
+    else:
+        run(delete=False)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,6 +5,6 @@ bcrypt==4.2.0
 cryptography==43.0.1
 python-engineio==4.9.1
 python-socketio==5.11.4
-peewee==3.17.6
+peewee==3.17.5
 pydantic==1.10.13
 typing_extensions==4.12.2


### PR DESCRIPTION
The last release upgraded the version of the db framework which seems to have introduced a bug in certain remove calls.

In practice this affects PA when a user removes a Character (note: Character is a specific concept, it's not about shapes in general). When this happens there is a chance for some data to be corrupted related to the character's shape. Any attempt to load a location with that shape will fail.

A script to remove shapes that are in this broken state has been added. See the CHANGELOG for details.