### PR TITLE
feat(Tech:Notes): Move tags to own tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ tech changes will usually be stripped from release notes for the public
         -   Can be linked to multiple locations or no location (global/local concept is removed)
     -   List filters have been redesigned to be mure useful
         -   Many preferences have been removed as a result
+    -   [tech] tags are now stored in their own tables instead of being a json array on notes
 -   [tech] refactor of intermediate shape handling on client side (see `transformations.ts`)
 -   [tech] upgraded pydantic from 1.x to 2.x
 

--- a/server/src/db/all.py
+++ b/server/src/db/all.py
@@ -3,6 +3,7 @@ from .models.asset_share import AssetShare  # isort: skip
 from .models.note_access import NoteAccess  # isort: skip
 from .models.note_room import NoteRoom  # isort: skip
 from .models.note_shape import NoteShape  # isort: skip
+from .models.note_tag import NoteTag  # isort: skip
 
 from .base import BaseDbModel, BaseViewModel
 from .models.asset import Asset
@@ -28,6 +29,7 @@ from .models.mod import Mod
 from .models.mod_player_room import ModPlayerRoom
 from .models.mod_room import ModRoom
 from .models.note import Note
+from .models.note_user_tag import NoteUserTag
 from .models.notification import Notification
 from .models.player_room import PlayerRoom
 from .models.polygon import Polygon
@@ -78,6 +80,8 @@ ALL_NORMAL_MODELS: list[type[BaseDbModel]] = [
     NoteAccess,
     NoteRoom,
     NoteShape,
+    NoteTag,
+    NoteUserTag,
     Notification,
     PlayerRoom,
     Polygon,

--- a/server/src/db/models/note.py
+++ b/server/src/db/models/note.py
@@ -1,4 +1,3 @@
-import json
 from typing import TYPE_CHECKING, cast
 
 from peewee import JOIN, ForeignKeyField, TextField
@@ -9,6 +8,7 @@ from ..typed import SelectSequence
 from .note_access import NoteAccess
 from .note_room import NoteRoom
 from .note_shape import NoteShape
+from .note_tag import NoteTag
 from .shape_room_view import ShapeRoomView
 from .user import User
 
@@ -20,12 +20,12 @@ class Note(BaseDbModel):
     access: SelectSequence["NoteAccess"]
     rooms: SelectSequence["NoteRoom"]
     shapes: SelectSequence["NoteShape"]
+    tags: SelectSequence["NoteTag"]
 
     uuid = cast(str, TextField(primary_key=True))
     creator = ForeignKeyField(User, backref="notes", on_delete="CASCADE")
     title = cast(str, TextField())
     text = cast(str, TextField())
-    tags = cast(str | None, TextField(null=True))
 
     show_on_hover = cast(bool, TextField(default="false"))
     show_icon_on_shape = cast(bool, TextField(default="false"))
@@ -34,7 +34,7 @@ class Note(BaseDbModel):
         return f"<Note {self.title} - {self.creator.name}"
 
     def as_pydantic(self):
-        tags = json.loads(self.tags) if self.tags else []
+        tags = [t.tag.tag for t in self.tags]
         access = [a.as_pydantic() for a in self.access]
         rooms = [r.as_pydantic() for r in self.rooms]
         return ApiNote(

--- a/server/src/db/models/note_tag.py
+++ b/server/src/db/models/note_tag.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING, cast
+
+from peewee import DeferredForeignKey
+
+from ..base import BaseDbModel
+
+if TYPE_CHECKING:
+    from .note import Note
+    from .note_user_tag import NoteUserTag
+
+
+class NoteTag(BaseDbModel):
+    note_id: str
+
+    tag = cast(
+        "NoteUserTag",
+        DeferredForeignKey("NoteUserTag", deferrable="INITIALLY DEFERRED", backref="note_tags", on_delete="CASCADE"),
+    )
+    note = cast(
+        "Note", DeferredForeignKey("Note", deferrable="INITIALLY DEFERRED", backref="tags", on_delete="CASCADE")
+    )
+
+    class Meta:
+        indexes = ((("note_id", "tag_id"), True),)

--- a/server/src/db/models/note_user_tag.py
+++ b/server/src/db/models/note_user_tag.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING, cast
+
+from peewee import ForeignKeyField, TextField
+
+from ..base import BaseDbModel
+from ..typed import SelectSequence
+from .user import User
+
+
+if TYPE_CHECKING:
+    from .note_tag import NoteTag
+
+
+class NoteUserTag(BaseDbModel):
+    note_tags: SelectSequence["NoteTag"]
+
+    user = cast("User", ForeignKeyField(User, backref="note_tags", on_delete="CASCADE"))
+    tag = cast(str, TextField())
+
+    class Meta:
+        indexes = ((("user_id", "tag"), True),)


### PR DESCRIPTION
_includes migration_

Note tags are currently stored as a JSON array on the Note itself, this was an easy approach when notes were introduced as I wasn't sure yet which direction I wanted to go with them.

I'm however working on moving note search/filter to be done on the server instead of the client, which makes the tag filters expensive as way more notes have to be scanned to check relevant tags.

Additionally it also makes it difficult to show already used tags to the user.

This PR moves them to their own dedicated tables. There are two:
- NoteUserTag: keeps track of all tags for a particular user
- NoteTag: keeps track of all links between Notes and NoteUserTags