### PR TITLE
bug(Auras): Fix public aura syncing to non-owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ tech changes will usually be stripped from release notes for the public
     -   This was broken since a recent change to how templates/assets work
     -   dd2vtt (or uvtt) files will have to be removed and reuploaded from your asset manager
 -   Collapse selection not immediately syncing position change until a move
+-   Public aura syncing to non-owners not working as intended
 -   [tech] Asset db rows were not properly being cleaned up when a file was removed on disk
 
 ### Removed

--- a/server/src/api/socket/shape/options.py
+++ b/server/src/api/socket/shape/options.py
@@ -583,7 +583,7 @@ async def update_aura(sid: str, raw_data: Any):
     aura = Aura.get_by_id(data.uuid)
 
     changed_visible = False
-    if data.visible is not None and data.visible != aura.visible:
+    if data.visible is not MISSING and data.visible != aura.visible:
         changed_visible = True
 
     # don't use data.model_dump() as it contains a bunch of None's


### PR DESCRIPTION
When changing a property of a public aura, the data is wrongly synced to clients that do not have vision access to the aura.

Due to a type mismatch it would always create a new aura on the client, keeping the old one intact, which leads to funky results that are undesirable. A refresh would always fix this as this is purely on the client end rendering wrong, but that's of course not ideal.