### PR TITLE
feat(Assets): Generate & Use thumbnails for assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ tech changes will usually be stripped from release notes for the public
 -   NoteManager:
     -   Added a button to clear the current search
 -   [server] Assets:
-    -   Added limits to the total size of assets a user can upload and the size of a single asset
-    -   These limits can be configured in the server config
-    -   By default there are no limits, it's up to the server admin to configure them
-    -   These limits will only apply to new assets, existing assets are not affected
+    -   limits:
+        -   Added limits to the total size of assets a user can upload and the size of a single asset
+        -   These limits can be configured in the server config
+        -   By default there are no limits, it's up to the server admin to configure them
+        -   These limits will only apply to new assets, existing assets are not affected
+    -   Thumbnails:
+        -   The server will now generate thumbnails for all assets
 
 ### Changed
 
@@ -38,6 +41,9 @@ tech changes will usually be stripped from release notes for the public
     -   This fixes some of the entries in the Fixed section
 -   AssetManager:
     -   Changed UI of renaming assets, allowing inline editing rather than opening a popup
+    -   The images shown in the asset manager will now use the thumbnail of the asset if available
+        -   This should reduce load times and improve general performance
+        -   This also applies to the preview when hovering over assets in the in-game assets sidebar
 -   Notes:
     -   Add filtering option 'All' to note manager to show both global and local notes
     -   Note popouts for clients without edit access now show 'view source' instead of 'edit'

--- a/client/src/assetManager/utils.ts
+++ b/client/src/assetManager/utils.ts
@@ -7,12 +7,21 @@ export function showIdName(dir: AssetId): string {
     return assetState.raw.idMap.get(dir)?.name ?? "";
 }
 
