### PR TITLE
bug(Notes): Fix shape specific overrides not updating the note list data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ tech changes will usually be stripped from release notes for the public
 -   Note icons on shapes no longer rendering
 -   Asset thumbnails not cleaning up on asset removal
 -   More cases were badges ended up as 0 until reload
+-   Note listing was ignoring the shape specific override when present
 -   [tech] Updated sector system to be more performant (impacts rendering)
 -   [tech] Fixed some unnecessary Vue rerenders on a variety of mouse interactions in the select tool (impacts general performance)
 -   [tech] Removed some unnecessary work during panning (e.g. note hover logic, some ws events)

--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -140,11 +140,12 @@ function filterToServer<T extends number | string>(value: symbol | T): DefaultNo
 async function search(): Promise<void> {
     if (!isOpen.value) return;
     loading.value = true;
+    const shapes = noteState.raw.shapeFilter ? [noteState.raw.shapeFilter] : filters.shapes;
     const [serverNotes, count] = (await socket.emitWithAck("Note.Search", {
         search: searchFilter.value,
         campaign_filter: filterToServer(filters.rooms[0]!),
         location_filter: filters.locations.map(filterToServer),
-        shape_filter: filters.shapes
+        shape_filter: shapes
             .map((s) => (typeof s !== "symbol" ? getGlobalId(s) : s))
             .filter((s) => s !== undefined)
             .map(filterToServer),
@@ -198,7 +199,7 @@ watch([searchFilter], debouncedSearch, {
 });
 
 watch(
-    [filters, pageSize],
+    [filters, pageSize, () => noteState.reactive.shapeFilter],
     async () => {
         currentPage.value = 1;
         await search();


### PR DESCRIPTION
The note manager has a shape filter that was working properly. There however is also a way to immediately filter for a particular shape when its selected using the selection info UI in the top-right.

This was not properly triggering a search update, causing a bunch of notes to be visible that were not related to the selected shape.

Fixes #1824