### PR TITLE
bug(Asset): Fix Asset instances not being removed upon cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ tech changes will usually be stripped from release notes for the public
 -   Dungeondraft file handling
     -   This was broken since a recent change to how templates/assets work
     -   dd2vtt (or uvtt) files will have to be removed and reuploaded from your asset manager   
+-   [tech] Asset db rows were not properly being cleaned up when a file was removed on disk
 
 ### Removed
 

--- a/server/src/db/models/asset.py
+++ b/server/src/db/models/asset.py
@@ -45,6 +45,7 @@ class Asset(BaseDbModel):
                 await storage.delete(self.file_hash)
                 await storage.delete(self.file_hash, suffix=".thumb.webp")
                 await storage.delete(self.file_hash, suffix=".thumb.jpeg")
+            self.delete_instance(True)
 
     async def generate_thumbnails(self) -> None:
         await generate_thumbnail_for_asset(self.file_hash)


### PR DESCRIPTION
This is a minor technical fix that should have no impact on players.