### PR TITLE
bug(Assets): Fix asset context background being wrong in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ They will be removed in a future release though.
 -   Select tool build UI not appearing when mode toggling
 -   Datablocks for room and user categories had a bug in the server preventing creating them
 -   Asset context-menu remove not working
+-   Asset context-menu background colour being wrong in-game sometimes
 
 ## [2025.1.1] - 2025-02-08
 

--- a/client/src/dashboard/Assets.vue
+++ b/client/src/dashboard/Assets.vue
@@ -136,18 +136,6 @@ function canEdit(data: AssetId | DeepReadonly<ApiAsset> | undefined, includeRoot
     </div>
 </template>
 
-<style lang="scss">
-.ContextMenu ul {
-    background: rgba(77, 0, 21);
-
-    box-shadow: 0 0 1rem rgba(77, 0, 21, 0.5);
-
-    li:hover {
-        background: rgba(219, 0, 59, 1);
-    }
-}
-</style>
-
 <style scoped lang="scss">
 #content {
     background-color: rgba(77, 59, 64, 0.6);
@@ -190,6 +178,16 @@ function canEdit(data: AssetId | DeepReadonly<ApiAsset> | undefined, includeRoot
         background: rgba(219, 0, 59, 1);
         border-radius: 1rem;
         padding: 1rem;
+    }
+}
+
+:deep(.ContextMenu) ul {
+    background: rgba(77, 0, 21);
+
+    box-shadow: 0 0 1rem rgba(77, 0, 21, 0.5);
+
+    li:hover {
+        background: rgba(219, 0, 59, 1);
     }
 }
 </style>


### PR DESCRIPTION
The dashboard's asset context menu styling was being applied to the in-game asset context menu when the dashboard asset manager was opened first.

Closes #1586