### PR TITLE
bug(LightTool): Fix point light edit not updating bright/dim radii

### DIFF
--- a/client/src/game/tools/variants/light.ts
+++ b/client/src/game/tools/variants/light.ts
@@ -533,7 +533,18 @@ class LightTool extends Tool implements ITool {
         if (this.state.selectedShape === undefined) return;
         const auras = auraSystem.getAll(this.state.selectedShape);
         if (auras.length === 0) return;
-        auraSystem.update(this.state.selectedShape, auras[0]!.uuid, this.state.pointLight.edit, SERVER_SYNC);
+        const e = this.state.pointLight.edit;
+        auraSystem.update(
+            this.state.selectedShape,
+            auras[0]!.uuid,
+            {
+                value: e.brightRadius,
+                dim: e.dimRadius,
+                colour: e.colour,
+                angle: e.angle,
+            },
+            SERVER_SYNC,
+        );
     }
 
     // --- Mouse styles ---


### PR DESCRIPTION
Problem: pointLight.edit uses brightRadius/dimRadius (UI labels) but Aura and partialAuraToServer use value/dim. Passing the edit object directly to auraSystem.update() meant Object.assign and the server payload never updated the real aura radii.

Solution: build a Partial<Aura> from edit (value/dim/colour/angle) before calling auraSystem.update().

Made-with: Cursor

Make sure to do your PR on the `dev` branch and NOT on the `master` branch.  This repo uses gitflow which only uses the master branch as a release branch.

Make sure to update the `CHANGELOG`.