### PR TITLE
bug(ClientSettings): Fix initiative settings button not opening the correct tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ tech changes will usually be stripped from release notes for the public
 -   Hovering on an initiative entry that is part of a group but not marked as a group entry would highlight all group members
 -   Error log about viewports on the server
 -   Toggling initiative off vision lock interactions
+-   Initiative cog wheel not opening initiative tab in the client settings
 
 ## [2025.3]
 

--- a/client/src/game/ui/settings/client/ClientSettings.vue
+++ b/client/src/game/ui/settings/client/ClientSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import PanelModal from "../../../../core/components/modals/PanelModal.vue";
@@ -14,8 +14,6 @@ import InitiativeSettings from "./InitiativeSettings.vue";
 import PerformanceSettings from "./PerformanceSettings.vue";
 
 const { t } = useI18n();
-
-const activeTab = ref(ClientSettingCategory.Appearance);
 
 const visible = computed({
     get() {
@@ -59,7 +57,7 @@ const tabs = computed(() => [
 </script>
 
 <template>
-    <PanelModal v-model:visible="visible" v-model:selection="activeTab" :tabs="tabs">
+    <PanelModal v-model:visible="visible" v-model:selection="uiState.reactive.clientSettingsTab" :tabs="tabs">
         <template #title>{{ t("game.ui.settings.client.ClientSettings.client_settings") }}</template>
     </PanelModal>
 </template>


### PR DESCRIPTION
A bug in the client settings component caused it to ignore any requested tab, so pressing the cog wheel on the initiative UI would just open the client settings without changing the tab.