### PR TITLE
bug(Notes): Fix note creation -> edit flow not always working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ tech changes will usually be stripped from release notes for the public
 -   Undoing a shape removal causing the related group to be removed (i.e. last shape of the group)
 -   Cutting a rotated polygon would be wrong on refresh
 -   Resizing a rotated polygon did not correctly recalculate center, causing sudden shifts on move
+-   Note creation not going straight to edit mode in some cases
 
 ## [2025.3]
 

--- a/client/src/game/ui/notes/NoteEdit.vue
+++ b/client/src/game/ui/notes/NoteEdit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, ref, watch, watchEffect } from "vue";
+import { computed, onActivated, ref, watch, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import VueMarkdown from "vue-markdown-render";
 
@@ -161,7 +161,7 @@ const accessLevels = computed(() => {
     return [defaultAccess, ...access];
 });
 
-onBeforeMount(() => {
+onActivated(() => {
     if (noteState.reactive.currentNote === undefined) emit("mode", NoteManagerMode.List);
     if ((note.value?.text ?? "").trim().length === 0) activeTabIndex.value = 1;
 });


### PR DESCRIPTION
When creating a new note, the note should immediately be opened for further configuration and it should be opened on the edit tab.

This works, but only for the first note created, afterwards the view tab would be opened instead. This PR fixes that.