### PR TITLE
bug(Notes): Fix a timing issue when opening notes for a shape

### DIFF
--- a/client/src/game/ui/notes/NoteList.vue
+++ b/client/src/game/ui/notes/NoteList.vue
@@ -138,7 +138,6 @@ function filterToServer<T extends number | string>(value: symbol | T): DefaultNo
 }
 
 async function search(): Promise<void> {
-    if (!isOpen.value) return;
     loading.value = true;
     const shapes = noteState.raw.shapeFilter ? [noteState.raw.shapeFilter] : filters.shapes;
     const [serverNotes, count] = (await socket.emitWithAck("Note.Search", {
@@ -194,9 +193,7 @@ async function updateTagFilter(): Promise<void> {
 
 // **** SEARCH TRIGGERS ****
 
-watch([searchFilter], debouncedSearch, {
-    immediate: true,
-});
+watch([searchFilter], debouncedSearch);
 
 watch(
     [filters, pageSize, () => noteState.reactive.shapeFilter],


### PR DESCRIPTION
Depending on the open state of the note manager the note list search query would be cancelled in some cases.

Additionally a redundant search query was removed.

Fixes #1824 