### PR TITLE
bug(Group): Fix another badge 0 case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ tech changes will usually be stripped from release notes for the public
 
 -   Note icons on shapes no longer rendering
 -   Asset thumbnails not cleaning up on asset removal
+-   More cases were badges ended up as 0 until reload
 -   [tech] Updated sector system to be more performant (impacts rendering)
 -   [tech] Fixed some unnecessary Vue rerenders on a variety of mouse interactions in the select tool (impacts general performance)
 -   [tech] Removed some unnecessary work during panning (e.g. note hover logic, some ws events)

--- a/client/src/game/systems/groups/emits.ts
+++ b/client/src/game/systems/groups/emits.ts
@@ -1,5 +1,5 @@
 import type { ApiGroup, GroupJoin, GroupLeave, GroupMemberBadge } from "../../../apiTypes";
-import { wrapSocket } from "../../api/socket";
+import { wrapSocket, wrapSocketWithDataAck } from "../../api/socket";
 
 export const sendGroupUpdate = wrapSocket<ApiGroup>("Group.Update");
 export const sendMemberBadgeUpdate = wrapSocket<GroupMemberBadge[]>("Group.Members.Update");
@@ -7,3 +7,4 @@ export const sendCreateGroup = wrapSocket<ApiGroup>("Group.Create");
 export const sendGroupJoin = wrapSocket<GroupJoin>("Group.Join");
 export const sendGroupLeave = wrapSocket<GroupLeave[]>("Group.Leave");
 export const sendRemoveGroup = wrapSocket<string>("Group.Remove");
+export const sendGetGroupInfo = wrapSocketWithDataAck<string, ApiGroup | undefined>("Group.GetInfo");

--- a/client/src/game/systems/groups/index.ts
+++ b/client/src/game/systems/groups/index.ts
@@ -10,6 +10,7 @@ import { propertiesSystem } from "../properties";
 
 import {
     sendCreateGroup,
+    sendGetGroupInfo,
     sendGroupJoin,
     sendGroupLeave,
     sendGroupUpdate,
@@ -47,15 +48,17 @@ class GroupSystem implements ShapeSystem<{ groupId: string | undefined; badge: n
     import(id: LocalId, data: { groupId: string | undefined; badge: number }, mode: SystemInformMode): void {
         if (data.groupId === undefined) return;
 
-        if (mode !== "load") {
-            if (!readonly.groups.has(data.groupId)) {
-                const oldGroup = mutable.removedGroupCache.get(data.groupId);
-                if (oldGroup) {
-                    this.addNewGroup(oldGroup, true);
-                } else {
-                    console.error(`Group ${data.groupId} not found, skipping shape import for ${id}`);
-                    return;
-                }
+        if (!readonly.groups.has(data.groupId)) {
+            const oldGroup = mutable.removedGroupCache.get(data.groupId);
+            if (oldGroup) {
+                this.addNewGroup(oldGroup, true);
+            } else {
+                // This can happen if e.g. a group is moved from DM to token layer
+                // in this case, the group info can be missing as that is only loaded on location open
+                // so we need to load it from the server
+                // this will potentially be called multiple times if an entire group is moved
+                // but for now we're ok with this
+                void this.loadGroupInfo(data.groupId);
             }
         }
         // sync happens in the layerAdd already, so not necessary here
@@ -74,6 +77,13 @@ class GroupSystem implements ShapeSystem<{ groupId: string | undefined; badge: n
 
     fromServerShape(data: ApiCoreShape): { groupId: string | undefined; badge: number } {
         return { groupId: data.group ?? undefined, badge: data.badge };
+    }
+
+    async loadGroupInfo(groupId: string): Promise<void> {
+        const group = await sendGetGroupInfo(groupId);
+        if (group) {
+            this.addNewGroup(groupToClient(group), false);
+        }
     }
 
     // REACTIVE

--- a/server/src/api/socket/groups.py
+++ b/server/src/api/socket/groups.py
@@ -15,6 +15,16 @@ from ..models.groups import GroupJoin, GroupLeave
 from ..models.groups.members import GroupMemberBadge
 
 
+@sio.on("Group.GetInfo", namespace=GAME_NS)
+@auth.login_required(app, sio, "game")
+async def get_group_info(_sid: str, group_id: str) -> ApiGroup | None:
+    try:
+        group = Group.get_by_id(group_id)
+    except Group.DoesNotExist:
+        return None
+    return group.as_pydantic()
+
+
 @sio.on("Group.Update", namespace=GAME_NS)
 @auth.login_required(app, sio, "game")
 async def update_group(sid: str, raw_data: Any):


### PR DESCRIPTION
Group info is generally loaded along with the location info as it's likely needed for rendering so there is no point on delaying the data fetch.

Sometimes however a group may not be known to the players because it's for example on the DM layer at the start of the session. When they get moved to the token layer, the clients don't know about these groups and end up showing the badges as 0 until the client reloads.

This PR fixes this by adding a way to fetch the info from the server when necessary.