### PR TITLE
bug(ToggleComposites): Fix server delete composite handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ tech changes will usually be stripped from release notes for the public
     -   Input changes could not persist or save on the wrong shape if selection focus was changed while editing (see selection changes)
 -   Modals
     -   Dragging modals (e.g. notes) now also brings them to the foreground as if clicked
+-   Composites:
+    -   Moving composites to a different location could sometimes lead to errors on the client even though the moves were succesful serverside
 
 ## [2024.3.1] - 2024-11-12
 

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -150,13 +150,9 @@ async def send_remove_shapes(
 def _get_shapes_from_uuids(
     uuids: list[str], filter_layer: bool
 ) -> SelectSequence[Shape]:
-    query = Shape.select().where(
-        (Shape.uuid << uuids)  # type: ignore
-    )
+    query = Shape.select().where((Shape.uuid << uuids))  # type: ignore
     if filter_layer:
-        query = query.where(
-            ~(Shape.layer >> None)  # type: ignore
-        )
+        query = query.where(~(Shape.layer >> None))  # type: ignore
     return query
 
 

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -151,11 +151,11 @@ def _get_shapes_from_uuids(
     uuids: list[str], filter_layer: bool
 ) -> SelectSequence[Shape]:
     query = Shape.select().where(
-        (Shape.uuid << uuids)  # pyright: ignore[reportGeneralTypeIssues]
+        (Shape.uuid << uuids)  # type: ignore
     )
     if filter_layer:
         query = query.where(
-            ~(Shape.layer >> None)  # pyright: ignore[reportGeneralTypeIssues]
+            ~(Shape.layer >> None)  # type: ignore
         )
     return query
 
@@ -407,14 +407,19 @@ async def move_shapes(sid: str, raw_data: Any):
     if data.target.layer:
         target_layer = floor.layers.where(Layer.name == data.target.layer)[0]
 
+    shape_uuids = set()
     shapes = []
     old_floor = None
     for shape in _get_shapes_from_uuids(data.shapes, False):
+        if shape.uuid in shape_uuids:
+            continue
+
         # toggle composite patch
         parent = None
         if shape.composite_parent:
             parent = shape.composite_parent[0].parent
             shape = Shape.get_by_id(parent.subtype.active_variant)
+            print(f"Parent found for {shape.uuid}")
 
         layer = target_layer
         if shape.layer:
@@ -425,13 +430,19 @@ async def move_shapes(sid: str, raw_data: Any):
             logger.warn("Attempt to move a shape without layer info")
             continue
 
-        shapes.append((shape, layer))
+        # Shape can be different from the one checked at the start of the loop
+        if shape.uuid not in shape_uuids:
+            shape_uuids.add(shape.uuid)
+            shapes.append((shape, layer))
 
         if parent:
-            shapes.append((parent, layer))
+            if parent.uuid not in shape_uuids:
+                shape_uuids.add(parent.uuid)
+                shapes.append((parent, layer))
             for csa in parent.shape_variants:
                 variant = csa.variant
-                if variant != shape:
+                if variant != shape and variant.uuid not in shape_uuids:
+                    shape_uuids.add(variant.uuid)
                     shapes.append((variant, layer))
 
     if old_floor:


### PR DESCRIPTION
When moving shapes to a different location, the client sends which shapes to move and the server will move them and inform any client still on the old location which shapes to remove.

The server will check for each shape whether it's part of a toggle composite and move all variants along as well. It will also the variants to the list of shapes it sends to clients on the old location to remove.

The client however can sometimes also include the list of variants already in its original move request and the server was not handling this correctly, resulting in multiple requests to remove the same variants to be sent to some clients which would throw an error when they have to remove something a second time when it's already removed.

TL;DR The server now takes into account shapes already handled when moving them