### PR TITLE
feat(Dice): Add dice auto complete modal for custom data references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ tech changes will usually be stripped from release notes for the public
     -   Currently supported data types are text, number, toggle and dice expressions
     -   Dice expressions can reference other data entries and open the dice tool with the evaluated expression
     -   Dice tool has a quick access sidebar to selected shapes with dice expressions
+    -   Dice tool shows auto completion on expression references
 
 ### Changed
 

--- a/client/src/game/ui/tools/dice/DiceAutoComplete.vue
+++ b/client/src/game/ui/tools/dice/DiceAutoComplete.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { nextTick, onUnmounted, ref, watch } from "vue";
+
+import type { LocalId } from "../../../../core/id";
+import type { DistributiveOmit } from "../../../../core/types";
+import { getShape } from "../../../id";
+import type { IAsset } from "../../../interfaces/shapes/asset";
+import { customDataState } from "../../../systems/customData/state";
+import type { UiShapeCustomData } from "../../../systems/customData/types";
+import { diceState } from "../../../systems/dice/state";
+import { selectedState } from "../../../systems/selected/state";
+
+const showAutoComplete = ref(false);
+const autoCompleteSearchIndex = ref(0);
+const autoCompleteSearchText = ref("");
+type AutoCompleteOption = DistributiveOmit<UiShapeCustomData, "shapeId"> & { shapeId: LocalId; src: string };
+const autoCompleteOptions = ref<AutoCompleteOption[]>([]);
+
+const { inputElement } = defineProps<{
+    inputElement: HTMLInputElement | null;
+}>();
+
+const emit = defineEmits<{
+    (e: "roll"): void;
+}>();
+
+// hook up event listeners
+
+watch(
+    () => inputElement,
+    (newVal) => {
+        if (newVal === null) return;
+        newVal.addEventListener("input", checkAutoComplete);
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        newVal.addEventListener("keydown", handleAutoCompleteKey);
+    },
+    { immediate: true }, // needed for hot reloading
+);
+
+onUnmounted(() => {
+    if (inputElement === null) return;
+    inputElement.removeEventListener("input", checkAutoComplete);
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    inputElement.removeEventListener("keydown", handleAutoCompleteKey);
+});
+
+function checkAutoComplete(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    const value = target.value;
+    if (value.length === 0) {
+        showAutoComplete.value = false;
+        return;
+    }
+
+    // figure out if we're typing a reference
+    // look back until we find a {, the start of the input, or a different non-letter
+
+    const end = (target.selectionStart ?? 0) - 1;
+    let start = end;
+    for (let i = end; i >= 0; i--) {
+        if (target.value[i] === "{") {
+            start = i + 1;
+            break;
+        } else if (value[i]!.match(/[a-z]/) === null) {
+            break;
+        }
+    }
+
+    autoCompleteSearchText.value = value.slice(start, end + 1);
+    // Require at least 1 character after the { to search
+    if (autoCompleteSearchText.value.length > 1) {
+        autoCompleteOptions.value = getAutoCompleteOptions(autoCompleteSearchText.value);
+        autoCompleteSearchIndex.value = 0;
+        showAutoComplete.value = true;
+    } else {
+        showAutoComplete.value = false;
+    }
+}
+
+async function completeAutoComplete(option: AutoCompleteOption): Promise<void> {
+    if (inputElement === null) return;
+    const start = (inputElement.selectionStart ?? 0) - autoCompleteSearchText.value.length - 1;
+
+    const oldMessage = diceState.raw.textInput;
+    diceState.mutableReactive.textInput =
+        oldMessage.slice(0, start) + option.value + oldMessage.slice(start + autoCompleteSearchText.value.length + 1);
+
+    showAutoComplete.value = false;
+
+    const newStart = start + option.name.length + 3;
+
+    await nextTick(() => {
+        inputElement?.setSelectionRange(newStart, newStart);
+        inputElement?.focus();
+    });
+}
+
+async function handleAutoCompleteKey(event: KeyboardEvent): Promise<void> {
+    if (event.key === "Enter") {
+        if (showAutoComplete.value) {
+            await completeAutoComplete(autoCompleteOptions.value[autoCompleteSearchIndex.value]!);
+            event.preventDefault();
+        } else {
+            emit("roll");
+        }
+    } else if (event.key === "{" || event.key === "}") {
+        autoCompleteSearchText.value = "";
+    } else if (event.key === "Escape") {
+        showAutoComplete.value = false;
+    } else if (event.key === "ArrowDown") {
+        if (showAutoComplete.value) {
+            event.preventDefault();
+            autoCompleteSearchIndex.value = (autoCompleteSearchIndex.value + 1) % autoCompleteOptions.value.length;
+        }
+    } else if (event.key === "ArrowUp") {
+        if (showAutoComplete.value) {
+            event.preventDefault();
+            autoCompleteSearchIndex.value =
+                (autoCompleteSearchIndex.value - 1 + autoCompleteOptions.value.length) %
+                autoCompleteOptions.value.length;
+        }
+    }
+}
+
+function getAutoCompleteOptions(value: string): AutoCompleteOption[] {
+    const options: AutoCompleteOption[] = [];
+    for (const [shapeId, shapeData] of customDataState.readonly.data.entries()) {
+        let shape: IAsset | undefined;
+        for (const data of shapeData) {
+            if (data.name.toLowerCase().startsWith(value.toLowerCase())) {
+                if (shape === undefined) {
+                    const sh = getShape(shapeId);
+                    if (sh === undefined || sh.type !== "assetrect") continue;
+                    shape = sh as IAsset;
+                }
+                options.push({ src: shape.src, ...data, shapeId });
+            }
+        }
+    }
+    // sort results according to selection and focus
+    const selection = selectedState.raw.selected;
+    const focus = selectedState.raw.focus;
+    return options.sort((a, b) => {
+        const aSelected = selection.has(a.shapeId);
+        const bSelected = selection.has(b.shapeId);
+        if (aSelected && !bSelected) return -1;
+        if (!aSelected && bSelected) return 1;
+        if (aSelected && bSelected) {
+            if (a.shapeId === focus) return -1;
+            if (b.shapeId === focus) return 1;
+        }
+        return 0;
+    });
+}
+</script>
+
+<template>
+    <div v-if="showAutoComplete" id="auto-complete">
+        <div
+            v-for="(option, i) of autoCompleteOptions"
+            :key="`${option.shapeId}-${option.id}`"
+            :class="{ selected: i === autoCompleteSearchIndex }"
+        >
+            <img :src="option.src" />
+            <div>
+                <div class="ref-prefix">{{ option.prefix }}</div>
+                <div>{{ option.name }}</div>
+            </div>
+            <div style="flex: 1"></div>
+            <div class="ref-value">{{ option.value }}</div>
+        </div>
+    </div>
+</template>
+
+<style scoped lang="scss">
+#auto-complete {
+    position: absolute;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 1em;
+    max-height: 12.5em;
+    overflow-y: auto;
+
+    box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.5);
+
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+
+    left: 0em;
+    bottom: 2em;
+    right: 0em;
+
+    > div {
+        display: flex;
+        align-items: center;
+        padding: 0 0.25em;
+
+        > * {
+            height: 100%;
+            align-items: center;
+        }
+
+        > div:first-of-type {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+
+            .ref-prefix {
+                opacity: 0.5;
+            }
+        }
+
+        .ref-value {
+            font-weight: bold;
+            padding-right: 0.5em;
+        }
+
+        &.selected,
+        &:hover {
+            background-color: #e0e0e0;
+            cursor: pointer;
+        }
+
+        img {
+            height: 2em;
+            margin-right: 1em;
+        }
+    }
+}
+</style>

