### PR TITLE
feat(Dice): Update @planarally/dice to v0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ tech changes will usually be stripped from release notes for the public
     -   Added a reroll button to history entries
     -   Add an option to roll 3D dice inside a dice box rather than over the playfield
     -   Input field now scrolls to the end after populating via the on screen buttons
+-   @planarally/dice:
+    -   (this is the standalone dice library that handles most of the dice logic and rendering)
+    -   Upgraded to v0.7
+    -   Dice will now stop sliding smoother
+    -   Clear state can be configured
+    -   D100 dice now properly work in 3D for the full range (1-100 / 0-99)
+        -   Currently hardcoded to 1-100 in the client, but the library can be told otherwise
 -   I18n:
     -   Added 95% i18n for zh (except diceTool)
 -   [server] Assets:

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,14 +8,14 @@
             "name": "client",
             "version": "2024.3.0",
             "dependencies": {
-                "@babylonjs/core": "^7.20.1",
-                "@babylonjs/materials": "^7.20.1",
+                "@babylonjs/core": "^7.43.0",
+                "@babylonjs/materials": "^7.43.0",
                 "@fortawesome/fontawesome-svg-core": "^6.6.0",
                 "@fortawesome/free-brands-svg-icons": "^6.6.0",
                 "@fortawesome/free-regular-svg-icons": "^6.6.0",
                 "@fortawesome/free-solid-svg-icons": "^6.6.0",
                 "@fortawesome/vue-fontawesome": "^3.0.8",
-                "@planarally/dice": "^0.6.0",
+                "@planarally/dice": "^0.7.0",
                 "mathjs": "^13.2.0",
                 "path-data-polyfill": "^1.0.6",
                 "socket.io-client": "^4.8.0",
@@ -609,23 +609,26 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.20.1.tgz",
-            "integrity": "sha512-gVsU460ZXH0Xb40t9Y8PkZhJ6ZQlAqHPG8vP8/mEuiURFm64v78s+IXG/hb/GQT1Wm5IJcX8MvG0+WWbO2xLbQ=="
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-7.43.0.tgz",
+            "integrity": "sha512-IgIHoju3kprOyJJzKa/3LcprYffl35LVFW55IWGSeZ0hOVnAdUkjDXuGVGue31PKmjVI/uonpsR0nJ4ZHHI4UQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/@babylonjs/gui": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.20.1.tgz",
-            "integrity": "sha512-AqOYCdgo4Z05z6O7geb0m1TDXLi/gKbTD84X2kzce0Zaxg5HEOOfXXPmkAtLu093ycsaf9Jw+ILG8i3qlFOD9Q==",
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-7.43.0.tgz",
+            "integrity": "sha512-P6dyGtUW3Iblr+o7NXK/z2gbByANJ9K3MFMAQTKAODIcdsu+UtzaPTpGvd9lhEph9ih3/B6Myz/u7677IZ8Sqw==",
+            "license": "Apache-2.0",
             "peer": true,
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0"
             }
         },
         "node_modules/@babylonjs/gui-editor": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/gui-editor/-/gui-editor-7.20.1.tgz",
-            "integrity": "sha512-JDNEt6U2UJxhkN9JOoiDpQqhU6rxFAJaG99tcl/32+YuHOZgSoR1H51irq+tDALWFmm3+sPkK0zp9x6I7fJQ8A==",
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/gui-editor/-/gui-editor-7.43.0.tgz",
+            "integrity": "sha512-jPmTVeVMYJ7iU1DX0LUEWKfMn0TEbrBqTeOXbble3kxkMB+frhTM66ds+N0dxGUy02boxG2KLBRUQp0LFGjKZw==",
+            "license": "Apache-2.0",
             "peer": true,
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0",
@@ -635,17 +638,19 @@
             }
         },
         "node_modules/@babylonjs/havok": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/@babylonjs/havok/-/havok-1.3.8.tgz",
