### PR TITLE
feat(Performance): A variety of performance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ tech changes will usually be stripped from release notes for the public
 
 -   Note icons on shapes no longer rendering
 -   Asset thumbnails not cleaning up on asset removal
+-   [tech] Updated sector system to be more performant (impacts rendering)
+-   [tech] Fixed some unnecessary Vue rerenders on a variety of mouse interactions in the select tool (impacts general performance)
+-   [tech] Removed some unnecessary work during panning (e.g. note hover logic, some ws events)
 
 ### Fixed
 

--- a/client/src/game/layers/variants/layer.ts
+++ b/client/src/game/layers/variants/layer.ts
@@ -4,7 +4,6 @@ import type { ApiShape } from "../../../apiTypes";
 import { g2l, l2g, l2gz } from "../../../core/conversions";
 import { Ray, cloneP, toLP } from "../../../core/geometry";
 import type { LocalId } from "../../../core/id";
-import { filter } from "../../../core/iter";
 import { InvalidationMode, SyncMode, UI_SYNC } from "../../../core/models/types";
 import { callbackProvider } from "../../../core/utils";
 import { debugLayers } from "../../../localStorageHelpers";
@@ -67,6 +66,12 @@ export class Layer implements ILayer {
     shapesInSector: IShape[] = [];
     protected xSectors = new Map<number, Set<LocalId>>();
     protected ySectors = new Map<number, Set<LocalId>>();
+    private shapeSectorKeys = new Map<LocalId, { x: number[]; y: number[] }>();
+
+    private viewSectorLeft = 0;
+    private viewSectorRight = 0;
+    private viewSectorTop = 0;
+    private viewSectorBot = 0;
 
     shapeIdsInSector = new Set<LocalId>();
 
@@ -94,43 +99,74 @@ export class Layer implements ILayer {
     updateView(): void {
         if (!gameState.raw.boardInitialized) return;
 
-        this.shapeIdsInSector.clear();
-
         const topLeft = l2g(toLP(0, 0));
         const botRight = l2g(toLP(this.width, this.height));
-        const sectorLeft = getSector(topLeft.x);
-        const sectorRight = getSector(botRight.x);
-        const sectorTop = getSector(topLeft.y);
-        const sectorBot = getSector(botRight.y);
+        const newLeft = getSector(topLeft.x);
+        const newRight = getSector(botRight.x);
+        const newTop = getSector(topLeft.y);
+        const newBot = getSector(botRight.y);
 
-        let i = 0;
-        let j = 0;
+        if (
+            newLeft === this.viewSectorLeft &&
+            newRight === this.viewSectorRight &&
+            newTop === this.viewSectorTop &&
+            newBot === this.viewSectorBot &&
+            this.shapesInSector.length > 0
+        ) {
+            return;
+        }
 
-        for (i = sectorLeft; i <= sectorRight; i += SECTOR_SIZE) {
-            for (j = sectorTop; j <= sectorBot; j += SECTOR_SIZE) {
-                const xShapes = this.xSectors.get(i);
-                const yShapes = this.ySectors.get(j);
-                if (xShapes !== undefined && yShapes !== undefined) {
-                    for (const id of filter(xShapes, (x) => yShapes.has(x))) {
-                        this.shapeIdsInSector.add(id);
-                    }
-                    for (const id of filter(yShapes, (y) => xShapes.has(y))) {
-                        this.shapeIdsInSector.add(id);
-                    }
+        this.viewSectorLeft = newLeft;
+        this.viewSectorRight = newRight;
+        this.viewSectorTop = newTop;
+        this.viewSectorBot = newBot;
+
+        this.shapeIdsInSector.clear();
+
+        const xVisible = new Set<LocalId>();
+        for (let i = this.viewSectorLeft; i <= this.viewSectorRight; i += SECTOR_SIZE) {
+            const xShapes = this.xSectors.get(i);
+            if (xShapes !== undefined) {
+                for (const id of xShapes) xVisible.add(id);
+            }
+        }
+
+        for (let j = this.viewSectorTop; j <= this.viewSectorBot; j += SECTOR_SIZE) {
+            const yShapes = this.ySectors.get(j);
+            if (yShapes !== undefined) {
+                for (const id of yShapes) {
+                    if (xVisible.has(id)) this.shapeIdsInSector.add(id);
                 }
             }
         }
+
+        this.rebuildShapesInSector();
+        visionState.updateSourcesInSector(this.floor, this.name, this.shapeIdsInSector);
+    }
+
+    private rebuildShapesInSector(): void {
         this.shapesInSector = [];
         for (const shape of this.shapes) {
             if (this.shapeIdsInSector.has(shape.id)) this.shapesInSector.push(shape);
         }
-        visionState.updateSourcesInSector(this.floor, this.name, this.shapeIdsInSector);
+    }
+
+    private isShapeInViewSectors(shapeId: LocalId): boolean {
+        if (!gameState.raw.boardInitialized) return false;
+        const keys = this.shapeSectorKeys.get(shapeId);
+        if (keys === undefined) return false;
+        if (!keys.x.some((k) => k >= this.viewSectorLeft && k <= this.viewSectorRight)) return false;
+        return keys.y.some((k) => k >= this.viewSectorTop && k <= this.viewSectorBot);
     }
 
     updateSectors(shapeId: LocalId, aabb: BoundingRect): void {
+        const wasInView = this.shapeIdsInSector.has(shapeId);
         this.removeShapeFromSectors(shapeId);
         this.addShapeToSectors(shapeId, aabb);
-        this.updateView();
+
+        if (wasInView !== this.isShapeInViewSectors(shapeId)) {
+            this.updateView();
+        }
     }
 
     invalidate(skipLightUpdate: boolean): void {
@@ -171,22 +207,35 @@ export class Layer implements ILayer {
     }
 
     private addShapeToSectors(shapeId: LocalId, aabb: BoundingRect): void {
+        const xKeys: number[] = [];
+        const yKeys: number[] = [];
         for (let i = getSector(aabb.topLeft.x); i <= getSector(aabb.topRight.x); i += SECTOR_SIZE) {
-            if (!this.xSectors.has(i)) this.xSectors.set(i, new Set());
-            this.xSectors.get(i)!.add(shapeId);
+            let set = this.xSectors.get(i);
+            if (set === undefined) {
+                set = new Set();
+                this.xSectors.set(i, set);
+            }
+            set.add(shapeId);
+            xKeys.push(i);
         }
         for (let i = getSector(aabb.topLeft.y); i <= getSector(aabb.botLeft.y); i += SECTOR_SIZE) {
-            if (!this.ySectors.has(i)) this.ySectors.set(i, new Set());
-            this.ySectors.get(i)!.add(shapeId);
+            let set = this.ySectors.get(i);
+            if (set === undefined) {
+                set = new Set();
+                this.ySectors.set(i, set);
+            }
+            set.add(shapeId);
+            yKeys.push(i);
         }
+        this.shapeSectorKeys.set(shapeId, { x: xKeys, y: yKeys });
     }
 
     private removeShapeFromSectors(shapeId: LocalId): void {
-        for (const sector of this.xSectors.values()) {
-            sector.delete(shapeId);
-        }
-        for (const sector of this.ySectors.values()) {
-            sector.delete(shapeId);
+        const keys = this.shapeSectorKeys.get(shapeId);
+        if (keys !== undefined) {
+            for (const k of keys.x) this.xSectors.get(k)?.delete(shapeId);
+            for (const k of keys.y) this.ySectors.get(k)?.delete(shapeId);
+            this.shapeSectorKeys.delete(shapeId);
         }
     }
 
@@ -199,7 +248,11 @@ export class Layer implements ILayer {
 
         this.shapes.push(shape);
         this.addShapeToSectors(shape.id, shape.getAuraAABB());
-        this.updateView(); // todo: other method that only adds instead of rechecking all existing
+        if (this.isShapeInViewSectors(shape.id)) {
+            this.shapeIdsInSector.add(shape.id);
+            this.shapesInSector.push(shape);
+            visionState.addShapeToSourcesInView(this.floor, shape.id);
+        }
 
         const props = getProperties(shape.id);
         if (props === undefined) return console.error("Missing shape properties");
@@ -253,6 +306,7 @@ export class Layer implements ILayer {
         this.shapes = shapes;
         this.xSectors.clear();
         this.ySectors.clear();
+        this.shapeSectorKeys.clear();
         for (const shape of shapes) {
             shape.resetVisionIteration();
             this.addShapeToSectors(shape.id, shape.getAuraAABB());
@@ -269,13 +323,6 @@ export class Layer implements ILayer {
     }
 
     private async setServerShape(serverShape: ApiShape): Promise<void> {
-        // if (serverShape.uuid === "11ae4209-2503-4b33-935a-3d5a3d4add00") {
-        //     serverShape.type_ = "fontawesome";
-        //     serverShape.icon = {
-        //         prefix: "fas",
-        //         iconName: "arrows-to-circle",
-        //     };
-        // }
         const compact = await loadFromServer(serverShape, this.floor, this.name);
         instantiateCompactForm(compact, "load", (shape) => {
             let invalidate = InvalidationMode.NO;
@@ -308,7 +355,11 @@ export class Layer implements ILayer {
         shape.removeDependentShapes({ dropShapeId: true });
         this.shapes.splice(idx, 1);
         this.removeShapeFromSectors(shape.id);
-        this.updateView();
+        if (this.shapeIdsInSector.delete(shape.id)) {
+            const sectorIdx = this.shapesInSector.indexOf(shape);
+            if (sectorIdx >= 0) this.shapesInSector.splice(sectorIdx, 1);
+            visionState.removeShapeFromSourcesInView(this.floor, shape.id);
+        }
 
         groupSystem.removeGroupMember(shape.id, false);
 
@@ -346,7 +397,7 @@ export class Layer implements ILayer {
                     temporary: sync === SyncMode.TEMP_SYNC,
                 });
         }
-        this.updateView();
+        this.rebuildShapesInSector();
         this.invalidate(true);
     }
 

--- a/client/src/game/systems/position/index.ts
+++ b/client/src/game/systems/position/index.ts
@@ -125,6 +125,11 @@ class PositionSystem implements System {
 
     checkOutOfBounds(): void {
         mutable.performOobCheck = false;
+        const oob = this.computeOutOfBounds();
+        if (oob !== $.outOfBounds) $.outOfBounds = oob;
+    }
+
+    private computeOutOfBounds(): boolean {
         // First check if there are any shapes at all
         // Displaying a "return to content" when there is no content is pretty silly.
         // We however don't want to iterate over _all_ shapes if there are a lot
@@ -137,38 +142,27 @@ class PositionSystem implements System {
                     break;
                 }
             }
-            if (!foundShape) {
-                $.outOfBounds = false;
-                return;
-            }
+            if (!foundShape) return false;
         }
 
-        $.outOfBounds = true;
         const floor = floorState.currentFloor.value;
         if (floor !== undefined && !gameState.raw.isDm && locationSettingsState.raw.fullFow.value) {
             if (locationSettingsSystem.isLosActive()) {
                 const visionLayer = floorSystem.getLayer(floor, LayerName.Vision) as FowLayer;
-                if (!visionLayer.isEmpty) {
-                    $.outOfBounds = false;
-                    return;
-                }
+                if (!visionLayer.isEmpty) return false;
             }
             const lightingLayer = floorSystem.getLayer(floor, LayerName.Lighting) as FowLayer;
-            if (!lightingLayer.isEmpty) {
-                $.outOfBounds = false;
-                return;
-            }
+            if (!lightingLayer.isEmpty) return false;
 
-            if ($.outOfBounds) return;
+            // fow is active but no vision/lighting layers have content — truly OOB
+            return true;
         }
         for (const layer of floorState.raw.layers) {
             for (const sh of layer.shapesInSector) {
-                if (!(sh.options.skipDraw ?? false)) {
-                    $.outOfBounds = false;
-                    return;
-                }
+                if (!(sh.options.skipDraw ?? false)) return false;
             }
         }
+        return true;
     }
 
     returnToBounds(): void {

--- a/client/src/game/systems/selected/index.ts
+++ b/client/src/game/systems/selected/index.ts
@@ -33,6 +33,7 @@ class SelectedSystem implements System {
     }
 
     set(...ids: LocalId[]): void {
+        if (ids.length === $.selected.size && ids.every((id) => $.selected.has(id))) return;
         this.clear();
         this.push(...ids);
     }

--- a/client/src/game/tools/events.ts
+++ b/client/src/game/tools/events.ts
@@ -84,28 +84,30 @@ export async function mouseMove(event: MouseEvent): Promise<void> {
         await toolMap[permitted.name].onMouseMove(event, permitted.features);
     }
 
-    // HOVER code
-    const eventPoint = l2g(getLocalPointFromEvent(event));
-    // Annotation hover
-    let foundAnnotation = false;
-    if (floorSystem.hasLayer(floorState.currentFloor.value!, LayerName.Draw)) {
-        for (const [shapeId, notes] of noteState.raw.shapeNotes.entries1()) {
-            const shape = getShape(shapeId);
-            if (shape && shape.floorId === floorState.currentFloor.value!.id && shape.contains(eventPoint)) {
-                for (const noteId of notes) {
-                    const note = noteState.raw.notes.get(noteId);
-                    if (note?.showOnHover === true) {
-                        foundAnnotation = true;
-                        uiSystem.setAnnotationText(note.text);
-                        break;
+    // HOVER code — skip during pan since positions are shifting anyway
+    if (targetTool !== ToolName.Pan) {
+        const eventPoint = l2g(getLocalPointFromEvent(event));
+        // Annotation hover
+        let foundAnnotation = false;
+        if (floorSystem.hasLayer(floorState.currentFloor.value!, LayerName.Draw)) {
+            for (const [shapeId, notes] of noteState.raw.shapeNotes.entries1()) {
+                const shape = getShape(shapeId);
+                if (shape && shape.floorId === floorState.currentFloor.value!.id && shape.contains(eventPoint)) {
+                    for (const noteId of notes) {
+                        const note = noteState.raw.notes.get(noteId);
+                        if (note?.showOnHover === true) {
+                            foundAnnotation = true;
+                            uiSystem.setAnnotationText(note.text);
+                            break;
+                        }
                     }
+                    if (foundAnnotation) break;
                 }
-                if (foundAnnotation) break;
             }
         }
-    }
-    if (!foundAnnotation && uiState.raw.annotationText.length > 0) {
-        uiSystem.setAnnotationText("");
+        if (!foundAnnotation && uiState.raw.annotationText.length > 0) {
+            uiSystem.setAnnotationText("");
+        }
     }
 }
 
@@ -281,30 +283,32 @@ export async function touchMove(event: TouchEvent): Promise<void> {
         else await otherTool.onTouchMove(event, permitted.features);
     }
 
-    // Annotation hover
-    let found = false;
-    if (floorSystem.hasLayer(floorState.currentFloor.value!, LayerName.Draw)) {
-        for (const [shapeId, notes] of noteState.raw.shapeNotes.entries1()) {
-            const shape = getShape(shapeId);
-            if (
-                shape &&
-                shape.floorId === floorState.currentFloor.value!.id &&
-                shape.contains(l2g(getLocalPointFromEvent(event)))
-            ) {
-                for (const noteId of notes) {
-                    const note = noteState.raw.notes.get(noteId);
-                    if (note?.showOnHover === true) {
-                        found = true;
-                        uiSystem.setAnnotationText(note.text);
-                        break;
+    // Annotation hover — skip during pinch/pan gestures
+    if (!tool.scaling && event.touches.length < 3) {
+        let found = false;
+        if (floorSystem.hasLayer(floorState.currentFloor.value!, LayerName.Draw)) {
+            for (const [shapeId, notes] of noteState.raw.shapeNotes.entries1()) {
+                const shape = getShape(shapeId);
+                if (
+                    shape &&
+                    shape.floorId === floorState.currentFloor.value!.id &&
+                    shape.contains(l2g(getLocalPointFromEvent(event)))
+                ) {
+                    for (const noteId of notes) {
+                        const note = noteState.raw.notes.get(noteId);
+                        if (note?.showOnHover === true) {
+                            found = true;
+                            uiSystem.setAnnotationText(note.text);
+                            break;
+                        }
                     }
+                    if (found) break;
                 }
-                if (found) break;
             }
         }
-    }
-    if (!found && uiState.raw.annotationText.length > 0) {
-        uiSystem.setAnnotationText("");
+        if (!found && uiState.raw.annotationText.length > 0) {
+            uiSystem.setAnnotationText("");
+        }
     }
 }
 

--- a/client/src/game/tools/variants/pan.ts
+++ b/client/src/game/tools/variants/pan.ts
@@ -25,9 +25,12 @@ class PanTool extends Tool implements ITool {
         positionSystem.increasePan(Math.round(distance.x), Math.round(distance.y));
         this.panStart = target;
 
-        if (full) floorSystem.invalidateAllFloors();
-        else floorSystem.invalidateVisibleFloors();
-        sendClientLocationOptions(!full);
+        if (full) {
+            floorSystem.invalidateAllFloors();
+            sendClientLocationOptions(false);
+        } else {
+            floorSystem.invalidateVisibleFloors();
+        }
     }
 
     onDown(lp: LocalPoint): Promise<void> {

--- a/client/src/game/ui/contextmenu/DefaultContext.vue
+++ b/client/src/game/ui/contextmenu/DefaultContext.vue
@@ -97,6 +97,7 @@ function showTokenDialog(): boolean {
 }
 
 const sections = computed<Section[]>(() => {
+    if (!showDefaultContextMenu.value) return [];
     return [
         {
             title: t("game.ui.tools.DefaultContext.bring_pl"),

--- a/client/src/game/ui/contextmenu/ShapeContext.vue
+++ b/client/src/game/ui/contextmenu/ShapeContext.vue
@@ -462,6 +462,7 @@ const currentFloorIndex = toRef(floorState.reactive, "floorIndex");
 const floors = toRef(floorState.reactive, "floors");
 
 const sections = computed(() => {
+    if (!showShapeContextMenu.value) return [];
     const focus = selectedState.reactive.focus;
     if (focus === undefined) return [];
     // MOVE [group A] >

--- a/client/src/game/ui/settings/shape/ShapeSettings.vue
+++ b/client/src/game/ui/settings/shape/ShapeSettings.vue
@@ -38,6 +38,7 @@ const visible = computed({
 const owned = accessState.hasEditAccess;
 
 watchEffect(() => {
+    if (!visible.value) return;
     const id = selectedState.reactive.focus;
     if (id !== undefined) {
         accessSystem.loadState(id);
@@ -104,7 +105,7 @@ const ownedTabs = computed<PanelTab[]>(() => [
 
 const tabs = computed(() => {
     const tabs: PanelTab[] = [];
-    if (!hasShape.value) return tabs;
+    if (!visible.value || !hasShape.value) return tabs;
 
     tabs.push(...fixedTabs);
     if (owned.value) {

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -348,6 +348,26 @@ class VisionState extends Store<State> {
         }
     }
 
+    addShapeToSourcesInView(floor: FloorId, shapeId: LocalId): void {
+        const sources = this.visionSourcesInView.get(floor);
+        if (sources === undefined) return;
+        for (const source of this.visionSources.get(floor) ?? []) {
+            if (source.shape === shapeId) sources.push(source);
+        }
+    }
+
+    removeShapeFromSourcesInView(floor: FloorId, shapeId: LocalId): void {
+        const sources = this.visionSourcesInView.get(floor);
+        if (sources === undefined) return;
+        let write = 0;
+        for (let i = 0; i < sources.length; i++) {
+            if (sources[i]!.shape !== shapeId) {
+                sources[write++] = sources[i]!;
+            }
+        }
+        sources.length = write;
+    }
+
     // todo: to be removed, but it's no longer on the hot path currently so not priority
     invalidateView(floor: FloorId): void {
         const layer = floorState.currentLayer.value;

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -324,18 +324,23 @@ class VisionState extends Store<State> {
         }
         const found = new Set<LocalId>();
         // 1. Wipe all layer sources no longer in view
-        for (let i = sources.length - 1; i >= 0; i--) {
+        // We keep track of a moving write index, moving sources we need to keep to the current write index
+        // and at the end truncating the length of the array to retain the correct size.
+        // This ensures that we iterate exactly once over the array.
+        let writeIndex = 0;
+        for (let i = 0; i < sources.length; i++) {
             const source = sources[i]!;
             const shape = getShape(source.shape);
-            if (shape === undefined) continue;
-            if (shape.layerName === layer) {
+            if (shape !== undefined && shape.layerName === layer) {
                 if (shapeIds.has(shape.id)) {
                     found.add(shape.id);
-                } else {
-                    sources.splice(i, 1);
+                    sources[writeIndex++] = source;
                 }
+            } else {
+                sources[writeIndex++] = source;
             }
         }
+        sources.length = writeIndex;
         // 2. Add layer sources new to view
         for (const source of this.visionSources.get(floor)!) {
             if (found.has(source.shape)) continue;


### PR DESCRIPTION
This PR tackles a couple of different performance related issues. Whether they have a noticeable effect on your system will mostly depend on your computer's specs.

If you notice a performance degradation however, please do notify me.

Changed:
- Sector logic has been updated significantly
  - no longer re-calculates the shapes in view on most operations
  - instead uses smarter add/remove logic
  - or just skips re-calculation when the sector bounds have not actually changed
- Vision sources in view also received an update to its algorithm and should now perform at O(N) at all times
- panning skips some things now
  - no longer does note-hover checks during pan
  - no longer sends client position during pan to server
- OOB code got cleaned up a bit, no real performance impact
- Reduce significant bugs with some Vue components re-rendering a bazillion times during select tool operations
  - The selected shapes state was continuously being wiped and then configured with the exact same data, causing the re-renders to occur. This is fixed
  - Similarly ContextMenu and ShapeSettings modals no longer update while hidden

The latter might have to be reverted. I'm pretty sure that at one point I made the Shape Settings update while hidden for a specific reason, but I can't remember why. I guess we'll notice when people complain about something :)