### PR TITLE
bug(Initiative): Fix issues related to round/turn handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ tech changes will usually be stripped from release notes for the public
 -   Rapid (dis)connect sequences flooding the stats
 -   Don't re-open shape properties after a re-select
 -   Last grid-line in X or Y axis sometimes not rendering
+-   Deleting first initiative entry would enter invalid state
+-   Going to previous initiative would decrement effect timers
+-   Going to previous initiative could enter negative rounds
 
 ## [2025.2.2]
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -19,6 +19,8 @@ export type ApiDataBlock = ApiRoomDataBlock | ApiShapeDataBlock | ApiUserDataBlo
 /* Do not modify it by hand - just update the pydantic models and then re-run the script
 */
 
+export type InitiativeDirection = -1 | 0 | 1;
+
 export interface ApiAsset {
   id: AssetId;
   name: string;
@@ -536,6 +538,11 @@ export interface InitiativeEffectRename {
   shape: GlobalId;
   index: number;
   name: string;
+}
+export interface InitiativeTurnUpdate {
+  turn: number;
+  direction: number;
+  processEffects: InitiativeDirection;
 }
 export interface InitiativeEffectTurns {
   shape: GlobalId;

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -541,8 +541,8 @@ export interface InitiativeEffectRename {
 }
 export interface InitiativeTurnUpdate {
   turn: number;
-  direction: number;
-  processEffects: InitiativeDirection;
+  direction: InitiativeDirection;
+  processEffects: boolean;
 }
 export interface InitiativeEffectTurns {
   shape: GlobalId;

--- a/client/src/game/api/emits/initiative.ts
+++ b/client/src/game/api/emits/initiative.ts
@@ -2,6 +2,7 @@ import type {
     InitiativeAdd,
     InitiativeEffectNew,
     InitiativeEffectRemove,
+    InitiativeTurnUpdate,
     InitiativeEffectRename,
     InitiativeEffectTurns,
     InitiativeOptionSet,
@@ -16,7 +17,7 @@ export const sendInitiativeActive = wrapSocket<boolean>("Initiative.Active.Set")
 export const sendInitiativeAdd = wrapSocket<InitiativeAdd>("Initiative.Add");
 export const sendInitiativeRemove = wrapSocket<GlobalId>("Initiative.Remove");
 export const sendInitiativeSetValue = wrapSocket<InitiativeValueSet>("Initiative.Value.Set");
-export const sendInitiativeTurnUpdate = wrapSocket<number>("Initiative.Turn.Update");
+export const sendInitiativeTurnUpdate = wrapSocket<InitiativeTurnUpdate>("Initiative.Turn.Update");
 export const sendInitiativeRoundUpdate = wrapSocket<number>("Initiative.Round.Update");
 export const sendInitiativeNewEffect = wrapSocket<InitiativeEffectNew>("Initiative.Effect.New");
 export const sendInitiativeRenameEffect = wrapSocket<InitiativeEffectRename>("Initiative.Effect.Rename");

--- a/client/src/game/api/events/initiative.ts
+++ b/client/src/game/api/events/initiative.ts
@@ -2,12 +2,14 @@ import type {
     ApiInitiative,
     InitiativeEffectNew,
     InitiativeEffectRemove,
+    InitiativeTurnUpdate,
     InitiativeEffectRename,
     InitiativeEffectTurns,
     InitiativeOptionSet,
 } from "../../../apiTypes";
 import type { GlobalId } from "../../../core/id";
 import type { InitiativeSort } from "../../models/initiative";
+import { InitiativeTurnDirection } from "../../models/initiative";
 import { initiativeStore } from "../../ui/initiative/state";
 import { socket } from "../socket";
 
@@ -15,11 +17,11 @@ socket.on("Initiative.Set", (data: ApiInitiative) => initiativeStore.setData(dat
 socket.on("Initiative.Active.Set", (isActive: boolean) => initiativeStore.setActive(isActive));
 socket.on("Initiative.Remove", (data: GlobalId) => initiativeStore.removeInitiative(data, false));
 
-socket.on("Initiative.Turn.Update", (turn: number) =>
-    initiativeStore.setTurnCounter(turn, { sync: false, updateEffects: true }),
+socket.on("Initiative.Turn.Update", (data: InitiativeTurnUpdate) =>
+    initiativeStore.setTurnCounter(data.turn, data.direction, { sync: false, updateEffects: data.processEffects }),
 );
 socket.on("Initiative.Turn.Set", (turn: number) =>
-    initiativeStore.setTurnCounter(turn, { sync: false, updateEffects: false }),
+    initiativeStore.setTurnCounter(turn, InitiativeTurnDirection.Null, { sync: false, updateEffects: false }),
 );
 socket.on("Initiative.Round.Update", (round: number) => initiativeStore.setRoundCounter(round, false));
 socket.on("Initiative.Effect.New", (data: InitiativeEffectNew) => {

--- a/client/src/game/models/initiative.ts
+++ b/client/src/game/models/initiative.ts
@@ -28,3 +28,9 @@ export enum InitiativeEffectMode {
     ActiveAndHover = "active",
     Always = "always",
 }
+
+export enum InitiativeTurnDirection {
+    Backward = -1,
+    Null = 0,
+    Forward = 1,
+}

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -13,7 +13,7 @@ import { sendRequestInitiatives } from "../../api/emits/initiative";
 import { getShape } from "../../id";
 import type { IShape } from "../../interfaces/shape";
 import type { IAsset } from "../../interfaces/shapes/asset";
-import type { InitiativeData } from "../../models/initiative";
+import { InitiativeTurnDirection, type InitiativeData } from "../../models/initiative";
 import { InitiativeEffectMode, InitiativeSort } from "../../models/initiative";
 import { accessSystem } from "../../systems/access";
 import { gameState } from "../../systems/game/state";
@@ -122,6 +122,7 @@ function canSee(actor: InitiativeData): boolean {
 }
 
 function reset(): void {
+    initiativeStore.setTurnCounter(0, InitiativeTurnDirection.Null, { sync: true, updateEffects: false });
     initiativeStore.setRoundCounter(1, true);
     sendRequestInitiatives();
 }

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -218,7 +218,7 @@ class InitiativeStore extends Store<InitiativeState> {
         this.handleCameraLock();
         this.handleVisionLock();
         if (options.sync)
-            sendInitiativeTurnUpdate({ turn: turn, direction: direction, processEffects: options.updateEffects });
+            sendInitiativeTurnUpdate({ turn, direction, processEffects: options.updateEffects });
     }
 
     setRoundCounter(round: number, sync: boolean): void {

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -222,7 +222,6 @@ class InitiativeStore extends Store<InitiativeState> {
 
     setRoundCounter(round: number, sync: boolean): void {
         if (sync && !gameState.raw.isDm && !this.owns()) return;
-        if (round < 0) round = 0;
         this._state.roundCounter = round;
         if (sync) {
             sendInitiativeRoundUpdate(round);

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -219,20 +219,19 @@ class InitiativeStore extends Store<InitiativeState> {
 
     setRoundCounter(round: number, sync: boolean): void {
         if (sync && !gameState.raw.isDm && !this.owns()) return;
+        if (round < 0) round = 0;
         this._state.roundCounter = round;
         if (sync) {
             sendInitiativeRoundUpdate(round);
-            if (this.getDataSet().length > 0) {
-                // TODO: accept forward and backward
-                this.setTurnCounter(0, InitiativeTurnDirection.Forward, { sync, updateEffects: true });
-            }
         }
     }
 
     nextTurn(): void {
         if (!gameState.raw.isDm && !this.owns()) return;
-        if (this._state.turnCounter === this.getDataSet().length - 1) {
+        if (this.getDataSet().length === 0) return;
+        if (this._state.turnCounter >= this.getDataSet().length - 1) {
             this.setRoundCounter(this._state.roundCounter + 1, true);
+            this.setTurnCounter(0, InitiativeTurnDirection.Forward, { sync: true, updateEffects: true });
         } else {
             this.setTurnCounter(this._state.turnCounter + 1, InitiativeTurnDirection.Forward, { sync: true, updateEffects: true });
         }
@@ -240,10 +239,10 @@ class InitiativeStore extends Store<InitiativeState> {
 
     previousTurn(): void {
         if (!gameState.raw.isDm) return;
-        if (this._state.turnCounter === 0) {
+        if (this._state.turnCounter === 0 && this.getDataSet().length > 0) {
             this.setRoundCounter(this._state.roundCounter - 1, true);
             this.setTurnCounter(this.getDataSet().length - 1, InitiativeTurnDirection.Backward, { sync: true, updateEffects: true });
-        } else {
+        } else if (this._state.turnCounter > 0) {
             this.setTurnCounter(this._state.turnCounter - 1, InitiativeTurnDirection.Backward, { sync: true, updateEffects: true });
         }
     }

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -19,8 +19,7 @@ import {
     sendInitiativeActive,
 } from "../../api/emits/initiative";
 import { getGlobalId, getLocalId, getShape } from "../../id";
-import { InitiativeSort } from "../../models/initiative";
-import type { InitiativeData, InitiativeEffect } from "../../models/initiative";
+import { type InitiativeData, type InitiativeEffect, InitiativeSort } from "../../models/initiative";
 import { InitiativeTurnDirection } from "../../models/initiative";
 import { setCenterPosition } from "../../position";
 import { accessSystem } from "../../systems/access";
@@ -189,13 +188,17 @@ class InitiativeStore extends Store<InitiativeState> {
 
     // TURN / ROUND TRACKING
 
-    setTurnCounter(turn: number, direction: InitiativeTurnDirection, options: { sync: boolean; updateEffects: boolean }): void {
+    setTurnCounter(
+        turn: number,
+        direction: InitiativeTurnDirection,
+        options: { sync: boolean; updateEffects: boolean },
+    ): void {
         if (options.sync && !gameState.raw.isDm && !this.owns()) return;
 
         if (turn < 0) turn = 0;
 
         if (options.updateEffects) {
-            let entry = direction === InitiativeTurnDirection.Forward ? this._state.turnCounter : turn;
+            const entry = direction === InitiativeTurnDirection.Forward ? this._state.turnCounter : turn;
 
             const actor = this.getDataSet()[entry];
             if (actor !== undefined) {
@@ -214,7 +217,8 @@ class InitiativeStore extends Store<InitiativeState> {
 
         this.handleCameraLock();
         this.handleVisionLock();
-        if (options.sync) sendInitiativeTurnUpdate({ turn: turn, direction: direction, processEffects: options.updateEffects });
+        if (options.sync)
+            sendInitiativeTurnUpdate({ turn: turn, direction: direction, processEffects: options.updateEffects });
     }
 
     setRoundCounter(round: number, sync: boolean): void {
@@ -233,7 +237,10 @@ class InitiativeStore extends Store<InitiativeState> {
             this.setRoundCounter(this._state.roundCounter + 1, true);
             this.setTurnCounter(0, InitiativeTurnDirection.Forward, { sync: true, updateEffects: true });
         } else {
-            this.setTurnCounter(this._state.turnCounter + 1, InitiativeTurnDirection.Forward, { sync: true, updateEffects: true });
+            this.setTurnCounter(this._state.turnCounter + 1, InitiativeTurnDirection.Forward, {
+                sync: true,
+                updateEffects: true,
+            });
         }
     }
 
@@ -241,9 +248,15 @@ class InitiativeStore extends Store<InitiativeState> {
         if (!gameState.raw.isDm) return;
         if (this._state.turnCounter === 0 && this.getDataSet().length > 0) {
             this.setRoundCounter(this._state.roundCounter - 1, true);
-            this.setTurnCounter(this.getDataSet().length - 1, InitiativeTurnDirection.Backward, { sync: true, updateEffects: true });
+            this.setTurnCounter(this.getDataSet().length - 1, InitiativeTurnDirection.Backward, {
+                sync: true,
+                updateEffects: true,
+            });
         } else if (this._state.turnCounter > 0) {
-            this.setTurnCounter(this._state.turnCounter - 1, InitiativeTurnDirection.Backward, { sync: true, updateEffects: true });
+            this.setTurnCounter(this._state.turnCounter - 1, InitiativeTurnDirection.Backward, {
+                sync: true,
+                updateEffects: true,
+            });
         }
     }
 

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -217,8 +217,7 @@ class InitiativeStore extends Store<InitiativeState> {
 
         this.handleCameraLock();
         this.handleVisionLock();
-        if (options.sync)
-            sendInitiativeTurnUpdate({ turn, direction, processEffects: options.updateEffects });
+        if (options.sync) sendInitiativeTurnUpdate({ turn, direction, processEffects: options.updateEffects });
     }
 
     setRoundCounter(round: number, sync: boolean): void {

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -21,6 +21,7 @@ import {
 import { getGlobalId, getLocalId, getShape } from "../../id";
 import { InitiativeSort } from "../../models/initiative";
 import type { InitiativeData, InitiativeEffect } from "../../models/initiative";
+import { InitiativeTurnDirection } from "../../models/initiative";
 import { setCenterPosition } from "../../position";
 import { accessSystem } from "../../systems/access";
 import { accessState } from "../../systems/access/state";
@@ -89,7 +90,7 @@ class InitiativeStore extends Store<InitiativeState> {
 
         if (!this._state.manuallyOpened) this.setActive(data.isActive);
         this.setRoundCounter(data.round, false);
-        this.setTurnCounter(data.turn, { sync: false, updateEffects: false });
+        this.setTurnCounter(data.turn, InitiativeTurnDirection.Null, { sync: false, updateEffects: false });
         this._state.sort = data.sort;
     }
 
@@ -188,28 +189,32 @@ class InitiativeStore extends Store<InitiativeState> {
 
     // TURN / ROUND TRACKING
 
-    setTurnCounter(turn: number, options: { sync: boolean; updateEffects: boolean }): void {
+    setTurnCounter(turn: number, direction: InitiativeTurnDirection, options: { sync: boolean; updateEffects: boolean }): void {
         if (options.sync && !gameState.raw.isDm && !this.owns()) return;
-        this._state.turnCounter = turn;
+
+        if (turn < 0) turn = 0;
 
         if (options.updateEffects) {
-            const actor = this.getDataSet()[this._state.turnCounter];
-            if (actor === undefined) return;
+            let entry = direction === InitiativeTurnDirection.Forward ? this._state.turnCounter : turn;
 
-            if (actor.effects.length > 0) {
-                for (let e = actor.effects.length - 1; e >= 0; e--) {
-                    const turns = +actor.effects[e]!.turns;
-                    if (!isNaN(turns)) {
-                        if (turns <= 0) actor.effects.splice(e, 1);
-                        else actor.effects[e]!.turns = (turns - 1).toString();
+            const actor = this.getDataSet()[entry];
+            if (actor !== undefined) {
+                if (actor.effects.length > 0) {
+                    for (let e = actor.effects.length - 1; e >= 0; e--) {
+                        const turns = +actor.effects[e]!.turns;
+                        if (!isNaN(turns)) {
+                            if (turns <= 0) actor.effects.splice(e, 1);
+                            else actor.effects[e]!.turns = (turns - direction).toString();
+                        }
                     }
                 }
             }
         }
+        this._state.turnCounter = turn;
 
         this.handleCameraLock();
         this.handleVisionLock();
-        if (options.sync) sendInitiativeTurnUpdate(turn);
+        if (options.sync) sendInitiativeTurnUpdate({ turn: turn, direction: direction, processEffects: options.updateEffects });
     }
 
     setRoundCounter(round: number, sync: boolean): void {
@@ -218,7 +223,8 @@ class InitiativeStore extends Store<InitiativeState> {
         if (sync) {
             sendInitiativeRoundUpdate(round);
             if (this.getDataSet().length > 0) {
-                this.setTurnCounter(0, { sync, updateEffects: true });
+                // TODO: accept forward and backward
+                this.setTurnCounter(0, InitiativeTurnDirection.Forward, { sync, updateEffects: true });
             }
         }
     }
@@ -228,7 +234,7 @@ class InitiativeStore extends Store<InitiativeState> {
         if (this._state.turnCounter === this.getDataSet().length - 1) {
             this.setRoundCounter(this._state.roundCounter + 1, true);
         } else {
-            this.setTurnCounter(this._state.turnCounter + 1, { sync: true, updateEffects: true });
+            this.setTurnCounter(this._state.turnCounter + 1, InitiativeTurnDirection.Forward, { sync: true, updateEffects: true });
         }
     }
 
@@ -236,9 +242,9 @@ class InitiativeStore extends Store<InitiativeState> {
         if (!gameState.raw.isDm) return;
         if (this._state.turnCounter === 0) {
             this.setRoundCounter(this._state.roundCounter - 1, true);
-            this.setTurnCounter(this.getDataSet().length - 1, { sync: true, updateEffects: true });
+            this.setTurnCounter(this.getDataSet().length - 1, InitiativeTurnDirection.Backward, { sync: true, updateEffects: true });
         } else {
-            this.setTurnCounter(this._state.turnCounter - 1, { sync: true, updateEffects: true });
+            this.setTurnCounter(this._state.turnCounter - 1, InitiativeTurnDirection.Backward, { sync: true, updateEffects: true });
         }
     }
 

--- a/server/src/api/models/initiative/__init__.py
+++ b/server/src/api/models/initiative/__init__.py
@@ -42,5 +42,5 @@ class InitiativeAdd(TypeIdModel):
 
 class InitiativeTurnUpdate(BaseModel):
     turn: int
-    direction: int
-    processEffects: InitiativeDirection
+    direction: InitiativeDirection
+    processEffects: bool

--- a/server/src/api/models/initiative/__init__.py
+++ b/server/src/api/models/initiative/__init__.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+from enum import IntEnum
 
 from ..helpers import TypeIdModel
 from .effect import *
@@ -6,6 +7,12 @@ from .effect import ApiInitiativeEffect
 from .option import *
 from .order import *
 from .value import *
+
+
+class InitiativeDirection(IntEnum):
+    BACKWARD = -1
+    NULL = 0
+    FORWARD = 1
 
 
 class ApiInitiativeData(TypeIdModel):
@@ -31,3 +38,9 @@ class InitiativeAdd(TypeIdModel):
     isVisible: bool
     isGroup: bool
     effects: list[ApiInitiativeEffect]
+
+
+class InitiativeTurnUpdate(BaseModel):
+    turn: int
+    direction: int
+    processEffects: InitiativeDirection

--- a/server/src/api/socket/initiative/__init__.py
+++ b/server/src/api/socket/initiative/__init__.py
@@ -389,23 +389,20 @@ async def update_initiative_turn(sid: str, raw_data: Any):
             if process_effects:
                 entry = location_data.turn if data.direction == InitiativeDirection.FORWARD else turn
                 effect_list = json_data[entry]["effects"]
-                i = 0
-                while i < len(effect_list):
-                    _effect = effect_list[i]
+                starting_len = len(effect_list)
+                for i, _effect in enumerate(effect_list[::-1]):
                     effect_turns = _effect["turns"]
-                    if effect_turns is not None:
-                        try:
-                            turns = int(effect_turns)
-                            if turns <= 0 and data.direction == InitiativeDirection.FORWARD:
-                                effect_list.pop(i)
-                                continue
-                                # Element removed, do not increment
-                            else:
-                                _effect["turns"] = str(turns - data.direction)
-                        except ValueError:
-                            # For non-number inputs do not update the effect
-                            pass
-                    i = i + 1
+                    if effect_turns is None:
+                        continue
+                    try:
+                        turns = int(effect_turns)
+                        if turns <= 0 and data.direction == InitiativeDirection.FORWARD:
+                            effect_list.pop(starting_len - 1 - i)
+                        else:
+                            _effect["turns"] = str(turns - data.direction)
+                    except ValueError:
+                        # For non-number inputs do not update the effect
+                        pass
             location_data.turn = turn
             location_data.data = json.dumps(json_data)
     else:

--- a/server/src/api/socket/initiative/__init__.py
+++ b/server/src/api/socket/initiative/__init__.py
@@ -13,7 +13,7 @@ from ....models.access import has_ownership
 from ....models.role import Role
 from ....state.game import game_state
 from ...helpers import _send_game
-from ...models.initiative import ApiInitiative, InitiativeAdd
+from ...models.initiative import ApiInitiative, InitiativeAdd, InitiativeTurnUpdate, InitiativeDirection
 from ...models.initiative.option import InitiativeOptionSet
 from ...models.initiative.order import InitiativeOrderChange
 from ...models.initiative.value import InitiativeValueSet
@@ -349,17 +349,22 @@ async def change_initiative_order(sid: str, raw_data: Any):
 
 @sio.on("Initiative.Turn.Update", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
-async def update_initiative_turn(sid: str, turn: int):
+async def update_initiative_turn(sid: str, raw_data: Any):
+    data = InitiativeTurnUpdate(**raw_data)
     pr = game_state.get(sid)
 
     location_data: Initiative = Initiative.get(location=pr.active_location)
     json_data = json.loads(location_data.data)
+    data_len = len(json_data)
 
-    if turn < 0 or turn >= len(json_data):
+    turn = data.turn
+    process_effects = data.processEffects
+
+    if turn < 0 or turn >= data_len:
         logger.warning("Provided turn is out of bounds.")
         return
 
-    db_turn_valid = 0 <= location_data.turn < len(json_data)
+    db_turn_valid = 0 <= location_data.turn < data_len
 
     if db_turn_valid:
         shape = Shape.get_or_none(uuid=json_data[location_data.turn]["shape"])
@@ -374,22 +379,27 @@ async def update_initiative_turn(sid: str, turn: int):
             return
 
         with db.atomic():
-            next_turn = turn > location_data.turn
+            if process_effects:
+                entry = location_data.turn if data.direction == InitiativeDirection.FORWARD else turn
+                effect_list = json_data[entry]["effects"]
+                i = 0
+                while i < len(effect_list):
+                    _effect = effect_list[i]
+                    effect_turns = _effect["turns"]
+                    if effect_turns is not None:
+                        try:
+                            turns = int(effect_turns)
+                            if turns <= 0 and data.direction == InitiativeDirection.FORWARD:
+                                json_data[entry]["effects"].pop(i)
+                                continue
+                                # Element removed, do not increment
+                            else:
+                                _effect["turns"] = str(turns - data.direction)
+                        except ValueError:
+                            # For non-number inputs do not update the effect
+                            pass
+                    i = i + 1
             location_data.turn = turn
-
-            for i, _effect in enumerate(json_data[turn]["effects"][-1:]):
-                try:
-                    turns = int(_effect["turns"])
-                    if turns <= 0 and next_turn:
-                        json_data[turn]["effects"].pop(i)
-                    elif turns > 0 and next_turn:
-                        _effect["turns"] = str(turns - 1)
-                    else:
-                        _effect["turns"] = str(turns + 1)
-                except ValueError:
-                    # For non-number inputs do not update the effect
-                    pass
-
             location_data.data = json.dumps(json_data)
     else:
         logger.error("!DB turn state was invalid! Hard setting turn without effect processing.")
@@ -397,7 +407,7 @@ async def update_initiative_turn(sid: str, turn: int):
 
     location_data.save()
 
-    await _send_game("Initiative.Turn.Update", turn, room=pr.active_location.get_path(), skip_sid=sid)
+    await _send_game("Initiative.Turn.Update", data, room=pr.active_location.get_path(), skip_sid=sid)
 
 
 @sio.on("Initiative.Round.Update", namespace=GAME_NS)


### PR DESCRIPTION
This PR fixes a number of smaller issues in the handling of turn changes and round changes. I'll address each individually:

## Effect Timers
When going to a previous turn in initiative, the effects attached to an entry would decrement as though you had gone to the next turn. I decided to add navigation direction to the calls to `setTurnCounter` in the client and `update_initiative_turn` in the server. It was otherwise impossible to tell which direction (forward or backward) the initiative was moving when only 2 entries were present. This information allows us to decrement the effect counters of an entry only when going forward.

I also thought that *incrementing* the effect counters when going in reverse seemed desirable. Imagine accidentally advancing and going back causing the effect timers to be inaccurate.

https://github.com/user-attachments/assets/eeaa2160-55e3-46ac-ab40-6f1a77a0f497

## Invalid Turn Index

When removing a shape from the beginning of the initiative list, the turn counter would enter an invalid state. This was a straight forward fix of index checking.

https://github.com/user-attachments/assets/d9c0fdcc-84da-4aca-bb1b-704157498351

## Negative Round Counter

The round counter could go below 0 by pressing the previous turn button repeatedly. I considered this as an invalid state, though the logic had no problem handling it. I believe that round 0 is a valid round as it could be treated as a 'surprise round'. You could make the same argument for negative rounds being additional surprise rounds, but this seems like a rather hacky way to use the tool.

https://github.com/user-attachments/assets/5275146a-b86f-42d4-b704-412472395d57

## Entry Removal Should Go to Next Turn

When removing an entry from initiative, I believe that one would typically want to go to the next entry in the list rather than the one preceding. Usually when I remove an entry, it has left combat due to fleeing or death and the next entry would immediately take its turn. The current behavior is to go to the previous entry. I believe this would cause issues with effect timers and add an extra step to finding the next entry to act.