### PR TITLE
bug(Fow): Fix pre-fog-shapes leaving the fow layer not being cleaned up correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ tech changes will usually be stripped from release notes for the public
 -   Resizing a rotated polygon did not correctly recalculate center, causing sudden shifts on move
 -   Note creation not going straight to edit mode in some cases
 -   Account settings text overlapping on smaller viewport widths
+-   Moving special hide/reveal shapes from the fow layer could lead to a niche bug
 
 ## [2025.3]
 

--- a/client/src/game/interfaces/layer.ts
+++ b/client/src/game/interfaces/layer.ts
@@ -37,6 +37,8 @@ export interface ILayer {
     moveShapeOrder: (shape: IShape, destinationIndex: number, sync: SyncMode) => void;
     pushShapes: (...shapes: IShape[]) => void;
     removeShape: (shape: IShape, options: { sync: SyncMode; recalculate: boolean; dropShapeId: boolean }) => boolean;
+    enterLayer: (shape: IShape) => void;
+    exitLayer: (shape: IShape) => void;
     resize: (width: number, height: number) => void;
     setServerShapes: (shapes: ApiShape[]) => Promise<void>;
     setShapes: (...shapes: IShape[]) => void;

--- a/client/src/game/layers/variants/fowLighting.ts
+++ b/client/src/game/layers/variants/fowLighting.ts
@@ -1,6 +1,6 @@
 import { g2l, g2lz, g2lr, toRadians } from "../../../core/conversions";
 import type { LocalId } from "../../../core/id";
-import type { SyncMode, InvalidationMode } from "../../../core/models/types";
+import type { SyncMode } from "../../../core/models/types";
 import { FOG_COLOUR } from "../../colour";
 import { getShape } from "../../id";
 import type { IShape } from "../../interfaces/shape";
@@ -18,13 +18,7 @@ import { visionState } from "../../vision/state";
 import { FowLayer } from "./fow";
 
 export class FowLightingLayer extends FowLayer {
-    addShape(shape: IShape, sync: SyncMode, invalidate: InvalidationMode): void {
-        super.addShape(shape, sync, invalidate);
-        if (shape.options.preFogShape ?? false) {
-            this.preFogShapes.push(shape);
-        }
-    }
-
+    // We still need removeShapes as this does not inherently call .setLayer, which addShape does
     removeShape(shape: IShape, options: { sync: SyncMode; recalculate: boolean; dropShapeId: boolean }): boolean {
         let idx = -1;
         if (shape.options.preFogShape ?? false) {
@@ -33,6 +27,16 @@ export class FowLightingLayer extends FowLayer {
         const remove = super.removeShape(shape, options);
         if (remove && idx >= 0) this.preFogShapes.splice(idx, 1);
         return remove;
+    }
+
+    enterLayer(shape: IShape): void {
+        if (shape.options.preFogShape ?? false) {
+            this.preFogShapes.push(shape);
+        }
+    }
+
+    exitLayer(shape: IShape): void {
+        this.preFogShapes = this.preFogShapes.filter((s) => s.id !== shape.id);
     }
 
     draw(): void {

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -191,6 +191,10 @@ export class Layer implements ILayer {
         }
     }
 
+    // Utility functions to do cleanup in case of layer move
+    enterLayer(_shape: IShape): void {}
+    exitLayer(_shape: IShape): void {}
+
     addShape(shape: IShape, sync: SyncMode, invalidate: InvalidationMode): void {
         shape.setLayer(this.floor, this.name);
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -275,8 +275,12 @@ export abstract class Shape implements IShape {
         for (const { shape } of this._dependentShapes) {
             shape.setLayer(floor, layer);
         }
+        if (this.floorId !== undefined && this.layerName !== undefined) {
+            this.layer?.exitLayer(this);
+        }
         this.floorId = floor;
         this.layerName = layer;
+        this.layer?.enterLayer(this);
     }
 
     getPositionRepresentation(): { angle: number; points: [number, number][] } {


### PR DESCRIPTION
When you move a pre fog shape away from their fow layer and then delete them, the render loop can crash.

This is because an internal data structure of the fow layer was not being cleaned properly in the layer-move scenario, only in the shape removal scenario.

This fixes #1715