### PR TITLE
Fix initiative entries remaining blurred again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ tech changes will usually be stripped from release notes for the public
 -   Toggling initiative off vision lock interactions
 -   Initiative cog wheel not opening initiative tab in the client settings
 -   Initiative entries would remain blurred if the focused entry was removed by another player.
+-   Initiative entries would remain blurred if using enter to submit initiative value while having a shape selected.
 -   Group system not properly cleaning up on location changes
 
 ## [2025.3]

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -342,6 +342,12 @@ function openSettings(): void {
     uiSystem.showClientSettings(true);
 }
 
+function inputSubmit(event: Event): void {
+    getTarget(event).blur();
+    event.stopPropagation();
+    event.preventDefault();
+}
+
 // shitty helper because draggable loses all type information :arghfist:
 function n(e: any): number {
     return e as number;
@@ -494,7 +500,7 @@ function n(e: any): number {
                                                 @focus="lock(actor.globalId)"
                                                 @blur="unlock"
                                                 @change="setInitiative(actor.globalId, getValue($event))"
-                                                @keyup.enter="getTarget($event).blur()"
+                                                @keyup.enter="inputSubmit"
                                             />
                                         </div>
                                         <Transition name="effects-expand">
@@ -534,7 +540,7 @@ function n(e: any): number {
                                                             @change="
                                                                 setEffectName(actor.globalId, n(e), getValue($event))
                                                             "
-                                                            @keyup.enter="getTarget($event).blur()"
+                                                            @keyup.enter="inputSubmit"
                                                         />
                                                         <input
                                                             v-if="effect.turns !== null"
@@ -546,7 +552,7 @@ function n(e: any): number {
                                                             @change="
                                                                 setEffectTurns(actor.globalId, n(e), getValue($event))
                                                             "
-                                                            @keyup.enter="getTarget($event).blur()"
+                                                            @keyup.enter="inputSubmit"
                                                         />
                                                         <div v-else class="effect-turn-counter infinite-placeholder">
                                                             &infin;


### PR DESCRIPTION
Initiative entries remained blurred if the user submitted an initiative value by hitting the enter key while having a shape selected. The key event would propagate and open the shape settings modal for the shape and the desired blur event handler would never be called.

This fixes #1755 again.