### PR TITLE
feat(Assets): Add debounce to asset search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Smoothed out the scroll zoom behaviour when zoomed in furthest
 -   [server] Config values that are not known will now error and stop the server from starting
+-   [tech] Add debounce to asset search
 
 ### Removed
 


### PR DESCRIPTION
There apparently was no debounce on the asset search, which is just inefficient.