### PR TITLE
chore(Client): Remove old (and broken) client viewport visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ tech changes will usually be stripped from release notes for the public
 -   [tech] DB storage of asset data is reworked
     -   Asset size is now also stored in DB for easier user total size calculation
 
+### Removed
+
+-   [DM] Client viewport visualization
+
 ### Fixed
 
 -   Note icons on shapes no longer rendering

--- a/client/src/game/api/events/client.ts
+++ b/client/src/game/api/events/client.ts
@@ -38,7 +38,7 @@ socket.on("Client.Move", (data: ClientMove) => {
 });
 
 socket.on("Client.Viewport.Set", (data: ClientViewport) => {
-    clientSystem.setClientViewport(data.client, data.viewport, true);
+    clientSystem.setClientViewport(data.client, data.viewport);
 });
 
 socket.on("Client.Offset.Set", (data: ClientOffsetSet) => {

--- a/client/src/game/api/events/player/players.ts
+++ b/client/src/game/api/events/player/players.ts
@@ -10,7 +10,7 @@ socket.on("Players.Info.Set", (data: PlayersInfoSet[]) => {
     let found = false;
     for (const player of data) {
         const id = player.core.id;
-        playerSystem.addPlayer({ ...player.core, showRect: false });
+        playerSystem.addPlayer(player.core);
 
         if (player.position !== undefined) {
             playerSystem.setPosition(id, player.position);
@@ -26,12 +26,12 @@ socket.on("Players.Info.Set", (data: PlayersInfoSet[]) => {
         return;
     }
 
-    // then we add client rects if applicable
+    // then we add client info if applicable
     for (const player of data) {
         for (const client of player.clients ?? []) {
             const clientId = client.client;
             clientSystem.addClient(player.core.id, clientId);
-            if (client.viewport) clientSystem.setClientViewport(clientId, client.viewport, false);
+            if (client.viewport) clientSystem.setClientViewport(clientId, client.viewport);
         }
     }
 });

--- a/client/src/game/models/shapes.ts
+++ b/client/src/game/models/shapes.ts
@@ -5,8 +5,6 @@ import type { TeleportOptions } from "../systems/logic/tp/models";
 import type { NoteId } from "../systems/notes/types";
 
 export interface ShapeOptions {
-    isPlayerRect: boolean;
-
     preFogShape: boolean;
     skipDraw: boolean;
     borderOperation: GlobalCompositeOperation;

--- a/client/src/game/operations/movement.ts
+++ b/client/src/game/operations/movement.ts
@@ -5,7 +5,6 @@ import { sendShapePositionUpdate } from "../api/emits/shape/core";
 import { getShape } from "../id";
 import type { IShape } from "../interfaces/shape";
 import { accessSystem } from "../systems/access";
-import { clientSystem } from "../systems/client";
 import { gameState } from "../systems/game/state";
 import { teleportZoneSystem } from "../systems/logic/tp";
 import { getProperties } from "../systems/properties/state";
@@ -90,9 +89,6 @@ export async function moveShapes(
             visionState.addToTriangulation({ target: TriangulationTarget.VISION, shape: shape.id });
 
         if (!shape.preventSync) updateList.push(shape);
-        if (shape.options.isPlayerRect ?? false) {
-            clientSystem.moveClient(shape.id);
-        }
     }
 
     sendShapePositionUpdate(updateList, temporary);

--- a/client/src/game/systems/client/index.ts
+++ b/client/src/game/systems/client/index.ts
@@ -5,23 +5,16 @@ import { toGP } from "../../../core/geometry";
 import type { GlobalPoint } from "../../../core/geometry";
 import type { LocalId } from "../../../core/id";
 import { filter, map } from "../../../core/iter";
-import { InvalidationMode, SyncMode } from "../../../core/models/types";
 import { registerSystem } from "../../../core/systems";
 import type { System } from "../../../core/systems/models";
 import { setLocalStorageObject } from "../../../localStorageHelpers";
 import { sendMoveClient, sendOffset, sendViewport } from "../../api/emits/client";
 import { getClientId } from "../../api/socket";
 import { getShape } from "../../id";
-import { LayerName } from "../../models/floor";
-import { Polygon } from "../../shapes/variants/polygon";
-import { floorSystem } from "../floors";
-import { floorState } from "../floors/state";
 import { playerSystem } from "../players";
 import type { PlayerId } from "../players/models";
-import { playerState } from "../players/state";
 import { positionSystem } from "../position";
 import { positionState } from "../position/state";
-import { locationSettingsState } from "../settings/location/state";
 
 import type { ClientId } from "./models";
 import { clientState } from "./state";
@@ -43,7 +36,6 @@ class ClientSystem implements System {
 
     removeClient(client: ClientId): void {
         $.clientIds.delete(client);
-        this.removeClientRect(client);
         $.clientViewports.delete(client);
     }
 
@@ -58,114 +50,14 @@ class ClientSystem implements System {
         }
     }
 
-    updatePlayerRect(player: PlayerId): void {
-        for (const [c, p] of $.clientIds.entries()) {
-            if (player === p) this.updateClientRect(c);
-        }
-    }
-
-    updateAllClientRects(): void {
-        for (const client of $.clientIds.keys()) {
-            this.updateClientRect(client);
-        }
-    }
-
-    private updateClientRect(client: ClientId): void {
-        const shapeId = $.clientRectIds.get(client);
-        const playerId = $.clientIds.get(client);
-        if (playerId === undefined) return;
-
-        if (playerState.raw.players.get(playerId)?.location === locationSettingsState.raw.activeLocation) {
-            let shape: Polygon;
-            if (shapeId === undefined) {
-                shape = this.createClientRect(client)!;
-                if (shape === undefined) return;
-            } else {
-                shape = getShape(shapeId) as Polygon;
-                if (shape === undefined) return;
-                this.moveClientRect(client, shape);
-            }
-        } else if (shapeId !== undefined) {
-            this.removeClientRect(client);
-        }
-    }
-
-    private removeClientRect(client: ClientId): void {
-        const rect = $.clientRectIds.get(client);
-        if (rect !== undefined) {
-            const shape = getShape(rect);
-            if (shape !== undefined) {
-                shape.layer?.removeShape(shape, {
-                    sync: SyncMode.NO_SYNC,
-                    recalculate: false,
-                    dropShapeId: true,
-                });
-            }
-            $.clientRectIds.delete(client);
-        }
-    }
-
-    private moveClientRect(client: ClientId, polygon: Polygon): void {
-        const dimensions = this.getDimensions(client);
-        if (dimensions === undefined) return;
-        const { center, h, w } = dimensions;
-        polygon.vertices = [toGP(0, 0), toGP(0, h), toGP(w, h), toGP(w, 0), toGP(0, 0)];
-        polygon.center = center;
-        polygon.invalidate(true);
-    }
-
     private getClientPosition(client: ClientId): ClientPosition | undefined {
         const player = $.clientIds.get(client);
         if (player === undefined) return undefined;
         return playerSystem.getPosition(player);
     }
 
-    private createClientRect(client: ClientId): Polygon | undefined {
-        const locationData = this.getClientPosition(client);
-        const viewport = $.clientViewports.get(client);
-        if (locationData === undefined || viewport === undefined) {
-            console.error("Could not create new client rect: missing data.");
-            return;
-        }
-        if ($.clientRectIds.has(client)) {
-            console.error("Could not create new client rect: already exists.");
-            return;
-        }
-        const playerId = $.clientIds.get(client);
-        if (playerId === undefined) {
-            console.error("Could not find player for client");
-            return;
-        }
-
-        const polygon = new Polygon(
-            toGP(0, 0),
-            undefined,
-            {
-                lineWidth: [30, 15],
-                openPolygon: true,
-                isSnappable: false,
-            },
-            {
-                fillColour: "rgba(0, 0, 0, 0)",
-                strokeColour: ["rgba(0, 0, 0, 1)", "rgba(255, 255, 255, 1)"],
-            },
-        );
-        $.clientRectIds.set(client, polygon.id);
-        polygon.options.isPlayerRect = true;
-        polygon.options.skipDraw = !(playerSystem.getPlayer(playerId)?.showRect ?? false);
-        polygon.preventSync = true;
-
-        const layer = floorSystem.getLayer(floorState.currentFloor.value!, LayerName.Dm)!;
-        layer.addShape(polygon, SyncMode.NO_SYNC, InvalidationMode.NO);
-
-        this.moveClientRect(client, polygon);
-
-        return polygon;
-    }
-
-    setClientViewport(client: ClientId, viewport: Viewport, update: boolean): void {
+    setClientViewport(client: ClientId, viewport: Viewport): void {
         $.clientViewports.set(client, viewport);
-        if (update) this.updateClientRect(client);
     }
 
     moveClient(rectUuid: LocalId): void {
@@ -296,8 +188,6 @@ class ClientSystem implements System {
 
         if (offset.x !== undefined) viewport.offset_x = offset.x;
         if (offset.y !== undefined) viewport.offset_y = offset.y;
-
-        this.updateClientRect(client);
 
         if (sync) sendOffset({ client, x: viewport.offset_x, y: viewport.offset_y });
         if (client === getClientId()) {

--- a/client/src/game/systems/players/index.ts
+++ b/client/src/game/systems/players/index.ts
@@ -1,6 +1,6 @@
 import type { DeepReadonly } from "vue";
 
-import type { ClientPosition, PositionTupleWithFloor } from "../../../apiTypes";
+import type { ClientPosition, PlayerInfoCore, PositionTupleWithFloor } from "../../../apiTypes";
 import { registerSystem } from "../../../core/systems";
 import type { System, SystemClearReason } from "../../../core/systems/models";
 import { getLocalStorageObject } from "../../../localStorageHelpers";
@@ -14,11 +14,10 @@ import { Role } from "../../models/role";
 import type { ServerUserLocationOptions } from "../../models/settings";
 import { startDrawLoop } from "../../rendering/core";
 import { clientSystem } from "../client";
-import { clientState } from "../client/state";
 import { floorSystem } from "../floors";
 import { positionSystem } from "../position";
 
-import type { Player, PlayerId } from "./models";
+import type { PlayerId } from "./models";
 import { playerState } from "./state";
 
 const { mutableReactive: $, raw } = playerState;
@@ -28,7 +27,7 @@ class PlayerSystem implements System {
         if (reason !== "partial-loading") $.players.clear();
     }
 
-    addPlayer(player: Player): void {
+    addPlayer(player: PlayerInfoCore): void {
         $.players.set(player.id, player);
     }
 
@@ -38,7 +37,6 @@ class PlayerSystem implements System {
 
     setPosition(player: PlayerId, position: ClientPosition): void {
         $.playerLocation.set(player, position);
-        clientSystem.updatePlayerRect(player);
     }
 
     updatePlayersLocation(
@@ -90,18 +88,7 @@ class PlayerSystem implements System {
         if (sync) sendChangePlayerRole({ player: playerId, role });
     }
 
-    setShowPlayerRect(playerId: PlayerId, showPlayerRect: boolean): void {
-        const player = this.getPlayer(playerId);
-        if (player === undefined) return;
-
-        player.showRect = showPlayerRect;
-
-        for (const [clientId, _playerId] of clientState.raw.clientIds.entries()) {
-            if (playerId === _playerId) clientSystem.showClientRect(clientId, showPlayerRect);
-        }
-    }
-
-    getPlayer(playerId: PlayerId): Player | undefined {
+    getPlayer(playerId: PlayerId): PlayerInfoCore | undefined {
         return $.players.get(playerId);
     }
 
@@ -114,7 +101,7 @@ class PlayerSystem implements System {
         }
     }
 
-    getCurrentPlayer(): Player | undefined {
+    getCurrentPlayer(): PlayerInfoCore | undefined {
         for (const player of raw.players.values()) {
             if (player.name === coreStore.state.username) {
                 return player;
@@ -135,7 +122,6 @@ class PlayerSystem implements System {
         clientSystem.initViewport();
         if (offset !== undefined) clientSystem.setOffset(getClientId(), offset, false);
         clientSystem.sendViewportInfo();
-        clientSystem.updateAllClientRects();
         // then we can start the draw loop
         startDrawLoop();
     }

--- a/client/src/game/systems/players/models.ts
+++ b/client/src/game/systems/players/models.ts
@@ -1,5 +1,3 @@
-import type { PlayerInfoCore } from "../../../apiTypes";
 import type { NumberId } from "../../../core/id";
 
 export type PlayerId = NumberId<"playerId">;
-export type Player = PlayerInfoCore & { showRect: boolean };

--- a/client/src/game/systems/players/state.ts
+++ b/client/src/game/systems/players/state.ts
@@ -1,10 +1,11 @@
+import { PlayerInfoCore } from "../../../apiTypes";
 import { buildState } from "../../../core/systems/state";
 import type { ServerUserLocationOptions } from "../../models/settings";
 
-import type { Player, PlayerId } from "./models";
+import type { PlayerId } from "./models";
 
 interface PlayerState {
-    players: Map<PlayerId, Player>;
+    players: Map<PlayerId, PlayerInfoCore>;
     playerLocation: Map<PlayerId, ServerUserLocationOptions>;
 }
 

--- a/client/src/game/systems/room/events.ts
+++ b/client/src/game/systems/room/events.ts
@@ -26,7 +26,7 @@ socket.on("Room.Info.InvitationCode.Set", (invitationCode: string) => {
 });
 
 socket.on("Room.Info.Players.Add", (data: RoomInfoPlayersAdd) => {
-    playerSystem.addPlayer({ ...data, role: Role.Player, showRect: false });
+    playerSystem.addPlayer({ ...data, role: Role.Player });
 });
 
 socket.on("Room.Features.Chat.Set", (data: boolean) => {

--- a/client/src/game/ui/settings/dm/AdminSettings.vue
+++ b/client/src/game/ui/settings/dm/AdminSettings.vue
@@ -55,13 +55,6 @@ function changePlayerRole(event: Event, player: PlayerId): void {
     playerSystem.setPlayerRole(player, role, true);
 }
 
-function togglePlayerRect(player: PlayerId): void {
-    const p = playerSystem.getPlayer(player)?.showRect;
-    if (p === undefined) return;
-
-    playerSystem.setShowPlayerRect(player, !p);
-}
-
 async function deleteSession(): Promise<void> {
     const value = await modals.prompt(
         t("game.ui.settings.dm.AdminSettings.delete_session_msg_CREATOR_ROOM", {
@@ -94,13 +87,6 @@ const toggleLock = (): void => gameSystem.setIsLocked(!gameState.raw.isLocked, t
                         {{ role }}
                     </option>
                 </select>
-                <div
-                    title="Show player viewport"
-                    :style="{ opacity: player.showRect ? 1 : 0.3 }"
-                    @click="togglePlayerRect(player.id)"
-                >
-                    <font-awesome-icon icon="eye" />
-                </div>
                 <div :style="{ opacity: player.name === creator ? 0.3 : 1.0 }" @click="kickPlayer(player.id)">
                     {{ t("game.ui.settings.dm.AdminSettings.kick") }}
                 </div>

--- a/client/test/helpers.ts
+++ b/client/test/helpers.ts
@@ -1,4 +1,4 @@
-import type { ApiFloor } from "../src/apiTypes";
+import type { ApiFloor, PlayerInfoCore } from "../src/apiTypes";
 import { toGP } from "../src/core/geometry";
 import type { LocalId } from "../src/core/id";
 import { addServerFloor } from "../src/game/floor/server";
@@ -8,7 +8,7 @@ import { LayerName } from "../src/game/models/floor";
 import { Role } from "../src/game/models/role";
 import { Rect } from "../src/game/shapes/variants/rect";
 import { floorSystem } from "../src/game/systems/floors";
-import type { Player, PlayerId } from "../src/game/systems/players/models";
+import type { PlayerId } from "../src/game/systems/players/models";
 
 export async function generateTestShape(options?: { floor?: string }): Promise<IShape> {
     const rect = new Rect(toGP(0, 0), 0, 0);
@@ -33,13 +33,12 @@ export async function generateTestLocalId(shape?: IShape): Promise<LocalId> {
     return id;
 }
 
-export function generatePlayer(name: string): Player {
+export function generatePlayer(name: string): PlayerInfoCore {
     return {
         id: (100 * Math.random()) as PlayerId,
         name,
         location: 1,
         role: Role.Player,
-        showRect: false,
     };
 }
 


### PR DESCRIPTION
This was an older feature primarily implemented as a request for the lastgameboard integration PA used to have.

It's been in a broken state for a longer time and I've had nobody reach out about it, so I'm pretty sure I can safely remove it.