--- a/client/src/game/ui/tools/dice/DiceCore.vue
+++ b/client/src/game/ui/tools/dice/DiceCore.vue
@@ -14,6 +14,8 @@ import { DxHelper } from "../../../systems/dice/dx";
 import { diceState } from "../../../systems/dice/state";
 import { diceTool } from "../../../tools/variants/dice";
 
+import DiceAutoComplete from "./DiceAutoComplete.vue";
+
 const { t } = useI18n();
 
 // const limitOperatorOptionNames = [t('game.ui.tools.DiceTool.limit_operator_options.keep'), t('game.ui.tools.DiceTool.limit_operator_options.drop'), t('game.ui.tools.DiceTool.limit_operator_options.min'), t('game.ui.tools.DiceTool.limit_operator_options.max')]
@@ -461,13 +463,7 @@ async function roll(): Promise<void> {
         </div>
         <div id="buttons">
             <div id="input-bar">
-                <input
-                    id="input"
-                    ref="inputElement"
-                    v-model="diceState.mutableReactive.textInput"
-                    type="text"
-                    @keyup.enter="roll"
-                />
+                <input id="input" ref="inputElement" v-model="diceState.mutableReactive.textInput" type="text" />
                 <font-awesome-icon
                     v-show="diceState.reactive.textInput.length > 0"
                     id="clear-input-icon"
@@ -475,6 +471,7 @@ async function roll(): Promise<void> {
                     :title="t('game.ui.tools.DiceTool.clear_selection_title')"
                     @click.stop="clear"
                 />
+                <DiceAutoComplete :input-element="inputElement" @roll="roll" />
             </div>
             <font-awesome-icon
                 id="roll-button"
@@ -905,6 +902,7 @@ async function roll(): Promise<void> {
         align-items: center;
 
         > #input-bar {
+            position: relative;
             flex: 1 0 0;
             display: flex;
             align-items: center;


### PR DESCRIPTION
This adds an auto complete modal when starting to type a custom data reference.

Note that at least 2 characters have to be entered after the `{` before suggestions show up. This is to limit the amount of options.

<img width="376" height="155" alt="image" src="https://github.com/user-attachments/assets/1eaeaf5f-11bf-4e38-b126-a040730d35ef" />

It will search across _all_ known custom data entries that have an entry that starts with the same name.

It will sort the data by showing entries in your active selection first, with your active focus being at the top.

You can use the arrow keys to navigate the menu, use escape to close it and enter to select it.
When using enter it will automatically fill in the appropriate value instead of the characters you've already typed.

Note that if you haven't actively selected any entry, but typed out the reference manually. It's evaluation will be postponed to the moment you roll, at which time the behavior from the original PR will be used: Only check the active selection for matching entries and pick the first entry that happens to have it.