### PR TITLE
lang: Fix broken English translation + remove some old translations

### DIFF
--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -260,8 +260,7 @@
                         "remove_location_yes": "Ja, lösche diesen Ort",
                         "remove_location_no": "Bitte nicht",
                         "move_existing_pl": "Bestehende Spieler zu diesem Ort bewegen",
-                        "delete_this_location": "Diesen Ort löschen",
-                        "remove_location": "Ort entfernen"
+                        "delete_this_location": "Diesen Ort löschen"
                     },
                     "LocationSettings": {
                         "location_settings": "Ortseinstellungen:"

--- a/client/src/locales/dk.json
+++ b/client/src/locales/dk.json
@@ -228,8 +228,7 @@
                         "remove_location_yes": "Ja, slet placeringen",
                         "remove_location_no": "Vær sød at lade være",
                         "move_existing_pl": "Flyt eksisterende spiller til denne placering",
-                        "delete_this_location": "Slet denne placering",
-                        "remove_location": "Fjern placering"
+                        "delete_this_location": "Slet denne placering"
                     },
                     "LocationSettings": {
                         "location_settings": "Placeringsinstillinger:"

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -358,7 +358,7 @@
                     "set_marker": "Set marker",
                     "no_spawn_set_title": "Could not move shapes",
                     "no_spawn_set_text": "The destination has no spawn locations configured. Make sure to create at least one by using the context-menu in the destination location.",
-                    "open-notes": "Open notes",
+                    "open_notes": "Open notes",
                     "create_character": "Create character",
                     "move": "Move",
                     "group": "Group",
@@ -740,8 +740,6 @@
                         "archived_location": "include archived locations",
                         "local_shapes": "Local: Shapes",
                         "note_with_shape": "show notes with shapes",
-                        "global_note": "show global note if local shape",
-                        "global_note_title": "Global notes might be associated with a specific shape due to templating. Toggle this setting if you wish to list global notes that are associated with a shape in the current campaign",
                         "active_location_title": "Show only notes that were made in the current location"
                     },
                     "empty_note": "You don't have any notes yet!",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -253,8 +253,7 @@
                         "remove_location_yes": "Sí, borrar esta ubicación",
                         "remove_location_no": "Por favor no",
                         "move_existing_pl": "Mover jugadores existentes en esta ubicación",
-                        "delete_this_location": "Borrar esta ubicación",
-                        "remove_location": "Remover esta ubicación"
+                        "delete_this_location": "Borrar esta ubicación"
                     },
                     "LocationSettings": {
                         "location_settings": "Opciones de Ubicación:"

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -607,11 +607,7 @@
                         "header": "Créer une nouvelle note",
                         "title": "Titre :",
                         "title_placeholder": "Nouvelle note...",
-                        "type": "Type :",
-                        "local_note_title": "Note locale",
-                        "local_note_body": "Une note qui ne concerne que la campagne actuelle. C'est le type le plus courant et à privilégier dans la majorité des cas.",
-                        "global_note_title": "Note globale",
-                        "global_note_body": "Une note visible dans toutes les campagnes. Ce type spécial est utile pour enregistrer des informations communes, comme des statistiques de monstres utilisées dans plusieurs campagnes."
+                        "type": "Type :"
                     },
                     "NoteDialog": {
                         "show": "afficher",
@@ -638,8 +634,6 @@
                             "archived_location": "inclure les lieux archivés",
                             "local_shapes": "Local : Formes",
                             "note_with_shape": "afficher les notes avec des formes",
-                            "global_note": "afficher les notes globales si une forme locale existe",
-                            "global_note_title": "Les notes globales peuvent être associées à une forme via un modèle. Activez ce paramètre pour afficher les notes globales associées à une forme dans la campagne actuelle",
                             "active_location_title": "Afficher uniquement les notes créées dans le lieu actuel"
                         },
                         "empty_note": "Vous n'avez encore aucune note !",

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -248,8 +248,7 @@
                         "remove_location_yes": "Sì, rimuovi questa location",
                         "remove_location_no": "No, per favore!",
                         "move_existing_pl": "Sposta i giocatori in questa location",
-                        "delete_this_location": "Elimina questa location",
-                        "remove_location": "Rimuovi Location"
+                        "delete_this_location": "Elimina questa location"
                     },
                     "LocationSettings": {
                         "location_settings": "Impostazioni Location:"

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -228,8 +228,7 @@
                         "remove_location_yes": "Да, удалить этот регион",
                         "remove_location_no": "пожалуйста не надо",
                         "move_existing_pl": "Перенести существующих игроков в этот регион",
-                        "delete_this_location": "Удалить этот регион",
-                        "remove_location": "Удалить регион"
+                        "delete_this_location": "Удалить этот регион"
                     },
                     "LocationSettings": {
                         "location_settings": "Настройки региона:"

--- a/client/src/locales/tw.json
+++ b/client/src/locales/tw.json
@@ -240,8 +240,7 @@
                         "remove_location_yes": "確認，移除該地點",
                         "remove_location_no": "否",
                         "move_existing_pl": "移動此地點的玩家",
-                        "delete_this_location": "移除該地點",
-                        "remove_location": "移除地點"
+                        "delete_this_location": "移除該地點"
                     },
                     "LocationSettings": {
                         "location_settings": "地點設定："

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -519,8 +519,7 @@
                         "delete_this_location": "移除该地点",
                         "archive_this_location": "存档此地点",
                         "clone_this_location": "克隆此地点",
-                        "choose_room": "选择房间",
-                        "remove_location": "移除地点"
+                        "choose_room": "选择房间"
                     },
                     "LocationSettings": {
                         "location_settings": "地点设置："
@@ -715,11 +714,7 @@
                     "location_note_title": "特定地点便签",
                     "location_note_body": "仅与当前地点相关的便签。通常用于记录不适用于其他地点的说明（例如：特殊规则、隐藏房间信息等）。",
                     "no_link_note_title": "无链接便签",
-                    "no_link_note_body": "未链接到任何战局或地点的便签。通常用于素材模板或通用系统规则（例如：怪物数据、状态规则、随机表等）。",
-                    "local_note_title": "战局内便签",
-                    "local_note_body": "仅与当前战局相关的便签，最常见的便签类型，适用于大多数情况。",
-                    "global_note_title": "全局便签",
-                    "global_note_body": "在所有战局中均可见的便签，一种特殊类型，可以用于记录例如怪物能力等在多个战局中通用的信息。"
+                    "no_link_note_body": "未链接到任何战局或地点的便签。通常用于素材模板或通用系统规则（例如：怪物数据、状态规则、随机表等）。"
                 },
                 "NoteDialog": {
                     "show": "预览",
@@ -746,8 +741,6 @@
                         "archived_location": "包含留档地点",
                         "local_shapes": "战局内：图形",
                         "note_with_shape": "显示与图形有关联的便签",
-                        "global_note": "显示战局内图形关联的全局便签",
-                        "global_note_title": "全局便签有时因为模板会关联于某个图形，勾选该选项以显示关联于本战局内图形的全局便签。",
                         "active_location_title": "仅显示在当前地点创建的便签。"
                     },
                     "empty_note": "这里还没有便签呢！",


### PR DESCRIPTION
Small fix to the new translations that were added, which had `open-notes` instead of `open_notes`.

Also removing some translation keys that are no longer in use.