### PR TITLE
bug(Stats): Ensure stat export is chunked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Fixed
+
+-   Ensure stat export is chunked to prevent rejection from stat server
+
 ## [2025.2.2]
 
 ### Fixed

--- a/server/src/stats/data.py
+++ b/server/src/stats/data.py
@@ -47,8 +47,6 @@ async def export_stats():
             },
         }
 
-        print(data)
-
         try:
             await send_stats(data)
         except Exception as e:


### PR DESCRIPTION
Limit amount of stat entries to 1000 per export to prevent stat server from rejecting the data.