### PR TITLE
chore(Server): Update server shutdown sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ tech changes will usually be stripped from release notes for the public
     -   e.g. edit access used to automatically include movement & vision access, this is no longer the case
 -   Selection draw box now appears on top of the fog
 -   Selection rotate UI now appears on top fo the fog
+-   [tech] Server shutdown sequence has been modified
 
 ### Removed
 

--- a/server/src/app.py
+++ b/server/src/app.py
@@ -31,7 +31,7 @@ async def setup_runner(app: web.Application, site: Type[web.BaseSite], **kwargs)
     runner = web.AppRunner(app)
     runners.append(runner)
     await runner.setup()
-    s = site(runner, **kwargs)
+    s = site(runner, shutdown_timeout=5, **kwargs)
     app.loop.set_exception_handler(handle_async_exception)
     await s.start()
 

--- a/server/src/state/__init__.py
+++ b/server/src/state/__init__.py
@@ -1,14 +1,28 @@
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Dict, Generator, Generic, Tuple, TypeVar
 
+from ..app import sio
 from ..db.models.user import User
 
 T = TypeVar("T")
 
 
 class State(ABC, Generic[T]):
-    def __init__(self) -> None:
+    def __init__(self, namespace: str | None) -> None:
         self._sid_map: Dict[str, T] = {}
+        self.namespace = namespace
+
+    async def disconnect_all(self) -> None:
+        if self.namespace is None:
+            return
+
+        await asyncio.gather(
+            *[
+                sio.disconnect(sid, namespace=self.namespace)
+                for sid in self._sid_map.keys()
+            ]
+        )
 
     async def add_sid(self, sid: str, value: T) -> None:
         self._sid_map[sid] = value

--- a/server/src/state/asset.py
+++ b/server/src/state/asset.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from ..api.models.asset import ApiAssetUpload
+from ..api.socket.constants import ASSET_NS
 from ..app import app
 from ..db.models.user import User
 from . import State
@@ -8,7 +9,7 @@ from . import State
 
 class AssetState(State[User]):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(ASSET_NS)
         self.pending_file_upload_cache: Dict[str, Dict[int, ApiAssetUpload]] = {}
 
     def get_user(self, sid: str) -> User:

--- a/server/src/state/auth.py
+++ b/server/src/state/auth.py
@@ -9,7 +9,7 @@ from . import State
 
 class AuthState(State[User]):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(None)
         # reset_tokens[token] = (user_id, expiration)
         self.reset_tokens: Dict[str, tuple[int, datetime]] = {}
 

--- a/server/src/state/dashboard.py
+++ b/server/src/state/dashboard.py
@@ -1,3 +1,4 @@
+from ..api.socket.constants import DASHBOARD_NS
 from ..app import app
 from ..db.models.user import User
 from . import State
@@ -5,7 +6,7 @@ from . import State
 
 class DashboardState(State[User]):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(DASHBOARD_NS)
 
     def get_user(self, sid: str) -> User:
         return self._sid_map[sid]

--- a/server/src/state/game.py
+++ b/server/src/state/game.py
@@ -10,7 +10,7 @@ from . import State
 
 class GameState(State[PlayerRoom]):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(GAME_NS)
         self.client_temporaries: Dict[str, Set[str]] = {}
         self.client_viewports: Dict[str, Viewport] = {}
 
@@ -28,7 +28,7 @@ class GameState(State[PlayerRoom]):
             await sio.emit(
                 "Temp.Clear",
                 list(self.client_temporaries[sid]),
-                namespace=GAME_NS,
+                namespace=self.namespace,
             )
             if sid in self.client_temporaries:
                 del self.client_temporaries[sid]


### PR DESCRIPTION
This cleans up the server shutdown sequence a bit.

- DB close is now ran in the on_cleanup hook instead of the on_shutdown hook.
- The dashboard sockets were not being cleaned up explicitly
- The asset socket was being cleaned up with the wrong namespace
- A text is printed on shutdown to ensure that the shutdown process started