### PR TITLE
bug(Mods): Ensure mods are removed when leaving a campaign

### DIFF
--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -3,6 +3,7 @@ import throttle from "lodash/throttle";
 import { defineComponent, onMounted, onUnmounted, watchEffect } from "vue";
 
 import { useModal } from "../core/plugins/modals/plugin";
+import { unloadRoomMods } from "../mods";
 import { modEvents } from "../mods/events";
 import { coreStore } from "../store/core";
 
@@ -79,6 +80,7 @@ export default defineComponent({
             window.removeEventListener("keydown", keyDown);
             window.removeEventListener("resize", resizeWindow);
             mediaQuery.removeEventListener("change", resizeWindow);
+            unloadRoomMods();
         });
 
         // Window events

--- a/client/src/mods/index.ts
+++ b/client/src/mods/index.ts
@@ -36,6 +36,14 @@ export async function loadRoomMods(mods: ApiModMeta[]): Promise<void> {
     resolveModsLoading();
 }
 
+export function unloadRoomMods(): void {
+    const roomMods = document.querySelectorAll("[data-room-mod]");
+    for (const lnk of roomMods) {
+        lnk.remove();
+    }
+    loadedMods.value = [];
+}
+
 async function handleMod(modId: string, modMeta: ApiModMeta, mod: Mod): Promise<void> {
     await mod.events?.init?.(modMeta);
     loadedMods.value.push({ id: modId, meta: modMeta, mod });
@@ -46,6 +54,7 @@ function createCss(modId: string): void {
     lnk.href = baseAdjust(`/static/mods/${modId}/index.css`);
     lnk.rel = "stylesheet";
     lnk.type = "text/css";
+    lnk.dataset.roomMod = "true";
 
     document.head.appendChild(lnk);
 }


### PR DESCRIPTION
Mods were not properly cleaned up when leaving a campaign, making it possible to have duplicate entries when leaving and rejoining a session.