### PR TITLE
bug(Validation): fix missing sentinel check

### DIFF
--- a/server/src/api/socket/location.py
+++ b/server/src/api/socket/location.py
@@ -285,7 +285,7 @@ async def change_location(sid: str, raw_data: Any):
             # loading times might vary and we don't want to snap people back when they already move around
             # And it's possible that there are already users on the new location
             # that don't want to be moved to this new position
-            if data.position:
+            if data.position is not MISSING:
                 await sio.emit(
                     "Position.Set",
                     data=data.position,


### PR DESCRIPTION
When changing locations a server validation error could appear.

The error itself is not harmful and does not impact any game logic, but it was noisy and is now resolved.