### PR TITLE
feat(Assets): Add remote asset storage option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,17 @@ tech changes will usually be stripped from release notes for the public
 
 ## Unreleased
 
+### Added
+
+-   [server] Option to store user uploaded assets in remote storage solutions (e.g. S3)
+
 ### Changed
 
 -   Variant shapes are completely reworked
     -   UI should be more intuitive
     -   No longer completely separate shapes with their own state
--   Asset size is now also stored in DB for easier user total size calculation
 -   [tech] DB storage of asset data is reworked
+    -   Asset size is now also stored in DB for easier user total size calculation
 
 ### Fixed
 

--- a/client/src/assets/utils.ts
+++ b/client/src/assets/utils.ts
@@ -1,23 +1,25 @@
 import { baseAdjust } from "../core/http";
+import { coreStore } from "../store/core";
 
 import type { AssetEntryId } from "./models";
 import { assetState } from "./state";
 
-export function getImageSrcFromAssetId(
-    file: AssetEntryId,
-    options?: { addBaseUrl?: boolean; thumbnailFormat?: string },
-): string {
+export function getImageSrcFromAssetId(file: AssetEntryId, options?: { thumbnailFormat?: string }): string {
     const fileHash = assetState.raw.idMap.get(file)!.fileHash ?? "";
     return getImageSrcFromHash(fileHash, options);
 }
 
-export function getImageSrcFromHash(
-    fileHash: string,
-    options?: { addBaseUrl?: boolean; thumbnailFormat?: string },
-): string {
-    let path = `/static/assets/${fileHash.slice(0, 2)}/${fileHash.slice(2, 4)}/${fileHash}`;
+export function getImageSrcFromHash(fileHash: string, options?: { thumbnailFormat?: string }): string {
+    const hashPath = `${fileHash.slice(0, 2)}/${fileHash.slice(2, 4)}/${fileHash}`;
+    const assetUrlBase = coreStore.state.assetUrlBase;
+
+    let suffix = hashPath;
     if (options?.thumbnailFormat !== undefined) {
-        path = `${path}.thumb.${options.thumbnailFormat}`;
+        suffix = `${suffix}.thumb.${options.thumbnailFormat}`;
     }
-    return (options?.addBaseUrl ?? true) ? baseAdjust(path) : path;
+
+    if (assetUrlBase !== null) {
+        return `${assetUrlBase}/${suffix}`;
+    }
+    return baseAdjust(`/static/assets/${suffix}`);
 }

--- a/client/src/core/http.ts
+++ b/client/src/core/http.ts
@@ -1,3 +1,5 @@
+// Add the base URL of the server to the given URL
+// Note that this should NOT be used for user uploaded assets as those can be served from a different domain
 export function baseAdjust(url: string): string {
     if (url.startsWith("/")) url = url.slice(1);
     return import.meta.env.BASE_URL + url;

--- a/client/src/dashboard/games/CreateGame.vue
+++ b/client/src/dashboard/games/CreateGame.vue
@@ -62,13 +62,7 @@ function setLogo(data: { id: AssetId; fileHash: string }): void {
             <div class="logo">
                 <img
                     alt="Campaign Logo Preview"
-                    :src="
-                        baseAdjust(
-                            logo.id >= 0
-                                ? getImageSrcFromHash(logo.path, { addBaseUrl: false })
-                                : '/static/img/d20.svg',
-                        )
-                    "
+                    :src="logo.id >= 0 ? getImageSrcFromHash(logo.path) : baseAdjust('/static/img/d20.svg')"
                 />
                 <div class="edit" @click="showAssetPicker = true">
                     <font-awesome-icon icon="pencil-alt" />

--- a/client/src/dashboard/games/GameList.vue
+++ b/client/src/dashboard/games/GameList.vue
@@ -174,13 +174,7 @@ async function exportCampaign(): Promise<void> {
                 >
                     <img
                         class="logo"
-                        :src="
-                            baseAdjust(
-                                session.logo
-                                    ? getImageSrcFromHash(session.logo, { addBaseUrl: false })
-                                    : '/static/img/dice.svg',
-                            )
-                        "
+                        :src="session.logo ? getImageSrcFromHash(session.logo) : baseAdjust('/static/img/dice.svg')"
                         alt="Campaign logo"
                     />
                     <div
@@ -241,13 +235,7 @@ async function exportCampaign(): Promise<void> {
                 >
                     <img
                         class="logo"
-                        :src="
-                            baseAdjust(
-                                session.logo
-                                    ? getImageSrcFromHash(session.logo, { addBaseUrl: false })
-                                    : '/static/img/dice.svg',
-                            )
-                        "
+                        :src="session.logo ? getImageSrcFromHash(session.logo) : baseAdjust('/static/img/dice.svg')"
                         alt="Campaign logo"
                     />
                     <div class="data">

--- a/client/src/game/dropAsset.ts
+++ b/client/src/game/dropAsset.ts
@@ -6,10 +6,10 @@ import { getImageSrcFromHash } from "../assets/utils";
 import { l2gx, l2gy, l2gz } from "../core/conversions";
 import { type GlobalPoint, toGP, Vector } from "../core/geometry";
 import { DEFAULT_GRID_SIZE, snapPointToGrid } from "../core/grid";
-import { baseAdjust } from "../core/http";
 import { SyncMode, InvalidationMode, UI_SYNC } from "../core/models/types";
 import { uuidv4 } from "../core/utils";
 import { i18n } from "../i18n";
+import { coreStore } from "../store/core";
 
 import { requestAssetTemplates } from "./api/emits/asset";
 import { fetchFullShape, sendShapesMove } from "./api/emits/shape/core";
@@ -101,7 +101,7 @@ async function dropHelper(assetInfo: DropAssetInfo, location: GlobalPoint): Prom
             {
                 entryId: assetInfo.entryId,
                 assetId: assetInfo.assetId,
-                imageSource: getImageSrcFromHash(assetInfo.assetHash, { addBaseUrl: false }),
+                imageSource: getImageSrcFromHash(assetInfo.assetHash),
             },
             location,
         );
@@ -164,10 +164,14 @@ export async function dropAsset(
         }
     }
 
-    if (!data.imageSource.startsWith("/static")) return;
+    if (
+        !data.imageSource.startsWith("/static") &&
+        (coreStore.state.assetUrlBase === null || !data.imageSource.startsWith(coreStore.state.assetUrlBase))
+    )
+        return;
     const image = document.createElement("img");
     const uuid = uuidv4();
-    image.src = baseAdjust(data.imageSource);
+    image.src = data.imageSource;
     const assetHash = data.imageSource.split("/").pop()!;
 
     const layer = floorState.currentLayer.value!;

--- a/client/src/game/shapes/transformations.ts
+++ b/client/src/game/shapes/transformations.ts
@@ -36,7 +36,6 @@ import type {
 import type { AssetId } from "../../assets/models";
 import { getImageSrcFromHash } from "../../assets/utils";
 import { toGP } from "../../core/geometry";
-import { baseAdjust } from "../../core/http";
 import type { GlobalId, LocalId } from "../../core/id";
 import { SyncMode } from "../../core/models/types";
 import { getShapeSystems } from "../../core/systems";
@@ -296,8 +295,7 @@ function createShapeInstanceFromCore(compact: CompactForm): IShape | undefined {
         } else if (core.type_ === "assetrect") {
             const asset = subShape as AssetRectCompactCore;
             const img = new Image(asset.width, asset.height);
-            if (asset.assetHash.startsWith("http")) img.src = baseAdjust(new URL(asset.assetHash).pathname);
-            else img.src = getImageSrcFromHash(asset.assetHash);
+            img.src = getImageSrcFromHash(asset.assetHash);
             sh = new Asset(img, refPoint, asset.width, asset.height, asset.assetId, asset.assetHash, { uuid });
             img.onload = () => {
                 (sh as Asset).setLoaded();

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -38,10 +38,15 @@ router.beforeEach(async (to, _from, next) => {
                 username: string;
                 email: string;
             };
-            const versionData = (await versionResponse!.json()) as { release: string; env: string };
+            const versionData = (await versionResponse!.json()) as {
+                release: string;
+                env: string;
+                assetUrl: string | null;
+            };
 
             coreStore.setAuthenticated(authData.auth);
             coreStore.setVersion(versionData);
+            coreStore.setAssetUrlBase(versionData.assetUrl);
             coreStore.setInitialized(true);
 
             if (authData.auth) {

--- a/client/src/store/core.ts
+++ b/client/src/store/core.ts
@@ -9,6 +9,7 @@ interface CoreState {
     email?: string;
     version: { release: string; env: string };
     changelog: string;
+    assetUrlBase: string | null;
 }
 
 class CoreStore extends Store<CoreState> {
@@ -20,6 +21,7 @@ class CoreStore extends Store<CoreState> {
             loading: false,
             version: { release: "", env: "" },
             changelog: "",
+            assetUrlBase: null,
         };
     }
 
@@ -51,6 +53,10 @@ class CoreStore extends Store<CoreState> {
 
     setVersion(version: { release: string; env: string }): void {
         this._state.version = version;
+    }
+
+    setAssetUrlBase(assetUrlBase: string | null): void {
+        this._state.assetUrlBase = assetUrlBase;
     }
 }
 

--- a/server/src/api/http/version.py
+++ b/server/src/api/http/version.py
@@ -32,7 +32,15 @@ async def get_version(_request: web.Request):
     if env_version is None:
         return web.HTTPInternalServerError(reason="Version file could not be loaded")
 
-    return web.json_response({"release": release_version, "env": env_version})
+    from ...storage import get_storage
+
+    return web.json_response(
+        {
+            "release": release_version,
+            "env": env_version,
+            "assetUrl": get_storage().get_public_url_base(),
+        }
+    )
 
 
 async def get_changelog(_request: web.Request):

--- a/server/src/api/socket/asset_manager/core.py
+++ b/server/src/api/socket/asset_manager/core.py
@@ -12,7 +12,7 @@ from ....db.models.user import User
 from ....logs import logger
 from ....state.asset import asset_state
 from ....transform.to_api.asset import transform_asset
-from ....utils import ASSETS_DIR, get_asset_hash_subpath
+from ....storage import get_storage
 from ...models.asset import (
     ApiAsset,
     ApiAssetAdd,
@@ -211,19 +211,19 @@ async def assetmgmt_rm(sid: str, data: int):
     if remove_asset:
         asset_model = transform_asset(entry, user, children=True, recursive=True)
         entry.delete_instance()
-        cleanup_assets([asset_model])
+        await cleanup_assets([asset_model])
 
     await update_live_game(user)
 
 
-def cleanup_assets(entries: list[ApiAsset]):
+async def cleanup_assets(entries: list[ApiAsset]):
     for entry in entries:
         if entry.assetId:
             asset = Asset.get_by_id(entry.assetId)
-            asset.cleanup_check()
+            await asset.cleanup_check()
 
         if entry.children:
-            cleanup_assets(entry.children)
+            await cleanup_assets(entry.children)
 
 
 async def handle_regular_file(
@@ -237,18 +237,19 @@ async def handle_regular_file(
     sh = hashlib.sha1(data)
     hashname = sh.hexdigest()
 
-    full_hash_path = ASSETS_DIR / get_asset_hash_subpath(hashname)
-
-    if not full_hash_path.exists():
-        full_hash_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(full_hash_path, "wb") as f:
-            f.write(data)
+    storage = get_storage()
+    if not await storage.exists(hashname):
+        await storage.store(hashname, data)
 
     user = asset_state.get_user(sid)
 
-    asset, created = Asset.get_or_create(file_hash=hashname, kind=kind, defaults={"extension": extension})
+    asset, created = Asset.get_or_create(
+        file_hash=hashname,
+        kind=kind,
+        defaults={"extension": extension, "file_size": len(data)},
+    )
     if created:
-        asset.generate_thumbnails()
+        await asset.generate_thumbnails()
 
     target = upload_data.directory
 

--- a/server/src/api/socket/shape/__init__.py
+++ b/server/src/api/socket/shape/__init__.py
@@ -225,7 +225,7 @@ async def remove_shapes(sid: str, raw_data: Any):
 
                 # The Shape has to be removed before cleaning
                 if asset_to_clean:
-                    asset_to_clean.cleanup_check()
+                    await asset_to_clean.cleanup_check()
             else:
                 shape.layer = None
                 shape.save()

--- a/server/src/config/manager.py
+++ b/server/src/config/manager.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
-from ..utils import set_save_path
+from ..utils import ASSETS_DIR, set_save_path
 from .types import ServerConfig
 
 
@@ -34,6 +34,7 @@ class ConfigManager:
         self._file_observer = Observer()
 
         self.load_config(startup=True)
+        self._init_storage_backend()
 
         # Setup file watching
         event_handler = ConfigFileHandler(self.load_config)
@@ -47,6 +48,7 @@ class ConfigManager:
                 config_data = rtoml.loads(self.config_path.read_text())
                 self.config = ServerConfig(**config_data)
                 set_save_path(self.config.general.save_file)
+                self._init_storage_backend()
 
                 if not startup:
                     from ..logs import logger
@@ -60,6 +62,20 @@ class ConfigManager:
             print(f"Error validating config: {e}")
             if startup:
                 sys.exit(1)
+
+    def _init_storage_backend(self) -> None:
+        from ..storage import set_storage
+        from ..storage.local import LocalStorageBackend
+        from .types import LocalStorageConfig
+
+        storage_cfg = self.config.assets.storage
+        if isinstance(storage_cfg, LocalStorageConfig):
+            assets_dir = Path(storage_cfg.directory) if storage_cfg.directory else ASSETS_DIR
+            set_storage(LocalStorageBackend(assets_dir))
+        else:
+            from ..storage.s3 import S3StorageBackend
+
+            set_storage(S3StorageBackend(storage_cfg))
 
     def save_config(self) -> None:
         """Save current config to file (debounced)"""

--- a/server/src/config/types.py
+++ b/server/src/config/types.py
@@ -52,9 +52,26 @@ class WebserverConfig(ConfigModel):
     max_upload_size_in_bytes: int = 10_485_760
 
 
-class AssetsConfig(ConfigModel):
-    # Can be used to signal that assets are stored in a different directory
+class LocalStorageConfig(ConfigModel):
+    type: Literal["local"] = "local"
+    # Custom directory for asset storage
     directory: str | None = None
+
+
+class S3StorageConfig(ConfigModel):
+    type: Literal["s3"] = "s3"
+    bucket: str
+    region: str
+    # For S3-compatible services (DigitalOcean Spaces, Backblaze B2, MinIO, …)
+    endpoint_url: str | None = None
+    # Public URL override (e.g. a CloudFront distribution)
+    public_url: str | None = None
+    # Optional key prefix inside the bucket
+    prefix: str = ""
+
+
+class AssetsConfig(ConfigModel):
+    storage: LocalStorageConfig | S3StorageConfig = LocalStorageConfig()
 
     # Configuration limits for User asset uploads
     # Single asset is simply the max allowed upload size for a single asset

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -4,8 +4,8 @@ from peewee import IntegerField, TextField
 
 
 from ...logs import logger
+from ...storage import get_storage
 from ...thumbnail import generate_thumbnail_for_asset
-from ...utils import ASSETS_DIR, get_asset_hash_subpath
 from ..base import BaseDbModel
 from ..typed import SelectSequence
 from .user import User
@@ -32,17 +32,17 @@ class Asset(BaseDbModel):
     def __repr__(self):
         return f"<Asset {self.file_hash}>"
 
-    def cleanup_check(self):
-        full_hash_path = get_asset_hash_subpath(self.file_hash)
-        if (ASSETS_DIR / full_hash_path).exists():
-            if self.entries.count() == 0 and self.asset_rects.count() == 0 and self.templates.count() == 0:
+    async def cleanup_check(self):
+        storage = get_storage()
+        if self.entries.count() == 0 and self.asset_rects.count() == 0 and self.templates.count() == 0:
+            if await storage.exists(self.file_hash):
                 logger.info(f"No data maps to file {self.file_hash}, removing from server")
-                (ASSETS_DIR / full_hash_path).unlink()
-                for suffix in [".thumb.webp", ".thumb.jpeg"]:
-                    (ASSETS_DIR / f"{full_hash_path}{suffix}").unlink(missing_ok=True)
+                await storage.delete(self.file_hash)
+                await storage.delete(self.file_hash, suffix=".thumb.webp")
+                await storage.delete(self.file_hash, suffix=".thumb.jpeg")
 
-    def generate_thumbnails(self) -> None:
-        generate_thumbnail_for_asset(self.file_hash)
+    async def generate_thumbnails(self) -> None:
+        await generate_thumbnail_for_asset(self.file_hash)
 
     def has_entry_with_access(self, user: User, right: Literal["edit", "view", "all"]) -> bool:
         return any(entry.can_be_accessed_by(user, right=right) for entry in self.entries)

--- a/server/src/export/campaign.py
+++ b/server/src/export/campaign.py
@@ -60,7 +60,8 @@ from ..db.typed import SelectSequence
 from ..logs import logger
 from ..save import SAVE_VERSION, upgrade_save
 from ..state.dashboard import dashboard_state
-from ..utils import ASSETS_DIR, SAVE_PATH, TEMP_DIR, get_asset_hash_subpath
+from ..storage import get_storage
+from ..utils import SAVE_PATH, TEMP_DIR, get_asset_hash_subpath
 
 
 async def export_campaign(
@@ -256,19 +257,22 @@ class CampaignExporter:
             tar.addfile(sqlite_info, open(self.sqlite_path, "rb"))
             tar.addfile(assets_dir_info)
 
+            storage = get_storage()
             for asset_id in self.migrator._asset_mapping.keys():
                 asset: Asset = Asset[asset_id]
                 if not asset.file_hash:
                     continue
                 try:
+                    if not storage.exists_sync(asset.file_hash):
+                        continue
+                    data = storage.retrieve_sync(asset.file_hash)
                     full_hash_name = get_asset_hash_subpath(asset.file_hash)
-                    file_path = ASSETS_DIR / full_hash_name
-                    info = tar.gettarinfo(str(file_path))
-                    info.name = str(Path("assets") / full_hash_name)
+                    info = tarfile.TarInfo(str(Path("assets") / full_hash_name))
+                    info.size = len(data)
                     info.mtime = time()  # type: ignore
                     info.mode = 0o755
-                    tar.addfile(info, open(file_path, "rb"))  # type: ignore
-                except FileNotFoundError:
+                    tar.addfile(info, BytesIO(data))
+                except Exception:
                     pass
 
         self.migrator.from_db.close()
@@ -385,7 +389,7 @@ class CampaignImporter:
                     if member.name != str(Path("assets") / full_hash_name):
                         continue
 
-                    if (ASSETS_DIR / full_hash_name).exists():
+                    if get_storage().exists_sync(filehash):
                         continue
 
                     assets.append(member)
@@ -404,7 +408,13 @@ class CampaignImporter:
 
             if len(assets) > 0:
                 send_status(self.loop, "import", self.sid, f"> Importing {len(assets)} asset(s)")
-                tar.extractall(path=ASSETS_DIR.parent, members=assets)
+                storage = get_storage()
+                for member in assets:
+                    f = tar.extractfile(member)
+                    if f is None:
+                        continue
+                    filehash = member.name.split("/")[-1]
+                    storage.store_sync(filehash, f.read())
 
     def import_users(self, room: Room):
         # Different modes should be available

--- a/server/src/routes.py
+++ b/server/src/routes.py
@@ -8,7 +8,9 @@ from .api import http
 from .api.http import auth, mods, notifications, rooms, server, users, version
 from .app import app as main_app
 from .config import cfg
-from .utils import ASSETS_DIR, FILE_DIR, STATIC_DIR
+from .storage import get_storage
+from .storage.local import LocalStorageBackend
+from .utils import FILE_DIR, STATIC_DIR
 
 subpath = os.environ.get("PA_BASEPATH", "/")
 if subpath[-1] == "/":
@@ -44,7 +46,9 @@ async def root_dev(request):
 
 # MAIN ROUTES
 
-main_app.router.add_static(f"{subpath}/static/assets", ASSETS_DIR)
+storage = get_storage()
+if isinstance(storage, LocalStorageBackend):
+    main_app.router.add_static(f"{subpath}/static/assets", storage.assets_dir)
 main_app.router.add_static(f"{subpath}/static", STATIC_DIR)
 main_app.router.add_get(f"{subpath}/api/auth", auth.is_authed)
 main_app.router.add_post(f"{subpath}/api/users/email", users.set_email)

--- a/server/src/save.py
+++ b/server/src/save.py
@@ -30,7 +30,7 @@ from playhouse.sqlite_ext import SqliteExtDatabase
 from .db.all import ALL_NORMAL_MODELS, ALL_VIEWS
 from .db.db import db as ACTIVE_DB
 from .db.models.constants import Constants
-from .thumbnail import generate_thumbnail_for_asset
+from .thumbnail import generate_thumbnail_for_asset_sync
 from .utils import ASSETS_DIR, FILE_DIR, SAVE_PATH, OldVersionException, UnknownVersionException, get_asset_hash_subpath
 from .logs import logger
 
@@ -975,7 +975,7 @@ async def generate_thumbnails(data, loop):
 
     def generate():
         for i, (asset_name, file_hash) in enumerate(data):
-            generate_thumbnail_for_asset(file_hash)
+            generate_thumbnail_for_asset_sync(file_hash)
 
             if i % 100 == 0:
                 print(f"Generated {i} / {total_size} thumbnails")

--- a/server/src/storage/__init__.py
+++ b/server/src/storage/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from .base import StorageBackend
+
+_backend: StorageBackend | None = None
+
+
+def get_storage() -> StorageBackend:
+    assert _backend is not None, "Storage backend not initialised"
+    return _backend
+
+
+def set_storage(backend: StorageBackend) -> None:
+    global _backend
+    _backend = backend

--- a/server/src/storage/base.py
+++ b/server/src/storage/base.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class StorageBackend(ABC):
+    """Abstract base for asset storage backends (local filesystem, S3, etc.)."""
+
+    @abstractmethod
+    async def store(self, file_hash: str, data: bytes, *, suffix: str | None = None) -> None: ...
+
+    @abstractmethod
+    async def exists(self, file_hash: str) -> bool: ...
+
+    @abstractmethod
+    async def retrieve(self, file_hash: str) -> bytes: ...
+
+    @abstractmethod
+    async def delete(self, file_hash: str, *, suffix: str | None = None) -> None:
+        """
+        Delete the asset with the given hash from storage.
+        A suffix can be provided to delete a specific thumbnail of the asset.
+
+        This function should NOT throw an error if the asset or thumbnail does not exist.
+        """
+        ...
+
+    # SYNC API (used by import/export in threaded context)
+
+    @abstractmethod
+    def store_sync(self, file_hash: str, data: bytes, *, suffix: str | None = None) -> None: ...
+
+    @abstractmethod
+    def exists_sync(self, file_hash: str) -> bool: ...
+
+    @abstractmethod
+    def retrieve_sync(self, file_hash: str) -> bytes: ...
+
+    # HELPERS
+
+    @abstractmethod
+    def get_url(self, file_hash: str, *, thumbnail_format: str | None = None) -> str:
+        """Return a URL the *frontend* can use to fetch this asset."""
+        ...
+
+    @abstractmethod
+    def get_public_url_base(self) -> str | None:
+        """Return the base URL for asset access.
+
+        ``None`` means "use the default relative path" (local backend).
+        A non-None string is an absolute URL prefix (remote backends).
+        """
+        ...

--- a/server/src/storage/local.py
+++ b/server/src/storage/local.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..utils import get_asset_hash_subpath
+from .base import StorageBackend
+
+
+class LocalStorageBackend(StorageBackend):
+    def __init__(self, assets_dir: Path) -> None:
+        self.assets_dir = assets_dir
+        self.assets_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, file_hash: str, suffix: str | None = None) -> Path:
+        sub = get_asset_hash_subpath(file_hash)
+        if suffix:
+            return self.assets_dir / f"{sub}{suffix}"
+        return self.assets_dir / sub
+
+    async def store(self, file_hash: str, data: bytes, *, suffix: str | None = None) -> None:
+        self.store_sync(file_hash, data, suffix=suffix)
+
+    async def exists(self, file_hash: str) -> bool:
+        return self.exists_sync(file_hash)
+
+    async def retrieve(self, file_hash: str) -> bytes:
+        return self.retrieve_sync(file_hash)
+
+    async def delete(self, file_hash: str, *, suffix: str | None = None) -> None:
+        path = self._path(file_hash, suffix)
+        if path.exists():
+            path.unlink()
+
+    def store_sync(self, file_hash: str, data: bytes, *, suffix: str | None = None) -> None:
+        path = self._path(file_hash, suffix)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(data)
+
+    def exists_sync(self, file_hash: str) -> bool:
+        return self._path(file_hash).exists()
+
+    def retrieve_sync(self, file_hash: str) -> bytes:
+        with open(self._path(file_hash), "rb") as f:
+            return f.read()
+
+    def get_url(self, file_hash: str, *, thumbnail_format: str | None = None) -> str:
+        sub = get_asset_hash_subpath(file_hash)
+        path = f"/static/assets/{sub}"
+        if thumbnail_format is not None:
+            path = f"{path}.thumb.{thumbnail_format}"
+        return path
+
+    def get_public_url_base(self) -> str | None:
+        return None

--- a/server/src/storage/s3.py
+++ b/server/src/storage/s3.py
@@ -1,0 +1,250 @@
+"""
+S3-compatible storage backend
+
+Implements AWS Signature V4 signing from scratch so no extra packages are needed.
+(and our docker setup does not become more complicated with optional dependencies)
+Works with AWS S3, DigitalOcean Spaces, Backblaze B2, MinIO, and other S3-compatible services.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import aiohttp
+
+from ..utils import get_asset_hash_subpath
+from .base import StorageBackend
+
+if TYPE_CHECKING:
+    from ..config.types import S3StorageConfig
+
+EMPTY_HASH = hashlib.sha256(b"").hexdigest()
+UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
+
+
+def sign(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+
+def get_signing_key(secret_key: str, date_stamp: str, region: str, service: str = "s3") -> bytes:
+    k_date = sign(f"AWS4{secret_key}".encode(), date_stamp)
+    k_region = sign(k_date, region)
+    k_service = sign(k_region, service)
+    return sign(k_service, "aws4_request")
+
+
+def build_auth_headers(
+    *,
+    method: str,
+    path: str,
+    query: str,
+    headers: dict[str, str],
+    payload_hash: str,
+    region: str,
+    access_key: str,
+    secret_key: str,
+    service: str = "s3",
+) -> dict[str, str]:
+    now = datetime.now(UTC)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = now.strftime("%Y%m%d")
+
+    headers = {k.lower(): v for k, v in headers.items()}
+    headers["x-amz-date"] = amz_date
+    headers["x-amz-content-sha256"] = payload_hash
+
+    signed_header_keys = sorted(headers.keys())
+    signed_headers_str = ";".join(signed_header_keys)
+
+    canonical_headers = "".join(f"{k}:{headers[k]}\n" for k in signed_header_keys)
+
+    canonical_request = "\n".join(
+        [
+            method,
+            urllib.parse.quote(path, safe="/"),
+            query,
+            canonical_headers,
+            signed_headers_str,
+            payload_hash,
+        ]
+    )
+
+    credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
+    string_to_sign = "\n".join(
+        [
+            "AWS4-HMAC-SHA256",
+            amz_date,
+            credential_scope,
+            hashlib.sha256(canonical_request.encode()).hexdigest(),
+        ]
+    )
+
+    signing_key = get_signing_key(secret_key, date_stamp, region, service)
+    signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+
+    headers["authorization"] = (
+        f"AWS4-HMAC-SHA256 "
+        f"Credential={access_key}/{credential_scope}, "
+        f"SignedHeaders={signed_headers_str}, "
+        f"Signature={signature}"
+    )
+
+    return headers
+
+
+class S3StorageBackend(StorageBackend):
+    def __init__(self, config: S3StorageConfig) -> None:
+        self.bucket = config.bucket
+        self.region = config.region
+        self.prefix = config.prefix or ""
+
+        self.access_key = os.environ.get("PA_S3_ACCESS_KEY", "")
+        self.secret_key = os.environ.get("PA_S3_SECRET_KEY", "")
+        if not self.access_key or not self.secret_key:
+            raise ValueError("S3 storage requires PA_S3_ACCESS_KEY and PA_S3_SECRET_KEY environment variables")
+
+        if config.endpoint_url:
+            # S3-compatible service (path-style)
+            self._api_base = config.endpoint_url.rstrip("/")
+            self._path_style = True
+        else:
+            # Standard AWS (virtual-hosted style)
+            self._api_base = f"https://{self.bucket}.s3.{self.region}.amazonaws.com"
+            self._path_style = False
+
+        if config.public_url:
+            self._public_base = config.public_url.rstrip("/")
+        else:
+            self._public_base = self._api_base
+            if self._path_style:
+                self._public_base += f"/{self.bucket}"
+
+        self._session: aiohttp.ClientSession | None = None
+
+    def get_signed_headers(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload_hash: str = EMPTY_HASH,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        url_parts = urllib.parse.urlparse(self._api_base)
+        headers: dict[str, str] = {"host": url_parts.netloc}
+        if extra_headers:
+            headers.update(extra_headers)
+        return build_auth_headers(
+            method=method,
+            path=path,
+            query="",
+            headers=headers,
+            payload_hash=payload_hash,
+            region=self.region,
+            access_key=self.access_key,
+            secret_key=self.secret_key,
+        )
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def _put(self, key: str, data: bytes) -> None:
+        url, path = self.get_url_and_path(key)
+        payload_hash = hashlib.sha256(data).hexdigest()
+        headers = self.get_signed_headers("PUT", path, payload_hash=payload_hash)
+        session = await self._get_session()
+        async with session.put(url, data=data, headers=headers) as resp:
+            if resp.status >= 300:
+                body = await resp.text()
+                raise RuntimeError(f"S3 PUT {url} failed ({resp.status}): {body}")
+
+    async def store(self, file_hash: str, data: bytes, *, suffix: str | None = None) -> None:
+        await self._put(self.get_key(file_hash, suffix), data)
+
+    async def exists(self, file_hash: str) -> bool:
+        url, path = self.get_url_and_path(self.get_key(file_hash))
+        headers = self.get_signed_headers("HEAD", path)
+        session = await self._get_session()
+        async with session.head(url, headers=headers) as resp:
+            return resp.status == 200
+
+    async def retrieve(self, file_hash: str) -> bytes:
+        url, path = self.get_url_and_path(self.get_key(file_hash))
+        headers = self.get_signed_headers("GET", path)
+        session = await self._get_session()
+        async with session.get(url, headers=headers) as resp:
+            if resp.status >= 300:
+                body = await resp.text()
+                raise RuntimeError(f"S3 GET {url} failed ({resp.status}): {body}")
+            return await resp.read()
+
+    async def delete(self, file_hash: str, *, suffix: str | None = None) -> None:
+        url, path = self.get_url_and_path(self.get_key(file_hash, suffix))
+        headers = self.get_signed_headers("DELETE", path)
+        session = await self._get_session()
+        async with session.delete(url, headers=headers) as resp:
+            if resp.status >= 300 and resp.status != 404:
+                body = await resp.text()
+                raise RuntimeError(f"S3 DELETE {url} failed ({resp.status}): {body}")
+
+    def _put_sync(self, key: str, data: bytes) -> None:
+        url, path = self.get_url_and_path(key)
+        payload_hash = hashlib.sha256(data).hexdigest()
+        headers = self.get_signed_headers("PUT", path, payload_hash=payload_hash)
+        req = urllib.request.Request(url, data=data, headers=headers, method="PUT")
+        with urllib.request.urlopen(req) as resp:
+            if resp.status >= 300:
+                raise RuntimeError(f"S3 PUT {url} failed ({resp.status})")
+
+    def store_sync(self, file_hash: str, data: bytes, *, suffix: str | None = None) -> None:
+        self._put_sync(self.get_key(file_hash, suffix), data)
+
+    def exists_sync(self, file_hash: str) -> bool:
+        url, path = self.get_url_and_path(self.get_key(file_hash))
+        headers = self.get_signed_headers("HEAD", path)
+        req = urllib.request.Request(url, headers=headers, method="HEAD")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.status == 200
+        except urllib.error.HTTPError:
+            return False
+
+    def retrieve_sync(self, file_hash: str) -> bytes:
+        url, path = self.get_url_and_path(self.get_key(file_hash))
+        headers = self.get_signed_headers("GET", path)
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        with urllib.request.urlopen(req) as resp:
+            return resp.read()
+
+    def get_key(self, file_hash: str, suffix: str | None = None) -> str:
+        sub = str(get_asset_hash_subpath(file_hash))
+        if suffix:
+            sub = f"{sub}{suffix}"
+        return f"{self.prefix}/{sub}" if self.prefix else sub
+
+    def get_url_and_path(self, key: str) -> tuple[str, str]:
+        if self._path_style:
+            path = f"/{self.bucket}/{key}"
+        else:
+            path = f"/{key}"
+        return f"{self._api_base}{path}", path
+
+    def get_url(self, file_hash: str, *, thumbnail_format: str | None = None) -> str:
+        sub = str(get_asset_hash_subpath(file_hash))
+        key = f"{self.prefix}/{sub}" if self.prefix else sub
+        if thumbnail_format is not None:
+            key = f"{key}.thumb.{thumbnail_format}"
+        return f"{self._public_base}/{key}"
+
+    def get_public_url_base(self) -> str | None:
+        if self.prefix:
+            return f"{self._public_base}/{self.prefix}"
+        return self._public_base

--- a/server/src/thumbnail.py
+++ b/server/src/thumbnail.py
@@ -1,10 +1,9 @@
 import io
 import warnings
-from pathlib import Path
 
 from PIL import Image
 
-from .utils import ASSETS_DIR, get_asset_hash_subpath
+from .storage import get_storage
 
 warnings.simplefilter("ignore", Image.DecompressionBombWarning)
 
@@ -48,23 +47,41 @@ def create_thumbnail_from_bytes(input_bytes, max_size=(200, 200)):
     return {"webp": webp_output.getvalue(), "jpeg": jpeg_output.getvalue()}
 
 
-def generate_thumbnail_for_asset(file_hash: str) -> None:
-    full_hash_name = get_asset_hash_subpath(file_hash)
-    asset_path = ASSETS_DIR / full_hash_name
+async def generate_thumbnail_for_asset(file_hash: str) -> None:
+    storage = get_storage()
 
-    if not asset_path.exists():
+    if not await storage.exists(file_hash):
         return
 
     try:
-        with open(asset_path, "rb") as f:
-            thumbnail = create_thumbnail_from_bytes(f.read())
-        if thumbnail is None:
+        data = await storage.retrieve(file_hash)
+        thumbnails = create_thumbnail_from_bytes(data)
+        if thumbnails is None:
             return
-        for format, data in thumbnail.items():
-            path = ASSETS_DIR / Path(f"{full_hash_name}.thumb.{format}")
+        for fmt, thumb_data in thumbnails.items():
+            await storage.store(file_hash, thumb_data, suffix=f".thumb.{fmt}")
+    except Image.DecompressionBombError:
+        print()
+        print(f"Thumbnail generation failed for {file_hash}: The asset is too large")
+    except Exception as e:
+        print()
+        print(f"Thumbnail generation failed for {file_hash}: {e}")
 
-            with open(path, "wb") as f:
-                f.write(data)
+
+def generate_thumbnail_for_asset_sync(file_hash: str) -> None:
+    """Sync version for use in thread-executor contexts (save migrations)."""
+    storage = get_storage()
+
+    if not storage.exists_sync(file_hash):
+        return
+
+    try:
+        data = storage.retrieve_sync(file_hash)
+        thumbnails = create_thumbnail_from_bytes(data)
+        if thumbnails is None:
+            return
+        for fmt, thumb_data in thumbnails.items():
+            storage.store_sync(file_hash, thumb_data, suffix=f".thumb.{fmt}")
     except Image.DecompressionBombError:
         print()
         print(f"Thumbnail generation failed for {file_hash}: The asset is too large")


### PR DESCRIPTION
This PR adds the option to configure a S3-compatible storage remote for user uploaded assets. This can alleviate some costs or maintenance on the server host.

This comes with some configuration changes, a PR to the docs will be opened later today (likely) with specifics on that front. I'll update this description with a link once that's done.

By default without any config changes[^1], the original local storage approach will be used and stored in `/static/assets/` (relative to the server folder).

You'll however now be able to instead refer to a S3-compatible host by providing some URL info (e.g. bucket name etc) as well as 2 env variables to provide secrets.

The implementation is done without any extra dependencies to make it as generic as possible and without having to deal with whether or not I want to publish a docker image without and with the optional dependencies.

It's important that you FIRST run the migrations added in #1801 before moving to a remote solution if you intend to move your existing asset folder over.

It should be noted that I've only tested this with cloudflare R2 as that had an easy to setup free tier. I cannot vouch for any other service and I have only verified some basic operations. You'll have to look up for each service which values for region/bucket/url etc you need to provide. These can be added to the docs once known for a particular service.

**!! It should also be noted that by using a remote solution you accept the risk of data costs that could occur if something in PA behaves faulty and ends up requesting from the remote too much. !!**

This closes #1725 and #500

[^1]: The existing `assets.directory` config key is moved, it however didn't properly work as far as I'm aware so I don't think this should impact anybody. It now works properly.