### PR TITLE
bug(Initiative): Fix edits sometimes opening selected edit dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ tech changes will usually be stripped from release notes for the public
     -   dd2vtt (or uvtt) files will have to be removed and reuploaded from your asset manager
 -   Collapse selection not immediately syncing position change until a move
 -   Public aura syncing to non-owners not working as intended
+-   Pressing enter in the initiative UI could sometimes open a selected shape's property dialog
 -   [tech] Asset db rows were not properly being cleaned up when a file was removed on disk
 
 ### Removed

--- a/client/src/game/ui/initiative/Initiative.vue
+++ b/client/src/game/ui/initiative/Initiative.vue
@@ -526,6 +526,7 @@ function n(e: any): number {
                                                 @blur="unlock"
                                                 @change="setInitiative(actor.globalId, getValue($event))"
                                                 @keyup.enter="getTarget($event).blur()"
+                                                @keydown.enter.prevent
                                             />
                                         </div>
                                         <Transition name="effects-expand">
@@ -612,6 +613,7 @@ function n(e: any): number {
                                                                 setEffectTurns(actor.globalId, n(e), getValue($event))
                                                             "
                                                             @keyup.enter="getTarget($event).blur()"
+                                                            @keydown.enter.prevent
                                                             @focus="setEntryFocus(index, true, false)"
                                                             @blur="setEntryFocus(index, false, false)"
                                                         />


### PR DESCRIPTION
When you have a shape selected and modify an initiative value in the initiative UI, the edit dialog of the selected shape can sometimes open.

The behaviour was inconsistent and is seemingly browser event timing based, with the workaround in this PR I seemingly can't trigger it again.