### PR TITLE
feat(Render): Remove render calls on non-draw layers for some tools

### DIFF
--- a/client/src/game/tools/variants/ping.ts
+++ b/client/src/game/tools/variants/ping.ts
@@ -1,6 +1,6 @@
 import { l2g } from "../../../core/conversions";
 import type { GlobalPoint, LocalPoint } from "../../../core/geometry";
-import { InvalidationMode, NO_SYNC, SyncMode } from "../../../core/models/types";
+import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import { i18n } from "../../../i18n";
 import { sendShapePositionUpdate } from "../../api/emits/shape/core";
 import { LayerName } from "../../models/floor";
@@ -8,10 +8,8 @@ import { ToolName } from "../../models/tools";
 import type { ITool, ToolPermission } from "../../models/tools";
 import { deleteShapes } from "../../shapes/utils";
 import { Circle } from "../../shapes/variants/circle";
-import { accessSystem } from "../../systems/access";
 import { floorSystem } from "../../systems/floors";
 import { floorState } from "../../systems/floors/state";
-import { playerSystem } from "../../systems/players";
 import { playerSettingsState } from "../../systems/settings/players/state";
 import { SelectFeatures } from "../models/select";
 import { Tool } from "../tool";
@@ -33,7 +31,7 @@ class PingTool extends Tool implements ITool {
             return;
 
         this.active.value = false;
-        deleteShapes([this.ping, this.border], SyncMode.TEMP_SYNC);
+        deleteShapes([this.ping, this.border], SyncMode.TEMP_SYNC, false);
         this.ping = undefined;
         this.startPoint = undefined;
     }
@@ -69,18 +67,6 @@ class PingTool extends Tool implements ITool {
         );
         this.ping.ignoreZoomSize = true;
         this.border.ignoreZoomSize = true;
-        accessSystem.addAccess(
-            this.ping.id,
-            playerSystem.getCurrentPlayer()!.name,
-            { edit: false, movement: false, vision: false },
-            NO_SYNC,
-        );
-        accessSystem.addAccess(
-            this.border.id,
-            playerSystem.getCurrentPlayer()!.name,
-            { edit: false, movement: false, vision: false },
-            NO_SYNC,
-        );
         layer.addShape(this.ping, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
         layer.addShape(this.border, SyncMode.TEMP_SYNC, InvalidationMode.NORMAL);
         return Promise.resolve();

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -19,7 +19,7 @@ import { DEFAULT_GRID_SIZE } from "../../../../core/grid";
 import { baseAdjust } from "../../../../core/http";
 import { map } from "../../../../core/iter";
 import { equalPoints, rotateAroundPoint, snapToPoint } from "../../../../core/math";
-import { InvalidationMode, NO_SYNC, SyncMode } from "../../../../core/models/types";
+import { InvalidationMode, SyncMode } from "../../../../core/models/types";
 import { ctrlOrCmdPressed } from "../../../../core/utils";
 import { i18n } from "../../../../i18n";
 import { sendRequest } from "../../../api/emits/logic";
@@ -410,12 +410,6 @@ class SelectTool extends Tool implements ISelectTool {
                 );
                 this.selectionHelper.strokeWidth = 2;
                 this.selectionHelper.options.UiHelper = true;
-                accessSystem.addAccess(
-                    this.selectionHelper.id,
-                    playerSystem.getCurrentPlayer()!.name,
-                    { edit: false, movement: false, vision: false },
-                    NO_SYNC,
-                );
                 drawLayer.addShape(this.selectionHelper, SyncMode.NO_SYNC, InvalidationMode.NO);
             } else {
                 this.selectionHelper.refPoint = this.selectionStartPoint;
@@ -431,7 +425,6 @@ class SelectTool extends Tool implements ISelectTool {
                 this.removeRotationUi();
             }
 
-            layer.invalidate(true);
             drawLayer.invalidate(true);
         }
         if (this.checkRuler()) {
@@ -976,12 +969,6 @@ class SelectTool extends Tool implements ISelectTool {
         );
 
         for (const rotationShape of [this.rotationAnchor, this.rotationBox, this.rotationEnd]) {
-            accessSystem.addAccess(
-                rotationShape.id,
-                playerSystem.getCurrentPlayer()!.name,
-                { edit: false, movement: false, vision: false },
-                NO_SYNC,
-            );
             layer.addShape(rotationShape, SyncMode.NO_SYNC, InvalidationMode.NO);
         }
 


### PR DESCRIPTION
I noticed the tools that have UI helpers (select/ruler/ping) were also re-rendering non-draw layers while nothing is really going on on the other layers. This was due to some generic vision update code in the access code. Though these tools don't really need access rights anyway.

This is ultimately a small tweak that won't contribute to any noticeable speed improvement, but can help me with debugging things.