### PR TITLE
bug(Group): Fix undo shape removal with group sometimes failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ tech changes will usually be stripped from release notes for the public
 -   Ampersand in campaign name preventing game load
 -   Duplicating (copy/paste) or undoing a removal of shapes would lose some info (e.g. notes)
 -   Undoing a shape removal related to a character did not work
+-   Undoing a shape removal causing the related group to be removed (i.e. last shape of the group)
 
 ## [2025.3]
 

--- a/client/src/game/systems/groups/state.ts
+++ b/client/src/game/systems/groups/state.ts
@@ -12,6 +12,8 @@ interface GroupState {
     shapeData: Map<LocalId, { groupId: string | undefined; badge: number }>;
     groups: Map<string, Group>;
     groupMembers: Map<string, Set<LocalId>>;
+    // Used to restore a group after removal (e.g. undo a shape removal related to a group)
+    removedGroupCache: Map<string, Group>;
 }
 
 const state = buildState<ReactiveGroupState, GroupState>(
@@ -19,7 +21,12 @@ const state = buildState<ReactiveGroupState, GroupState>(
         activeId: undefined,
         groupInfo: undefined,
     },
-    { shapeData: new Map(), groups: new Map(), groupMembers: new Map() },
+    {
+        shapeData: new Map(),
+        groups: new Map(),
+        groupMembers: new Map(),
+        removedGroupCache: new Map(),
+    },
 );
 
 export const groupState = {

--- a/server/src/api/socket/groups.py
+++ b/server/src/api/socket/groups.py
@@ -166,11 +166,14 @@ async def remove_group(sid: str, group_id: str):
         await _send_game("Group.Remove", group_id, room=psid, skip_sid=sid)
 
 
-async def remove_group_if_empty(group_id: str):
+async def remove_group_if_empty(group_id: str) -> bool:
     try:
         group = Group.get_by_id(group_id)
     except Group.DoesNotExist:
-        return
+        return False
 
     if Shape.filter(group=group_id).count() == 0:
         group.delete_instance(True)
+        return True
+
+    return False

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -173,7 +173,7 @@ async def remove_shapes(sid: str, raw_data: Any):
 
         layer = shapes[0].layer
 
-        group_ids = set()
+        group_ids: set[str] = set()
 
         for shape in shapes:
             if not has_ownership(shape, pr, edit=True):
@@ -183,7 +183,7 @@ async def remove_shapes(sid: str, raw_data: Any):
             await initiative.remove_shape(pr, shape.uuid, shape.group)
 
             if shape.group:
-                group_ids.add(shape.group)
+                group_ids.add(shape.group.uuid)
 
             is_char_related = shape.character_id is not None
             # ToggleComposite patches
@@ -218,7 +218,8 @@ async def remove_shapes(sid: str, raw_data: Any):
                 shape.save()
 
         for group_id in group_ids:
-            await remove_group_if_empty(group_id)
+            if await remove_group_if_empty(group_id):
+                await _send_game("Group.Remove", group_id, room=sid)
 
         await send_remove_shapes([sh.uuid for sh in shapes], room=pr.active_location.get_path(), skip_sid=sid)
 


### PR DESCRIPTION
If you remove the last shape of a group and then try to undo the removal, the server would error out.
It tries to re-attach the group, but it no longer exists on the server at that time.

This PR fixes this problem (as well as a small bug added in the big refactor earlier related to groups)

Fixes #1682