### PR TITLE
bug(Router): Fix some vue router deprecation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ tech changes will usually be stripped from release notes for the public
 -   [tech] Updated sector system to be more performant (impacts rendering)
 -   [tech] Fixed some unnecessary Vue rerenders on a variety of mouse interactions in the select tool (impacts general performance)
 -   [tech] Removed some unnecessary work during panning (e.g. note hover logic, some ws events)
+-   [tech] Vue-router deprecation issues
 
 ### Fixed
 

--- a/client/src/auth/logout.ts
+++ b/client/src/auth/logout.ts
@@ -8,12 +8,12 @@ import { coreStore } from "../store/core";
 export const Logout = defineComponent({
     // eslint-disable-next-line vue/multi-word-component-names
     name: "Logout",
-    async beforeRouteEnter(_to, _from, next) {
+    async beforeRouteEnter() {
         await http.postJson("/api/logout");
         coreStore.setAuthenticated(false);
         coreStore.setUsername("");
         clearSystems("logging-out");
         socket.disconnect();
-        next({ path: "/auth/login" });
+        return { path: "/auth/login" };
     },
 });

--- a/client/src/game/Game.vue
+++ b/client/src/game/Game.vue
@@ -38,14 +38,12 @@ export default defineComponent({
     // eslint-disable-next-line vue/multi-word-component-names
     name: "Game",
     components: { UI }, // DebugInfo
-    beforeRouteEnter(to, _from, next) {
+    beforeRouteEnter(to) {
         coreStore.setLoading(true);
         createConnection(to);
-        next();
     },
-    beforeRouteLeave(_to, _from, next) {
+    beforeRouteLeave() {
         socket.disconnect();
-        next();
     },
     setup() {
         const modals = useModal();

--- a/client/src/game/ui/Floors.vue
+++ b/client/src/game/ui/Floors.vue
@@ -82,7 +82,7 @@ const selectedLayer = computed(() => {
             v-if="visible"
             id="floor-selector"
             :title="t('game.ui.FloorSelect.title')"
-            @click="detailsOpen = !detailsOpen"
+            @click.prevent="detailsOpen = !detailsOpen"
         >
             <a href="#">
                 <template v-if="playerSettingsState.reactive.useToolIcons.value">
@@ -130,7 +130,7 @@ const selectedLayer = computed(() => {
                 :key="layer"
                 class="layer"
                 :class="{ 'layer-selected': layer === selectedLayer }"
-                @click="selectLayer(layer)"
+                @click.prevent="selectLayer(layer)"
             >
                 <a href="#" :title="layerTranslationMapping[layer]">
                     <template v-if="playerSettingsState.reactive.useToolIcons.value">

--- a/client/src/game/ui/UI.vue
+++ b/client/src/game/ui/UI.vue
@@ -161,13 +161,18 @@ function setTempZoomDisplay(value: number): void {
                             id="rm-locations"
                             class="rm-item"
                             :title="t('game.ui.ui.open_loc_menu')"
-                            @click="toggleLocations"
+                            @click.prevent="toggleLocations"
                         >
                             <a href="#">
                                 <font-awesome-icon :icon="['far', 'compass']" />
                             </a>
                         </li>
-                        <li id="rm-settings" class="rm-item" :title="t('game.ui.ui.open_settings')" @click="toggleMenu">
+                        <li
+                            id="rm-settings"
+                            class="rm-item"
+                            :title="t('game.ui.ui.open_settings')"
+                            @click.prevent="toggleMenu"
+                        >
                             <a href="#">
                                 <font-awesome-icon icon="cog" />
                             </a>

--- a/client/src/invitation.ts
+++ b/client/src/invitation.ts
@@ -1,19 +1,19 @@
 import { defineComponent } from "vue";
-import type { NavigationGuardNext, RouteLocationNormalized } from "vue-router";
+import type { RouteLocationNormalized } from "vue-router";
 
 import { http } from "./core/http";
 
 export default defineComponent({
-    async beforeRouteEnter(to: RouteLocationNormalized, _from: RouteLocationNormalized, next: NavigationGuardNext) {
+    async beforeRouteEnter(to: RouteLocationNormalized) {
         const response = await http.postJson("/api/invite", {
             code: to.params.code,
         });
         if (response.ok) {
             const data = (await response.json()) as { sessionUrl: string };
-            next({ path: data.sessionUrl });
+            return { path: data.sessionUrl };
         } else {
             console.error("Invitation code could not be redeemed");
-            next({ path: "/dashboard" });
+            return { path: "/dashboard" };
         }
     },
 });

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory, type NavigationGuardNext, type RouteLocationNormalized } from "vue-router";
+import { createRouter, createWebHistory, NavigationGuardReturn, type RouteLocationNormalized } from "vue-router";
 
 import { http } from "../core/http";
 import { handleNotifications } from "../notifications";
@@ -9,7 +9,7 @@ export const router = createRouter({
     routes: [],
 });
 
-router.beforeEach(async (to, _from, next) => {
+router.beforeEach(async (to) => {
     // disable for now as it gives a flicker on transition between login and dashboard.
     // coreStore.setLoading(true);
     if (!coreStore.state.initialized) {
@@ -52,24 +52,21 @@ router.beforeEach(async (to, _from, next) => {
             if (authData.auth) {
                 coreStore.setUsername(authData.username);
                 coreStore.setEmail(authData.email);
-                next();
             } else {
-                checkLogin(next, to);
+                return checkLogin(to);
             }
         } else {
             console.error("Authentication check could not be fulfilled.");
-            checkLogin(next, to);
+            return checkLogin(to);
         }
     } else {
-        checkLogin(next, to);
+        return checkLogin(to);
     }
 });
 
-function checkLogin(next: NavigationGuardNext, to: RouteLocationNormalized): void {
+function checkLogin(to: RouteLocationNormalized): NavigationGuardReturn {
     if (to.meta.auth === true && !coreStore.state.authenticated) {
-        next({ name: "login", query: { redirect: to.path } });
-    } else {
-        next();
+        return { name: "login", query: { redirect: to.path } };
     }
 }
 


### PR DESCRIPTION
This cleans up the deprecated use of the `next()` callback for vue route handling.

It also cleans up some unnecessary router checks when clicking on the DM layer bar or the radial menu in the topleft, though this won't be something a user will notice.