### PR TITLE
bug(Stats): Prevent stat flooding with unstable connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ tech changes will usually be stripped from release notes for the public
 ### Fixed
 
 -   Ensure stat export is chunked to prevent rejection from stat server
+-   Rapid (dis)connect sequences flooding the stats
 
 ## [2025.2.2]
 

--- a/server/src/db/models/stats.py
+++ b/server/src/db/models/stats.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import cast
 
-from peewee import DateTimeField, TextField
+from peewee import DateTimeField, IntegerField, TextField
 
 from ..base import BaseDbModel
 
@@ -20,10 +20,16 @@ class Stats(BaseDbModel):
     kind = cast(StatsKind, TextField())
     timestamp = cast(datetime, DateTimeField(default=datetime.now))
     data = cast(str | None, TextField(null=True))
+    # If relevant, the campaign that it applied to
+    campaign_id = cast(int | None, IntegerField(null=True))
+    # If relevant, the user that it applied to
+    user_id = cast(int | None, IntegerField(null=True))
 
     def to_export_format(self):
         return {
             "kind": self.kind,
             "timestamp": self.timestamp.isoformat(),
             "data": self.data,
+            "campaign_id": self.campaign_id,
+            "user_id": self.user_id,
         }

--- a/server/src/stats/data.py
+++ b/server/src/stats/data.py
@@ -43,7 +43,7 @@ async def export_stats():
             "versions": {
                 "serverEnv": env_version,
                 "serverRelease": release_version,
-                "statsFormat": 1,
+                "statsFormat": 2,
             },
         }
 

--- a/server/src/stats/events.py
+++ b/server/src/stats/events.py
@@ -1,4 +1,4 @@
-import json
+from datetime import datetime, timedelta
 
 from ..config import cfg
 from ..db.models.stats import Stats, StatsKind
@@ -9,43 +9,41 @@ def campaign_created(campaign_id: int, user_id: int):
     if not cfg().stats.enabled:
         return
 
-    data = {
-        "campaignId": anonymize(campaign_id),
-        "userId": anonymize(user_id),
-    }
-    Stats.create(kind=StatsKind.CAMPAIGN_CREATED, data=json.dumps(data))
+    Stats.create(kind=StatsKind.CAMPAIGN_CREATED, campaign_id=anonymize(campaign_id), user_id=anonymize(user_id))
 
 
 def campaign_opened(campaign_id: int, player_id: int):
     if not cfg().stats.enabled:
         return
 
-    data = {
-        "campaignId": anonymize(campaign_id),
-        "playerId": anonymize(player_id),
-    }
-    Stats.create(kind=StatsKind.USER_GAME_CONNECTED, data=json.dumps(data))
+    Stats.create(kind=StatsKind.USER_GAME_CONNECTED, campaign_id=anonymize(campaign_id), user_id=anonymize(player_id))
 
 
 def campaign_closed(campaign_id: int, player_id: int):
     if not cfg().stats.enabled:
         return
 
-    data = {
-        "campaignId": anonymize(campaign_id),
-        "playerId": anonymize(player_id),
-    }
-    Stats.create(kind=StatsKind.USER_GAME_DISCONNECTED, data=json.dumps(data))
+    c_id = anonymize(campaign_id)
+    p_id = anonymize(player_id)
+
+    connect_event = (
+        Stats.select()
+        .where(Stats.kind == StatsKind.USER_GAME_CONNECTED, Stats.campaign_id == c_id, Stats.user_id == p_id)
+        .order_by(Stats.timestamp.desc())  # type: ignore
+        .get_or_none()
+    )
+    # We only care about connect/disconnect events if the connection stays open for at least 60 seconds
+    if connect_event is not None and connect_event.timestamp - datetime.now() < timedelta(seconds=60):
+        connect_event.delete_instance()
+    else:
+        Stats.create(kind=StatsKind.USER_GAME_DISCONNECTED, campaign_id=c_id, user_id=p_id)
 
 
 def user_created(user_id: int):
     if not cfg().stats.enabled:
         return
 
-    data = {
-        "userId": anonymize(user_id),
-    }
-    Stats.create(kind=StatsKind.USER_CREATED, data=json.dumps(data))
+    Stats.create(kind=StatsKind.USER_CREATED, user_id=anonymize(user_id))
 
 
 def server_started():


### PR DESCRIPTION
If someone with an unstable connection connects to your server, the stats can be flooded with a lot of useless campaign_connected campaign_disconnected messages.

The server now checks if there is less than a minute between the connect and disconnect, in which case it will not track those stats.