### PR TITLE
bug(Select): Fix select tool UI disappearing [dev]

### DIFF
--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -801,12 +801,11 @@ class SelectTool extends Tool implements ISelectTool {
             }
         }
 
-        this.syncSelection();
-        this.currentSelection = [];
-
         if (this.operationReady) addOperation(this.operationList!);
 
         _$.hasSelection = this.currentSelection.length > 0;
+        this.syncSelection();
+        this.currentSelection = [];
 
         this.mode = SelectOperations.Noop;
     }


### PR DESCRIPTION
_This issue was reported on discord._

The internal selection clear happened just 1 operation too early, causing the select UI to disappear on mouse up.