### PR TITLE
bug(Access): Fix access toggles not correctly updating

### DIFF
--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -189,15 +189,15 @@ class AccessSystem implements ShapeSystem {
 
         const oldAccess = mutable.access.get(shapeId)?.get(user) ?? DEFAULT_ACCESS;
 
-        // Check owned-token changes
-        this._updateOwnedState(shapeId);
-
         // Commit to state
         const newAccess = { ...oldAccess, ...access };
         if (!mutable.access.has(shapeId)) {
             mutable.access.set(shapeId, new Map());
         }
         mutable.access.get(shapeId)!.set(user, newAccess);
+
+        // Check owned-token changes
+        this._updateOwnedState(shapeId);
 
         if ($.id === shapeId) {
             if (user === DEFAULT_ACCESS_SYMBOL) {


### PR DESCRIPTION
When toggling access rights the sync to the server happens correctly, but the internal state was updated at a wrong time causing the old data to be used and ultimately the wrong visual render to happen.