### PR TITLE
feat(Stats): Add stats collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ They will be removed in a future release though.
     -   Upload/Remove mods for a specific campaign
 -   Asset create folder/upload file/remove buttons to the in-game asset browser
 -   [server] Email configuration setup
+-   [server] Anonymous stat collection
+    -   Sends usage stats about number of campaigns and users to stats.planarally.io
+    -   Identifiers are anonymized, no personal info is included
+    -   Can be disabled
 
 ### Changed
 

--- a/server/src/api/common/rooms/create.py
+++ b/server/src/api/common/rooms/create.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from .... import stats
 from ....db.create.floor import create_floor
 from ....db.db import db
 from ....db.models.location import Location
@@ -29,5 +30,7 @@ def create_room(name: str, user: User, logo: int) -> Optional[Room]:
         create_floor(loc, "ground")
         PlayerRoom.create(player=user, room=room, role=Role.DM, active_location=loc)
         room.save()
+
+    stats.events.campaign_created(room.id, user.id)
 
     return room

--- a/server/src/api/http/auth.py
+++ b/server/src/api/http/auth.py
@@ -4,6 +4,7 @@ import random
 from aiohttp import web
 from aiohttp_security import authorized_userid, forget, remember
 
+from ... import stats
 from ...auth import get_authorized_user
 from ...config import cfg
 from ...db.db import db
@@ -61,7 +62,8 @@ async def register(request):
     else:
         try:
             with db.atomic():
-                User.create_new(username, password, email)
+                user = User.create_new(username, password, email)
+                stats.events.user_created(user.id)
         except:
             return web.HTTPServerError(
                 reason="An unexpected error occured on the server during account creation.  Operation reverted."

--- a/server/src/api/socket/connection.py
+++ b/server/src/api/socket/connection.py
@@ -3,6 +3,7 @@ from urllib.parse import unquote
 
 from aiohttp import web
 
+from ... import stats
 from ...api.socket.constants import GAME_NS
 from ...app import sio
 from ...auth import get_authorized_user
@@ -55,6 +56,8 @@ async def connect(sid, environ):
         skip_sid=sid,
     )
 
+    stats.events.campaign_opened(pr.room.id, user.id)
+
 
 @sio.on("disconnect", namespace=GAME_NS)
 async def disconnect(sid):
@@ -75,3 +78,5 @@ async def disconnect(sid):
         room=pr.room.get_path(),
         skip_sid=sid,
     )
+
+    stats.events.campaign_closed(pr.room.id, pr.player.id)

--- a/server/src/config/types.py
+++ b/server/src/config/types.py
@@ -103,10 +103,27 @@ class MailConfig(BaseModel):
     default_from_address: EmailStr
 
 
+class StatsConfig(BaseModel):
+    # Enable collection of stats
+    enabled: bool = True
+
+    # Enable exporting of stats
+    # If disabled, stats will be collected locally but not sent to the stats server
+    enable_export: bool = True
+
+    # The frequency to export stats in seconds
+    # Defaults to 24 * 60 * 60 = 1 day
+    export_frequency_in_seconds: int = 24 * 60 * 60
+
+    # The base URL to send stats to
+    stats_url: str = "https://stats.planarally.io"
+
+
 class ServerConfig(BaseModel):
     general: GeneralConfig = GeneralConfig()
     assets: AssetsConfig = AssetsConfig()
     webserver: WebserverConfig = WebserverConfig()
+    stats: StatsConfig = StatsConfig()
     mail: Optional[MailConfig] = None
     # Optional API server configuration
     # If not specified, the API server will not be started

--- a/server/src/db/all.py
+++ b/server/src/db/all.py
@@ -36,6 +36,7 @@ from .models.shape import Shape
 from .models.shape_data_block import ShapeDataBlock
 from .models.shape_owner import ShapeOwner
 from .models.shape_type import ShapeType
+from .models.stats import Stats
 from .models.text import Text
 from .models.toggle_composite import ToggleComposite
 from .models.tracker import Tracker
