### PR TITLE
bug(AssetManager): Fix upload progress no longer working after extension changes

### DIFF
--- a/client/src/assets/index.ts
+++ b/client/src/assets/index.ts
@@ -17,6 +17,15 @@ const toast = useToast();
 
 const { raw, mutableReactive: $ } = assetState;
 
+/** Same as server `assetmgmt_upload` naming: AssetEntry name is filename without final extension. */
+function entryNameFromUploadFilename(uploadName: string): string {
+    const parts = uploadName.split(".");
+    if (parts.length > 1) {
+        return parts.slice(0, -1).join(".");
+    }
+    return uploadName;
+}
+
 class AssetSystem implements System {
     rootCallback = callbackProvider();
 
@@ -232,7 +241,7 @@ class AssetSystem implements System {
         for (const file of fls) {
             const uuid = uuidv4();
             const slices = Math.ceil(file.size / CHUNK_SIZE);
-            $.pendingUploads.push(file.name);
+            $.pendingUploads.push(entryNameFromUploadFilename(file.name));
             for (let slice = 0; slice < slices; slice++) {
                 // oxlint-disable-next-line no-await-in-loop
                 const uploadedFile = await new Promise<ApiAsset | undefined>((resolve) => {


### PR DESCRIPTION
pendingUploads stored file.name (e.g. map.png) but Asset.Upload.Finish and resolveUpload use asset.name from the server, which strips the last extension (map). findIndex never matched, so resolvedUploads stayed 0 and the upload bar showed 0/N until stuck.

Align pending keys with server assetmgmt_upload naming.

Made-with: Cursor

Make sure to do your PR on the `dev` branch and NOT on the `master` branch.  This repo uses gitflow which only uses the master branch as a release branch.

Make sure to update the `CHANGELOG`.