### PR TITLE
bug(Grid): Fix square grid render sometimes skipping last line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ tech changes will usually be stripped from release notes for the public
 -   Ensure stat export is chunked to prevent rejection from stat server
 -   Rapid (dis)connect sequences flooding the stats
 -   Don't re-open shape properties after a re-select
+-   Last grid-line in X or Y axis sometimes not rendering
 
 ## [2025.2.2]
 

--- a/client/src/game/layers/variants/grid.ts
+++ b/client/src/game/layers/variants/grid.ts
@@ -36,12 +36,16 @@ export class GridLayer extends Layer implements IGridLayer {
                 if (locationSettingsState.raw.gridType.value === GridType.Square) {
                     const zoomed_grid_size = DEFAULT_GRID_SIZE * state.zoom;
                     for (let i = 0; i < this.height; i += zoomed_grid_size) {
-                        const zoomed_pan_size = (state.panY % DEFAULT_GRID_SIZE) * state.zoom;
+                        let pan_size = state.panY % DEFAULT_GRID_SIZE;
+                        if (pan_size < 0) pan_size += DEFAULT_GRID_SIZE;
+                        const zoomed_pan_size = pan_size * state.zoom;
                         ctx.moveTo(0, i + zoomed_pan_size);
                         ctx.lineTo(this.width, i + zoomed_pan_size);
                     }
                     for (let i = 0; i < this.width; i += zoomed_grid_size) {
-                        const zoomed_pan_size = (state.panX % DEFAULT_GRID_SIZE) * state.zoom;
+                        let pan_size = state.panX % DEFAULT_GRID_SIZE;
+                        if (pan_size < 0) pan_size += DEFAULT_GRID_SIZE;
+                        const zoomed_pan_size = pan_size * state.zoom;
                         ctx.moveTo(i + zoomed_pan_size, 0);
                         ctx.lineTo(i + zoomed_pan_size, this.height);
                     }


### PR DESCRIPTION
Sometimes the last line on the X or Y axis would be skipped when rendering the grid.

This happens in specific cases where the pan value for that given axis is negative. In this case we were also drawing an extra line out of screen on the other side.

Image of the issue:
![image](https://github.com/user-attachments/assets/2f65bc39-bcfc-48ea-b598-25e2e08dc485)
