### PR TITLE
feat(Asset): Store asset file size in DB & cleanup fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ tech changes will usually be stripped from release notes for the public
 -   Variant shapes are completely reworked
     -   UI should be more intuitive
     -   No longer completely separate shapes with their own state
+-   Asset size is now also stored in DB for easier user total size calculation
 -   [tech] DB storage of asset data is reworked
 
 ### Fixed
 
 -   Note icons on shapes no longer rendering
+-   Asset thumbnails not cleaning up on asset removal
 
 ### Fixed
 

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Literal, cast
 
-from peewee import TextField
+from peewee import IntegerField, TextField
 
 
 from ...logs import logger
@@ -12,7 +12,7 @@ from .user import User
 
 if TYPE_CHECKING:
     from .asset_entry import AssetEntry
-    from .shape import Shape
+    from .asset_rect import AssetRect
     from .shape_template import ShapeTemplate
 
 
@@ -21,12 +21,13 @@ class Asset(BaseDbModel):
 
     # !! When links are added update the cleanup function !!
     entries: SelectSequence["AssetEntry"]
-    shapes: SelectSequence["Shape"]
+    asset_rects: SelectSequence["AssetRect"]
     templates: SelectSequence["ShapeTemplate"]
 
     file_hash = cast(str, TextField())
     kind = cast(Literal["regular", "ddraft"], TextField())
     extension = cast(str | None, TextField(null=True))
+    file_size = cast(int | None, IntegerField(null=True))
 
     def __repr__(self):
         return f"<Asset {self.file_hash}>"
@@ -34,9 +35,11 @@ class Asset(BaseDbModel):
     def cleanup_check(self):
         full_hash_path = get_asset_hash_subpath(self.file_hash)
         if (ASSETS_DIR / full_hash_path).exists():
-            if self.entries.count() == 0 and self.shapes.count() == 0 and self.templates.count() == 0:
+            if self.entries.count() == 0 and self.asset_rects.count() == 0 and self.templates.count() == 0:
                 logger.info(f"No data maps to file {self.file_hash}, removing from server")
                 (ASSETS_DIR / full_hash_path).unlink()
+                for suffix in [".thumb.webp", ".thumb.jpeg"]:
+                    (ASSETS_DIR / f"{full_hash_path}{suffix}").unlink(missing_ok=True)
 
     def generate_thumbnails(self) -> None:
         generate_thumbnail_for_asset(self.file_hash)

--- a/server/src/db/models/shape.py
+++ b/server/src/db/models/shape.py
@@ -45,7 +45,6 @@ class Shape(BaseDbModel):
     data_blocks: SelectSequence["ShapeDataBlock"]
     custom_data: SelectSequence["ShapeCustomData"]
     notes: SelectSequence["NoteShape"]
-    asset_id: int | None
 
     uuid = cast(str, TextField(primary_key=True))
     layer = cast(

--- a/server/src/db/models/user.py
+++ b/server/src/db/models/user.py
@@ -6,7 +6,6 @@ from peewee import DateField, ForeignKeyField, TextField, fn
 from playhouse.shortcuts import model_to_dict
 from typing_extensions import Self
 
-from ...utils import ASSETS_DIR, get_asset_hash_subpath
 from ..base import BaseDbModel
 from ..typed import SelectSequence
 from .user_options import UserOptions
@@ -53,14 +52,11 @@ class User(BaseDbModel):
         )
 
     def get_total_asset_size(self) -> int:
-        handled_assets = set[int]()
-        total_size = 0
-        for asset in self.asset_entries:
-            if asset.asset and asset.asset.id not in handled_assets:
-                if asset.asset.file_hash and (ASSETS_DIR / get_asset_hash_subpath(asset.asset.file_hash)).exists():
-                    total_size += (ASSETS_DIR / get_asset_hash_subpath(asset.asset.file_hash)).stat().st_size
-                    handled_assets.add(asset.asset.id)
-        return total_size
+        from .asset import Asset
+        from .asset_entry import AssetEntry
+
+        query = Asset.select(fn.COALESCE(fn.SUM(Asset.file_size), 0)).join(AssetEntry).where(AssetEntry.owner == self)
+        return query.scalar()
 
     def update_last_login(self):
         today = date.today()

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -15,7 +15,7 @@ When writing migrations make sure that these things are respected:
 - It's often a good idea to start the server with a clean save and use `.schema <table_name>` in sqlite to get the exact schema output that a clean save creates
 """
 
-SAVE_VERSION = 116
+SAVE_VERSION = 117
 
 import asyncio
 import json
@@ -867,6 +867,25 @@ def upgrade(
 
             db.execute_sql("DROP TABLE toggle_composite")
             db.execute_sql("DROP TABLE composite_shape_association")
+    elif version == 116:
+        # Add file_size column to asset & clean up orphaned thumbnail files
+        with db.atomic():
+            db.execute_sql('ALTER TABLE "asset" ADD COLUMN "file_size" INTEGER')
+            if not is_import:
+                rows = db.execute_sql("SELECT id, file_hash FROM asset WHERE file_hash IS NOT NULL").fetchall()
+                for asset_id, file_hash in rows:
+                    path = ASSETS_DIR / get_asset_hash_subpath(file_hash)
+                    if path.exists():
+                        db.execute_sql("UPDATE asset SET file_size = ? WHERE id = ?", (path.stat().st_size, asset_id))
+
+        if not is_import:
+            known_hashes = {
+                row[0] for row in db.execute_sql("SELECT file_hash FROM asset WHERE file_hash IS NOT NULL").fetchall()
+            }
+            for subdir in ASSETS_DIR.rglob("*.thumb.*"):
+                asset_hash = subdir.name.split(".thumb.")[0]
+                if asset_hash not in known_hashes:
+                    subdir.unlink()
     else:
         raise UnknownVersionException(f"No upgrade code for save format {version} was found.")
     inc_save_version(db)


### PR DESCRIPTION
A PR is coming up where remote storage solutions for the assets can be configured. Currently PA calculates the amount of bytes a user has uploaded on a somewhat regular basis and does this by actually checking all the physical files. This is not feasible with remote storage (both cost wise and latency wise). So this PR makes this process simpler by storing the file size of each asset in the DB itself.

Additionally I noticed that we never actually cleanup the generated thumbnails when removing a physical file, so I cleaned that up while I was at it.