-            "integrity": "sha512-FD6fWe4q5Hu4j9ykoDWQxY2Yw//ftxIaULYhVwq2mYGR4YjSsE1hXCt4IjukJGo/SMgp4ZOoJjZysSPxGJwAWg==",
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/@babylonjs/havok/-/havok-1.3.10.tgz",
+            "integrity": "sha512-ddF0LPBVmg+rmPaMmwTPA9FcHyUnrSsQqFoBbYbN51WMhEJQ+7gRFW3J5lML6lN9M/fbknh6bh1ZirZ2bU2B/w==",
+            "license": "MIT",
             "dependencies": {
                 "@types/emscripten": "^1.39.6"
             }
         },
         "node_modules/@babylonjs/inspector": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/inspector/-/inspector-7.20.1.tgz",
-            "integrity": "sha512-R5h5GHXv8FjVibETJX8kwXSjidw4Bo5umhZsjl+Dc9FLplI9qQ3rmV/3ApLmKXtB+9R73fTaPBTmM/CD3++l6g==",
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/inspector/-/inspector-7.43.0.tgz",
+            "integrity": "sha512-SpkRUqhHwK/rU1rS+q/lHDLaOwBySyChVnKZOrclIR+/yDYouzh1aT4kdmHjaL34uGQXcilecyGNnSOOF72siQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.1.0",
                 "@fortawesome/free-regular-svg-icons": "^6.0.0",
@@ -663,9 +668,10 @@
             }
         },
         "node_modules/@babylonjs/loaders": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.20.1.tgz",
-            "integrity": "sha512-yhw4CwoJLnfNX6rlbN9jyEhCATuuCs4qvgWsYF8fxr3wOLUld/vwmtvhd6SwOs4mK61pq3lggS9AfrCtCllqnA==",
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-7.43.0.tgz",
+            "integrity": "sha512-NUPluqw+LmFabr+sbmMa2baaVyZ7CfQmuK+4y+M3i47mqlayvWpN62U66ccLrIhrwN9EGbGmdQqKyrQ3hZ3xTA==",
+            "license": "Apache-2.0",
             "peer": true,
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0",
@@ -673,17 +679,19 @@
             }
         },
         "node_modules/@babylonjs/materials": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.20.1.tgz",
-            "integrity": "sha512-b+8lSwYDC4xiJ9dwiYrpIBsne2nWipxNd1eUQoISMDjId4MRiE0tLNL9Kpm6ba8/PXvjNF7YkeaQlsq+OEZUfA==",
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-7.43.0.tgz",
+            "integrity": "sha512-S2UtMyLHmhw4oedm5gQpaQ2v9tCbyCdh+11ONVvdTc3YOIR98+36zHMC9KdK729Wau50T2392gWkhBd8YHYC8A==",
+            "license": "Apache-2.0",
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0"
             }
         },
         "node_modules/@babylonjs/serializers": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.20.1.tgz",
-            "integrity": "sha512-ND5L0nbu9r3i3oBDwJ3l7GHTKl9YVQtmKO0n2un/fg4BTo15zBISbJaviqCmd1+qkzh9Z18DvgXoW7+pVwzaxA==",
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/serializers/-/serializers-7.43.0.tgz",
+            "integrity": "sha512-pbaWnVHihQ+IgORs2/uvbXo51Qb4ZZ693IKeIAT1Ais9GmvCK7qLH08QOTmhAkG+EO5ZqMRCnWHlu0djY2DEUg==",
+            "license": "Apache-2.0",
             "peer": true,
             "peerDependencies": {
                 "@babylonjs/core": "^7.0.0",
@@ -1617,13 +1625,13 @@
             }
         },
         "node_modules/@planarally/dice": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@planarally/dice/-/dice-0.6.0.tgz",
-            "integrity": "sha512-hY2OXW2aCiUKuBUJxJA0YAfCqYZ55bzGV8/Oo2zJ2duWxEjMwWXiC2xmCNANHQ+Axs8dDU6RbRVb/fY+xZFzUg==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@planarally/dice/-/dice-0.7.0.tgz",
+            "integrity": "sha512-93z5Nul81qECqMyZFpNFxBh3z6j/3JYDjAml1kWFgcoB/XGaF5iLZb4ZS30b3gmZMJ9FrESdSgRhmOuA9167Cg==",
             "dependencies": {
-                "@babylonjs/core": "^7.20.1",
-                "@babylonjs/havok": "^1.3.8",
-                "@babylonjs/inspector": "^7.20.1"
+                "@babylonjs/core": "^7.43.0",
+                "@babylonjs/havok": "^1.3.10",
+                "@babylonjs/inspector": "^7.43.0"
             }
         },
         "node_modules/@polka/url": {
@@ -1876,7 +1884,8 @@
         "node_modules/@types/emscripten": {
             "version": "1.39.13",
             "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.13.tgz",
-            "integrity": "sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw=="
+            "integrity": "sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw==",
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.5",
@@ -1941,29 +1950,24 @@
                 "undici-types": "~5.26.4"
             }
         },
