### PR TITLE
bug(Draw): Fix polygon draw vision delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Fixed
+
+-   Draw tool polygon was not updating vision until shape completion
+
 ## [2025.1.1] - 2025-02-08
 
 ### Fixed

--- a/client/src/game/tools/variants/draw/index.ts
+++ b/client/src/game/tools/variants/draw/index.ts
@@ -502,10 +502,15 @@ class DrawTool extends Tool implements ITool {
             }
             const points = this.shape.points;
             const props = getProperties(this.shape.id)!;
-            if (props.blocksVision !== VisionBlock.No && points.length > 1)
+            if (props.blocksVision !== VisionBlock.No && points.length > 1) {
                 visionState.insertConstraint(TriangulationTarget.VISION, this.shape, points.at(-2)!, points.at(-1)!);
-            if (props.blocksMovement && points.length > 1)
+                if (this.shape.floorId !== undefined) visionState.recalculateVision(this.shape.floorId);
+            }
+            if (props.blocksMovement && points.length > 1) {
                 visionState.insertConstraint(TriangulationTarget.MOVEMENT, this.shape, points.at(-2)!, points.at(-1)!);
+                if (this.shape.floorId !== undefined) visionState.recalculateMovement(this.shape.floorId);
+            }
+
             layer.invalidate(false);
             if (!this.shape.preventSync) sendShapeSizeUpdate({ shape: this.shape, temporary: true });
         }


### PR DESCRIPTION
When using the draw tool in polygon mode, the vision redraw was only done at the very end of the shape completion (i.e. when right click is pressed)

It will now re-render on every point.

_I'm slightly confused as to when this broke as this is something that I use frequently and can't remember no longer behaving like this, oh well :D_