### PR TITLE
bug(Polygon): Fix some operations on rotated polygons not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ tech changes will usually be stripped from release notes for the public
 -   Duplicating (copy/paste) or undoing a removal of shapes would lose some info (e.g. notes)
 -   Undoing a shape removal related to a character did not work
 -   Undoing a shape removal causing the related group to be removed (i.e. last shape of the group)
+-   Cutting a rotated polygon would be wrong on refresh
+-   Resizing a rotated polygon did not correctly recalculate center, causing sudden shifts on move
 
 ## [2025.3]
 

--- a/client/src/game/shapes/variants/polygon.ts
+++ b/client/src/game/shapes/variants/polygon.ts
@@ -141,6 +141,20 @@ export class Polygon extends Shape implements IShape {
         this._points = this.vertices.map((point) => this.invalidatePoint(point, center));
     }
 
+    /**
+     * This normalizes the polygon back to an angle of 0.
+     * Some operations (e.g. resizing) don't work correctly in angled-mode if we want to keep the center up to date.
+     * By first normalizing the angle, all operations work as expected.
+     */
+    private normalizeAngle(): void {
+        if (this.angle === 0) return;
+        this._refPoint = rotateAroundPoint(this._refPoint, this.center, this.angle);
+        for (let i = 0; i < this._vertices.length; i++) {
+            this._vertices[i] = rotateAroundPoint(this._vertices[i]!, this.center, this.angle);
+        }
+        this.angle = 0;
+    }
+
     draw(ctx: CanvasRenderingContext2D, lightRevealRender: boolean): void {
         if (lightRevealRender && this.openPolygon) return;
 
@@ -218,8 +232,10 @@ export class Polygon extends Shape implements IShape {
     }
 
     resize(resizePoint: number, point: GlobalPoint): number {
-        if (resizePoint === 0) this._refPoint = rotateAroundPoint(point, this.center, -this.angle);
-        else this._vertices[resizePoint - 1] = rotateAroundPoint(point, this.center, -this.angle);
+        this.normalizeAngle();
+        if (resizePoint === 0) this._refPoint = point;
+        else this._vertices[resizePoint - 1] = point;
+        this._center = this.__center();
         this.invalidatePoints();
         return resizePoint;
     }
@@ -263,19 +279,22 @@ export class Polygon extends Shape implements IShape {
                 );
             });
 
+            this.normalizeAngle();
             this.invalidatePoints();
 
             // Do the OG shape update AFTER sending the new polygon or there might (depending on network)
             // be a couple of frames where the new polygon is not shown and the old one is already cut
             // potentially showing hidden stuff
             if (!this.preventSync) sendShapePositionUpdate([this], false);
+
+            console.log(this.center, this.refPoint, this.points, this.vertices);
         }
     }
 
     pushPoint(point: GlobalPoint, options?: { simplifyEnd?: boolean }): void {
         this._vertices.push(point);
-        this._points.push(this.invalidatePoint(point, this.center));
-        this.layer?.updateSectors(this.id, this.getAuraAABB());
+        this._center = this.__center();
+        this.invalidatePoints();
         if (options?.simplifyEnd === true) this.simplifyEnd();
     }
 


### PR DESCRIPTION
_This fixes #1676_

When a polygon is rotated, the polygon cut action would visually result in a correct separation. On refresh of the page however, the original polygon would be positioned wrongly.

Additionally while debugging this, I also noticed that while visually correct, the center of a rotated polygon would not be recalculated when you moved a point on the polygon around. When you then dragged the polygon, it would have an abrupt jump first.

Both issues are related to internal representations and math on rotated shapes. To move a rotated point, we need to know it's non-rotated position, for which we need the center, but the center depends on the points themselves, causing funky interactions.
The fix is that polygons are now internally recalculated to a 0 angle when doing certain operations, so that we don't have to rotate points. Visually the rotation box will reset, but the points will remain in their correct positions.

I could in theory make it so that after doing the calculations we revert to the original angle, but I don't actually think anybody really cares about what angle the shape is, only what it looks like.