-        "node_modules/@types/prop-types": {
-            "version": "15.7.12",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-            "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-            "peer": true
-        },
         "node_modules/@types/react": {
-            "version": "18.3.3",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-            "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+            "version": "19.0.4",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.4.tgz",
+            "integrity": "sha512-3O4QisJDYr1uTUMZHA2YswiQZRq+Pd8D+GdVFYikTutYsTz+QZgWkAPnP7rx9txoI6EXKcPiluMqWPFV3tT9Wg==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.3.0",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-            "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+            "version": "19.0.2",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.2.tgz",
+            "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
+            "license": "MIT",
             "peer": true,
-            "dependencies": {
-                "@types/react": "*"
+            "peerDependencies": {
+                "@types/react": "^19.0.0"
             }
         },
         "node_modules/@types/swiper": {
@@ -2872,9 +2876,10 @@
             }
         },
         "node_modules/babylonjs-gltf2interface": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.20.1.tgz",
-            "integrity": "sha512-t+vUGmeUcwvBVCLJQR2ERkJBoopGcdiuKBQqdj+dJZk/QDR+/XRMlHWe15ySM0WgMs+LuhRMo27JOoYjFmVnJg==",
+            "version": "7.43.0",
+            "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-7.43.0.tgz",
+            "integrity": "sha512-/I8nyrsEV7ihpiuqNadT9eZxVLdfnIL5wTGovotmoMCUScR+5/Ibm31gD/U2ND8W0JfQxGKEI+aUETlfOceJ1w==",
+            "license": "Apache-2.0",
             "peer": true
         },
         "node_modules/balanced-match": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,14 +18,14 @@
         "coverage": "vitest run --coverage"
     },
     "dependencies": {
-        "@babylonjs/core": "^7.20.1",
-        "@babylonjs/materials": "^7.20.1",
+        "@babylonjs/core": "^7.43.0",
+        "@babylonjs/materials": "^7.43.0",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "^6.6.0",
         "@fortawesome/free-regular-svg-icons": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/vue-fontawesome": "^3.0.8",
-        "@planarally/dice": "^0.6.0",
+        "@planarally/dice": "^0.7.0",
         "mathjs": "^13.2.0",
         "path-data-polyfill": "^1.0.6",
         "socket.io-client": "^4.8.0",

--- a/client/src/game/tools/variants/dice.ts
+++ b/client/src/game/tools/variants/dice.ts
@@ -89,9 +89,13 @@ class DiceTool extends Tool implements ITool {
         if (use3d) {
             const dieDefaults = await generate3dOptions();
             const { diceThrower } = await getDiceEnvironment();
-            roll = await rollString(input, diceState.raw.systems!["3d"], { thrower: diceThrower!, dieDefaults });
+            roll = await rollString(input, diceState.raw.systems!["3d"], {
+                thrower: diceThrower!,
+                dieDefaults,
+                d100Mode: 100 as const,
+            });
         } else {
-            roll = await rollString(input, diceState.raw.systems!["2d"]);
+            roll = await rollString(input, diceState.raw.systems!["2d"], { d100Mode: 100 as const });
         }
 
         if (shareWith !== "none") {


### PR DESCRIPTION
This updates the sister library https://github.com/Kruptein/planarally-dice to v0.7.

This adds some nice functionality:

- D100 rolls in 3D are now done with 2 dice that correctly sum up to 1 total number. The system can be configured to be either 1-100 or 0-99 range.
- 3D dice now have proper restitution and friction so that they no longer slide for a long period after settling. (Contributed by Rexy)
- 3D dice clear is no longer hardcoded, but can be modified. (Contributed by Rexy)

It has to be noted that for the D100 behaviour currently the client will just always select 1-100. The idea is that in the future this can be configured in some UI.