### PR TITLE
feat(Notes): Add tag-search to note edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ tech changes will usually be stripped from release notes for the public
     -   List filters have been redesigned to be mure useful
         -   Many preferences have been removed as a result
     -   Pagination is now in the bottom left and clearly notes the amount of pages
+    -   Tags in the note edit panel now have a "search" and "remove" action instead of always removing on click
     -   [tech] Searching/Filtering/Pagination is now done on the server
     -   [tech] tags are now stored in their own tables instead of being a json array on notes
 -   [tech] refactor of intermediate shape handling on client side (see `transformations.ts`)

--- a/client/src/game/systems/notes/state.ts
+++ b/client/src/game/systems/notes/state.ts
@@ -19,9 +19,6 @@ interface ReactiveNoteState {
         shapeFilter: boolean;
         tagFilter: boolean;
     };
-    filterOptions: {
-        tags: string[];
-    };
 
     shapeFilter: LocalId | undefined;
 
@@ -45,9 +42,6 @@ const state = buildState<ReactiveNoteState, NonReactiveNoteState>(
             locationFilter: true,
             shapeFilter: true,
             tagFilter: true,
-        },
-        filterOptions: {
-            tags: [],
         },
 
         shapeFilter: undefined,

--- a/client/src/game/ui/notes/NoteFilter.vue
+++ b/client/src/game/ui/notes/NoteFilter.vue
@@ -93,7 +93,7 @@ function onFocusOut(event: FocusEvent): void {
                             ? `${selected.length} selected`
                             : (options.default.find((o) => selected.includes(o.value))?.label ??
                               options.search?.find((o) => selected.includes(o.value))?.label ??
-                              "")
+                              selected[0])
                     }}
                 </span>
                 <font-awesome-icon icon="chevron-down" class="chevron-icon" />

--- a/client/src/game/ui/notes/NoteTagAdd.vue
+++ b/client/src/game/ui/notes/NoteTagAdd.vue
@@ -6,6 +6,8 @@ import { useModal } from "../../../core/plugins/modals/plugin";
 import { noteSystem } from "../../systems/notes";
 import { noteState } from "../../systems/notes/state";
 
+import { customFilterOptions } from "./noteFilters";
+
 const { t } = useI18n();
 const modals = useModal();
 
@@ -13,14 +15,12 @@ const searchQuery = ref("");
 const isOpen = ref(false);
 const searchInput = ref<HTMLInputElement | null>(null);
 
