### PR TITLE
chore(Dice): Re-organize dice tool input handling

### DIFF
--- a/client/src/game/systems/customData/components/DiceFormat.vue
+++ b/client/src/game/systems/customData/components/DiceFormat.vue
@@ -5,10 +5,7 @@ import type { ApiShapeCustomDataDiceExpression } from "../../../../apiTypes";
 import type { LocalId } from "../../../../core/id";
 import { ToolName } from "../../../models/tools";
 import { activateTool } from "../../../tools/tools";
-import { diceToolInput } from "../../../tools/variants/dice";
 import { diceSystem } from "../../dice";
-import { diceState } from "../../dice/state";
-import { DiceUiState } from "../../dice/types";
 import type { ElementId } from "../types";
 import { getVariableSegments } from "../utils";
 
@@ -23,12 +20,10 @@ const segments = computed(() => {
 
 async function loadRoll(): Promise<void> {
     if (!diceSystem.isLoaded) await diceSystem.loadSystems();
-    diceState.mutableReactive.uiState = DiceUiState.Roll;
     activateTool(ToolName.Dice);
-    const system = diceSystem.getSystem("2d")!;
     // We need a short timeout when loading the dice tool for the first time
     await new Promise((resolve) => setTimeout(resolve, 100));
-    diceToolInput.value = system.parse(
+    diceSystem.setInput(
         segments.value
             .filter((segment) => !segment.isVariable || segment.ref.value !== undefined)
             .map((segment) => (segment.isVariable ? segment.ref.value!.value : segment.text))

--- a/client/src/game/systems/dice/dx.ts
+++ b/client/src/game/systems/dice/dx.ts
@@ -1,8 +1,27 @@
 import { type DxSegment, DxSegmentType } from "@planarally/dice/systems/dx";
-import type { Ref } from "vue";
+import { ref, watch, type Ref } from "vue";
+
+import { diceState } from "./state";
+
+import { diceSystem } from ".";
 
 const addOptions = ["d4", "d6", "d8", "d10", "d12", "d20", "d100"] as const;
 const symbolOptions = ["+", "-"] as const; // , "*", "/", "(", ")"] as const;
+
+const parts = ref<DxSegment[]>([]);
+
+watch(
+    () => diceState.reactive.textInput,
+    (text) => {
+        parts.value = diceState.raw.systems!["2d"].parse(text);
+    },
+);
+
+// We don't want to do this on every change, as that can remove pending text changes
+// which will update parts using the watcher above
+function syncToState(): void {
+    diceSystem.setInput(stringifySegments());
+}
 
 function addSegment(partsRef: Ref<DxSegment[]>, segment: DxSegment): void {
     const parts = partsRef.value;
@@ -10,9 +29,10 @@ function addSegment(partsRef: Ref<DxSegment[]>, segment: DxSegment): void {
         parts.push({ type: DxSegmentType.Operator, input: "+" });
     }
     parts.push(segment);
+    syncToState();
 }
 
-function addDie(parts: Ref<DxSegment[]>, die: (typeof addOptions)[number]): void {
+function addDie(die: (typeof addOptions)[number]): void {
     const seg = parts.value.at(-1);
     if (seg?.type === DxSegmentType.Die && seg.die === die) {
         seg.amount += 1;
@@ -23,9 +43,10 @@ function addDie(parts: Ref<DxSegment[]>, die: (typeof addOptions)[number]): void
     } else {
         addSegment(parts, { type: DxSegmentType.Die, amount: 1, die, input: `1${die}` });
     }
+    syncToState();
 }
 
-function addLiteral(parts: Ref<DxSegment[]>, value: number): void {
+function addLiteral(value: number): void {
     const seg = parts.value.at(-1);
     if (seg?.type === DxSegmentType.Die && seg.operator !== undefined) {
         if (seg.selectorValue === undefined) seg.selectorValue = value;
@@ -35,15 +56,17 @@ function addLiteral(parts: Ref<DxSegment[]>, value: number): void {
     } else {
         addSegment(parts, { type: DxSegmentType.Literal, input: value.toString(), value });
     }
+    syncToState();
 }
 
-function addOperator(parts: Ref<DxSegment[]>, input: (typeof symbolOptions)[number]): void {
+function addOperator(input: (typeof symbolOptions)[number]): void {
     addSegment(parts, { type: DxSegmentType.Operator, input });
+    syncToState();
 }
 
-function stringifySegments(parts: DxSegment[]): string {
+function stringifySegments(): string {
     let text = "";
-    for (const seg of parts) {
+    for (const seg of parts.value) {
         if (seg.type === DxSegmentType.Die) {
             text += `${seg.amount}${seg.die}`;
             if (seg.operator === "keep") text += "k";
@@ -70,5 +93,5 @@ export const DxHelper = {
     addDie,
     addLiteral,
     addOperator,
-    stringifySegments,
+    parts,
 };

--- a/client/src/game/systems/dice/index.ts
+++ b/client/src/game/systems/dice/index.ts
@@ -7,6 +7,7 @@ import type { SystemClearReason } from "../../../core/systems/models";
 import type { AsyncReturnType } from "../../../core/types";
 
 import { diceState } from "./state";
+import { DiceUiState } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const _env = () => import("./environment");
@@ -23,6 +24,12 @@ class DiceSystem implements System {
         if (reason !== "full-loading") {
             $.history = [];
         }
+    }
+
+    setInput(input: string): void {
+        $.textInput = input;
+        $.updateTextInputScroll = true;
+        $.uiState = DiceUiState.Roll;
     }
 
     addToHistory(roll: RollResult<Part>, player: string, name?: string): string {

--- a/client/src/game/systems/dice/state.ts
+++ b/client/src/game/systems/dice/state.ts
@@ -9,6 +9,8 @@ import { DiceUiState } from "./types";
 
 interface DiceState {
     uiState: LocalId | DiceUiState;
+    textInput: string;
+    updateTextInputScroll: boolean;
     dimensions3d: { width: number; height: number };
     history: { roll: RollResult<Part>; name: string; player: string }[];
     systems?: { "2d": AsyncReturnType<typeof SYSTEMS.DX>["DX"]; "3d": AsyncReturnType<typeof SYSTEMS.DX3>["DX3"] };
@@ -17,8 +19,10 @@ interface DiceState {
 
 const state = buildState<DiceState>({
     uiState: DiceUiState.Roll,
+    updateTextInputScroll: false,
     dimensions3d: { width: 0, height: 0 },
     history: [],
+    textInput: "",
 });
 export const diceState = {
     ...state,

--- a/client/src/game/tools/variants/dice.ts
+++ b/client/src/game/tools/variants/dice.ts
@@ -1,8 +1,7 @@
 import type { Vector3 } from "@babylonjs/core/Maths/math";
 import { type Part, type RollResult, rollString } from "@planarally/dice/core";
-import type { DxSegment } from "@planarally/dice/systems/dx";
 import tinycolor from "tinycolor2";
-import { reactive, ref } from "vue";
+import { reactive } from "vue";
 
 import type { DiceRollResult } from "../../../apiTypes";
 import { randomInterval } from "../../../core/utils";
@@ -62,8 +61,6 @@ async function generate3dOptions(): Promise<{
         physics,
     };
 }
-
-export const diceToolInput = ref<DxSegment[]>([]);
 
 class DiceTool extends Tool implements ITool {
     readonly toolName = ToolName.Dice;

--- a/client/src/game/ui/tools/dice/DiceCore.vue
+++ b/client/src/game/ui/tools/dice/DiceCore.vue
@@ -466,7 +466,6 @@ async function roll(): Promise<void> {
                     ref="inputElement"
                     v-model="diceState.mutableReactive.textInput"
                     type="text"
-                    @change="updateFromString"
                     @keyup.enter="roll"
                 />
                 <font-awesome-icon

--- a/client/src/game/ui/tools/dice/DiceCore.vue
+++ b/client/src/game/ui/tools/dice/DiceCore.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type Part, type RollResult } from "@planarally/dice/core";
 import { DxConfig, DxSegmentType } from "@planarally/dice/systems/dx";
-import { type DeepReadonly, computed, nextTick, ref, watch } from "vue";
+import { type DeepReadonly, computed, nextTick, ref, useTemplateRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
 import type { DiceRollResult } from "../../../../apiTypes";
@@ -12,7 +12,7 @@ import { convertVariables } from "../../../systems/customData/utils";
 import { diceSystem } from "../../../systems/dice";
 import { DxHelper } from "../../../systems/dice/dx";
 import { diceState } from "../../../systems/dice/state";
-import { diceTool, diceToolInput } from "../../../tools/variants/dice";
+import { diceTool } from "../../../tools/variants/dice";
 
 const { t } = useI18n();
 
@@ -43,7 +43,7 @@ const showRollHistory = ref(false);
 const showHistoryBreakdownFor = ref<number | null>(null);
 
 const canvasElement = ref<HTMLCanvasElement | null>(null);
-const inputElement = ref<HTMLInputElement | null>(null);
+const inputElement = useTemplateRef<HTMLInputElement>("inputElement");
 
 const translationMapping = {
     dice3dOptions: {
@@ -72,7 +72,7 @@ const lastRoll = ref<RollResult<Part>>({
 
 const literalOptions = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ...DxConfig.symbolOptions] as const;
 
-const lastSeg = computed(() => diceToolInput.value.at(-1));
+const lastSeg = computed(() => DxHelper.parts.value.at(-1));
 
 watch(breakdownDetailOptionHistory, () => {
     localStorage.setItem("diceTool.breakdownDetailOptionHistory", breakdownDetailOptionHistory.value);
@@ -115,16 +115,18 @@ const showSelector = computed(() => {
     );
 });
 
-const inputText = ref("");
+// Update the scroll position of the input element when the text input changes
+// This is only set when the input was changed explicitly through the dice system
+// manual text changes will not trigger this (on purpose)
 watch(
-    diceToolInput,
-    async (parts) => {
-        inputText.value = DxHelper.stringifySegments(parts);
+    () => diceState.reactive.updateTextInputScroll,
+    async (value) => {
+        if (!value) return;
         await nextTick();
         inputElement.value!.scrollLeft = inputElement.value!.scrollWidth;
         inputElement.value!.focus();
+        diceState.mutableReactive.updateTextInputScroll = false;
     },
-    { deep: true },
 );
 
 function scrollToHistoryEntry(element: Element): void {
@@ -132,11 +134,11 @@ function scrollToHistoryEntry(element: Element): void {
 }
 
 function clear(): void {
-    diceToolInput.value = [];
+    diceState.mutableReactive.textInput = "";
 }
 
 function addDie(die: (typeof DxConfig.addOptions)[number]): void {
-    DxHelper.addDie(diceToolInput, die);
+    DxHelper.addDie(die);
 }
 
 function addOperator(
@@ -157,16 +159,11 @@ function addLiteral(literal: (typeof literalOptions)[number]): void {
     const literalAsOperator = literal as (typeof DxConfig.symbolOptions)[number];
 
     if (DxConfig.symbolOptions.includes(literalAsOperator)) {
-        diceToolInput.value.push({ type: DxSegmentType.Operator, input: literalAsOperator });
+        DxHelper.parts.value.push({ type: DxSegmentType.Operator, input: literalAsOperator });
     } else {
         const value = Number.parseInt(literal);
-        DxHelper.addLiteral(diceToolInput, value);
+        DxHelper.addLiteral(value);
     }
-}
-
-function updateFromString(event: Event): void {
-    const text = (event.target as HTMLInputElement).value;
-    diceToolInput.value = diceState.raw.systems!["2d"].parse(convertVariables(text));
 }
 
 function populateInputFromHistoryRoll(roll: DeepReadonly<RollResult<Part>>): void {
@@ -177,7 +174,7 @@ function populateInputFromHistoryRoll(roll: DeepReadonly<RollResult<Part>>): voi
     for (const part of parts) {
         content += part.input ?? "";
     }
-    diceToolInput.value = diceState.raw.systems!["2d"].parse(content);
+    diceSystem.setInput(content);
 }
 
 function populateInputFromHistoryIndex(index: number): void {
@@ -187,13 +184,14 @@ function populateInputFromHistoryIndex(index: number): void {
 }
 
 async function roll(): Promise<void> {
-    if (inputText.value.length === 0) return;
+    const content = diceState.raw.textInput;
+    if (content.length === 0) return;
 
     clear();
     awaitingRoll.value = true;
 
     lastRoll.value = await diceTool.roll(
-        inputText.value,
+        convertVariables(content),
         dice3dSetting.value !== "off",
         shareResult.value.toLowerCase() as DiceRollResult["shareWith"],
     );
@@ -466,13 +464,13 @@ async function roll(): Promise<void> {
                 <input
                     id="input"
                     ref="inputElement"
-                    v-model="inputText"
+                    v-model="diceState.mutableReactive.textInput"
                     type="text"
                     @change="updateFromString"
                     @keyup.enter="roll"
                 />
                 <font-awesome-icon
-                    v-show="inputText.length > 0"
+                    v-show="diceState.reactive.textInput.length > 0"
                     id="clear-input-icon"
                     icon="circle-xmark"
                     :title="t('game.ui.tools.DiceTool.clear_selection_title')"
@@ -481,7 +479,7 @@ async function roll(): Promise<void> {
             </div>
             <font-awesome-icon
                 id="roll-button"
-                :class="{ disabled: inputText.length === 0 }"
+                :class="{ disabled: diceState.reactive.textInput.length === 0 }"
                 class="svg-button"
                 icon="dice-six"
                 :title="t('game.ui.tools.DiceTool.roll')"


### PR DESCRIPTION
This is a technical PR that re-organizes some logic regarding dice input handling.

There is both a string representation and an array parts presentation which are used for different aspects of the UI/logic, but kept each-other in sync.

This caused some annoyances with upcoming work and was also not well laid out from an architectural standpoint.

The string representation is now the main source of truth and also kept in the main dice state, allowing easier access to modify this by places outside of the dice tool.

The array logic is now contained with the dx helper file, which is were it always should have resided as its specialized logic that's not relevant for the main dice tool.