### PR TITLE
feat(AdminSettings): Prevent creator self-kick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ tech changes will usually be stripped from release notes for the public
 -   Logging:
     -   Enabling configuration of the logger via a new logging section
     -   Allows for multiple logging file streams at different levels
-    
+
 ### Changed
 
 -   Initiative
@@ -57,6 +57,7 @@ tech changes will usually be stripped from release notes for the public
     -   Tags in the note edit panel now have a "search" and "remove" action instead of always removing on click
     -   [tech] Searching/Filtering/Pagination is now done on the server
     -   [tech] tags are now stored in their own tables instead of being a json array on notes
+-   Campaign creator can no longer change their own role or kick themselves
 -   [tech] refactor of intermediate shape handling on client side (see `transformations.ts`)
 -   [tech] upgraded pydantic from 1.x to 2.x
 

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -6,7 +6,6 @@ import { useRoute, useRouter } from "vue-router";
 import InputCopyElement from "../../../../core/components/InputCopyElement.vue";
 import { baseAdjust } from "../../../../core/http";
 import { useModal } from "../../../../core/plugins/modals/plugin";
-import { coreStore } from "../../../../store/core";
 import { sendDeleteRoom, sendRefreshInviteCode } from "../../../api/emits/room";
 import { getRoles } from "../../../models/role";
 import { gameSystem } from "../../../systems/game";
@@ -36,7 +35,6 @@ const invitationUrl = computed(
 );
 
 const creator = computed(() => route.params.creator);
-const username = toRef(coreStore.state, "username");
 
 function refreshInviteCode(): void {
     sendRefreshInviteCode();
@@ -86,10 +84,7 @@ const toggleLock = (): void => gameSystem.setIsLocked(!gameState.raw.isLocked, t
         <div v-for="player of players.values()" :key="player.id" class="row smallrow">
             <div>{{ player.name }}</div>
             <div class="player-actions">
-                <select
-                    :disabled="username !== creator && player.name === creator"
-                    @change="changePlayerRole($event, player.id)"
-                >
+                <select :disabled="player.name === creator" @change="changePlayerRole($event, player.id)">
                     <option
                         v-for="[i, role] of roles.entries()"
                         :key="'role-' + i + '-' + player.id"
@@ -106,10 +101,7 @@ const toggleLock = (): void => gameSystem.setIsLocked(!gameState.raw.isLocked, t
                 >
                     <font-awesome-icon icon="eye" />
                 </div>
-                <div
-                    :style="{ opacity: username !== creator && player.name === creator ? 0.3 : 1.0 }"
-                    @click="kickPlayer(player.id)"
-                >
+                <div :style="{ opacity: player.name === creator ? 0.3 : 1.0 }" @click="kickPlayer(player.id)">
                     {{ t("game.ui.settings.dm.AdminSettings.kick") }}
                 </div>
             </div>

--- a/server/src/api/socket/room.py
+++ b/server/src/api/socket/room.py
@@ -64,7 +64,7 @@ async def kick_player(sid: str, player_id: int):
     pr: PlayerRoom = game_state.get(sid)
 
     if pr.role != Role.DM:
-        logger.warning(f"{pr.player.name} attempted to refresh the invitation code.")
+        logger.warning(f"{pr.player.name} attempted to kick a player.")
         return
 
     target_pr = PlayerRoom.get_or_none(player=player_id, room=pr.room)
@@ -73,7 +73,7 @@ async def kick_player(sid: str, player_id: int):
 
     creator: User = pr.room.creator
 
-    if pr.player != creator and creator == target_pr.player:
+    if creator == target_pr.player:
         logger.warning(f"{target_pr.player.name} attempted to kick the campaign creator")
         return
 


### PR DESCRIPTION
This change makes it so that the creator of the campaign can no longer kick themselves or change their role to player.

There was a modal that pops up if you tried to kick yourself, but it's been proven that that was not enough to prevent people from actually kicking themselves :)

This does mean that currently there will be no way to get the original creator out of a campaign.