### PR TITLE
bug(Select): Fix DM not being able to select shapes without vision access

### DIFF
--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -259,7 +259,7 @@ export abstract class Shape implements IShape {
         this.invalidatePoints();
 
         // Update off-screen token directions
-        if (accessSystem.hasAccessTo(this.id, "vision", true)) {
+        if (accessSystem.hasAccessTo(this.id, "vision")) {
             const floor = this.floor;
             if (floor !== undefined) floorSystem.getLayer(floor, LayerName.Draw)?.invalidate(true);
         }
@@ -296,7 +296,7 @@ export abstract class Shape implements IShape {
         this.updateShapeVision(false, false);
 
         // Update off-screen token directions
-        if (accessSystem.hasAccessTo(this.id, "vision", true)) {
+        if (accessSystem.hasAccessTo(this.id, "vision")) {
             const floor = this.floor;
             if (floor !== undefined) floorSystem.getLayer(floor, LayerName.Draw)?.invalidate(true);
         }

--- a/client/src/game/shapes/variants/asset.ts
+++ b/client/src/game/shapes/variants/asset.ts
@@ -70,7 +70,7 @@ export class Asset extends BaseRect implements IAsset {
         this.layer?.invalidate(true);
 
         // invalidate token directions
-        if (accessSystem.hasAccessTo(this.id, "vision", true)) {
+        if (accessSystem.hasAccessTo(this.id, "vision")) {
             const floor = this.floor;
             if (floor !== undefined) floorSystem.getLayer(floor, LayerName.Draw)?.invalidate(true);
         }

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -336,7 +336,7 @@ class SelectTool extends Tool implements ISelectTool {
                 }
             }
             if (shape.contains(gp)) {
-                if (!accessSystem.hasAccessTo(shape.id, "vision", true) && !visionState.isInVision(lp)) {
+                if (!accessSystem.hasAccessTo(shape.id, "vision", !gameState.raw.isDm) && !visionState.isInVision(lp)) {
                     continue;
                 }
                 const shapeSelectionIndex = this.currentSelection.findIndex((s) => s.id === shape.id);
@@ -629,7 +629,7 @@ class SelectTool extends Tool implements ISelectTool {
                 // We check the 4 corners of the shape's AABB as well as the midpoints
                 // If at least 4 are in vision, we consider enough of the shape to be visible
                 if (pendingAdd) {
-                    let checksOk = accessSystem.hasAccessTo(shape.id, "vision", true);
+                    let checksOk = accessSystem.hasAccessTo(shape.id, "vision", !gameState.raw.isDm);
                     if (!checksOk) {
                         let successChecks = 0;
                         for (const p of getHalfPoints(map(shape.getAABB().points, (p) => g2l(toGP(p))))) {


### PR DESCRIPTION
An update to the select code was a bit too strict and limited the DM itself also to vision access requirements for select purposes which we don't want.