### PR TITLE
bug(Shape): Fix shape creation properties bug

### DIFF
--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -144,7 +144,9 @@ export abstract class Shape implements IShape {
         this.isSnappable = options?.isSnappable ?? true;
         this._parentId = options?.parentId;
 
-        if (properties !== undefined) propertiesSystem.import(this.id, properties, "load");
+        // properties system is the only system that requires knowledge about all shapes
+        // (it basically does not properly handle interactions with shapes it doesn't know about)
+        propertiesSystem.import(this.id, properties ?? {}, "load");
     }
 
     abstract __center(): GlobalPoint;


### PR DESCRIPTION
_This only affects dev_

The properties system is still a little bit of an odd duck compared to the other systems and was not handling shape interactions well when not actively registered.

A known place where this would be a problem is the spell tool that no longer worked on dev.