### PR TITLE
bug(Selection): Don't re-open shape properties after a re-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Ensure stat export is chunked to prevent rejection from stat server
 -   Rapid (dis)connect sequences flooding the stats
+-   Don't re-open shape properties after a re-select
 
 ## [2025.2.2]
 

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -22,6 +22,7 @@ import { equalPoints, rotateAroundPoint, snapToPoint } from "../../../../core/ma
 import { InvalidationMode, SyncMode } from "../../../../core/models/types";
 import { ctrlOrCmdPressed } from "../../../../core/utils";
 import { i18n } from "../../../../i18n";
+import { activeShapeStore } from "../../../../store/activeShape";
 import { sendRequest } from "../../../api/emits/logic";
 import { sendShapePositionUpdate, sendShapeSizeUpdate } from "../../../api/emits/shape/core";
 import { calculateDelta } from "../../../drag";
@@ -230,6 +231,7 @@ class SelectTool extends Tool implements ISelectTool {
     // Syncs the local state tracked selection state to the global selection state
     private syncSelection(resetCurrentSelection = false): void {
         if (this.currentSelection.length === 0) {
+            activeShapeStore.setShowEditDialog(false);
             selectedSystem.clear();
         } else {
             selectedSystem.set(...this.currentSelection.map((s) => s.id));


### PR DESCRIPTION
When deselecting a shape while the shape properties are open, will close the dialog. If you reselect the shape it will open up again, which is odd behaviour and also does not happen if you select another shape.

As mentioned in the related ticket this is due to some legacy code lying around that I should really just clean up/remove.

This closes #1618