### PR TITLE
bug(Initiative) Fix initiative toggle vision lock interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ tech changes will usually be stripped from release notes for the public
 -   Moving shapes with keyboard keys while ruler was enabled on select tool would move shapes twice as far
 -   Hovering on an initiative entry that is part of a group but not marked as a group entry would highlight all group members
 -   Error log about viewports on the server
+-   Toggling initiative off vision lock interactions
 
 ## [2025.3]
 

--- a/client/src/game/ui/initiative/state.ts
+++ b/client/src/game/ui/initiative/state.ts
@@ -126,9 +126,12 @@ class InitiativeStore extends Store<InitiativeState> {
             else activeTokensBackup = new Set(accessState.raw.activeTokenFilters.get("vision") ?? []);
             this.handleCameraLock();
             this.handleVisionLock();
-        } else {
-            if (activeTokensBackup === undefined) accessSystem.clearActiveVisionTokens();
-            else accessSystem.setActiveVisionTokens(...activeTokensBackup.values());
+        } else if (playerSettingsState.raw.initiativeVisionLock.value) {
+            if (activeTokensBackup === undefined || activeTokensBackup.size === 0) {
+                accessSystem.clearActiveVisionTokens();
+            } else {
+                accessSystem.setActiveVisionTokens(...activeTokensBackup.values());
+            }
         }
     }
 


### PR DESCRIPTION
The initiative settings have a setting to auto modify the vision shown to only the active token.

This setting only activates when the initiative toggle function is used in the toolbar. When deactivating initiative, it's supposed to restore the vision-tool state to what it was before initiative started [^1]. This was only properly working if a vision-tool filter was in effect.

In most cases no active filter is in effect (i.e. all vision is shown) and deactivating initiative would not properly restore this.

Additionally the vision reset logic was running at all times when deactivating initiative, while it should only trigger when the vision lock initiative setting is turned on.

[^1]: The set of active vision filters before initiative starts is only remembered during the session currently, if initiative is deactivated in a later session, it will always fall back to the full vision setup.