### PR TITLE
bug(Text): Fix text resizing not saving correctly

### DIFF
--- a/server/src/api/models/shape/__init__.py
+++ b/server/src/api/models/shape/__init__.py
@@ -91,7 +91,7 @@ class ShapeCircleSizeUpdate(TypeIdModel):
 
 class ShapeTextSizeUpdate(TypeIdModel):
     uuid: str = Field(json_schema_extra={"typeId": "GlobalId"})
-    font_size: int
+    font_size: float
     temporary: bool
 
 

--- a/server/src/api/models/shape/subtypes.py
+++ b/server/src/api/models/shape/subtypes.py
@@ -35,13 +35,13 @@ class ApiPolygonShape(ApiCoreShape):
 
 class ApiTextShape(ApiCoreShape):
     text: str
-    font_size: int
+    font_size: float
 
 
 class ApiLineShape(ApiCoreShape):
     x2: float
     y2: float
-    line_width: int
+    line_width: float
 
 
 class ToggleVariant(TypeIdModel):

--- a/server/src/db/models/text.py
+++ b/server/src/db/models/text.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from peewee import IntegerField, TextField
+from peewee import FloatField, TextField
 
 from ...api.models.shape.shape import ApiCoreShape
 from ...api.models.shape.subtypes import ApiTextShape
@@ -9,7 +9,7 @@ from .shape_type import ShapeType
 
 class Text(ShapeType):
     text = cast(str, TextField())
-    font_size = cast(int, IntegerField())
+    font_size = cast(float, FloatField())
 
     def as_pydantic(self, shape: ApiCoreShape):
         return ApiTextShape(**shape.model_dump(), text=self.text, font_size=self.font_size)

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -14,7 +14,7 @@ When writing migrations make sure that these things are respected:
     - e.g. a column added to Circle also needs to be added to CircularToken
 """
 
-SAVE_VERSION = 112
+SAVE_VERSION = 113
 
 import asyncio
 import json
@@ -680,6 +680,17 @@ def upgrade(
                 'INSERT INTO "shape" ("uuid", "layer_id", "type_", "x", "y", "name", "name_visible", "fill_colour", "stroke_colour", "vision_obstruction", "movement_obstruction", "draw_operator", "index", "options", "badge", "show_badge", "default_edit_access", "default_vision_access", "is_invisible", "is_defeated", "default_movement_access", "is_locked", "angle", "stroke_width", "asset_id", "group_id", "ignore_zoom_size", "is_door", "is_teleport_zone", "character_id", "odd_hex_orientation", "size_x", "size_y", "show_cells", "cell_fill_colour", "cell_stroke_colour", "cell_stroke_width") SELECT "uuid", "layer_id", "type_", "x", "y", "name", "name_visible", "fill_colour", "stroke_colour", "vision_obstruction", "movement_obstruction", "draw_operator", "index", "options", "badge", "show_badge", "default_edit_access", "default_vision_access", "is_invisible", "is_defeated", "default_movement_access", "is_locked", "angle", "stroke_width", "asset_id", "group_id", "ignore_zoom_size", "is_door", "is_teleport_zone", "character_id", "odd_hex_orientation", "size", "size", "show_cells", "cell_fill_colour", "cell_stroke_colour", "cell_stroke_width" FROM _shape_111'
             )
             db.execute_sql("DROP TABLE _shape_111")
+    elif version == 112:
+        # Change text font size from int to float
+        with db.atomic():
+            db.execute_sql("CREATE TEMPORARY TABLE _text_112 AS SELECT * FROM text")
+            db.execute_sql("DROP TABLE text")
+            db.execute_sql(
+                'CREATE TABLE IF NOT EXISTS "text" ("shape_id" TEXT NOT NULL PRIMARY KEY, "text" TEXT NOT NULL, "font_size" REAL NOT NULL, FOREIGN KEY ("shape_id") REFERENCES "shape" ("uuid") ON DELETE CASCADE)'
+            )
+            db.execute_sql(
+                'INSERT INTO "text" ("shape_id", "text", "font_size") SELECT "shape_id", "text", "font_size" FROM _text_112'
+            )
     else:
         raise UnknownVersionException(f"No upgrade code for save format {version} was found.")
     inc_save_version(db)


### PR DESCRIPTION
It was no longer possible to resize a text shape on the current dev branch. (i.e. the server rejected the change)

This is because the code assumes the font size would be provided as a rounded number, but in practice it can be a float. In the current production version the server was not as strict, but the database would still round the number to an integer, so on refresh the actual size of the text could be different as well.

This PR changes the db and api formats of the font size to floating points.