### PR TITLE
feat(LoS): LoS quick toggle for DM only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Added
+
+-   New quick toggle to disable LoS rendering for the DM only
+
 ### Changed
 
 -   Access levels are no longer additive

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -10,6 +10,7 @@ import { auraSystem } from "../../systems/auras";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
 import { gameState } from "../../systems/game/state";
+import { locationSettingsSystem } from "../../systems/settings/location";
 import { locationSettingsState } from "../../systems/settings/location/state";
 import { visionState } from "../../vision/state";
 
@@ -76,7 +77,7 @@ export class FowLightingLayer extends FowLayer {
                     // Out of Bounds check
                     if (
                         // It's overkill to check this if fowLos is set
-                        !locationSettingsState.raw.fowLos.value &&
+                        !locationSettingsSystem.isLosActive() &&
                         bb.visibleInCanvas({ w: this.width, h: this.height })
                     ) {
                         this.isEmpty = false;
@@ -94,7 +95,7 @@ export class FowLightingLayer extends FowLayer {
                     if (aura === undefined) continue;
 
                     // Out of Bounds check
-                    if (!locationSettingsState.raw.fowLos.value) {
+                    if (!locationSettingsSystem.isLosActive()) {
                         if (!shapesBoundChecked.has(shape.id)) {
                             shapesBoundChecked.add(shape.id);
                             if (shape._visionBbox?.visibleInCanvas({ w: this.width, h: this.height }) ?? false) {
@@ -158,7 +159,7 @@ export class FowLightingLayer extends FowLayer {
                 }
             }
 
-            if (locationSettingsState.raw.fowLos.value && this.floor === activeFloor.id) {
+            if (locationSettingsSystem.isLosActive() && this.floor === activeFloor.id) {
                 this.ctx.globalCompositeOperation = "source-in";
                 this.ctx.drawImage(
                     floorSystem.getLayer(activeFloor, LayerName.Vision)!.canvas,

--- a/client/src/game/layers/variants/fowVision.ts
+++ b/client/src/game/layers/variants/fowVision.ts
@@ -5,6 +5,7 @@ import { accessState } from "../../systems/access/state";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
 import { gameState } from "../../systems/game/state";
+import { locationSettingsSystem } from "../../systems/settings/location";
 import { locationSettingsState } from "../../systems/settings/location/state";
 import { playerSettingsState } from "../../systems/settings/players/state";
 
@@ -15,7 +16,7 @@ export class FowVisionLayer extends FowLayer {
         if (!this.valid) {
             const originalOperation = this.ctx.globalCompositeOperation;
 
-            if (!locationSettingsState.raw.fowLos.value) {
+            if (!locationSettingsSystem.isLosActive()) {
                 this.ctx.clearRect(0, 0, this.width, this.height);
                 this.valid = true;
                 return;

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -11,7 +11,7 @@ import { initiativeStore } from "../../ui/initiative/state";
 import { floorSystem } from "../floors";
 import { gameState } from "../game/state";
 import { playerSystem } from "../players";
-import { locationSettingsState } from "../settings/location/state";
+import { locationSettingsSystem } from "../settings/location";
 
 import { sendShapeAddOwner, sendShapeDeleteOwner, sendShapeUpdateDefaultOwner, sendShapeUpdateOwner } from "./emits";
 import { accessToServer, ownerToServer } from "./helpers";
@@ -177,7 +177,7 @@ class AccessSystem implements ShapeSystem {
 
         this._updateOwnedState(shapeId);
 
-        if (locationSettingsState.raw.fowLos.value) floorSystem.invalidateLightAllFloors();
+        if (locationSettingsSystem.isLosActive()) floorSystem.invalidateLightAllFloors();
         if (syncTo.ui) initiativeStore._forceUpdate();
     }
 
@@ -224,7 +224,7 @@ class AccessSystem implements ShapeSystem {
             }
         }
 
-        if (locationSettingsState.raw.fowLos.value) {
+        if (locationSettingsSystem.isLosActive()) {
             if (access.vision !== undefined && access.vision !== oldAccess.vision) {
                 const shape = getShape(shapeId);
                 // The shape's aura on it's normal layer might not be up to date yet at this point
@@ -260,7 +260,7 @@ class AccessSystem implements ShapeSystem {
 
         this._updateOwnedState(shapeId);
 
-        if (locationSettingsState.raw.fowLos.value) floorSystem.invalidateLightAllFloors();
+        if (locationSettingsSystem.isLosActive()) floorSystem.invalidateLightAllFloors();
         initiativeStore._forceUpdate();
     }
 

--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -19,6 +19,7 @@ import { clientSystem } from "../client";
 import { floorSystem } from "../floors";
 import { floorState } from "../floors/state";
 import { gameState } from "../game/state";
+import { locationSettingsSystem } from "../settings/location";
 import { locationSettingsState } from "../settings/location/state";
 import { playerSettingsState } from "../settings/players/state";
 
@@ -145,7 +146,7 @@ class PositionSystem implements System {
         $.outOfBounds = true;
         const floor = floorState.currentFloor.value;
         if (floor !== undefined && !gameState.raw.isDm && locationSettingsState.raw.fullFow.value) {
-            if (locationSettingsState.raw.fowLos.value) {
+            if (locationSettingsSystem.isLosActive()) {
                 const visionLayer = floorSystem.getLayer(floor, LayerName.Vision) as FowLayer;
                 if (!visionLayer.isEmpty) {
                     $.outOfBounds = false;
@@ -173,7 +174,7 @@ class PositionSystem implements System {
     returnToBounds(): void {
         let nearest: GlobalPoint | undefined;
         if (!gameState.raw.isDm && locationSettingsState.raw.fullFow.value) {
-            if (locationSettingsState.raw.fowLos.value) {
+            if (locationSettingsSystem.isLosActive()) {
                 // find nearest token
                 nearest = this.findNearest(accessState.activeTokens.value.get("vision")!, (i) => getShape(i));
             }

--- a/client/src/game/systems/settings/location/helpers.ts
+++ b/client/src/game/systems/settings/location/helpers.ts
@@ -1,6 +1,8 @@
 import type { WithLocationDefault } from "./models";
 
-export function isDefaultWrapper(x: number | WithLocationDefault<unknown>): x is WithLocationDefault<unknown> {
-    if (typeof x === "number") return false;
+export function isDefaultWrapper(
+    x: number | boolean | WithLocationDefault<unknown>,
+): x is WithLocationDefault<unknown> {
+    if (typeof x === "number" || typeof x === "boolean") return false;
     return x.default !== undefined && x.location !== undefined;
 }

--- a/client/src/game/systems/settings/location/index.ts
+++ b/client/src/game/systems/settings/location/index.ts
@@ -84,6 +84,14 @@ class LocationSettingsSystem implements System {
         }
     }
 
+    /**
+     * Returns true if the LOS settings are active.
+     * This is the case if the LOS settings are not overwritten and the FOW LOS is enabled.
+     */
+    isLosActive(): boolean {
+        return !raw.losOverwritten && raw.fowLos.value;
+    }
+
     // GRID
 
     setUseGrid(useGrid: boolean | undefined, location: number | undefined, sync: boolean): void {

--- a/client/src/game/systems/settings/location/state.ts
+++ b/client/src/game/systems/settings/location/state.ts
@@ -5,12 +5,13 @@ import type { LocationOptions, WithDefault, WithLocationDefault } from "./models
 
 const init = <T>(x: T): WithLocationDefault<T> => ({ default: x, location: {}, value: x });
 
-type State = { activeLocation: number } & { [key in keyof LocationOptions]: WithLocationDefault<LocationOptions[key]> };
+type _S = {
+    [key in keyof LocationOptions]: WithLocationDefault<LocationOptions[key]>;
+};
+type State = { activeLocation: number; losOverwritten: boolean } & _S;
 
-function getInitState(): State {
+function getInitState(): _S {
     return {
-        activeLocation: 0,
-
         fowLos: init(false),
         fowOpacity: init(0),
         gridType: init(GridType.Square),
@@ -32,7 +33,7 @@ function getInitState(): State {
     };
 }
 
-const state = buildState<State>(getInitState());
+const state = buildState<State>({ ...getInitState(), activeLocation: 0, losOverwritten: false });
 
 function getOption<T>(key: WithLocationDefault<T>, location: number | undefined): WithDefault<T> {
     if (location === undefined) return { value: key.default, default: key.default };
@@ -44,9 +45,11 @@ export const locationSettingsState = {
     ...state,
     getOption,
     reset: () => {
+        state.mutableReactive.activeLocation = 0;
+        state.mutableReactive.losOverwritten = false;
         const i = getInitState();
         for (const key of Object.keys(i)) {
-            const a = key as keyof State;
+            const a = key as keyof _S;
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             state.mutableReactive[a] = i[a] as any; // typing cannot infer Key<>Value relation per key
         }

--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -6,9 +6,11 @@ import { useI18n } from "vue-i18n";
 import { baseAdjust } from "../../../core/http";
 import { ToolMode, ToolName } from "../../models/tools";
 import { accessState } from "../../systems/access/state";
+import { floorSystem } from "../../systems/floors";
 import { gameSystem } from "../../systems/game";
 import { gameState } from "../../systems/game/state";
 import { roomState } from "../../systems/room/state";
+import { locationSettingsState } from "../../systems/settings/location/state";
 import { playerSettingsState } from "../../systems/settings/players/state";
 import { activeModeTools, activeTool, activeToolMode, dmTools, toggleActiveMode, toolMap } from "../../tools/tools";
 import { initiativeStore } from "../initiative/state";
@@ -75,6 +77,11 @@ const toolModes = computed(() => {
 function toggleFakePlayer(): void {
     gameSystem.setFakePlayer(!gameState.raw.isFakePlayer);
 }
+
+function toggleLoS(): void {
+    locationSettingsState.mutableReactive.losOverwritten = !locationSettingsState.raw.losOverwritten;
+    floorSystem.invalidateLightAllFloors();
+}
 </script>
 
 <template>
@@ -106,6 +113,16 @@ function toggleFakePlayer(): void {
                         @click="toggleFakePlayer"
                     >
                         {{ t("game.ui.tools.tools.FP") }}
+                    </div>
+                    <div
+                        :class="{
+                            active: !locationSettingsState.reactive.losOverwritten,
+                            disabled: locationSettingsState.reactive.losOverwritten,
+                        }"
+                        :title="t('game.ui.tools.tools.LOS_title')"
+                        @click="toggleLoS"
+                    >
+                        {{ t("game.ui.tools.tools.LOS") }}
                     </div>
                     <div
                         :class="{ active: initiativeStore.state.isActive }"
@@ -206,6 +223,11 @@ function toggleFakePlayer(): void {
                 &.active {
                     border-color: #39ff14;
                     color: #39ff14;
+                }
+
+                &.disabled {
+                    border-color: #e74c3c;
+                    color: #e74c3c;
                 }
             }
         }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -522,7 +522,9 @@
                     "FP": "FP",
                     "INI": "INI",
                     "FP_title": "Toggle fake-player",
-                    "INI_title": "Toggle Initiative State"
+                    "INI_title": "Toggle Initiative State",
+                    "LOS": "LOS",
+                    "LOS_title": "LoS state (DM only)"
                 },
                 "DiceTool": {
                     "rolling": "Rolling...",


### PR DESCRIPTION
This adds a quick toggle to the DM side to enable/disable LoS (line-of-sight) rendering, but only for the DM. (i.e. players will always see the LoS render if that location setting is enabled).

This allows DMs to easier check if their light setups are correct without having to add temporary shapes or play with the location settings potentially forgetting about it and spoiling things for the players.