@@ -81,6 +82,7 @@ ALL_MODELS = [
     ShapeOwner,
     ShapeType,
     Shape,
+    Stats,
     Text,
     ToggleComposite,
     Tracker,

--- a/server/src/db/models/constants.py
+++ b/server/src/db/models/constants.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from typing import cast
+from uuid import uuid4
 
-from peewee import BlobField, IntegerField, TextField
+from peewee import BlobField, DateTimeField, IntegerField, TextField
 
 from ..base import BaseDbModel
 
@@ -9,3 +11,7 @@ class Constants(BaseDbModel):
     save_version = IntegerField()
     secret_token = cast(bytes, BlobField())
     api_token = TextField()
+
+    # Stats data
+    stats_uuid = cast(str, TextField(null=True, default=uuid4))
+    last_export_date = cast(datetime, DateTimeField(null=True, default=None))

--- a/server/src/db/models/stats.py
+++ b/server/src/db/models/stats.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from enum import Enum
+from typing import cast
+
+from peewee import DateTimeField, TextField
+
+from ..base import BaseDbModel
+
+
+class StatsKind(Enum):
+    CAMPAIGN_CREATED = "campaignCreated"
+    SERVER_STARTED = "serverStarted"
+    SERVER_STOPPED = "serverStopped"
+    USER_CREATED = "userCreated"
+    USER_GAME_CONNECTED = "userGameConnected"
+    USER_GAME_DISCONNECTED = "userGameDisconnected"
+
+
+class Stats(BaseDbModel):
+    kind = cast(StatsKind, TextField())
+    timestamp = cast(datetime, DateTimeField(default=datetime.now))
+    data = cast(str | None, TextField(null=True))
+
+    def to_export_format(self):
+        return {
+            "kind": self.kind,
+            "timestamp": self.timestamp.isoformat(),
+            "data": self.data,
+        }

--- a/server/src/db/models/user.py
+++ b/server/src/db/models/user.py
@@ -65,7 +65,7 @@ class User(BaseDbModel):
         return cls.get_or_none(cls.email == email)
 
     @classmethod
-    def create_new(cls, name: str, password: str, email: Optional[str] = None):
+    def create_new(cls, name: str, password: str, email: Optional[str] = None) -> "User":
         u = User(name=name)
         u.set_password(password)
         if email:
@@ -74,3 +74,5 @@ class User(BaseDbModel):
         default_options.save()
         u.default_options = default_options
         u.save()
+
+        return u

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 103
+SAVE_VERSION = 104
 
 import asyncio
 import json
@@ -419,6 +419,19 @@ def upgrade(
     elif version == 102:
         with db.atomic():
             db.execute_sql("CREATE UNIQUE INDEX unique_username ON user(name);")
+    elif version == 103:
+        with db.atomic():
+            db.execute_sql(
+                "CREATE TABLE IF NOT EXISTS stats (id INTEGER NOT NULL PRIMARY KEY, kind TEXT NOT NULL, timestamp DATETIME NOT NULL, data TEXT);"
+            )
+            db.execute_sql(
+                "ALTER TABLE constants ADD COLUMN stats_uuid TEXT;",
+            )
+            db.execute_sql("ALTER TABLE constants ADD COLUMN last_export_date DATETIME;")
+            db.execute_sql(
+                "UPDATE constants SET stats_uuid = ?",
+                (str(uuid4()),),
+            )
     else:
         raise UnknownVersionException(f"No upgrade code for save format {version} was found.")
     inc_save_version(db)

--- a/server/src/stats/__init__.py
+++ b/server/src/stats/__init__.py
@@ -1,0 +1,6 @@
+# Module to capture anonymous data from the server
+# This is being sent to an official PA server for processing
+
+from . import data, events
+
+__all__ = ["data", "events"]

--- a/server/src/stats/anonymize.py
+++ b/server/src/stats/anonymize.py
@@ -1,0 +1,22 @@
+import hashlib
+import os
+
+from ..utils import DATA_DIR
+
+STATS_PEPPER = None
+pepper_path = DATA_DIR / "stats_pepper"
+
+if not pepper_path.exists():
+    STATS_PEPPER = os.urandom(32)
+    with open(pepper_path, "wb") as f:
+        f.write(STATS_PEPPER)
+else:
+    with open(pepper_path, "rb") as f:
+        STATS_PEPPER = f.read().strip()
+
+
+def anonymize(value: int | str) -> str:
+    # Fall back to a random pepper if the file somehow fails
+    pepper = STATS_PEPPER or os.urandom(32)
+
+    return hashlib.sha256(str(value).encode() + pepper).hexdigest()

--- a/server/src/stats/data.py
+++ b/server/src/stats/data.py
@@ -1,0 +1,73 @@
+import asyncio
+from datetime import datetime, timedelta
+
+import aiohttp
+
+from ..api.http.version import env_version, release_version
+from ..config import cfg
+from ..db.models.constants import Constants
+from ..db.models.room import Room
+from ..db.models.stats import Stats
+from ..db.models.user import User
+from ..logs import logger
+
+
+async def send_stats(data):
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{cfg().stats.stats_url}/api/stats",
+            json=data,
+        ) as response:
+            response.raise_for_status()
+
+
+async def export_stats():
+    c = Constants.get()
+
+    # Get all entries since last export
+    stats = Stats.select()
+    if c.last_export_date:
+        stats = stats.where(Stats.timestamp > c.last_export_date)
+
+    if len(stats) == 0:
+        return
+
+    data = {
+        "stats": [s.to_export_format() for s in stats],
+        "serverId": c.stats_uuid,
+        "totals": {
+            "users": User.select().count(),
+            "rooms": Room.select().count(),
+        },
+        "versions": {
+            "serverEnv": env_version,
+            "serverRelease": release_version,
+            "statsFormat": 1,
+        },
+    }
+
+    try:
+        await send_stats(data)
+    except Exception as e:
+        logger.warning(f"Error exporting stats: {e}")
+        return
+
+    # Update last export date
+    c.last_export_date = datetime.now()
+    c.save()
+
+
+async def start_tracking():
+    if not cfg().stats.enable_export:
+        return
+
+    last_export_date = Constants.get().last_export_date
+
+    if last_export_date is None or last_export_date < datetime.now() - timedelta(days=1):
+        await export_stats()
+
+    # Once a day save the stats to the database
+    while True:
+        await asyncio.sleep(cfg().stats.export_frequency_in_seconds)
+
+        await export_stats()

--- a/server/src/stats/events.py
+++ b/server/src/stats/events.py
@@ -1,0 +1,62 @@
+import json
+
+from ..config import cfg
+from ..db.models.stats import Stats, StatsKind
+from .anonymize import anonymize
+
+
+def campaign_created(campaign_id: int, user_id: int):
+    if not cfg().stats.enabled:
+        return
+
+    data = {
+        "campaignId": anonymize(campaign_id),
+        "userId": anonymize(user_id),
+    }
+    Stats.create(kind=StatsKind.CAMPAIGN_CREATED, data=json.dumps(data))
+
+
+def campaign_opened(campaign_id: int, player_id: int):
+    if not cfg().stats.enabled:
+        return
+
+    data = {
+        "campaignId": anonymize(campaign_id),
+        "playerId": anonymize(player_id),
+    }
+    Stats.create(kind=StatsKind.USER_GAME_CONNECTED, data=json.dumps(data))
+
+
+def campaign_closed(campaign_id: int, player_id: int):
+    if not cfg().stats.enabled:
+        return
+
+    data = {
+        "campaignId": anonymize(campaign_id),
+        "playerId": anonymize(player_id),
+    }
+    Stats.create(kind=StatsKind.USER_GAME_DISCONNECTED, data=json.dumps(data))
+
+
+def user_created(user_id: int):
+    if not cfg().stats.enabled:
+        return
+
+    data = {
+        "userId": anonymize(user_id),
+    }
+    Stats.create(kind=StatsKind.USER_CREATED, data=json.dumps(data))
+
+
+def server_started():
+    if not cfg().stats.enabled:
+        return
+
+    Stats.create(kind=StatsKind.SERVER_STARTED)
+
+
+def server_stopped():
+    if not cfg().stats.enabled:
+        return
+
+    Stats.create(kind=StatsKind.SERVER_STOPPED)


### PR DESCRIPTION
## Intro

A question I often receive is how many users PA actually has and I can never actually answer this or even estimate this.

There is no official PA server that I can base myself on for some estimates, I only have some vague numbers like github stars or discord users, but those don't really say anything about actual users and if they're any indication at all they're more likely to represent server owners than players.

In order to get a feeling for what's actually going on out there I'm introducing a stats collection thingy on the server.

## Which stats

Although it would be nice to get some metrics into usage of various features of PA to see if things are actually used or not, this PR will focus on just 2 metrics. (And I don't expect other metrics being added anytime soon)

- Server total size: Get the total number of users and campaigns
- Server active use: Get the number of unique users and campaigns that interact with the server on a regular basis (e.g. Server X has 12 unique users active in the month of August)

## Where are the stats collected

Each local server will collect them locally and the goal is to ping this data on a weekly* basis to https://stats.planarally.io (yes there is nothing to see here)

Note that a lot of this will be configurable (see last section)

\* Initially the default will be set to daily to get a feeling for how it's behaving and catch early issues.

## How are the stats used

The goal is to get a feeling of actual use. Initially the stats will just exist in the database of each server as well as the stats server with no UI.

The goal is to provide a UI on the stats server itself that will show global use as well as provide admins a stat view of their own server.

## Privacy

The data that the stats server receives will consist of hashed IDs. They are hashed with a pepper that is uniquely generated on the local servers. It's also all just part of PA so it's opensource!
No other user info is provided (e.g. usernames, email addresses, ...).

Similarly the only info that I track about the server sending the data is a uuid that the server generates itself that is only used for sending the stats and the PA version in use, no other information (e.g. IP address) is stored.

## Configuration

This stats collection module comes with a bunch of configuration options for the server owner.
See the [PA docs](https://deploy-preview-191--planarally.netlify.app/server/management/configuration/#stats) for the details.

You'll be able to disable stats collection entirely, you can also enable it but disable the export to the PA stats server. Also the frequency of stats exporting will be adjustable as well as the endpoint that the stats are sent too.