### PR TITLE
bug(Selection): Fix collapse selection sync timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ tech changes will usually be stripped from release notes for the public
 
 -   Dungeondraft file handling
     -   This was broken since a recent change to how templates/assets work
-    -   dd2vtt (or uvtt) files will have to be removed and reuploaded from your asset manager   
+    -   dd2vtt (or uvtt) files will have to be removed and reuploaded from your asset manager
+-   Collapse selection not immediately syncing position change until a move
 -   [tech] Asset db rows were not properly being cleaned up when a file was removed on disk
 
 ### Removed

--- a/client/src/game/systems/selected/collapse.ts
+++ b/client/src/game/systems/selected/collapse.ts
@@ -2,6 +2,7 @@
 
 import { Vector } from "../../../core/geometry";
 import { SyncMode } from "../../../core/models/types";
+import { sendShapePositionUpdate } from "../../api/emits/shape/core";
 import { calculateDelta } from "../../drag";
 import { getShape } from "../../id";
 import type { IShape } from "../../interfaces/shape";
@@ -34,6 +35,7 @@ export function collapseSelection(): void {
             shape.center = center;
         }
     }
+    sendShapePositionUpdate(shapes, false);
 
     focusShape.invalidate(false);
 }


### PR DESCRIPTION
When using the Collapse selection mode, the initial collapse is not synced to other players, it's only until you start moving the selection that other clients are updated.