### PR TITLE
chore(Tech: Modals): Add a prop to PanelModal tabs to learn if they're selected

### DIFF
--- a/client/src/core/components/modals/PanelModal.vue
+++ b/client/src/core/components/modals/PanelModal.vue
@@ -21,7 +21,14 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 const selection = ref(props.tabs[0]?.category);
-const activeTab = computed(() => props.tabs.find((t) => t.category === selection.value));
+const activeTab = computed(() => {
+    const tab = props.tabs.find((t) => t.category === selection.value);
+    if (tab === undefined) return undefined;
+    return {
+        ...tab,
+        props: { ...tab.props, tabSelected: computed(() => tab.category === selection.value) },
+    };
+});
 
 watchEffect(() => {
     if (props.initialSelection === undefined) {


### PR DESCRIPTION
This is a purely internal technical change that passes a computed prop to the panel tabs so that they can act on being specifically selected.