### PR TITLE
bug: Fix ampersand in campaign name handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Images in the Token Direction indicator were overflowing
 -   Prevent shortcut handling when targetting an html select element
+-   Ampersand in campaign name preventing game load
 
 ## [2025.3]
 

--- a/server/src/api/socket/connection.py
+++ b/server/src/api/socket/connection.py
@@ -25,7 +25,10 @@ async def connect(sid, environ):
         await _send_game("redirect", "/", room=sid)
         return
 
-    ref = {k.split("=")[0]: k.split("=")[1] for k in unquote(environ["QUERY_STRING"]).strip().split("&")}
+    # note: ensure that the & split happens before the unquote
+    # or campaign names with & will not work
+    query_elements = [unquote(k) for k in environ["QUERY_STRING"].strip().split("&")]
+    ref = {k.split("=")[0]: k.split("=")[1] for k in query_elements}
     try:
         room = Room.select().join(User).where((Room.name == ref["room"]) & (User.name == ref["user"]))[0]
     except IndexError:


### PR DESCRIPTION
During the websocket connection setup on the server, the campaign name is pulled from a query string. This string has elements separated by an ampersand.

The parsing of this string was faulty, causing the ampersand in the campaign name to be indistinguishable from the query params.

This fixes #1680 