### PR TITLE
chore: Add *.sw? to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # editors
 .idea/**
 .vscode/**
+*.sw?
 
 # Python
 server/data/**


### PR DESCRIPTION
I use an editor that places .swp files alongside the original while a file is open. These swp should never be included in the repository, but git happily adds them when I use `git add .` or similar. The client already has a dedicated gitignore which handles these temporary files. This PR simply makes `.sw?` files ignored throughout the whole repository rather than just in the client.

Checking with `find -iname '*.sw*'`, no files would be affected by this change.