### PR TITLE
Apply grid snap on keyboard movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ tech changes will usually be stripped from release notes for the public
 -   [tech] refactor of intermediate shape handling on client side (see `transformations.ts`)
 -   [tech] upgraded pydantic from 1.x to 2.x
 -   Square grids now have distinct x and y size values
+-   Keyboard movement now also snaps to the closest grid cell when snapping is relevant
 
 ### Fixed
 

--- a/client/src/game/dropAsset.ts
+++ b/client/src/game/dropAsset.ts
@@ -75,7 +75,7 @@ async function dropHelper(
                 }
             }
             if (shape !== undefined && shape.options.skipDraw !== true) {
-                await moveShapes([shape], Vector.fromPoints(shape.center, location), false);
+                await moveShapes([shape], Vector.fromPoints(shape.center, location), { temporary: false });
                 return;
             }
         }

--- a/client/src/game/input/keyboard/down.ts
+++ b/client/src/game/input/keyboard/down.ts
@@ -21,6 +21,7 @@ import { propertiesSystem } from "../../systems/properties";
 import { getProperties } from "../../systems/properties/state";
 import { selectedSystem } from "../../systems/selected";
 import { locationSettingsState } from "../../systems/settings/location/state";
+import { playerSettingsState } from "../../systems/settings/players/state";
 import { uiSystem } from "../../systems/ui";
 import { moveFloor } from "../../temp";
 import { toggleActiveMode, toolMap } from "../../tools/tools";
@@ -107,7 +108,10 @@ export async function onKeyDown(event: KeyboardEvent): Promise<void> {
                 }
                 if (delta.length() === 0) return;
 
-                await moveShapes(selection, delta, false);
+                await moveShapes(selection, delta, {
+                    snapToGrid: playerSettingsState.useSnapping(event),
+                    temporary: false,
+                });
                 (toolMap[ToolName.Select] as ISelectTool).resetRotationHelper();
             } else {
                 // The pan offsets should be in the opposite direction to give the correct feel.

--- a/client/src/game/interfaces/shape.ts
+++ b/client/src/game/interfaces/shape.ts
@@ -37,7 +37,7 @@ export interface IShape extends SimpleShape {
 
     contains: (point: GlobalPoint, nearbyThreshold?: number) => boolean;
 
-    snapToGrid: (checkCollisions: boolean) => void;
+    snapToGrid: () => void;
     resizeToGrid: (resizePoint: number, retainAspectRatio: boolean) => void;
     resize: (resizePoint: number, point: GlobalPoint, retainAspectRatio: boolean) => number;
 

--- a/client/src/game/operations/undo.ts
+++ b/client/src/game/operations/undo.ts
@@ -92,7 +92,7 @@ async function handleMovement(shapes: ShapeMovementOperation[], direction: "undo
     const fullShapes = shapes.map((s) => getShape(s.uuid)!);
     let delta = Vector.fromPoints(toGP(shapes[0]!.to), toGP(shapes[0]!.from));
     if (direction === "redo") delta = delta.reverse();
-    await moveShapes(fullShapes, delta, false);
+    await moveShapes(fullShapes, delta, { temporary: false });
     (toolMap[ToolName.Select] as ISelectTool).resetRotationHelper();
 }
 

--- a/client/src/game/shapes/shape.ts
+++ b/client/src/game/shapes/shape.ts
@@ -354,12 +354,12 @@ export abstract class Shape implements IShape {
         return { x: Math.max(1, customRound(x)), y: Math.max(1, customRound(y)) };
     }
 
-    snapToGrid(checkCollisions: boolean = false): void {
+    snapToGrid(): void {
         const props = getProperties(this.id)!;
         const gridType = locationSettingsState.raw.gridType.value;
         const size = this.getSize(gridType);
         const newCenter = snapShapeToGrid(this.center, gridType, size, props.oddHexOrientation);
-        if (checkCollisions) {
+        if (this.layerName === LayerName.Tokens) {
             const snapDelta = subtractP(newCenter, this.center);
             const cappedDelta = calculateDelta(snapDelta, this, true);
             this.center = addP(this.center, cappedDelta);

--- a/client/src/game/systems/selected/collapse.ts
+++ b/client/src/game/systems/selected/collapse.ts
@@ -54,7 +54,7 @@ export async function expandSelection(updateList?: IShape[]): Promise<void> {
     for (const [collapsedId, vector] of shape.options.collapsedIds) {
         const collapsedShape = getShape(collapsedId);
         if (collapsedShape !== undefined) {
-            await moveShapes([collapsedShape], calculateDelta(vector, collapsedShape, true), true);
+            await moveShapes([collapsedShape], calculateDelta(vector, collapsedShape, true), { temporary: true });
             selectedSystem.push(collapsedShape.id);
             if (updateList && !collapsedShape.preventSync) updateList.push(collapsedShape);
         }

--- a/client/src/game/systems/settings/players/state.ts
+++ b/client/src/game/systems/settings/players/state.ts
@@ -72,7 +72,7 @@ export const playerSettingsState = {
             return state.reactive.gridSize.value;
         }
     }),
-    useSnapping(event: MouseEvent | TouchEvent): boolean {
+    useSnapping(event: MouseEvent | TouchEvent | KeyboardEvent): boolean {
         return state.raw.invertAlt.value === event.altKey;
     },
 };

--- a/client/src/game/tools/variants/select/index.ts
+++ b/client/src/game/tools/variants/select/index.ts
@@ -529,7 +529,7 @@ class SelectTool extends Tool implements ISelectTool {
                     }
                 }
 
-                await moveShapes(this.currentSelection, delta, true);
+                await moveShapes(this.currentSelection, delta, { temporary: true });
 
                 if (!this.deltaChanged) {
                     this.dragRay = Ray.fromPoints(this.dragRay.origin, lp);
@@ -720,7 +720,7 @@ class SelectTool extends Tool implements ISelectTool {
                             });
                         }
 
-                        sel.snapToGrid(layer.name === LayerName.Tokens);
+                        sel.snapToGrid();
 
                         if (props.blocksVision !== VisionBlock.No) {
                             visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: sel.id });


### PR DESCRIPTION
This fixes #1736 

Keyboard navigation will now also snap to the grid when snapping is relevant (i.e. depending on the alt key)