### PR TITLE
bug(Shapes): Skip sending unknown shapes to the server during position update

### DIFF
--- a/client/src/game/api/emits/shape/core.ts
+++ b/client/src/game/api/emits/shape/core.ts
@@ -7,6 +7,7 @@ import type {
     ShapeLayerChange,
     ShapeLocationMove,
     ShapeOrder,
+    ShapePositionUpdate,
     ShapeRectSizeUpdate,
     ShapesPositionUpdateList,
     ShapeTextSizeUpdate,
@@ -42,7 +43,8 @@ export const sendShapesMove = wrapSocket<ShapeLocationMove>("Shapes.Location.Mov
 export function sendShapePositionUpdate(shapes: readonly IShape[], temporary: boolean): void {
     const positions = shapes
         .filter((s) => !s.preventSync)
-        .map((s) => ({ uuid: getGlobalId(s.id)!, position: s.getPositionRepresentation() }));
+        .map((s) => ({ uuid: getGlobalId(s.id), position: s.getPositionRepresentation() }))
+        .filter((s): s is ShapePositionUpdate => s.uuid !== undefined);
     if (positions.length > 0) _sendShapePositionUpdate({ shapes: positions, temporary });
 }
 


### PR DESCRIPTION
Sometimes a shape can sneak in the update list to the server which does not actually exist on the server, causing some errors to appear in the logs.

These errors are not really useful and clog the logs, so this is just a simple fix to suppress this.