### PR TITLE
chore: Use logger.warning instead of logger.warn

### DIFF
--- a/server/src/api/helpers.py
+++ b/server/src/api/helpers.py
@@ -35,7 +35,7 @@ async def send_log_toast(
     event_name = "Toast."
     if severity == "warn":
         event_name += "Warn"
-        logger.warn(message)
+        logger.warning(message)
     else:
         logger.debug(message)
 

--- a/server/src/api/socket/asset_manager/core.py
+++ b/server/src/api/socket/asset_manager/core.py
@@ -117,7 +117,7 @@ async def create_folder(sid: str, raw_data: Any):
 
     asset = Asset.get_by_id(data.parent)
     if not asset.can_be_accessed_by(user, right="edit"):
-        logger.warn(f"{user.name} attempted to create a folder without permissions")
+        logger.warning(f"{user.name} attempted to create a folder without permissions")
         return
 
     asset = Asset.create(name=data.name, owner=user, parent=data.parent)
@@ -142,7 +142,7 @@ async def move_inode(sid: str, raw_data: Any):
 
     # The user NEEDS edit access in the target folder
     if not target.can_be_accessed_by(user, right="edit"):
-        logger.warn(
+        logger.warning(
             f"{user.name} attempted to move an asset into a folder they don't own"
         )
         return
@@ -319,7 +319,9 @@ async def assetmgmt_upload(sid: str, raw_data: Any):
 
     if asset := Asset.get_or_none(id=upload_data.directory):
         if not asset.can_be_accessed_by(user, right="edit"):
-            logger.warn(f"{user.name} attempted to upload into a folder they don't own")
+            logger.warning(
+                f"{user.name} attempted to upload into a folder they don't own"
+            )
             return
 
     uuid = upload_data.uuid
@@ -344,12 +346,12 @@ async def assetmgmt_upload(sid: str, raw_data: Any):
     max_total_asset_size = config.getint("Webserver", "max_total_asset_size_in_bytes")
 
     if max_single_asset_size > 0 and len(data) > max_single_asset_size:
-        logger.warn(
+        logger.warning(
             f"{user.name} attempted to upload a file that is too large ({len(data)} > {max_single_asset_size})"
         )
         return
     if max_total_asset_size > 0 and total_asset_size + len(data) > max_total_asset_size:
-        logger.warn(
+        logger.warning(
             f"{user.name} attempted to upload a file that is too large ({total_asset_size + len(data)} > {max_total_asset_size})"
         )
         return

--- a/server/src/api/socket/asset_manager/share.py
+++ b/server/src/api/socket/asset_manager/share.py
@@ -96,7 +96,7 @@ async def edit_asset_share(sid: str, raw_data: Any):
                 users_with_edit_access.append(share.user)
 
         if initiating_user not in users_with_edit_access:
-            logger.warn(
+            logger.warning(
                 f"{initiating_user.name} attempted to edit asset share rights without permissions."
             )
             return
@@ -117,10 +117,10 @@ async def edit_asset_share(sid: str, raw_data: Any):
                         )
                 break
         else:
-            logger.warn("Attempt to edit non-existing asset share.")
+            logger.warning("Attempt to edit non-existing asset share.")
             return
     else:
-        logger.warn("Attempt to edit asset share from unknown shape.")
+        logger.warning("Attempt to edit asset share from unknown shape.")
         return
 
 
@@ -140,7 +140,7 @@ async def remove_asset_share(sid: str, raw_data: Any):
                 users_with_edit_access.append(share.user)
 
         if initiating_user not in users_with_edit_access:
-            logger.warn(
+            logger.warning(
                 f"{initiating_user.name} attempted to remove asset share rights without permissions."
             )
             return
@@ -160,10 +160,10 @@ async def remove_asset_share(sid: str, raw_data: Any):
                         )
                 break
         else:
-            logger.warn("Attempt to remove non-existing asset share.")
+            logger.warning("Attempt to remove non-existing asset share.")
             return
     else:
-        logger.warn("Attempt to remove asset share from unknown shape.")
+        logger.warning("Attempt to remove asset share from unknown shape.")
         return
 
 

--- a/server/src/api/socket/character.py
+++ b/server/src/api/socket/character.py
@@ -26,10 +26,10 @@ async def create_character(sid: str, raw_data: Any):
         logger.error("Attempt to create character for incorrect shape")
         return
     elif not has_ownership(shape, pr, edit=True):
-        logger.warn("Attempt to create character without access")
+        logger.warning("Attempt to create character without access")
         return
     elif shape.character_id is not None:
-        logger.warn("Shape is already associated with a character")
+        logger.warning("Shape is already associated with a character")
         return
 
     try:

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -595,7 +595,7 @@ async def get_location_spawn_info(sid: str, location_id: int):
                     pass
                 else:
                     if shape.layer is None:
-                        logger.warn("Spawn location without layer detected")
+                        logger.warning("Spawn location without layer detected")
                         continue
                     data.append(
                         ApiSpawnInfo(

--- a/server/src/api/socket/note.py
+++ b/server/src/api/socket/note.py
@@ -93,7 +93,7 @@ async def set_note_title(sid: str, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update note not belonging to them.")
+        logger.warning(f"{pr.player.name} tried to update note not belonging to them.")
         return
 
     with db.atomic():
@@ -121,7 +121,7 @@ async def set_note_text(sid: str, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update note not belonging to them.")
+        logger.warning(f"{pr.player.name} tried to update note not belonging to them.")
         return
 
     with db.atomic():
@@ -149,7 +149,7 @@ async def add_note_tag(sid: str, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update note not belonging to them.")
+        logger.warning(f"{pr.player.name} tried to update note not belonging to them.")
         return
 
     tags: list[str] = json.loads(note.tags or "[]")
@@ -180,7 +180,7 @@ async def remove_note_tag(sid: str, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update note not belonging to them.")
+        logger.warning(f"{pr.player.name} tried to update note not belonging to them.")
         return
 
     tags: list[str] = json.loads(note.tags or "[]")
@@ -209,7 +209,9 @@ async def delete_note(sid, uuid):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to remove a note not belonging to them.")
+        logger.warning(
+            f"{pr.player.name} tried to remove a note not belonging to them."
+        )
         return
 
     note.delete_instance()
@@ -236,7 +238,9 @@ async def add_note_access(sid, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update a note not belonging to them.")
+        logger.warning(
+            f"{pr.player.name} tried to update a note not belonging to them."
+        )
         return
 
     user = None
@@ -275,7 +279,9 @@ async def edit_note_access(sid, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update a note not belonging to them.")
+        logger.warning(
+            f"{pr.player.name} tried to update a note not belonging to them."
+        )
         return
 
     old_default_can_view = False
@@ -336,7 +342,9 @@ async def remove_note_access(sid, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update a note not belonging to them.")
+        logger.warning(
+            f"{pr.player.name} tried to update a note not belonging to them."
+        )
         return
 
     default_can_view = False
@@ -372,7 +380,7 @@ async def add_shape(sid, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(
+        logger.warning(
             f"{pr.player.name} tried to add a shape to a note not belonging to them."
         )
         return
@@ -402,7 +410,7 @@ async def remove_shape(sid, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(
+        logger.warning(
             f"{pr.player.name} tried to add a shape to a note not belonging to them."
         )
         return
@@ -430,7 +438,7 @@ async def set_show_on_hover(sid: str, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update note not belonging to them.")
+        logger.warning(f"{pr.player.name} tried to update note not belonging to them.")
         return
 
     note.show_on_hover = data.value
@@ -457,7 +465,7 @@ async def set_show_icon_on_shape(sid: str, raw_data: Any):
         return
 
     if not can_edit(note, pr.player):
-        logger.warn(f"{pr.player.name} tried to update note not belonging to them.")
+        logger.warning(f"{pr.player.name} tried to update note not belonging to them.")
         return
 
     note.show_icon_on_shape = data.value

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -423,7 +423,7 @@ async def move_shapes(sid: str, raw_data: Any):
                 old_floor = shape.layer.floor
             layer = floor.layers.where(Layer.name == shape.layer.name)[0]
         elif layer is None:
-            logger.warn("Attempt to move a shape without layer info")
+            logger.warning("Attempt to move a shape without layer info")
             continue
 
         # Shape can be different from the one checked at the start of the loop


### PR DESCRIPTION
logger.warn was long deprecated and does no longer exist in python 3.13