### PR TITLE
feat(Assets): Add toggle to search through shared assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ tech changes will usually be stripped from release notes for the public
     -   Currently limited to the main admin_user as configured in the server's config
     -   Shows roughly same content as the original separate admin client
     -   Also shows total number of users/campaigns and a quick user create button
+-   Toggle to search through shared assets
+    -   This is heavier for the server and niche so not enabled by default
 
 ### Changed
 

--- a/client/src/assets/ui/AssetSearchCore.vue
+++ b/client/src/assets/ui/AssetSearchCore.vue
@@ -29,6 +29,10 @@ defineExpose({ search });
                 />
             </div>
         </div>
+        <div v-if="search.filter.value.length >= 3" id="search-options">
+            <input id="include-shared-assets" v-model="search.includeSharedAssets.value" type="checkbox" />
+            <label for="include-shared-assets">Include shared assets</label>
+        </div>
     </div>
 </template>
 
@@ -37,7 +41,7 @@ defineExpose({ search });
     margin: 1rem 0;
     position: relative;
 
-    > div {
+    > div:first-of-type {
         position: relative;
         display: flex;
         align-items: center;
@@ -136,6 +140,15 @@ defineExpose({ search });
                 display: inline-block;
             }
         }
+    }
+
+    > #search-options {
+        position: absolute;
+        right: 1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-left: 1rem;
     }
 }
 </style>

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -102,3 +102,15 @@ class Asset(BaseDbModel):
             else:
                 data[asset.name] = cls.get_user_structure(user, asset)
         return data
+
+    @classmethod
+    def get_all_assets(cls, user: User, parent=None):
+        if parent is None:
+            parent = cls.get_root_folder(user)
+
+        assets = [*Asset.select().where((Asset.parent == parent))]
+        for asset_share in AssetShare().select().where((AssetShare.parent == parent)):
+            assets.append(asset_share.asset)
+        for asset in assets:
+            yield asset
+            yield from cls.get_all_assets(user, asset)


### PR DESCRIPTION
While fixing a recent bug, I noticed that the asset search bar doesn't search through shared assets.
This is probably unexpected if you actually have shared assets.

With the current setup of assets it's pretty expensive query-wise to actually include this info. So I added it behind an extra toggle that appears below the asset search bar.

So by default it will not include them, but you can explicitly query them if needed. Given the more niche use of asset-sharing and the impact on the server it makes sense to me to default this to not be included.