### PR TITLE
bug(Config): Ensure config is always loaded before database setup

### DIFF
--- a/server/src/__init__.py
+++ b/server/src/__init__.py
@@ -1,0 +1,3 @@
+from . import config
+
+__all__ = ["config"]


### PR DESCRIPTION
This fixes some cases where the database could be opened before the config was read. This could mean the wrong `save_path` was being used.

This primarily affects non-default server usage. (e.g. using a python shell)