### PR TITLE
feat(Dice): Make references visually cleaner in the dice input

### DIFF
--- a/client/src/game/input/keyboard/up.ts
+++ b/client/src/game/input/keyboard/up.ts
@@ -15,7 +15,8 @@ export function onKeyUp(event: KeyboardEvent): Promise<void> {
     if (
         event.target instanceof HTMLInputElement ||
         event.target instanceof HTMLTextAreaElement ||
-        event.target instanceof HTMLSelectElement
+        event.target instanceof HTMLSelectElement ||
+        (event.target instanceof HTMLElement && event.target.contentEditable === "true")
     ) {
         // no-op (condition is cleaner this way)
     } else {

--- a/client/src/game/systems/customData/utils.ts
+++ b/client/src/game/systems/customData/utils.ts
@@ -1,5 +1,3 @@
-import { computed, type ComputedRef } from "vue";
-
 import type { LocalId } from "../../../core/id";
 import { selectedState } from "../selected/state";
 
@@ -7,11 +5,15 @@ import { customDataState } from "./state";
 import { type UiShapeCustomData } from "./types";
 
 const CUSTOM_DATA_VALID_CHARS = "\\w /";
-const CUSTOM_DATA_REGEX = /{([\w /]+)}/g; // keep in sync with the above (reads nicer as /../ compared to RegExp)
+// This should mostly be kept in sync with the above (reads nicer as /../ compared to RegExp)
+// The first part of the full regex is an optional shape LocalId discriminator
+// This can only be used in dice tool input for now, we might have to change this to a part of the GlobalId
+// if we want to store this in the db
+const CUSTOM_DATA_REGEX = /{(\[\d+\])?([\w /]+)}/g;
 
 type VariableSegment =
     | { text: string; isVariable: false }
-    | { text: string; isVariable: true; ref: ComputedRef<UiShapeCustomData | undefined> };
+    | { text: string; isVariable: true; ref: UiShapeCustomData | undefined; discriminator?: string };
 
 export function getCustomDataReference(name: string): string {
     return name.replaceAll(new RegExp(`[^${CUSTOM_DATA_VALID_CHARS}]`, "g"), "");
@@ -25,8 +27,10 @@ export function getVariableSegments(data: string, shapeFocus?: LocalId): Variabl
             result.push({ text: data.slice(nextIndex, part.index), isVariable: false });
             nextIndex = part.index;
         }
-        const match = part[1]!;
-        const parts = match.split("/");
+        const shapeMatch = part[1];
+        const shapeId = shapeMatch !== undefined ? (Number.parseInt(shapeMatch.slice(1, -1)) as LocalId) : undefined;
+        const refMatch = part[2]!;
+        const parts = refMatch.split("/");
         if (parts.length === 0) continue;
         const last = parts.at(-1)!;
         let prefix = parts.length === 1 ? undefined : parts.slice(0, -1).join("/");
@@ -34,19 +38,18 @@ export function getVariableSegments(data: string, shapeFocus?: LocalId): Variabl
         result.push({
             text: last,
             isVariable: true,
-            ref: computed(() =>
-                customDataState.mutableReactive.data
-                    .get(shapeFocus ?? selectedState.reactive.focus!)
-                    ?.find(
-                        (data) =>
-                            (prefix === undefined ||
-                                getCustomDataReference(data.prefix.toLowerCase()) === prefix.toLowerCase()) &&
-                            (data.reference?.toLowerCase() ?? getCustomDataReference(data.name.toLowerCase())) ===
-                                last.toLowerCase(),
-                    ),
-            ),
+            discriminator: shapeMatch ?? shapeFocus?.toString(),
+            ref: customDataState.readonly.data
+                .get(shapeId ?? shapeFocus ?? selectedState.reactive.focus!)
+                ?.find(
+                    (data) =>
+                        (prefix === undefined ||
+                            getCustomDataReference(data.prefix.toLowerCase()) === prefix.toLowerCase()) &&
+                        (data.reference?.toLowerCase() ?? getCustomDataReference(data.name.toLowerCase())) ===
+                            last.toLowerCase(),
+                ),
         });
-        nextIndex = part.index + match.length + 2; // the { and }
+        nextIndex = part.index + (shapeMatch?.length ?? 0) + refMatch.length + 2; // the { and }
     }
     // no matches at all
     if (result.length === 0) {
@@ -60,10 +63,10 @@ export function getVariableSegments(data: string, shapeFocus?: LocalId): Variabl
 export function convertVariables(data: string): string {
     const segments = getVariableSegments(data);
     return segments
-        .filter((segment) => !segment.isVariable || segment.ref.value !== undefined)
+        .filter((segment) => !segment.isVariable || segment.ref !== undefined)
         .map((segment) => {
             if (!segment.isVariable) return segment.text;
-            const ref = segment.ref.value!;
+            const ref = segment.ref!;
             if (ref.kind === "dice-expression") return convertVariables(ref.value);
             return ref.value;
         })

--- a/client/src/game/systems/dice/index.ts
+++ b/client/src/game/systems/dice/index.ts
@@ -27,8 +27,9 @@ class DiceSystem implements System {
     }
 
     setInput(input: string): void {
+        $.lastCursorPosition = input.length;
         $.textInput = input;
-        $.updateTextInputScroll = true;
+        $.updateInputCursor = true;
         $.uiState = DiceUiState.Roll;
     }
 

--- a/client/src/game/systems/dice/state.ts
+++ b/client/src/game/systems/dice/state.ts
@@ -11,7 +11,7 @@ interface DiceState {
     uiState: LocalId | DiceUiState;
     textInput: string;
     lastCursorPosition: number;
-    updateTextInputScroll: boolean;
+    updateInputCursor: boolean;
     dimensions3d: { width: number; height: number };
     history: { roll: RollResult<Part>; name: string; player: string }[];
     systems?: { "2d": AsyncReturnType<typeof SYSTEMS.DX>["DX"]; "3d": AsyncReturnType<typeof SYSTEMS.DX3>["DX3"] };
@@ -21,7 +21,7 @@ interface DiceState {
 const state = buildState<DiceState>({
     uiState: DiceUiState.Roll,
     lastCursorPosition: 0,
-    updateTextInputScroll: false,
+    updateInputCursor: false,
     dimensions3d: { width: 0, height: 0 },
     history: [],
     textInput: "",

--- a/client/src/game/systems/dice/state.ts
+++ b/client/src/game/systems/dice/state.ts
@@ -10,6 +10,7 @@ import { DiceUiState } from "./types";
 interface DiceState {
     uiState: LocalId | DiceUiState;
     textInput: string;
+    lastCursorPosition: number;
     updateTextInputScroll: boolean;
     dimensions3d: { width: number; height: number };
     history: { roll: RollResult<Part>; name: string; player: string }[];
@@ -19,6 +20,7 @@ interface DiceState {
 
 const state = buildState<DiceState>({
     uiState: DiceUiState.Roll,
+    lastCursorPosition: 0,
     updateTextInputScroll: false,
     dimensions3d: { width: 0, height: 0 },
     history: [],

--- a/client/src/game/ui/tools/dice/DiceCore.vue
+++ b/client/src/game/ui/tools/dice/DiceCore.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type Part, type RollResult } from "@planarally/dice/core";
 import { DxConfig, DxSegmentType } from "@planarally/dice/systems/dx";
-import { type DeepReadonly, computed, nextTick, ref, useTemplateRef, watch } from "vue";
+import { type DeepReadonly, computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 
 import type { DiceRollResult } from "../../../../apiTypes";
@@ -14,7 +14,7 @@ import { DxHelper } from "../../../systems/dice/dx";
 import { diceState } from "../../../systems/dice/state";
 import { diceTool } from "../../../tools/variants/dice";
 
-import DiceAutoComplete from "./DiceAutoComplete.vue";
+import DiceRollInput from "./DiceRollInput.vue";
 
 const { t } = useI18n();
 
@@ -45,7 +45,6 @@ const showRollHistory = ref(false);
 const showHistoryBreakdownFor = ref<number | null>(null);
 
 const canvasElement = ref<HTMLCanvasElement | null>(null);
-const inputElement = useTemplateRef<HTMLInputElement>("inputElement");
 
 const translationMapping = {
     dice3dOptions: {
@@ -116,20 +115,6 @@ const showSelector = computed(() => {
         seg.selector === undefined
     );
 });
-
-// Update the scroll position of the input element when the text input changes
-// This is only set when the input was changed explicitly through the dice system
-// manual text changes will not trigger this (on purpose)
-watch(
-    () => diceState.reactive.updateTextInputScroll,
-    async (value) => {
-        if (!value) return;
-        await nextTick();
-        inputElement.value!.scrollLeft = inputElement.value!.scrollWidth;
-        inputElement.value!.focus();
-        diceState.mutableReactive.updateTextInputScroll = false;
-    },
-);
 
 function scrollToHistoryEntry(element: Element): void {
     element.scrollIntoView({ block: "end", behavior: "smooth" });
@@ -462,17 +447,7 @@ async function roll(): Promise<void> {
             />
         </div>
         <div id="buttons">
-            <div id="input-bar">
-                <input id="input" ref="inputElement" v-model="diceState.mutableReactive.textInput" type="text" />
-                <font-awesome-icon
-                    v-show="diceState.reactive.textInput.length > 0"
-                    id="clear-input-icon"
-                    icon="circle-xmark"
-                    :title="t('game.ui.tools.DiceTool.clear_selection_title')"
-                    @click.stop="clear"
-                />
-                <DiceAutoComplete :input-element="inputElement" @roll="roll" />
-            </div>
+            <DiceRollInput @clear="clear" @roll="roll" />
             <font-awesome-icon
                 id="roll-button"
                 :class="{ disabled: diceState.reactive.textInput.length === 0 }"
@@ -901,27 +876,6 @@ async function roll(): Promise<void> {
         justify-content: space-between;
         align-items: center;
 
-        > #input-bar {
-            position: relative;
-            flex: 1 0 0;
-            display: flex;
-            align-items: center;
-            border: solid 1px black;
-            border-radius: 0.5rem;
-            padding: 0.25rem 0.5rem;
-            margin: 0 0.5rem;
-            > input {
-                border-radius: 0.5rem;
-                font-size: 110%;
-                outline: none;
-                border: none;
-                flex: 1 1 auto;
-            }
-            > #clear-input-icon {
-                padding: 0.25rem 0.25rem;
-                font-size: 85%;
-            }
-        }
         > #roll-button {
             flex: 0 0 auto;
             padding: 0.25rem;

--- a/client/src/game/ui/tools/dice/DiceRollInput.vue
+++ b/client/src/game/ui/tools/dice/DiceRollInput.vue
@@ -23,13 +23,16 @@ const emit = defineEmits<{
 // This is only set when the input was changed explicitly through the dice system
 // manual text changes will not trigger this (on purpose)
 watch(
-    () => diceState.reactive.updateTextInputScroll,
+    () => diceState.reactive.updateInputCursor,
     async (value) => {
         if (!value) return;
         await nextTick();
-        inputElement.value!.scrollLeft = inputElement.value!.scrollWidth;
         inputElement.value!.focus();
-        diceState.mutableReactive.updateTextInputScroll = false;
+        diceState.mutableReactive.updateInputCursor = false;
+        const sel = document.getSelection();
+        if (sel === null) return;
+        sel.selectAllChildren(inputElement.value!);
+        sel.collapseToEnd();
     },
 );
 

--- a/client/src/game/ui/tools/dice/DiceRollInput.vue
+++ b/client/src/game/ui/tools/dice/DiceRollInput.vue
@@ -40,11 +40,23 @@ const segments = computed(() => {
 async function handleKey(event: KeyboardEvent): Promise<void> {
     const isDeleteKey = event.key === "Backspace" || event.key === "Delete";
     const isModifierKey = event.ctrlKey || event.metaKey || event.altKey;
-    // const isPaste = event.key === "v" && ctrlOrCmdPressed(event);
 
     if (event.key === "Enter") {
         event.preventDefault();
         // roll is handled by the DiceAutoComplete component
+        return;
+    } else if (event.key === "Home" || event.key === "End") {
+        event.preventDefault();
+        const sel = document.getSelection();
+        if (sel === null) return;
+        // This was only moving the cursor within the sub-elements.
+        // So we select all children and then collapse to the start or end
+        sel.selectAllChildren(inputElement.value!);
+        if (event.key === "Home") {
+            sel.collapseToStart();
+        } else {
+            sel.collapseToEnd();
+        }
         return;
     }
 
@@ -103,11 +115,9 @@ async function handleText(text: string, isDelete: boolean, isBackspace: boolean)
         const segment = segments.value[i];
         if (segment === undefined) continue;
         statePos += segment.text.length;
-        // visualPos += segment.text.length;
         // If we're dealing with a reference, we need to add 2 for the { and }
         if (segment.isVariable) {
             statePos += 2;
-            // visualPos += 1; // we have a random space (see below)
             if (segment.discriminator !== undefined) statePos += segment.discriminator.length;
         }
     }
@@ -154,8 +164,6 @@ async function handleText(text: string, isDelete: boolean, isBackspace: boolean)
     diceState.mutableReactive.lastCursorPosition = statePos;
 
     await nextTick();
-
-    // const length = isDelete ? 0 : text.length - 1;
 
     for (let i = 0; i < visualPos; i++) {
         sel.modify("move", "forward", "character");

--- a/client/src/game/ui/tools/dice/DiceRollInput.vue
+++ b/client/src/game/ui/tools/dice/DiceRollInput.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+import { computed, nextTick, useTemplateRef, watch } from "vue";
+import { useI18n } from "vue-i18n";
+
+import { baseAdjust } from "../../../../core/http";
+import type { GlobalId } from "../../../../core/id";
+import { getLocalId, getShape } from "../../../id";
+import type { IAsset } from "../../../interfaces/shapes/asset";
+import { getVariableSegments } from "../../../systems/customData/utils";
+import { diceState } from "../../../systems/dice/state";
+
+import DiceAutoComplete from "./DiceAutoComplete.vue";
+
+const { t } = useI18n();
+
+const inputElement = useTemplateRef<HTMLInputElement>("inputElement");
+
+const emit = defineEmits<{
+    (e: "clear" | "roll"): void;
+}>();
+
+// Update the scroll position of the input element when the text input changes
+// This is only set when the input was changed explicitly through the dice system
+// manual text changes will not trigger this (on purpose)
+watch(
+    () => diceState.reactive.updateTextInputScroll,
+    async (value) => {
+        if (!value) return;
+        await nextTick();
+        inputElement.value!.scrollLeft = inputElement.value!.scrollWidth;
+        inputElement.value!.focus();
+        diceState.mutableReactive.updateTextInputScroll = false;
+    },
+);
+
+const segments = computed(() => {
+    return getVariableSegments(diceState.reactive.textInput);
+});
+
+async function handleKey(event: KeyboardEvent): Promise<void> {
+    const isDeleteKey = event.key === "Backspace" || event.key === "Delete";
+    const isModifierKey = event.ctrlKey || event.metaKey || event.altKey;
+    // const isPaste = event.key === "v" && ctrlOrCmdPressed(event);
+
+    if (event.key === "Enter") {
+        event.preventDefault();
+        // roll is handled by the DiceAutoComplete component
+        return;
+    }
+
+    if (isModifierKey || (!/^.$/u.test(event.key) && !isDeleteKey)) {
+        // non unicode character or modifier key
+        return;
+    }
+    event.preventDefault();
+
+    await handleText(event.key, isDeleteKey, event.key === "Backspace");
+}
+
+async function handlePaste(event: ClipboardEvent): Promise<void> {
+    event.preventDefault();
+    const text = event.clipboardData?.getData("text/plain") ?? "";
+    if (text.length === 0) return;
+
+    await handleText(text, false, false);
+}
+
+async function handleText(text: string, isDelete: boolean, isBackspace: boolean): Promise<void> {
+    const sel = document.getSelection();
+    if (sel === null) return;
+
+    const isCollapsed = sel.isCollapsed ?? false;
+    const selectionLength = isCollapsed ? 1 : (sel.toString().length ?? 0);
+    sel.collapseToStart();
+
+    // First we need to determine the position of the cursor in the state input
+    // we do this based on the segments and selection anchor info + modifications for references that have modified visuals
+    if (sel.anchorNode === null) return;
+    if (sel.anchorNode.nodeName !== "#text") {
+        // firefox shenanigans
+        // sometimes firefox decides that we don't need to have the anchor be the deepest element,
+        // but rather the main input element, which makes the anchorOffset mean something completely different
+        // FF can only do this if the selection is at the very end, so we force it to re-evaluate by moving backward and forward
+        sel.modify("move", "backward", "character");
+        sel.modify("move", "forward", "character");
+    }
+    const parentElement = sel.anchorNode.parentElement;
+    const segmentIndex = parentElement?.getAttribute("data-offset");
+    const isReferenceNode = parentElement?.classList.contains("reference") ?? false;
+
+    let segmentIndexInt = 0;
+    if (segmentIndex !== null && segmentIndex !== undefined) {
+        segmentIndexInt = parseInt(segmentIndex);
+    }
+
+    // We keep track of two positions:
+    // - statePos: The position in the state text input
+    // - visualPos: The position in the visual text input
+    let statePos = 0;
+    let visualPos = 0;
+    // handle all preceding segments
+    for (let i = 0; i < segmentIndexInt; i++) {
+        const segment = segments.value[i];
+        if (segment === undefined) continue;
+        statePos += segment.text.length;
+        // visualPos += segment.text.length;
+        // If we're dealing with a reference, we need to add 2 for the { and }
+        if (segment.isVariable) {
+            statePos += 2;
+            // visualPos += 1; // we have a random space (see below)
+            if (segment.discriminator !== undefined) statePos += segment.discriminator.length;
+        }
+    }
+    statePos += sel.anchorOffset;
+    visualPos += sel.anchorOffset;
+
+    if (isReferenceNode) {
+        const segment = segments.value[segmentIndexInt]!;
+        // just like with the preceding segments we need to account for the ref syntax
+        // for the node itself however, there is an extra space added to the front by the template engine
+        // so that already accounts for the preceding {, the ending } should only be added if we're at the end of the node
+        visualPos -= 1; // for the visual pos, the space is however ignored when doing the move forward by 1 character
+        if (segment.isVariable && segment.discriminator !== undefined) statePos += segment.discriminator.length;
+        if (text === " " && sel.anchorOffset === sel.anchorNode.textContent!.length) {
+            // if we're at the end of the node and we add a space, we want to go to the next segment,
+            // so we add 1 as if the ending } was handled
+            statePos += 1;
+        }
+    }
+
+    if (isCollapsed && isBackspace) {
+        statePos--;
+        visualPos--;
+    }
+
+    // Start actual text manipulation
+
+    let newText = diceState.raw.textInput;
+
+    if (!isCollapsed || isDelete) {
+        // If a key is pressed while there is a selection, we need to delete the selection
+        // It's a known bug that the selectionLength does not account for the reference syntax,
+        // so it will sometimes delete too little
+        newText = newText.slice(0, statePos) + newText.slice(statePos + selectionLength);
+    }
+
+    if (!isDelete) {
+        newText = newText.slice(0, statePos) + text + newText.slice(statePos);
+        statePos += text.length;
+        visualPos += text.length;
+    }
+
+    diceState.mutableReactive.textInput = newText;
+    diceState.mutableReactive.lastCursorPosition = statePos;
+
+    await nextTick();
+
+    // const length = isDelete ? 0 : text.length - 1;
+
+    for (let i = 0; i < visualPos; i++) {
+        sel.modify("move", "forward", "character");
+    }
+}
+
+function getImage(shapeId: GlobalId): string {
+    const local = getLocalId(shapeId);
+    if (local === undefined) return "";
+    const shape = getShape(local);
+    if (shape === undefined || shape.type !== "assetrect") return "";
+    return baseAdjust((shape as IAsset).src);
+}
+</script>
+
+<template>
+    <div id="input-bar">
+        <div
+            id="input"
+            ref="inputElement"
+            contenteditable="true"
+            spellcheck="false"
+            @keydown="handleKey($event as KeyboardEvent)"
+            @paste="handlePaste($event as ClipboardEvent)"
+        >
+            <template v-for="(segment, index) of segments" :key="index">
+                <div v-if="segment.isVariable" class="reference" :data-offset="index">
+                    <img v-if="segment.ref?.shapeId" :src="getImage(segment.ref.shapeId)" />
+                    {{ segment.text }}
+                </div>
+                <span v-else-if="segment.text.length > 0" :data-offset="index">{{ segment.text }}</span>
+            </template>
+        </div>
+        <font-awesome-icon
+            v-show="diceState.reactive.textInput.length > 0"
+            id="clear-input-icon"
+            icon="circle-xmark"
+            :title="t('game.ui.tools.DiceTool.clear_selection_title')"
+            @click.stop="emit('clear')"
+        />
+        <DiceAutoComplete :input-element="inputElement" @roll="emit('roll')" />
+    </div>
+</template>
+
+<style scoped lang="scss">
+#input-bar {
+    position: relative;
+    flex: 1 0 0;
+    display: flex;
+    align-items: center;
+    border: solid 1px black;
+    border-radius: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    margin: 0 0.5rem;
+
+    > #input {
+        border-radius: 0.5rem;
+        font-size: 110%;
+        outline: none;
+        border: none;
+        flex: 1 1 auto;
+        white-space: pre-wrap;
+
+        display: flex;
+        align-items: center;
+
+        min-height: 24px;
+
+        .reference {
+            display: flex;
+            align-items: center;
+            white-space: normal;
+
+            border: solid 1px rgb(255, 168, 191);
+            border-radius: 0.5rem;
+            padding: 0.25rem;
+            background-color: rgba(255, 168, 191, 0.5);
+
+            img {
+                margin-right: 0.5rem;
+                width: 1.5rem;
+            }
+        }
+    }
+
+    > #clear-input-icon {
+        padding: 0.25rem 0.25rem;
+        font-size: 85%;
+    }
+}
+</style>


### PR DESCRIPTION
In recent PRs I added the ability to use references in the dice tool.

This PR makes the handling of references in the input bar cleaner and also cleans up some other small improvement areas.

Instead of immediately filling in the value behind the reference, references will now show the label using a visual distinctive style as can be seen below.

<img width="267" height="88" alt="image" src="https://github.com/user-attachments/assets/85abeeba-c871-459e-a2f7-be28d862f4a1" />

Additionally you can see that the relevant shape's image is also shown, which should make it clear at all times which reference is being used.

Additionally when manually completing a reference from the auto complete, it will now auto-select the highlighted entry. This makes the issue mentioned at the end of #1672 no longer relevant.