### PR TITLE
chore(Settings): Success notification on email change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tech changes will usually be stripped from release notes for the public
 -   New quick toggle to disable LoS rendering for the DM only
 -   Forgot password flow if Mail is configured on the server
     -   This only works if the user account actually has an email-address
+-   Success notification when changing email in the settings
 -   [server] Email configuration setup
 
 ### Changed

--- a/client/src/dashboard/Settings.vue
+++ b/client/src/dashboard/Settings.vue
@@ -31,7 +31,7 @@ async function setEmail(event: Event): Promise<void> {
         });
         if (result.ok) {
             coreStore.setEmail(value);
-            // todo: show some kind of notification to notify of success
+            toast.success(t("dashboard.settings.email_changed"));
         } else {
             (event.target as HTMLInputElement).value = coreStore.state.email ?? "";
         }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -136,6 +136,9 @@
             "no_sessions": "No active campaigns",
             "create_session": "Create a campaign",
             "create_new_session": "Create a new campaign"
+        },
+        "settings": {
+            "email_changed": "Email changed successfully"
         }
     },
     "game": {


### PR DESCRIPTION
There is no visual indication whatsoever that informs you that a change to the email actually did something in the dashboard settings UI.

I was even under the impression that modification was actually not possible, but it turns out any change is saved. This PR adds a small notification popup to ensure this is slightly more obvious.