### PR TITLE
bug(Loading): Fix load whitescreen

### DIFF
--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -634,6 +634,7 @@ export interface RoomInfoSet {
   isLocked: boolean;
   clientUrl: string;
   features: RoomFeatures;
+  mods: ApiModMeta[];
 }
 export interface ShapeAdd {
   shape:

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -3,7 +3,6 @@ import throttle from "lodash/throttle";
 import { defineComponent, onMounted, onUnmounted, watchEffect } from "vue";
 
 import { useModal } from "../core/plugins/modals/plugin";
-import { loadRoomMods } from "../mods";
 import { modEvents } from "../mods/events";
 import { coreStore } from "../store/core";
 
@@ -38,14 +37,7 @@ export default defineComponent({
     beforeRouteEnter(to, _from, next) {
         coreStore.setLoading(true);
         createConnection(to);
-        loadRoomMods()
-            .then(() => {
-                next();
-            })
-            .catch(() => {
-                console.error("Failed to initialize mods");
-                next();
-            });
+        next();
     },
     beforeRouteLeave(_to, _from, next) {
         socket.disconnect();

--- a/client/src/game/api/emits/mods.ts
+++ b/client/src/game/api/emits/mods.ts
@@ -1,7 +1,5 @@
-import type { ApiModLink, ApiModMeta } from "../../../apiTypes";
-import { wrapSocket, wrapSocketWithAck } from "../helpers";
-
-export const sendGetRoomMods = wrapSocketWithAck<ApiModMeta[]>("Mods.Room.Get");
+import type { ApiModLink } from "../../../apiTypes";
+import { wrapSocket } from "../helpers";
 
 export const sendLinkModToRoom = wrapSocket<ApiModLink>("Mods.Room.Link");
 // export const sendLinkModToClient = wrapSocket<ApiModLink>("Mods.Room.LinkUser");

--- a/client/src/game/systems/room/events.ts
+++ b/client/src/game/systems/room/events.ts
@@ -1,4 +1,5 @@
 import type { RoomInfoPlayersAdd, RoomInfoSet } from "../../../apiTypes";
+import { loadRoomMods } from "../../../mods";
 import { socket } from "../../api/socket";
 import { Role } from "../../models/role";
 import { gameSystem } from "../game";
@@ -14,6 +15,10 @@ socket.on("Room.Info.Set", (data: RoomInfoSet) => {
     gameSystem.setClientUrl(data.clientUrl);
     roomSystem.setChat(data.features.chat, false);
     roomSystem.setDice(data.features.dice, false);
+
+    loadRoomMods(data.mods).catch(() => {
+        console.error("Failed to initialize mods");
+    });
 });
 
 socket.on("Room.Info.InvitationCode.Set", (invitationCode: string) => {

--- a/client/src/mods/events.ts
+++ b/client/src/mods/events.ts
@@ -4,7 +4,7 @@ import { registerContextMenuEntry, registerTab } from "../game/systems/ui/mods";
 
 import { getDataBlockFunctions } from "./db";
 
-import { loadedMods } from ".";
+import { loadedMods, modsLoading } from ".";
 
 const ui = {
     shape: {
@@ -14,6 +14,9 @@ const ui = {
 };
 
 async function gameOpened(mods?: (typeof loadedMods.value)[number][]): Promise<void> {
+    // It's timing dependent whether the main Game.vue loads before or after the mod info is transferred over the socket
+    // So we wait here for the mods to have loaded, to ensure that they all receive the initGame call
+    await modsLoading;
     for (const { id, mod, meta } of mods ?? loadedMods.value) {
         try {
             await mod.events?.initGame?.({

--- a/client/src/mods/index.ts
+++ b/client/src/mods/index.ts
@@ -2,13 +2,16 @@ import { ref } from "vue";
 
 import type { ApiModMeta } from "../apiTypes";
 import { baseAdjust } from "../core/http";
-import { sendGetRoomMods } from "../game/api/emits/mods";
 
 import "./events";
 import type { Mod } from "./models";
 
 // const enabledMods = ["simple-char-sheet"];
 export const loadedMods = ref<{ id: string; meta: ApiModMeta; mod: Mod }[]>([]);
+
+// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+const { promise: modsLoading, resolve: resolveModsLoading } = Promise.withResolvers<void>();
+export { modsLoading };
 
 export async function loadMod(meta: ApiModMeta): Promise<{ id: string; meta: ApiModMeta; mod: Mod } | undefined> {
     const id = `${meta.tag}-${meta.version}-${meta.hash}`;
@@ -26,12 +29,11 @@ export async function loadMod(meta: ApiModMeta): Promise<{ id: string; meta: Api
     }
 }
 
-export async function loadRoomMods(): Promise<void> {
-    const mods = await sendGetRoomMods();
-
+export async function loadRoomMods(mods: ApiModMeta[]): Promise<void> {
     for (const modMeta of mods) {
         await loadMod(modMeta);
     }
+    resolveModsLoading();
 }
 
 async function handleMod(modId: string, modMeta: ApiModMeta, mod: Mod): Promise<void> {

--- a/server/src/api/models/room/info/__init__.py
+++ b/server/src/api/models/room/info/__init__.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+from ...mods import ApiModMeta
 from .player import *
 
 
@@ -15,3 +16,4 @@ class RoomInfoSet(BaseModel):
     isLocked: bool
     clientUrl: str
     features: RoomFeatures
+    mods: list[ApiModMeta]

--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -18,6 +18,7 @@ from ...db.models.location import Location
 from ...db.models.location_options import LocationOptions
 from ...db.models.location_user_option import LocationUserOption
 from ...db.models.marker import Marker
+from ...db.models.mod_room import ModRoom
 from ...db.models.note import Note
 from ...db.models.note_access import NoteAccess
 from ...db.models.player_room import PlayerRoom
@@ -44,6 +45,7 @@ from ..models.location.settings import (
     LocationSettingsSet,
 )
 from ..models.location.spawn_info import ApiSpawnInfo
+from ..models.mods import ApiModMeta
 from ..models.players.info import PlayerInfoCore, PlayersInfoSet
 from ..models.players.options import PlayerOptionsSet
 from ..models.room.info import RoomFeatures, RoomInfoSet
@@ -126,6 +128,10 @@ async def load_location(sid: str, location: Location, *, complete=False):
     # 1. Load room info
 
     if complete:
+        mods = [
+            ApiModMeta(**mod.mod.as_pydantic().dict())
+            for mod in ModRoom.select().where(ModRoom.room == pr.room)
+        ]
         await _send_game(
             "Room.Info.Set",
             RoomInfoSet(
@@ -137,6 +143,7 @@ async def load_location(sid: str, location: Location, *, complete=False):
                 features=RoomFeatures(
                     chat=pr.room.enable_chat, dice=pr.room.enable_dice
                 ),
+                mods=mods,
             ),
             room=sid,
         )

--- a/server/src/api/socket/mods.py
+++ b/server/src/api/socket/mods.py
@@ -9,16 +9,7 @@ from ...db.models.mod_room import ModRoom
 from ...db.models.player_room import PlayerRoom
 from ...logs import logger
 from ...state.game import game_state
-from ..models.mods import ApiModLink, ApiModMeta
-
-
-@sio.on("Mods.Room.Get", namespace=GAME_NS)
-@auth.login_required(app, sio, "game")
-async def get_room_mods(sid: str):
-    pr: PlayerRoom = game_state.get(sid)
-
-    mods = ModRoom.select().where(ModRoom.room == pr.room)
-    return [ApiModMeta(**mod.mod.as_pydantic().dict()) for mod in mods]
+from ..models.mods import ApiModLink
 
 
 @sio.on("Mods.Room.Remove", namespace=GAME_NS)


### PR DESCRIPTION
Before we open the game proper we already create the socket to the server so that we can already start receiving data while loading the UI.

Recently an extra request was added before opening the UI to fetch the mod list, which ended up causing a race-condition where sometimes the socket data would already arrive and try to add layers to the board when the UI wasn't ready yet, causing a whitescreen with no game.

I've changed this loading strategy so that the mod loading no longer blocks this process.