### PR TITLE
bug(Select): Fix resize snapping not respecting earlier snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ tech changes will usually be stripped from release notes for the public
     -   Dragging modals (e.g. notes) now also brings them to the foreground as if clicked
 -   Composites:
     -   Moving composites to a different location could sometimes lead to errors on the client even though the moves were succesful serverside
+-   Select Tool:
+    -   Snapping an existing shape point to some other point could be overriden with a snap to the grid
 
 ## [2024.3.1] - 2024-11-12
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -729,6 +729,7 @@ class SelectTool extends Tool implements ISelectTool {
                         event &&
                         locationSettingsState.raw.useGrid.value &&
                         playerSettingsState.useSnapping(event) &&
+                        !this.snappedToPoint &&
                         this.hasFeature(SelectFeatures.Snapping, features)
                     ) {
                         if (props.blocksVision !== VisionBlock.No)


### PR DESCRIPTION
When moving the point of an existing shape with the select tool you can snap to a point or the grid.

Snapping to points happens during the drag move as a visual indicator. These snaps would however sometimes be overridden on mouse up to be snapped to the grid instead.

This is inconsistent with the behaviour of the draw tool and also just not nice, so it's fixed.