### PR TITLE
hotfix(v2026.1.2): Fix some NoteFilters missing details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+## [2026.1.2]
+
+### Fixed
+
+-   A bug causing the location and shape note filters to not show the proper details
+
 ## [2026.1.1]
 
 ### Fixed

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "client",
-    "version": "2026.1.1",
+    "version": "2026.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "client",
-            "version": "2026.1.1",
+            "version": "2026.1.2",
             "dependencies": {
                 "@babylonjs/core": "^8.22.2",
                 "@babylonjs/materials": "^8.22.2",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "client",
-    "version": "2026.1.1",
+    "version": "2026.1.2",
     "private": true,
     "type": "module",
     "scripts": {

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -4,7 +4,7 @@ import { computed, onActivated, onDeactivated, onMounted, onUnmounted, reactive,
 import { useI18n } from "vue-i18n";
 
 import type { DefaultNoteFilter } from "../../../apiTypes";
-import type { GlobalId, LocalId } from "../../../core/id";
+import type { GlobalId } from "../../../core/id";
 import { mostReadable, word2color } from "../../../core/utils";
 import { coreStore } from "../../../store/core";
 import { socket } from "../../api/socket";
@@ -119,10 +119,6 @@ const debouncedSearch = useDebounceFn(() => void search(), 300);
 const searchResults = ref<(Omit<QueryNote, "tags"> & { tags: NoteTag[] })[]>([]);
 const totalCount = ref(0);
 const loading = ref(false);
-const filterOptions = reactive({
-    locations: [] as { id: number; name: string }[],
-    shapes: [] as { id: LocalId; name: string; src: string }[],
-});
 
 enum DefaultFilter {
     NO_FILTER = "NO_FILTER",
@@ -169,7 +165,7 @@ async function search(): Promise<void> {
 
 async function updateLocationFilter(): Promise<void> {
     const filters = (await socket.emitWithAck("Note.Filters.Location.Get")) as { id: number; name: string }[];
-    filterOptions.locations = filters.sort((a, b) => a.name.localeCompare(b.name));
+    customFilterOptions.locations = filters.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 async function updateShapeFilter(): Promise<void> {
@@ -178,7 +174,7 @@ async function updateShapeFilter(): Promise<void> {
         name: string;
         src: string;
     }[];
-    filterOptions.shapes = filters
+    customFilterOptions.shapes = filters
         .map(({ uuid, ...s }) => ({ ...s, id: getLocalId(uuid, false)! }))
         .filter((s) => s.id !== undefined)
         .sort((a, b) => a.name.localeCompare(b.name));

--- a/server/VERSION
+++ b/server/VERSION
@@ -1,6 +1,10 @@
-2026.1.1
+2026.1.2
 
-2026.1.1 fixed a bug with templates not applying properly on drop.
+### Hotfixes
+
+- 2026.1.1 fixed a bug with templates not applying properly on drop.
+- 2026.1.2 fixed a bug with the new note filters not showing location and shape details.
+
 The rest of this changelog is from 2026.1.0
 
 ### Added

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "planarally-server"
-version = "2026.1.1"
+version = "2026.1.2"
 description = "Planarally server"
 readme = "README.md"
 requires-python = ">=3.13.2"

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -611,7 +611,7 @@ wheels = [
 
 [[package]]
 name = "planarally-server"
-version = "2026.1.1"
+version = "2026.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp", extra = ["speedups"] },


### PR DESCRIPTION
A small bug made it so that the new note filters for locations and shapes was not showing campaign specific detail options to filter on. The tag filter was working correctly.