-const options = computed(() => noteState.reactive.filterOptions.tags);
-
 const filteredOptions = computed(() => {
     if (!searchQuery.value.trim()) {
-        return options.value;
+        return customFilterOptions.tags;
     }
     const query = searchQuery.value.toLowerCase();
-    return options.value.filter((option) => option.toLowerCase().includes(query));
+    return customFilterOptions.tags.filter((option) => option.toLowerCase().includes(query));
 });
 
 function openDropdown(): void {

--- a/client/src/game/ui/notes/noteFilters.ts
+++ b/client/src/game/ui/notes/noteFilters.ts
@@ -1,0 +1,150 @@
+import { computed, reactive, watch } from "vue";
+
+import type { LocalId } from "../../../core/id";
+import { noteState } from "../../systems/notes/state";
+import { ACTIVE_FILTER, NO_FILTER, NO_LINK_FILTER } from "../../systems/notes/types";
+
+export const customFilterOptions = reactive({
+    locations: [] as { id: number; name: string }[],
+    shapes: [] as { id: LocalId; name: string; src: string }[],
+    tags: [] as string[],
+});
+
+export const roomFilterOptions = computed(() => {
+    return {
+        default: [
+            { label: "(no filter)", value: NO_FILTER },
+            {
+                label: "active campaign",
+                value: ACTIVE_FILTER,
+            },
+            {
+                label: "no campaign links",
+                value: NO_LINK_FILTER,
+            },
+        ],
+    };
+});
+
+export const locationFilterOptions = computed(() => {
+    return {
+        default: [
+            { label: "(no filter)", value: NO_FILTER },
+            {
+                label: "active location",
+                value: ACTIVE_FILTER,
+            },
+            {
+                label: "no location links",
+                value: NO_LINK_FILTER,
+            },
+        ],
+        search: customFilterOptions.locations.map((l) => ({ label: l.name, value: l.id })),
+    };
+});
+
+export const shapeFilterOptions = computed(() => {
+    return {
+        default: [
+            { label: "(no filter)", value: NO_FILTER },
+            {
+                label: "has shape(s)",
+                value: ACTIVE_FILTER,
+            },
+            {
+                label: "no shape(s)",
+                value: NO_LINK_FILTER,
+            },
+        ],
+        search: customFilterOptions.shapes.map((s) => ({
+            label: s.name,
+            value: s.id,
+            icon: s.src,
+        })),
+    };
+});
+
+// TAGS
+
+export const tagFilterOptions = computed(() => {
+    const tagList = new Set<string>();
+    for (const [_, note] of noteState.reactive.notes) {
+        for (const tag of note.tags) {
+            tagList.add(tag.name);
+        }
+    }
+    return {
+        default: [
+            { label: "(no filter)", value: NO_FILTER },
+            {
+                label: "has tag(s)",
+                value: ACTIVE_FILTER,
+            },
+            {
+                label: "no tag(s)",
+                value: NO_LINK_FILTER,
+            },
+        ],
+        search: customFilterOptions.tags.map((t) => ({ label: t, value: t })),
+    };
+});
+
+// CORE STATE
+
+export const filters = reactive({
+    locations: getDefaultFilter("note-location-filter", locationFilterOptions.value.default, [
+        ACTIVE_FILTER,
+        NO_LINK_FILTER,
+    ]) as (number | symbol)[],
+    rooms: getDefaultFilter("note-room-filter", roomFilterOptions.value.default, [ACTIVE_FILTER]),
+    shapes: getDefaultFilter("note-shape-filter", shapeFilterOptions.value.default, [NO_FILTER]) as (
+        | LocalId
+        | symbol
+    )[],
+    tags: getDefaultFilter("note-tag-filter", tagFilterOptions.value.default, [NO_FILTER]) as (string | symbol)[],
+});
+
+watch(filters.rooms, (rooms) => {
+    saveDefaultFilter("note-room-filter", roomFilterOptions.value.default, rooms);
+});
+
+watch(filters.locations, (locations) => {
+    saveDefaultFilter("note-location-filter", locationFilterOptions.value.default, locations);
+});
+
+watch(filters.shapes, (shapes) => {
+    saveDefaultFilter("note-shape-filter", shapeFilterOptions.value.default, shapes);
+});
+
+watch(filters.tags, (tags) => {
+    saveDefaultFilter("note-tag-filter", tagFilterOptions.value.default, tags);
+});
+
+// UTILITY FUNCTIONS
+
+function getDefaultFilter<T extends string | number | symbol>(
+    key: string,
+    defaultOptions: { label: string; value: T }[],
+    defaultValue: T[],
+): T[] {
+    const value = localStorage.getItem(key);
+    if (value !== null) {
+        let indices: number[] = [];
+        try {
+            indices = JSON.parse(value) as number[];
+            return indices.map((i) => defaultOptions[i]!.value);
+        } catch {
+            return defaultValue;
+        }
+    }
+    return defaultValue;
+}
+
+function saveDefaultFilter<T extends string | number | symbol>(
+    key: string,
+    defaultOptions: { label: string; value: T }[],
+    value: T[],
+): void {
+    const indices = value.map((v) => defaultOptions.findIndex((o) => o.value === v));
+    localStorage.setItem(key, JSON.stringify(indices));
+}


### PR DESCRIPTION
This changes the behaviour of the tags in the note edit view.

Instead of always removing the tag on click, now a search icon and delete icon appear on hover.
The remove action retains the original behaviour, the search icon will open the note list with the tag filter set to that tag (clearing any other elements in the tag filter at that point).