### PR TITLE
feat(Server): Improve server startup info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ tech changes will usually be stripped from release notes for the public
 -   Variant shapes are completely reworked
     -   UI should be more intuitive
     -   No longer completely separate shapes with their own state
+-   server startup info
+    -   Now contains a bit more info (e.g. where the DB and config are loaded from)
+    -   A help message to point to the config docs
+    -   A help message if there are no users yet, in case someone expects an admin user
 -   [tech] DB storage of asset data is reworked
     -   Asset size is now also stored in DB for easier user total size calculation
 

--- a/server/src/config/manager.py
+++ b/server/src/config/manager.py
@@ -32,6 +32,7 @@ class ConfigManager:
         self.config_path = config_path
         self.config = ServerConfig()
         self._file_observer = Observer()
+        self.is_default_config = True
 
         self.load_config(startup=True)
         self._init_storage_backend()
@@ -45,6 +46,7 @@ class ConfigManager:
         """Load configuration from file"""
         try:
             if self.config_path.exists():
+                self.is_default_config = False
                 config_data = rtoml.loads(self.config_path.read_text())
                 self.config = ServerConfig(**config_data)
                 set_save_path(self.config.general.save_file)

--- a/server/src/planarserver.py
+++ b/server/src/planarserver.py
@@ -23,7 +23,7 @@ from .config.types import WebserverConfig
 from .db.db import db
 from .db.models.room import Room
 from .db.models.user import User
-from .utils import FILE_DIR
+from .utils import ASSETS_DIR, FILE_DIR, SAVE_PATH
 
 save_newly_created = save.check_existence()
 
@@ -76,7 +76,6 @@ async def on_shutdown(_):
 
 
 async def start_http(app: web.Application, host, port):
-    logger.warning(" RUNNING IN NON SSL CONTEXT ")
     await setup_runner(app, web.TCPSite, host=host, port=port)
 
 
@@ -136,15 +135,33 @@ async def start_server(server_section: Literal["Webserver"], cfg: WebserverConfi
             await start_http(app, host, port)
             method = f"http://{host}:{port}{environ}"
 
-    print(f"======== Starting {server_section} on {method} ========")
+    print(f"======== Starting {server_section} ========")
+    print(f"Host: {method}")
+
+    if config.config_manager.is_default_config:
+        print("Config: Using default config.")
+        print("(See https://www.planarally.io/server/management/configuration/ for more information.)")
+    else:
+        print(f"Config: {config.config_manager.config_path}")
+
+    print(f"Database: {SAVE_PATH}")
+    print(f"Assets: {ASSETS_DIR}")
+    print()
+    user_count = User.select().count()
+    if user_count == 0:
+        print(
+            "There are no users yet. PA does not create an admin user out of the box, use the register page to create an account."
+        )
+    else:
+        print(f"Users: {user_count}")
+    print()
+    print("(Press CTRL+C to quit)")
 
 
 async def start_servers():
     cfg = config.cfg()
     print()
     await start_server("Webserver", cfg.webserver)
-    print()
-    print("(Press CTRL+C to quit)")
     print()
     stats.events.server_started()
 


### PR DESCRIPTION
This PR slightly re-arranges the server startup info to be a bit more helpful.

There is now a new line that mentions whether the default config is used or a specific path.
Additionally there is an extra line that refers to the config documentation if the default config is used, to help people out with configuring and avoid confusion.

Similarly a new line is added that shows the path to the main DB file.

Another line is added to list the number of users registered on the server.
When this is 0 a help message will instead be shown that informs the owner that they'll have to register a user. As PA does not create an admin user out of the box.

Lastly I removed the warning about running in a non-ssl context, as the default run mode should be behind a proxy server in which case you're very likely to run the PA server itself without https so it was just adding noise.