### PR TITLE
feat: add modals and activateTool API to mod-api

### DIFF
--- a/client/src/core/plugins/modals/plugin.ts
+++ b/client/src/core/plugins/modals/plugin.ts
@@ -13,7 +13,7 @@ import type { SelectionBoxFunction } from "./selectionBox";
 
 const modalSymbol: InjectionKey<Modals> = Symbol("PlanarAllyModals");
 
-interface Modals {
+export interface Modals {
     confirm: ConfirmFunction;
     prompt: PromptFunction;
     selectionBox: SelectionBoxFunction;
@@ -42,17 +42,23 @@ async function createModals(): Promise<Modals> {
     };
 }
 
-export const modals = shallowReactive<Partial<Modals>>({});
+const _modals = shallowReactive<Partial<Modals>>({});
+
+export const modals: Modals = {
+    confirm: (...args) => _modals.confirm!(...args),
+    prompt: (...args) => _modals.prompt!(...args),
+    selectionBox: (...args) => _modals.selectionBox!(...args),
+};
 
 export const PlanarAllyModalsPlugin: Plugin = async (App) => {
-    Object.assign(modals, await createModals());
-    App.provide(modalSymbol, modals as Modals);
+    Object.assign(_modals, await createModals());
+    App.provide(modalSymbol, modals);
 };
 
 export function useModal(): Modals {
-    const _modals = inject(modalSymbol);
-    if (_modals === undefined) {
+    const modalsInstance = inject(modalSymbol);
+    if (modalsInstance === undefined) {
         throw new Error("Could not inject modals");
     }
-    return _modals;
+    return modalsInstance;
 }

--- a/client/src/core/plugins/modals/plugin.ts
+++ b/client/src/core/plugins/modals/plugin.ts
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { createApp, inject, nextTick } from "vue";
+import { createApp, inject, nextTick, shallowReactive } from "vue";
 import type { InjectionKey, Plugin } from "vue";
 
 import PluginContainer from "../../components/PluginContainer.vue";
@@ -42,11 +42,11 @@ async function createModals(): Promise<Modals> {
     };
 }
 
-export let modals: Modals | undefined = undefined;
+export const modals = shallowReactive<Partial<Modals>>({});
 
 export const PlanarAllyModalsPlugin: Plugin = async (App) => {
-    modals = await createModals();
-    App.provide(modalSymbol, modals);
+    Object.assign(modals, await createModals());
+    App.provide(modalSymbol, modals as Modals);
 };
 
 export function useModal(): Modals {

--- a/client/src/core/plugins/modals/plugin.ts
+++ b/client/src/core/plugins/modals/plugin.ts
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { createApp, inject, nextTick, shallowReactive } from "vue";
+import { createApp, inject, nextTick } from "vue";
 import type { InjectionKey, Plugin } from "vue";
 
 import PluginContainer from "../../components/PluginContainer.vue";
@@ -42,16 +42,10 @@ async function createModals(): Promise<Modals> {
     };
 }
 
-const _modals = shallowReactive<Partial<Modals>>({});
-
-export const modals: Modals = {
-    confirm: (...args) => _modals.confirm!(...args),
-    prompt: (...args) => _modals.prompt!(...args),
-    selectionBox: (...args) => _modals.selectionBox!(...args),
-};
+export let modals: Modals;
 
 export const PlanarAllyModalsPlugin: Plugin = async (App) => {
-    Object.assign(_modals, await createModals());
+    modals = await createModals();
     App.provide(modalSymbol, modals);
 };
 

--- a/client/src/core/plugins/modals/plugin.ts
+++ b/client/src/core/plugins/modals/plugin.ts
@@ -42,8 +42,10 @@ async function createModals(): Promise<Modals> {
     };
 }
 
+export let modals: Modals | undefined = undefined;
+
 export const PlanarAllyModalsPlugin: Plugin = async (App) => {
-    const modals = await createModals();
+    modals = await createModals();
     App.provide(modalSymbol, modals);
 };
 

--- a/client/src/core/plugins/modals/plugin.ts
+++ b/client/src/core/plugins/modals/plugin.ts
@@ -50,9 +50,9 @@ export const PlanarAllyModalsPlugin: Plugin = async (App) => {
 };
 
 export function useModal(): Modals {
-    const modals = inject(modalSymbol);
-    if (modals === undefined) {
+    const _modals = inject(modalSymbol);
+    if (_modals === undefined) {
         throw new Error("Could not inject modals");
     }
-    return modals;
+    return _modals;
 }

--- a/client/src/mods/events.ts
+++ b/client/src/mods/events.ts
@@ -15,10 +15,10 @@ const ui = {
     },
     activateTool,
     modals: {
-        confirm: (title: string, text?: string, buttons?: any) => modals?.confirm(title, text, buttons),
-        prompt: (question: string, title: string, validation?: any) => modals?.prompt(question, title, validation),
+        confirm: (title: string, text?: string, buttons?: any) => modals.confirm?.(title, text, buttons),
+        prompt: (question: string, title: string, validation?: any) => modals.prompt?.(question, title, validation),
         selectionBox: (title: string, choices: string[], options?: any) =>
-            modals?.selectionBox(title, choices, options),
+            modals.selectionBox?.(title, choices, options),
     },
 };
 

