### PR TITLE
feat(Zoom) Smooth zoom behaviour when zoomed-in a lot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Changed
+
+-   Smoothed out the scroll zoom behaviour when zoomed in furthest
+
 ### Fixed
 
 -   Ensure stat export is chunked to prevent rejection from stat server

--- a/client/src/game/input/mouse.ts
+++ b/client/src/game/input/mouse.ts
@@ -6,8 +6,19 @@ import { positionState } from "../systems/position/state";
 
 export function scrollZoom(e: WheelEvent): void {
     if (!e.target || !(e.target as HTMLElement).tagName || (e.target as HTMLElement).tagName !== "CANVAS") return;
-    const delta = e.deltaY / 1000;
-    positionSystem.updateZoom(positionState.raw.zoomDisplay + delta, l2g(getLocalPointFromEvent(e)));
+    const rawDelta = e.deltaY / 1000;
+
+    // Our zoom display is a value between 0 and 1, where 0 is the smallest zoom and 1 is the largest zoom.
+    // Given the exponential nature of the zoom curve (see zoomDisplayToFactor),
+    // a linear scroll causes rapid jumps in zoom level at small values, while more smooth changes at larger values.
+    // Ideally this is just smooth all over. So we're going to add a non-linear scaling to alleviate this.
+    const currentZoom = positionState.raw.zoomDisplay;
+    // At zoom 0, we want to slow down the scaling so we use a power >1,
+    // towards the end of the curve we want to increase the scaling so we use a power <1
+    const scalingFactor = 1.3 - currentZoom * 0.7;
+    const scaledDelta = Math.sign(rawDelta) * Math.pow(Math.abs(rawDelta), scalingFactor);
+
+    positionSystem.updateZoom(currentZoom + scaledDelta, l2g(getLocalPointFromEvent(e)));
 }
 
 export function getLocalPointFromEvent(e: MouseEvent | TouchEvent): LocalPoint {


### PR DESCRIPTION
At low zoom levels (i.e. zoomed-in very far) using the mouse scroll can cause some drastic jumps in zoom level. This is not nice and although you can get more fine-grained zooming for those cases with the slider at the top right, this can be a bother if you're using an external monitor like a tv screen.

It should just work properly, so this PR adjusts the mouse zoom behaviour and smooths out the zooming at low levels.