### PR TITLE
bug(Assets): Fix shared asset map drop not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ They will be removed in a future release though.
 -   Asset context-menu remove not working
 -   Asset context-menu background colour being wrong in-game sometimes
 -   Asset upload bar missing in the dashboard asset manager
+-   Dropping assets you have shared-view permission for on the map was not working
 
 ## [2025.1.1] - 2025-02-08
 

--- a/client/src/assets/ui/drag.ts
+++ b/client/src/assets/ui/drag.ts
@@ -70,9 +70,8 @@ async function onDrop(event: DragEvent): Promise<void> {
 
 function startDrag(event: DragEvent, file: AssetId, assetHash: string | null): void {
     if (event.dataTransfer === null) return;
-    if (!canEdit(file, false)) {
-        return;
-    }
+    // Note: Start drag does NOT require an edit check, as it might be used to drag a file to the canvas
+    // The drop handlers will check if edit access is required
 
     // Find the image to use as the drag image
     const image = (event.target as HTMLElement).closest(".inode")?.querySelector("img");


### PR DESCRIPTION
Dropping an asset that you only have shared-view permission over on the map was no longer working. The drag handler was a bit too strict, this has been resolved.