### PR TITLE
bug(Floor/Aura): Fix bug in vision source floor movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ tech changes will usually be stripped from release notes for the public
 -   Collapse selection not immediately syncing position change until a move
 -   Public aura syncing to non-owners not working as intended
 -   Pressing enter in the initiative UI could sometimes open a selected shape's property dialog
+-   Moving shapes to a different floor with disabled auras now behaves correctly
 -   [tech] Asset db rows were not properly being cleaned up when a file was removed on disk
 
 ### Removed

--- a/client/src/game/vision/state.ts
+++ b/client/src/game/vision/state.ts
@@ -717,11 +717,13 @@ class VisionState extends Store<State> {
 
     moveVisionSource(source: LocalId, auras: readonly Aura[], oldFloor: FloorId, newFloor: FloorId): void {
         for (const aura of auras) {
-            if (!aura.visionSource) continue;
-            this.sliceVisionSources(
-                this.getVisionSources(oldFloor).findIndex((s) => s.shape === source && s.aura === aura.uuid),
-                oldFloor,
-            );
+            if (!aura.active || !aura.visionSource) continue;
+            const index = this.getVisionSources(oldFloor).findIndex((s) => s.shape === source && s.aura === aura.uuid);
+            if (index === -1) {
+                console.error("Failed to find vision source in old floor - skipping.");
+                continue;
+            }
+            this.sliceVisionSources(index, oldFloor);
             this.addVisionSource({ shape: source, aura: aura.uuid, isFloodLight: aura.floodLight }, newFloor);
         }
     }


### PR DESCRIPTION
When moving a shape (or multiple shapes) to a different floor some internal data structures need to be adjusted accordingly. One of those is aura data that is stored per floor.

There was a bug in the aura moving code when attempting to move an aura that was not enabled, causing the move to crash mid execution and potentially leaving some vision in a funky state until a refresh.