### PR TITLE
bug(Select0: Fix select rotation UI not showing when toggling mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ tech changes will usually be stripped from release notes for the public
 -   Draw tool polygon was not updating vision until shape completion
 -   Reduced some render overhead when token shapes that the player did not own were moved
 -   Shape context menu not closing when selecting an option
+-   Select tool build UI not appearing when mode toggling
 
 ## [2025.1.1] - 2025-02-08
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -919,7 +919,10 @@ class SelectTool extends Tool implements ISelectTool {
     // ROTATION
 
     createRotationUi(features: ToolFeatures<SelectFeatures>): void {
-        const layerSelection = this.currentSelection;
+        // Check both current selection and selected system
+        // This can be entered through different means (e.g. mode change or selection change)
+        const layerSelection =
+            this.currentSelection.length > 0 ? this.currentSelection : selectedSystem.get({ includeComposites: false });
 
         if (layerSelection.length === 0 || this.rotationUiActive || !this.hasFeature(SelectFeatures.Rotate, features))
             return;


### PR DESCRIPTION
This bug was introduced with the improvements to selection sync handling in the last release.