### PR TITLE
bug(Select): Fix select tool UI sometimes lingering around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ They will be removed in a future release though.
 -   Asset upload bar missing in the dashboard asset manager
 -   Dropping assets you have shared-view permission for on the map was not working
 -   Movement only door toggle not immediately rerendering screen
+-   Select tool UI would sometimes stick around when there is no shape selected anymore
 
 ## [2025.1.1] - 2025-02-08
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -150,6 +150,7 @@ class SelectTool extends Tool implements ISelectTool {
 
             // rotation logic
             if (selection.size === 0) {
+                _$.hasSelection = false;
                 this.removeRotationUi();
             }
 


### PR DESCRIPTION
When another system causes shape deselect (e.g. keyboard shortcut) the select tool UI would not pick up on that and linger around which is odd as it seems that something somewhere is selected.