### PR TITLE
feat(Vision): Only show DM LoS toggle when relevant

### DIFF
--- a/client/src/game/ui/tools/Tools.vue
+++ b/client/src/game/ui/tools/Tools.vue
@@ -115,6 +115,7 @@ function toggleLoS(): void {
                         {{ t("game.ui.tools.tools.FP") }}
                     </div>
                     <div
+                        v-if="locationSettingsState.reactive.fowLos.value"
                         :class="{
                             active: !locationSettingsState.reactive.losOverwritten,
                             disabled: locationSettingsState.reactive.losOverwritten,


### PR DESCRIPTION
To prevent confusion, the new LoS DM quick toggle will only show up when LoS is enabled for the campaign/location.