### PR TITLE
bug(Assets): Fix asset upload bar missing in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ They will be removed in a future release though.
 -   Datablocks for room and user categories had a bug in the server preventing creating them
 -   Asset context-menu remove not working
 -   Asset context-menu background colour being wrong in-game sometimes
+-   Asset upload bar missing in the dashboard asset manager
 
 ## [2025.1.1] - 2025-02-08
 

--- a/client/src/dashboard/Assets.vue
+++ b/client/src/dashboard/Assets.vue
@@ -10,6 +10,7 @@ import type { AssetId } from "../assets/models";
 import { socket } from "../assets/socket";
 import { assetState } from "../assets/state";
 import AssetListCore from "../assets/ui/AssetListCore.vue";
+import AssetUploadProgress from "../assets/ui/AssetUploadProgress.vue";
 import { baseAdjust } from "../core/http";
 import { useModal } from "../core/plugins/modals/plugin";
 import { ctrlOrCmdPressed } from "../core/utils";


### PR DESCRIPTION
I'm confused that linting didn't catch this tbh, the import was straight up missing.