### PR TITLE
bug(Access): Fix DM only auras no longer rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Initiative effect rename losing focus after pressing 1 character
 -   Locked shapes not being selectable directly
+-   DM only auras where no longer rendered due to a bug in the new access logic
 
 ## [2025.2.1]
 

--- a/client/src/game/systems/access/index.ts
+++ b/client/src/game/systems/access/index.ts
@@ -51,7 +51,7 @@ class AccessSystem implements ShapeSystem {
     clear(): void {
         this.dropState();
         for (const al of ACCESS_LEVELS) {
-            $.activeTokenFilters.set(al, undefined);
+            $.activeTokenFilters.delete(al);
             $.ownedTokens.get(al)?.clear();
         }
         mutable.access.clear();
@@ -111,6 +111,11 @@ class AccessSystem implements ShapeSystem {
         if (gameState.raw.isDm && !limitToActiveTokens) return true;
 
         const _access: AccessLevel[] = Array.isArray(access) ? access : [access];
+
+        // This is an extra case to cover the special case where the shape has no attached users
+        // in which case the auras would be hidden for the DM with the normal behaviour.
+        // If we're not actively filtering tokens, we can assume we want to show them.
+        if (gameState.raw.isDm && _access.every((al) => !raw.activeTokenFilters.has(al))) return true;
 
         // 2. Otherwise check in the active tokens or owned tokens depending on the limitToActiveTokens flag
         return _access.every((al) => (limitToActiveTokens ? activeTokens.value : raw.ownedTokens).get(al)?.has(id));

--- a/client/src/game/systems/access/state.ts
+++ b/client/src/game/systems/access/state.ts
@@ -17,7 +17,7 @@ interface ReactiveAccessState {
     playerAccess: Map<string, AccessConfig>;
 
     ownedTokens: Map<AccessLevel, Set<LocalId>>;
-    activeTokenFilters: Map<AccessLevel, Set<LocalId> | undefined>;
+    activeTokenFilters: Map<AccessLevel, Set<LocalId>>;
 }
 
 interface AccessState {
@@ -35,7 +35,7 @@ const state = buildState<ReactiveAccessState, AccessState>(
         playerAccess: new Map(),
 
         ownedTokens: new Map(ACCESS_LEVELS.map((al) => [al, new Set<LocalId>()])),
-        activeTokenFilters: new Map(ACCESS_LEVELS.map((al) => [al, undefined])),
+        activeTokenFilters: new Map(),
     },
     { access: new Map<LocalId, AccessMap>() },
 );


### PR DESCRIPTION
The new access logic had a flaw causing DM only auras to no longer render unless they're set to public.

It is resolved by granting the access if there are no players associated at all with the shape.

This fixes #1616