### PR TITLE
bug(Shapes): Fix temp flag no longer being sent to server

### DIFF
--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -214,7 +214,7 @@ export class Layer implements ILayer {
         let compact;
         if (sync !== SyncMode.NO_SYNC && !shape.preventSync) {
             compact = fromSystemForm(shape.id);
-            createOnServer(compact, sync === SyncMode.TEMPLATE_SYNC);
+            createOnServer(compact, sync);
         }
         if (invalidate !== InvalidationMode.NO) this.invalidate(invalidate !== InvalidationMode.WITH_LIGHT);
 

--- a/client/src/game/shapes/transformations.ts
+++ b/client/src/game/shapes/transformations.ts
@@ -36,6 +36,7 @@ import type { AssetId } from "../../assets/models";
 import { toGP } from "../../core/geometry";
 import { baseAdjust } from "../../core/http";
 import type { GlobalId, LocalId } from "../../core/id";
+import { SyncMode } from "../../core/models/types";
 import { getShapeSystems } from "../../core/systems";
 import type { SystemInformMode } from "../../core/systems/models";
 import { uuidv4 } from "../../core/utils";
@@ -183,12 +184,14 @@ export async function loadFromServer(serverShape: ApiShape, floor: FloorId, laye
     return await createCompactFromServerData(serverShape, id, floor, layer);
 }
 
-export function createOnServer(compact: CompactForm, asTemplate: boolean): void {
+export function createOnServer(compact: CompactForm, sync: SyncMode): void {
+    if (sync === SyncMode.NO_SYNC) return;
+
     const uuid = getGlobalId(compact.id);
     if (uuid === undefined) throw new Error("Global ID not found");
     const shape = createServerDataFromCompact(compact);
     let data: ApiShapeAdd;
-    if (asTemplate) {
+    if (sync === SyncMode.TEMPLATE_SYNC) {
         data = {
             shape,
             template: true,
@@ -201,7 +204,7 @@ export function createOnServer(compact: CompactForm, asTemplate: boolean): void 
             shape,
             floor,
             layer: compact.layer,
-            temporary: false,
+            temporary: sync === SyncMode.TEMP_SYNC,
         };
     }
 

--- a/server/src/state/game.py
+++ b/server/src/state/game.py
@@ -1,5 +1,6 @@
 from typing import Set
 
+from ..logs import logger
 from ..api.models.client import Viewport
 from ..api.socket.constants import GAME_NS
 from ..app import app, sio
@@ -39,7 +40,11 @@ class GameState(State[PlayerRoom]):
         self.client_temporaries[sid].add(uid)
 
     def remove_temp(self, sid: str, uid: str) -> None:
-        self.client_temporaries[sid].remove(uid)
+        try:
+            self.client_temporaries[sid].remove(uid)
+        except KeyError:
+            logger.warning(f"Attempt to remove unknown temporary shape {uid} from client {sid}")
+            return
 
 
 game_state = GameState()


### PR DESCRIPTION
An oversight in the rework of the shape data communication led to the "temp" flag no longer being sent to the server for new shapes when necessary.

This caused things like the ping tool to be received on the server as if these are permanent shapes.
Combined with a follow up call to the server to remove the (non-existing) temporary ping shape the server failed to find this shape and could not remove the shape, causing the ping shapes to remain for eternity.

These shapes are also not selectable, so they're just a nuisance.

This PR fixes the behaviour for all new temporary shapes, but will not fix existing broken shapes hanging around.

This is only broken on the dev branch, if you need to get rid of these, you can reach out to me on discord to see what the easiest approach is.

This fixes #1713 