### PR TITLE
bug(Group): Fix group system not properly clearing between locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ tech changes will usually be stripped from release notes for the public
 -   Error log about viewports on the server
 -   Toggling initiative off vision lock interactions
 -   Initiative cog wheel not opening initiative tab in the client settings
+-   Group system not properly cleaning up on location changes
 
 ## [2025.3]
 


### PR DESCRIPTION
The group system was not doing proper cleanup of some state when changing locations. This can lead to a variety of exotic bugs as the state uses local ids, which have a different meaning when a new location is loaded.

Fixes #1754 