### PR TITLE
bug(Initiative): Fix initiative effect renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+## [2025.2.2]
+
+### Fixed
+
+-   Initiative effect rename losing focus after pressing 1 character
+
 ## [2025.2.1]
 
 This fixes/adds support for a wider variety of smtp email servers.

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -268,7 +268,7 @@ function n(e: any): number {
                             class="initiative-effect"
                             :class="{ 'effect-visible': alwaysShowEffects }"
                         >
-                            <div v-for="(effect, e) of actor.effects" :key="`${actor.globalId}-${effect.name}`">
+                            <div v-for="(effect, e) of actor.effects" :key="`${actor.globalId}-${e}`">
                                 <input
                                     v-model="effect.name"
                                     type="text"


### PR DESCRIPTION
This fixes #1619. The initiative effect input element lost focus after a single character press.

This must have broken due to the use of a newer Vue version as no actual change to the logic was made.

It's due to the name being used as part of the key, which is indeed wrong, but interestingly enough only posed a problem now. (It's been in the code for 3 years)