### PR TITLE
feat(Assets): Add an icon to the asset manager if the asset has template info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ tech changes will usually be stripped from release notes for the public
 -   Shape order inconsistency check
     -   Runs when moving a shape to the back
     -   Fixes the order of all shapes on the layer and requests a page refresh
+-   Asset manager icon when a shape has template info
 
 ### Changed
 

--- a/client/src/apiTypes.ts
+++ b/client/src/apiTypes.ts
@@ -31,6 +31,7 @@ export interface ApiAsset {
   fileHash: string | null;
   children: ApiAsset[] | null;
   shares: ApiAssetShare[];
+  has_templates: boolean;
 }
 export interface ApiAssetShare {
   user: string;

--- a/client/src/assets/ui/AssetListCore.vue
+++ b/client/src/assets/ui/AssetListCore.vue
@@ -38,11 +38,9 @@ const props = withDefaults(
 
 const assetContextMenu = useAssetContextMenu();
 const drag = useDrag(emit);
-// const route = useRoute();
 
 const thumbnailMisses = ref(new Set<AssetId>());
 
-// const body = document.getElementsByTagName("body")[0];
 const contextTargetElement = ref<HTMLElement | null>(null);
 const currentRenameAsset = ref<AssetId | null>(null);
 
@@ -60,7 +58,6 @@ const files = computed(() => {
 });
 
 function dragStart(event: DragEvent, file: AssetId, assetHash: string | null): void {
-    // emit("onDragStart", event);
     drag.startDrag(event, file, assetHash);
 }
 
@@ -219,9 +216,11 @@ async function showRenameUI(id: AssetId): Promise<void> {
                 @dragleave.prevent="drag.leaveDrag"
                 @drop.prevent.stop="drag.stopDrag($event, folder.id)"
             >
-                <font-awesome-icon v-if="isShared(folder)" icon="user-tag" class="asset-link" />
                 <font-awesome-icon icon="folder" :style="{ fontSize: props.fontSize }" />
                 <font-awesome-icon icon="folder-open" :style="{ fontSize: props.fontSize }" />
+                <div class="asset-icons">
+                    <font-awesome-icon v-if="isShared(folder)" icon="user-tag" />
+                </div>
                 <div
                     :contenteditable="folder.id === currentRenameAsset"
                     class="title"
@@ -246,13 +245,16 @@ async function showRenameUI(id: AssetId): Promise<void> {
                 @dragstart="dragStart($event, file.id, file.fileHash)"
                 @dragend="drag.onDragEnd"
             >
-                <font-awesome-icon v-if="isShared(file)" icon="user-tag" class="asset-link" />
                 <picture v-if="!thumbnailMisses.has(file.id)">
                     <source :srcset="getImageSrcFromAssetId(file.id, { thumbnailFormat: 'webp' })" type="image/webp" />
                     <source :srcset="getImageSrcFromAssetId(file.id, { thumbnailFormat: 'jpeg' })" type="image/jpeg" />
                     <img alt="" loading="lazy" @error="thumbnailMisses.add(file.id)" />
                 </picture>
                 <img v-else :src="getImageSrcFromAssetId(file.id)" alt="" loading="lazy" />
+                <div class="asset-icons">
+                    <font-awesome-icon v-if="isShared(file)" icon="user-tag" />
+                    <font-awesome-icon v-if="file.has_templates" icon="floppy-disk" />
+                </div>
                 <div
                     :contenteditable="file.id === currentRenameAsset"
                     class="title"
@@ -346,14 +348,18 @@ async function showRenameUI(id: AssetId): Promise<void> {
                 word-break: break-all;
             }
 
-            > .asset-link {
-                font-size: 2em;
+            > .asset-icons {
+                display: flex;
+                flex-direction: column;
+                gap: 0.25rem;
+
                 position: absolute;
-                left: 0.25rem;
-                top: 0.25rem;
+
+                font-size: 2em;
+                left: -0.2rem;
                 color: white;
 
-                :deep(> path) {
+                svg :deep(> path) {
                     stroke: black;
                     stroke-width: 1.5rem;
                 }

--- a/client/src/fa.ts
+++ b/client/src/fa.ts
@@ -90,6 +90,7 @@ import {
     faFolderTree,
     faDiceD20,
     faCircleExclamation,
+    faFloppyDisk,
 } from "@fortawesome/free-solid-svg-icons";
 
 export function loadFontAwesome(): void {
@@ -137,6 +138,7 @@ export function loadFontAwesome(): void {
         faExternalLinkAlt,
         faEye,
         faFilter,
+        faFloppyDisk,
         faFolder,
         faFolderOpen,
         faFolderTree,

--- a/server/src/api/models/asset/__init__.py
+++ b/server/src/api/models/asset/__init__.py
@@ -25,6 +25,7 @@ class ApiAsset(TypeIdModel):
     # And is only provided in specific calls
     children: list["ApiAsset"] | None
     shares: list[ApiAssetShare]  # Info on users that this specific asset is shared with
+    has_templates: bool
 
 
 class ApiAssetFolder(TypeIdModel):

--- a/server/src/transform/to_api/asset.py
+++ b/server/src/transform/to_api/asset.py
@@ -50,6 +50,7 @@ def transform_asset(
         fileHash=asset.file_hash,
         children=pydantic_children,
         shares=[],
+        has_templates=asset.templates.count() > 0,
     )
 
     if share_info is None or share_info.right == "edit":


### PR DESCRIPTION
This adds a simple floppy-disk icon in the top-left corner for shapes that have a template.

This should make it easier if you have multiple assets for a similar monster but from different sources and don't remember which one you already populated.