### PR TITLE
chore(UI): Move zoom & selection info UI behind modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ They will be removed in a future release though.
     -   e.g. edit access used to automatically include movement & vision access, this is no longer the case
 -   Selection draw box now appears on top of the fog
 -   Selection rotate UI now appears on top fo the fog
+-   Moved zoom bar and selection info behind main modals when overlapping
+    -   the selection info can pop-over when hovered with the mouse
 -   [server] Server config setup has changed
     -   The server config is now by default stored in the `data` directory and in toml format
     -   It's no longer tracked in git, as the default values are now coded in python itself

--- a/client/src/core/components/slider/SliderDot.vue
+++ b/client/src/core/components/slider/SliderDot.vue
@@ -51,7 +51,6 @@ $tooltipPadding: 2px 5px !default;
 
 .vue-slider-dot {
     position: absolute;
-    z-index: 5;
 
     transform: translate(-50%, -50%);
     top: 50%;

--- a/client/src/game/ui/SelectionInfo.vue
+++ b/client/src/game/ui/SelectionInfo.vue
@@ -209,7 +209,6 @@ function annotate(note: DeepReadonly<ClientNote>): void {
     flex-direction: column;
     top: 75px;
     right: 0;
-    z-index: 10;
     opacity: 0.5;
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
@@ -218,6 +217,7 @@ function annotate(note: DeepReadonly<ClientNote>): void {
 
     &:hover {
         opacity: 1;
+        z-index: 10;
 
         > div:first-child {
             background-color: #82c8a0;

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -193,13 +193,6 @@ function setTempZoomDisplay(value: number): void {
         <ShapeContext />
         <Annotation />
         <SelectionInfo />
-        <!-- Modals that can be rearranged -->
-        <ModalStack />
-        <!-- Modals that require immediate attention -->
-        <CreateTokenDialog />
-        <div id="teleport-modals"></div>
-        <MarkdownModal v-if="showChangelog" :title="t('game.ui.ui.new_ver_msg')" :source="changelogText" />
-        <!-- end of main modals -->
         <!-- When updating zoom boundaries, also update store updateZoom function;
             should probably do this using a store variable-->
         <SliderComponent
@@ -214,6 +207,13 @@ function setTempZoomDisplay(value: number): void {
             :max="1"
             @change="setTempZoomDisplay"
         />
+        <!-- Modals that can be rearranged -->
+        <ModalStack />
+        <!-- Modals that require immediate attention -->
+        <CreateTokenDialog />
+        <div id="teleport-modals"></div>
+        <MarkdownModal v-if="showChangelog" :title="t('game.ui.ui.new_ver_msg')" :source="changelogText" />
+        <!-- end of main modals -->
     </div>
 </template>
 


### PR DESCRIPTION
When modals are open and in the top-right, there is the odd behaviour of the selection info and the zoom bar overlapping the dialog which is kinda jarring.

This PR changes those elements to be lower in the UI stack. For the selection info however it will still pop-over the active dialog if you hover over a visible section of it.