### PR TITLE
bug(Assets): Fix asset manager no longer accepting dungeondraft files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ tech changes will usually be stripped from release notes for the public
 -   Moving special hide/reveal shapes from the fow layer could lead to a niche bug
 -   Rotation slider not showing current value in text input on component load
 -   Shapes snapping to square grid sometimes offset from grid
+-   DDraft files no longer being uploadable to the asset manager
 
 ## [2025.3]
 

--- a/server/src/api/socket/asset_manager/ddraft.py
+++ b/server/src/api/socket/asset_manager/ddraft.py
@@ -48,10 +48,11 @@ async def handle_ddraft_file(upload_data: ApiAssetUpload, data: bytes, sid: str)
     sh = hashlib.sha1(image)
     hashname = sh.hexdigest()
 
-    full_hash_path = get_asset_hash_subpath(hashname)
+    full_path = ASSETS_DIR / get_asset_hash_subpath(hashname)
 
-    if not (ASSETS_DIR / full_hash_path).exists():
-        with open(ASSETS_DIR / full_hash_path, "wb") as f:
+    if not full_path.exists():
+        full_path.parent.mkdir(exist_ok=True, parents=True)
+        with open(full_path, "wb") as f:
             f.write(image)
 
     template = {


### PR DESCRIPTION
This fixes a bug with ddraft files that since the 2025.1 asset rework are no longer uploadable.