### PR TITLE
Allow longer initiative effect names

### DIFF
--- a/client/src/core/components/ResizingTextArea.vue
+++ b/client/src/core/components/ResizingTextArea.vue
@@ -3,17 +3,7 @@ import { nextTick, onMounted, useTemplateRef, watch } from "vue";
 
 import { getTarget, getValue } from "../utils";
 
-const props = withDefaults(
-    defineProps<{
-        disabled?: boolean;
-        visible?: boolean;
-    }>(),
-    {
-        disabled: false,
-        visible: true,
-    },
-);
-
+const { visible = true, disabled = false } = defineProps<{ visible?: boolean; disabled?: boolean }>();
 const textArea = useTemplateRef("textarea");
 const emit = defineEmits<(e: "change", s: string) => void>();
 const text = defineModel<string>({ required: true });
@@ -21,30 +11,17 @@ const text = defineModel<string>({ required: true });
 onMounted(async () => {
     await nextTick(() => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        if (props.visible ?? true) resizeTextArea(textArea.value!);
+        if (visible ?? true) resizeTextArea(textArea.value!);
     });
 });
 
-watch(
-    () => text.value,
-    async () => {
-        if (props.visible) {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-            await nextTick(() => resizeTextArea(textArea.value!));
-        }
-    },
-);
-
-watch(
-    () => props.visible,
-    async (v) => {
-        if (v) {
-            // vue-tsc and eslint disagree on this assertion
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-            await nextTick(() => resizeTextArea(textArea.value!));
-        }
-    },
-);
+watch([() => visible, () => text.value], async () => {
+    if (visible) {
+        // vue-tsc and eslint disagree on this assertion
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        await nextTick(() => resizeTextArea(textArea.value!));
+    }
+});
 
 function resizeTextArea(element: HTMLElement): void {
     element.style.height = "auto";
@@ -53,20 +30,18 @@ function resizeTextArea(element: HTMLElement): void {
 </script>
 
 <template>
-    <div class="counter-wrapper">
-        <div class="grow-wrapper">
-            <textarea
-                ref="textarea"
-                v-model="text"
-                type="text"
-                :disabled="props.disabled"
-                rows="1"
-                @input="resizeTextArea(getTarget($event))"
-                @change="emit('change', getValue($event))"
-                @keyup.enter="getTarget($event).blur()"
-                @keydown.enter.prevent
-            />
-        </div>
+    <div class="grow-wrapper">
+        <textarea
+            ref="textarea"
+            v-model="text"
+            type="text"
+            :disabled="disabled"
+            rows="1"
+            @input="resizeTextArea(getTarget($event))"
+            @change="emit('change', getValue($event))"
+            @keyup.enter="getTarget($event).blur()"
+            @keydown.enter.prevent
+        />
     </div>
 </template>
 

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -531,7 +531,7 @@ function n(e: any): number {
                                                             :disabled="!owns(actor.globalId)"
                                                             :visible="initiativeStore.state.showInitiative"
                                                             @change="setEffectName(actor.globalId, n(e), $event)"
-                                                        ></ResizingTextArea>
+                                                        />
                                                         <input
                                                             v-if="effect.turns !== null"
                                                             v-model="effect.turns"


### PR DESCRIPTION
This replaces the input element for initiative effect names with a textarea and also increases the width of the effect list. This allows longer names to be used in the textbox, and even if the name is too long, the text will wrap.

~~Code is not in a fully cleaned up state as the known issues currently prevent this from being completed.~~

~~**Known Issues**: The textareas for the names of effects that span multiple lines do not automatically resize to fit the text when first loading the initiative tracker. Once a single character is typed, the textarea fits to the text as expected. I have no idea how to fix this.~~

**Edit**

The issue of initial resizing has been fixed by adding a prop 'visible' to the ResizingTextArea component. Passing a value to this prop allows it to have a pseudo callback for when the component becomes visible and make the textbox resize at that point.

This now also accounts for when the text is changed from outside the ResizingTextArea component, resizing to fit the new content.

I've also added a separator line between effects since they now have variable heights. This makes it easier to tell where one ends and the next begins.

Fixes #1766 