### PR TITLE
style(UI): Fix radial menu showing under location settings bar

### DIFF
--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -311,6 +311,7 @@ function setTempZoomDisplay(value: number): void {
 }
 
 #radialmenu {
+    overflow: hidden;
     grid-area: menutoggle;
     z-index: -1;
 }


### PR DESCRIPTION
While working on locations, I noticed that the radial menu in the top left of the UI is drawn underneath the locations settings bar if it's open. This is only really noticable if you hover over the locations toggle of the radial menu, but I still felt like fixing it. Turned out to be a super easy change.

before | after
:---: | :---:
![Screenshot_20241115_173434](https://github.com/user-attachments/assets/223cf007-3200-478c-aba4-e8dc9890617f) | ![Screenshot_20241115_173520](https://github.com/user-attachments/assets/9bbf65e2-37dc-442c-b237-55e62c4220b4)
