### PR TITLE
bug(Loading): Handle whitescreen during load

### DIFF
--- a/client/src/game/clear.ts
+++ b/client/src/game/clear.ts
@@ -12,7 +12,8 @@ export function clearGame(reason: SystemClearReason): void {
     stopDrawLoop();
     visionState.clear();
     locationStore.setLocations([], false);
-    document.getElementById("layers")!.innerHTML = "";
+    const layers = document.getElementById("layers");
+    if (layers) layers.innerHTML = "";
     compositeState.clear();
     initiativeStore.clear();
     clearSystems(reason);


### PR DESCRIPTION
There seems to be an edge-case where the clear is triggered before the layers element is actually added to the DOM causing a whitescreen.