### PR TITLE
bug(Viewport): Fix None viewport being sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ tech changes will usually be stripped from release notes for the public
 -   DDraft files no longer being uploadable to the asset manager
 -   Moving shapes with keyboard keys while ruler was enabled on select tool would move shapes twice as far
 -   Hovering on an initiative entry that is part of a group but not marked as a group entry would highlight all group members
+-   Error log about viewports on the server
 
 ## [2025.3]
 

--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -237,8 +237,8 @@ class ClientSystem implements System {
 
     sendViewportInfo(): void {
         if (Number.isNaN(positionState.readonly.zoom)) return;
-        const viewport = this.getViewport()!;
-        sendViewport(viewport);
+        const viewport = this.getViewport();
+        if (viewport) sendViewport(viewport);
     }
 
     updateZoomFactor(): void {


### PR DESCRIPTION
This is a fix to a harmless bug that was just adding error logs on the server, but didn't impact anything.