### PR TITLE
bug(Logging): Fix logging level handling not being correct

### DIFF
--- a/server/src/logs.py
+++ b/server/src/logs.py
@@ -30,7 +30,7 @@ if not config.logging:
 for log_config in config.logging:
     # Set the root log level to the lowest level among handlers
     # Otherwise it defaults to WARNING and removes lower level logs
-    if level_mapping.get(logger.level, logging.INFO) > level_mapping.get(log_config.level, logging.INFO):
+    if logger.getEffectiveLevel() > level_mapping.get(log_config.level, logging.INFO):
         logger.setLevel(log_config.level)
     match log_config.mode:
         case "stdout":


### PR DESCRIPTION
I noticed on my own server that user connections were no longer being logged despite my logger being configured to 'info'.

### tldr

Turns out there was a small bug keeping the main logger at an effective log level of warning.

### the technical details

non-root loggers start with a log level of 0 which is NOT SET. Their effective log level however is 30 (WARNING). The check to see if we have to lower the log level was using the `.level` value which would always be 0. This change makes it so that we use the actual effective log level instead.