### PR TITLE
bug(Character): Fix undoing of shapes with character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,15 @@ tech changes will usually be stripped from release notes for the public
         -   [DM] Add previous/next round buttons
     -   Add effects with infinite timespan
     -   Fix names in initiative list not being reactive
+-   [tech] refactor of intermediate shape handling on client side (see `transformations.ts`)
 
 ### Fixed
 
 -   Images in the Token Direction indicator were overflowing
 -   Prevent shortcut handling when targetting an html select element
 -   Ampersand in campaign name preventing game load
+-   Duplicating (copy/paste) or undoing a removal of shapes would lose some info (e.g. notes)
+-   Undoing a shape removal related to a character did not work
 
 ## [2025.3]
 

--- a/client/src/game/shapes/transformations.ts
+++ b/client/src/game/shapes/transformations.ts
@@ -373,7 +373,6 @@ export function createServerDataFromCompact(compact: CompactForm): ApiShape {
         owners: [],
         trackers: [],
         auras: [],
-        character: null,
         odd_hex_orientation: false,
         size: 0,
         show_cells: false,

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -68,6 +68,16 @@ async def add_shape(sid: str, raw_data: Any):
 
     if data.temporary:
         game_state.add_temp(sid, data.shape.uuid)
+    elif data.shape.character:
+        # Restore shape from character (e.g. undo a shape delete related to a character)
+        shape = Shape.get_or_none(Shape.character_id == data.shape.character)
+        if shape is None:
+            logger.error(f"Add shape failed: character {data.shape.character} not found")
+            return
+        shape.layer = layer
+        shape.x = data.shape.x
+        shape.y = data.shape.y
+        shape.save()
     else:
         shape = create_shape(data.shape, layer=layer)
         if shape is None:


### PR DESCRIPTION
Undoing the removal of a shape linked to a character would cause some server errors and not result in the shape being restored.

Fixes #1523