### PR TITLE
bug(Assets): Fix asset search query showing other user assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ tech changes will usually be stripped from release notes for the public
 -   Going to previous initiative would decrement effect timers
 -   Going to previous initiative could enter negative rounds
 -   Render bug in vision mode "behind" showing the entire shape under certain circumstances
+-   Asset search server query had a missing () causing assets from other users to show up
 
 ## [2025.2.2]
 

--- a/server/src/api/socket/asset_manager/core.py
+++ b/server/src/api/socket/asset_manager/core.py
@@ -370,7 +370,7 @@ async def assetmgmt_upload(sid: str, raw_data: Any):
 async def assetmgmt_search(sid: str, query: str):
     user = asset_state.get_user(sid)
 
-    assets = Asset.select().where(Asset.owner == user & Asset.name.contains(query)).order_by(Asset.name)  # type: ignore
+    assets = Asset.select().where((Asset.owner == user) & Asset.name.contains(query)).order_by(Asset.name)  # type: ignore
 
     return [transform_asset(asset, user) for asset in assets]
 


### PR DESCRIPTION
Fixes #1650

A sneaky bug in the asset search code caused the query to ignore the actual ownership check due to operator precedence.