### PR TITLE
bug(Dice): Multiple d100 rolls don't work properly

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,7 @@
                 "@fortawesome/free-regular-svg-icons": "^6.7.2",
                 "@fortawesome/free-solid-svg-icons": "^6.7.2",
                 "@fortawesome/vue-fontawesome": "^3.0.8",
-                "@planarally/dice": "^0.7.0",
+                "@planarally/dice": "^0.7.1",
                 "mathjs": "^14.2.1",
                 "path-data-polyfill": "^1.0.6",
                 "socket.io-client": "^4.8.1",
@@ -1956,9 +1956,9 @@
             }
         },
         "node_modules/@planarally/dice": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@planarally/dice/-/dice-0.7.0.tgz",
-            "integrity": "sha512-93z5Nul81qECqMyZFpNFxBh3z6j/3JYDjAml1kWFgcoB/XGaF5iLZb4ZS30b3gmZMJ9FrESdSgRhmOuA9167Cg==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@planarally/dice/-/dice-0.7.1.tgz",
+            "integrity": "sha512-sCq4F4vdPnoHeKKAHXme7n/UKXWbuCEZkQpr4RnwBQe6ii/tU7BLr82XBZCrdIcb1xHNweU0DIbPUPA79RULgQ==",
             "dependencies": {
                 "@babylonjs/core": "^7.43.0",
                 "@babylonjs/havok": "^1.3.10",

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/vue-fontawesome": "^3.0.8",
-        "@planarally/dice": "^0.7.0",
+        "@planarally/dice": "^0.7.1",
         "mathjs": "^14.2.1",
         "path-data-polyfill": "^1.0.6",
         "socket.io-client": "^4.8.1",


### PR DESCRIPTION
A bug in the algorithm for handling multiple d100 rolls in the pa-dice library was resolved in version 0.7.1.

This fixes #1552