### PR TITLE
fix: Add unique constraint to usernames

### DIFF
--- a/server/src/db/models/user.py
+++ b/server/src/db/models/user.py
@@ -22,7 +22,7 @@ class User(BaseDbModel):
     rooms_created: SelectSequence["Room"]
     rooms_joined: SelectSequence["PlayerRoom"]
 
-    name = cast(str, TextField())
+    name = cast(str, TextField(unique=True))
     email = TextField(null=True)
     password_hash = cast(str, TextField())
     default_options = cast(

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 102
+SAVE_VERSION = 103
 
 import asyncio
 import json
@@ -460,6 +460,9 @@ def upgrade(
             db.execute_sql(
                 'CREATE INDEX "mod_player_room_player_room_id" ON "mod_player_room" ("player_room_id");'
             )
+    elif version == 102:
+        with db.atomic():
+            db.execute_sql("CREATE UNIQUE INDEX unique_username ON user(name);")
     else:
         raise UnknownVersionException(
             f"No upgrade code for save format {version} was found."


### PR DESCRIPTION
Hi,

This merge will address https://github.com/Kruptein/PlanarAlly/issues/1589 by adding a `unique` constraint to usernames.  After setting up my dev environment, I attempted to create two `admin_test` users and it failed as expected:

```bash
>>> from src.db.all import User;
>>> User.create_new('admin_test', 'change_me')
2025-05-05 12:25:36,251 - CRITICAL - Uncaught exception (logs.py:33)
Traceback (most recent call last):
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 3322, in execute_sql
    cursor.execute(sql, params or ())
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
sqlite3.IntegrityError: UNIQUE constraint failed: user.name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    User.create_new('admin_test', 'change_me')
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/egg/code/PlanarAlly/server/src/db/models/user.py", line 79, in create_new
    u.save()
    ~~~~~~^^
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/playhouse/signals.py", line 71, in save
    ret = super(Model, self).save(*args, **kwargs)
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 6956, in save
    pk = self.insert(**field_dict).execute()
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 2036, in inner
    return method(self, database, *args, **kwargs)
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 2107, in execute
    return self._execute(database)
           ~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 2912, in _execute
    return super(Insert, self)._execute(database)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 2625, in _execute
    cursor = database.execute(self)
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 3330, in execute
    return self.execute_sql(sql, params)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 3320, in execute_sql
    with __exception_wrapper__:
         ^^^^^^^^^^^^^^^^^^^^^
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 3088, in __exit__
    reraise(new_type, new_type(exc_value, *exc_args), traceback)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 196, in reraise
    raise value.with_traceback(tb)
  File "/home/egg/code/PlanarAlly/server/.venv/lib/python3.13/site-packages/peewee.py", line 3322, in execute_sql
    cursor.execute(sql, params or ())
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
peewee.IntegrityError: UNIQUE constraint failed: user.name
```