-export function getImageSrcFromAssetId(file: AssetId, addBaseUrl = true): string {
+export function getImageSrcFromAssetId(
+    file: AssetId,
+    options?: { addBaseUrl?: boolean; thumbnailFormat?: string },
+): string {
     const fileHash = assetState.raw.idMap.get(file)!.fileHash ?? "";
-    return getImageSrcFromHash(fileHash, addBaseUrl);
+    return getImageSrcFromHash(fileHash, options);
 }
 
-export function getImageSrcFromHash(fileHash: string, addBaseUrl = true): string {
-    const path = `/static/assets/${fileHash.slice(0, 2)}/${fileHash.slice(2, 4)}/${fileHash}`;
-    return addBaseUrl ? baseAdjust(path) : path;
+export function getImageSrcFromHash(
+    fileHash: string,
+    options?: { addBaseUrl?: boolean; thumbnailFormat?: string },
+): string {
+    let path = `/static/assets/${fileHash.slice(0, 2)}/${fileHash.slice(2, 4)}/${fileHash}`;
+    if (options?.thumbnailFormat !== undefined) {
+        path = `${path}.thumb.${options.thumbnailFormat}`;
+    }
+    return (options?.addBaseUrl ?? true) ? baseAdjust(path) : path;
 }

--- a/client/src/core/models/types.ts
+++ b/client/src/core/models/types.ts
@@ -1,3 +1,5 @@
+import type { AssetId } from "../../assetManager/models";
+
 export type AssetListMap = Map<string, AssetListMap | AssetFile[]>;
 export type ReadonlyAssetListMap = ReadonlyMap<string, ReadonlyAssetListMap | AssetFile[]>;
 
@@ -6,7 +8,7 @@ export interface AssetList {
 }
 
 export interface AssetFile {
-    id: number;
+    id: AssetId;
     name: string;
     hash: string;
 }

--- a/client/src/game/dropAsset.ts
+++ b/client/src/game/dropAsset.ts
@@ -96,7 +96,7 @@ async function dropHelper(
         return;
     }
     await dropAsset(
-        { assetId: assetInfo.assetId, imageSource: getImageSrcFromHash(assetInfo.assetHash, false) },
+        { assetId: assetInfo.assetId, imageSource: getImageSrcFromHash(assetInfo.assetHash, { addBaseUrl: false }) },
         location,
     );
 }

--- a/client/src/game/ui/menu/AssetNode.vue
+++ b/client/src/game/ui/menu/AssetNode.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from "vue";
 
-import { AssetId } from "../../../assetManager/models";
+import type { AssetId } from "../../../assetManager/models";
 import { getImageSrcFromHash } from "../../../assetManager/utils";
 import { filter } from "../../../core/iter";
 import type { AssetFile, AssetListMap } from "../../../core/models/types";

--- a/client/src/game/ui/settings/shape/PropertySettings.vue
+++ b/client/src/game/ui/settings/shape/PropertySettings.vue
@@ -122,13 +122,13 @@ async function changeAsset(): Promise<void> {
     if (data === undefined || data.fileHash === undefined) return;
     const shape = getShape(activeShapeStore.state.id);
     if (shape === undefined || shape.type !== "assetrect") return;
-    (shape as Asset).setImage(getImageSrcFromHash(data.fileHash, false), true);
+    (shape as Asset).setImage(getImageSrcFromHash(data.fileHash, { addBaseUrl: false }), true);
 }
 </script>
 
 <template>
     <div v-if="shapeProps" class="panel restore-panel">
-        <div class="spanrow header">{{ t('game.ui.selection.edit_dialog.properties.common') }}</div>
+        <div class="spanrow header">{{ t("game.ui.selection.edit_dialog.properties.common") }}</div>
         <div class="row">
             <label for="shapeselectiondialog-name">{{ t("common.name") }}</label>
             <input
@@ -226,7 +226,7 @@ async function changeAsset(): Promise<void> {
             <label></label>
             <button @click="changeAsset">Change asset</button>
         </div>
-        <div class="spanrow header">{{ t('game.ui.selection.edit_dialog.properties.advanced') }}</div>
+        <div class="spanrow header">{{ t("game.ui.selection.edit_dialog.properties.advanced") }}</div>
         <div class="row">
             <label for="shapeselectiondialog-visionblocker">
                 {{ t("game.ui.selection.edit_dialog.dialog.block_vision_light") }}

--- a/client/src/game/ui/settings/shape/VariantSwitcher.vue
+++ b/client/src/game/ui/settings/shape/VariantSwitcher.vue
@@ -72,7 +72,7 @@ async function addVariant(): Promise<void> {
     if (name === undefined) return;
 
     const newShape = await dropAsset(
-        { imageSource: getImageSrcFromHash(asset.fileHash, false), assetId: asset.id },
+        { imageSource: getImageSrcFromHash(asset.fileHash, { addBaseUrl: false }), assetId: asset.id },
         shape.refPoint,
     );
     if (newShape === undefined) {

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,6 +3,7 @@ aiohttp_security==0.5.0
 aiohttp_session==2.12.1
 bcrypt==4.2.0
 cryptography==43.0.1
+pillow==11.0.0
 python-engineio==4.9.1
 python-socketio==5.11.4
 peewee==3.17.5

--- a/server/src/api/socket/asset_manager/core.py
+++ b/server/src/api/socket/asset_manager/core.py
@@ -295,6 +295,8 @@ async def handle_regular_file(upload_data: ApiAssetUpload, data: bytes, sid: str
         parent=target,
     )
 
+    asset.generate_thumbnails()
+
     asset_dict = transform_asset(asset, user)
     await sio.emit(
         "Asset.Upload.Finish",

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -1,12 +1,10 @@
 import json
-from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 from peewee import ForeignKeyField, TextField
 from typing_extensions import Self, TypedDict
 
-from ...thumbnail import create_thumbnail
-from ...utils import ASSETS_DIR, get_asset_hash_subpath
+from ...thumbnail import generate_thumbnail_for_asset
 from ..base import BaseDbModel
 from ..typed import SelectSequence
 from .asset_share import AssetShare
@@ -84,24 +82,7 @@ class Asset(BaseDbModel):
 
     def generate_thumbnails(self) -> None:
         if self.file_hash:
-            asset_path = ASSETS_DIR / self.file_hash
-            if not asset_path.exists():
-                return
-
-            try:
-                with open(asset_path, "rb") as f:
-                    thumbnail = create_thumbnail(f.read())
-                if thumbnail is None:
-                    return
-                for format, data in thumbnail.items():
-                    full_hash_name = get_asset_hash_subpath(self.file_hash)
-                    path = ASSETS_DIR / Path(f"{full_hash_name}.thumb.{format}")
-
-                    with open(path, "wb") as f:
-                        f.write(data)
-            except Exception as e:
-                print()
-                print(f"Thumbnail generation failed for {self.name}: {e}")
+            generate_thumbnail_for_asset(self.name, self.file_hash)
 
     @classmethod
     def get_root_folder(cls, user) -> Self:

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -1,9 +1,12 @@
 import json
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union, cast
 
 from peewee import ForeignKeyField, TextField
 from typing_extensions import Self, TypedDict
 
+from ...thumbnail import create_thumbnail
+from ...utils import ASSETS_DIR, get_asset_hash_subpath
 from ..base import BaseDbModel
 from ..typed import SelectSequence
 from .asset_share import AssetShare
@@ -78,6 +81,27 @@ class Asset(BaseDbModel):
                     return share
             asset = asset.parent
         return None
+
+    def generate_thumbnails(self) -> None:
+        if self.file_hash:
+            asset_path = ASSETS_DIR / self.file_hash
+            if not asset_path.exists():
+                return
+
+            try:
+                with open(asset_path, "rb") as f:
+                    thumbnail = create_thumbnail(f.read())
+                if thumbnail is None:
+                    return
+                for format, data in thumbnail.items():
+                    full_hash_name = get_asset_hash_subpath(self.file_hash)
+                    path = ASSETS_DIR / Path(f"{full_hash_name}.thumb.{format}")
+
+                    with open(path, "wb") as f:
+                        f.write(data)
+            except Exception as e:
+                print()
+                print(f"Thumbnail generation failed for {self.name}: {e}")
 
     @classmethod
     def get_root_folder(cls, user) -> Self:

--- a/server/src/planarserver.py
+++ b/server/src/planarserver.py
@@ -155,7 +155,7 @@ def server_main(args):
     mimetypes.types_map[".js"] = "application/javascript; charset=utf-8"
 
     if not save_newly_created:
-        save.upgrade_save()
+        save.upgrade_save(loop=loop)
 
     loop.create_task(start_servers())
 

--- a/server/src/thumbnail.py
+++ b/server/src/thumbnail.py
@@ -1,0 +1,45 @@
+import io
+import warnings
+
+from PIL import Image
+
+warnings.simplefilter("ignore", Image.DecompressionBombWarning)
+
+
+def create_thumbnail(input_bytes, max_size=(200, 200)):
+    image = Image.open(io.BytesIO(input_bytes))
+
+    # Handle palette mode with potential transparency
+    if image.mode == "P":
+        image = image.convert("RGBA")
+
+    # Calculate aspect ratio preserving dimensions
+    original_width, original_height = image.size
+    ratio = min(max_size[0] / original_width, max_size[1] / original_height)
+    new_size = (int(original_width * ratio), int(original_height * ratio))
+
+    # Resize using LANCZOS
+    image = image.resize(new_size, Image.Resampling.LANCZOS)
+
+    # Generate both formats
+    jpeg_output = io.BytesIO()
+    webp_output = io.BytesIO()
+
+    # For JPEG (fallback format), we need RGB
+    if image.mode in ("RGBA", "LA"):
+        jpeg_image = Image.new("RGB", image.size, (255, 255, 255))
+        jpeg_image.paste(image, mask=image.split()[-1])
+        jpeg_image.save(jpeg_output, format="JPEG", quality=85, optimize=True)
+    else:
+        image.save(jpeg_output, format="JPEG", quality=85, optimize=True)
+
+    # For WebP, we can keep transparency
+    image.save(
+        webp_output,
+        format="WebP",
+        quality=80,
+        method=4,
+        lossless=False,
+    )
+
+    return {"webp": webp_output.getvalue(), "jpeg": jpeg_output.getvalue()}


### PR DESCRIPTION
When browsing assets in the asset manager, the full images are used as that's the only data we currently have.

This can become quite heavy if a lot of images are shown.

This PR adds support for thumbnails which are 200x200 in size. They are generated in webp and jpeg formats and are stored in the new special `thumbnails` folder in the assets directory. (default is `server/static/assets/`)

The first server boot after this change will start a background task to generate thumbnails for all existing assets. This might spit out some errors for some assets that could not be converted for some reason.  For those assets the full image will be used as a fallback when showing assets. The main reasons for this to fail is that either the image on disk no longer exists or that the image is too big.