### PR TITLE
bug(Doors): Fix movement only door toggle not re-rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ They will be removed in a future release though.
 -   Asset context-menu background colour being wrong in-game sometimes
 -   Asset upload bar missing in the dashboard asset manager
 -   Dropping assets you have shared-view permission for on the map was not working
+-   Movement only door toggle not immediately rerendering screen
 
 ## [2025.1.1] - 2025-02-08
 

--- a/client/src/game/systems/properties/index.ts
+++ b/client/src/game/systems/properties/index.ts
@@ -186,6 +186,10 @@ class PropertiesSystem implements ShapeSystem {
         if (d) d.blocksMovement = blocksMovement;
 
         const alteredMovement = checkMovementSources(id, blocksMovement, recalculate);
+        // Generally movement related block changes do not need render recalculation,
+        // There are some niche things that can require an update though, so we play it safe and just rerender
+        // An example would be toggling a door with movement only mode and the open/door default draw colours in use
+        if (alteredMovement && recalculate) getShape(id)?.invalidate(false);
         doorSystem.checkCursorState(id);
 
         return alteredMovement;


### PR DESCRIPTION
We generally do not trigger re-renders when movement blockers are toggled as they tend to do nothing visually.

In 2025.1 however we introduced default draw colours which can change the colour of a door when it's open or closed. If a door is toggled and it is a movement only toggle, the colour of the door would not immediately change until something else caused a rerender (e.g. some mouse interaction).

This would not happen if the vision was also toggled as that already causes a re-render.

This PR now also re-renders on movement toggles. This will likely have an almost invisible impact on performance.