### PR TITLE
Fix note searchbar border not visible in firefox

### DIFF
--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -458,14 +458,15 @@ header {
             display: flex;
             align-items: center;
             width: 100%;
+            height: 100%;
 
             > input {
-                padding: 0.25rem 1rem;
+                padding: 0.5rem 1rem;
                 outline: none;
                 border: none;
                 border-radius: 1rem;
                 flex-grow: 1;
-
+                height: 100%;
                 font-size: 1.25em;
             }
             > #clear-button {


### PR DESCRIPTION
In firefox, the input element of the note list search bar was overlapping the border of the encapsulating `#search-bar` div. 
This PR decreases the input's padding to fix this.
Before: 
<img width="708" height="357" alt="Screenshot_20260125_092556" src="https://github.com/user-attachments/assets/45c38e4c-f5e1-448e-9a32-be4ebe23394e" />

After:
<img width="708" height="357" alt="Screenshot_20260125_092609" src="https://github.com/user-attachments/assets/2108aebf-f2d1-4627-a87a-117cb329ed97" />
