### PR TITLE
bug(Assets): Fix asset context menu remove action no longer working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ They will be removed in a future release though.
 -   Shape context menu not closing when selecting an option
 -   Select tool build UI not appearing when mode toggling
 -   Datablocks for room and user categories had a bug in the server preventing creating them
+-   Asset context-menu remove not working
 
 ## [2025.1.1] - 2025-02-08
 

--- a/client/src/core/components/contextMenu/ContextMenuSection.vue
+++ b/client/src/core/components/contextMenu/ContextMenuSection.vue
@@ -32,7 +32,7 @@ async function doAction(action: () => boolean | Promise<boolean>): Promise<void>
             </li>
         </template>
         <template v-else>
-            <li :class="{ selected: section.selected }" @click="doAction(section.action)">
+            <li :class="{ selected: section.selected }" @click.stop="doAction(section.action)">
                 <span>{{ section.title }}</span>
             </li>
         </template>


### PR DESCRIPTION
A bug in the context menu handling wiped the selection state, causing the remove action to no longer be functional.