--- a/client/src/mods/events.ts
+++ b/client/src/mods/events.ts
@@ -23,13 +23,15 @@ async function gameOpened(mods?: (typeof loadedMods.value)[number][]): Promise<v
                         systems: SYSTEMS,
                         systemsState: SYSTEMS_STATE,
                         ui: {
-                        shape: {
-                            registerContextMenuEntry,
-                            registerTab,
+                            shape: {
+                                registerContextMenuEntry,
+                                registerTab,
+                            },
+                            modals,
                         },
-                        activateTool,
-                        modals,
-                    },
+                        gameplay: {
+                            activateTool,
+                        },
                         getGlobalId,
                         getShape,
                         ...getDataBlockFunctions(meta.tag),

--- a/client/src/mods/events.ts
+++ b/client/src/mods/events.ts
@@ -1,31 +1,19 @@
-import { modals } from "../core/plugins/modals/plugin";
 import { SYSTEMS, SYSTEMS_STATE } from "../core/systems";
 import { getGlobalId, getShape } from "../game/id";
 import { registerContextMenuEntry, registerTab } from "../game/systems/ui/mods";
-import { activateTool } from "../game/tools/tools";
 
 import { getDataBlockFunctions } from "./db";
 
 import { loadedMods, modsLoading } from ".";
 
-const ui = {
-    shape: {
-        registerContextMenuEntry,
-        registerTab,
-    },
-    activateTool,
-    modals: {
-        confirm: (title: string, text?: string, buttons?: any) => modals.confirm?.(title, text, buttons),
-        prompt: (question: string, title: string, validation?: any) => modals.prompt?.(question, title, validation),
-        selectionBox: (title: string, choices: string[], options?: any) =>
-            modals.selectionBox?.(title, choices, options),
-    },
-};
-
 async function gameOpened(mods?: (typeof loadedMods.value)[number][]): Promise<void> {
     // It's timing dependent whether the main Game.vue loads before or after the mod info is transferred over the socket
     // So we wait here for the mods to have loaded, to ensure that they all receive the initGame call
     await modsLoading;
+
+    const { activateTool } = await import("../game/tools/tools");
+    const { modals } = await import("../core/plugins/modals/plugin");
+
     const promises: Promise<void>[] = [];
     for (const { id, mod, meta } of mods ?? loadedMods.value) {
         try {
@@ -34,7 +22,14 @@ async function gameOpened(mods?: (typeof loadedMods.value)[number][]): Promise<v
                     mod.events?.initGame?.({
                         systems: SYSTEMS,
                         systemsState: SYSTEMS_STATE,
-                        ui,
+                        ui: {
+                        shape: {
+                            registerContextMenuEntry,
+                            registerTab,
+                        },
+                        activateTool,
+                        modals,
+                    },
                         getGlobalId,
                         getShape,
                         ...getDataBlockFunctions(meta.tag),

--- a/client/src/mods/events.ts
+++ b/client/src/mods/events.ts
@@ -1,6 +1,8 @@
+import { modals } from "../core/plugins/modals/plugin";
 import { SYSTEMS, SYSTEMS_STATE } from "../core/systems";
 import { getGlobalId, getShape } from "../game/id";
 import { registerContextMenuEntry, registerTab } from "../game/systems/ui/mods";
+import { activateTool } from "../game/tools/tools";
 
 import { getDataBlockFunctions } from "./db";
 
@@ -10,6 +12,13 @@ const ui = {
     shape: {
         registerContextMenuEntry,
         registerTab,
+    },
+    activateTool,
+    modals: {
+        confirm: (title: string, text?: string, buttons?: any) => modals?.confirm(title, text, buttons),
+        prompt: (question: string, title: string, validation?: any) => modals?.prompt(question, title, validation),
+        selectionBox: (title: string, choices: string[], options?: any) =>
+            modals?.selectionBox(title, choices, options),
     },
 };
 

--- a/client/src/mods/models.ts
+++ b/client/src/mods/models.ts
@@ -2,9 +2,11 @@ import type { ApiModMeta } from "../apiTypes";
 import type { Section } from "../core/components/contextMenu/types";
 import { type GlobalId, type LocalId } from "../core/id";
 import type { Sync } from "../core/models/types";
+import type { Modals } from "../core/plugins/modals/plugin";
 import type { SYSTEMS_STATE } from "../core/systems";
 import type { System } from "../core/systems/models";
 import type { IShape } from "../game/interfaces/shape";
+import type { ToolName } from "../game/models/tools";
 import type { Tracker } from "../game/systems/trackers/models";
 import type { PanelTab } from "../game/systems/ui/types";
 
@@ -29,6 +31,8 @@ interface ModLoad {
             registerContextMenuEntry: (entry: (shape: LocalId) => Section[]) => void;
             registerTab: (tab: PanelTab, filter: (shape: LocalId) => boolean) => void;
         };
+        activateTool: (toolName: ToolName) => void;
+        modals: Modals;
     };
 
     getShape: (shape: LocalId) => IShape | undefined;

--- a/client/src/mods/models.ts
+++ b/client/src/mods/models.ts
@@ -31,8 +31,10 @@ interface ModLoad {
             registerContextMenuEntry: (entry: (shape: LocalId) => Section[]) => void;
             registerTab: (tab: PanelTab, filter: (shape: LocalId) => boolean) => void;
         };
-        activateTool: (toolName: ToolName) => void;
         modals: Modals;
+    };
+    gameplay: {
+        activateTool: (toolName: ToolName) => void;
     };
 
     getShape: (shape: LocalId) => IShape | undefined;


### PR DESCRIPTION
Exposed `activateTool` to the mod API, enabling interaction with tools.

Added modals API for mods to trigger standard dialogs, maintaining UI consistency.