### PR TITLE
feat(Select): Move select rotation UI over fog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ tech changes will usually be stripped from release notes for the public
 -   Access levels are no longer additive
     -   e.g. edit access used to automatically include movement & vision access, this is no longer the case
 -   Selection draw box now appears on top of the fog
+-   Selection rotate UI now appears on top fo the fog
 
 ### Removed
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -919,12 +919,12 @@ class SelectTool extends Tool implements ISelectTool {
     // ROTATION
 
     createRotationUi(features: ToolFeatures<SelectFeatures>): void {
-        const layer = floorState.currentLayer.value!;
-
         const layerSelection = this.currentSelection;
 
         if (layerSelection.length === 0 || this.rotationUiActive || !this.hasFeature(SelectFeatures.Rotate, features))
             return;
+
+        const layer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Draw)!;
 
         let bbox: BoundingRect;
         if (layerSelection.length === 1) {


### PR DESCRIPTION
The rotation UI was obscured by fog, which is inconvenient for players.